### PR TITLE
Add relevant files from .github

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,47 @@
+---
+name: Bug report
+about: Create a report to help us improve the library
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+<!-- Before raising, please check if somebody else has already reported your issue. -->
+
+### Describe the bug
+A clear and concise description of what the bug is.
+
+### Steps to reproduce
+1. Calling API X
+2. Doing this in the emulator...
+3. Throws error A or collects wrongly data B
+
+### Environment
+* OS version:
+* SDK version:
+
+<!--
+  Below are a few approaches you might take to communicate the issue, in
+  descending order of awesomeness. Please choose one and feel free to delete
+  the others from this template.
+-->
+
+### Example Repo <!-- Option 1 -->
+
+- [ ] Create a minimal repository that can reproduce the issue
+- [ ] Link to it here:
+
+### Example code snippet <!-- Option 2 -->
+
+```
+# (Insert code sample to reproduce the problem)
+```
+
+<!-- Error messages, if any -->
+<details><summary>Error messages:</summary>
+
+```
+
+```
+</details>

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,7 @@
+## Goal
+
+<!-- Describe what this change seeks to address -->
+
+## Testing
+
+<!-- Describe how this change has been tested -->

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,0 +1,47 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+  release:
+    types: [ released ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  gradle-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout Branch
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'adopt'
+          java-version: 21
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v5
+
+      - name: Gradle Build
+        run: ./gradlew assembleRelease check koverXmlReport --stacktrace
+
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          slug: open-telemetry/opentelemetry-kotlin
+          fail_ci_if_error: false
+          files: build/reports/kover/reportRelease.xml
+
+      - name: Build Example Apps
+        run: ./gradlew :examples:jvm-app:run :examples:android-app:assembleRelease :examples:js-app:jsNodeDevelopmentRun --stacktrace
+      - name: Build Telescope App
+        run: ./gradlew pTML && cd examples/telescope-app && ./gradlew assembleRelease --stacktrace


### PR DESCRIPTION
## Goal

Adds the issue + PR templates from the old repository's [github directory](https://github.com/embrace-io/opentelemetry-kotlin/tree/main/.github), along with a basic CI workflow that validates the project builds. 