### PR TITLE
Add User-Agent header to OTLP exporters

### DIFF
--- a/exporters-otlp/build.gradle.kts
+++ b/exporters-otlp/build.gradle.kts
@@ -5,6 +5,15 @@ plugins {
     id("signing")
     id("com.vanniktech.maven.publish")
     id("org.jetbrains.kotlinx.kover")
+    alias(libs.plugins.buildKonfig)
+}
+
+buildkonfig {
+    packageName = "io.opentelemetry.kotlin.export"
+
+    defaultConfigs {
+        buildConfigField(com.codingfeline.buildkonfig.compiler.FieldSpec.Type.STRING, "VERSION", project.version.toString())
+    }
 }
 
 kotlin {
@@ -35,4 +44,8 @@ kotlin {
             }
         }
     }
+}
+
+tasks.withType<io.gitlab.arturbosch.detekt.Detekt>().configureEach {
+    exclude { it.file.path.contains("buildkonfig") }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -26,6 +26,7 @@ androidxJunit = "1.3.0"
 protobufKotlin = "4.33.4"
 protobufPlugin = "0.9.6"
 wire = "5.5.0"
+buildKonfig = "0.17.1"
 
 [libraries]
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
@@ -76,3 +77,4 @@ kotlinx-benchmark = { id = "org.jetbrains.kotlinx.benchmark", version.ref = "kot
 kotlin-allopen = { id = "org.jetbrains.kotlin.plugin.allopen", version.ref = "kotlin" }
 google-protobuf = { id = "com.google.protobuf", version.ref = "protobufPlugin" }
 wire = { id = "com.squareup.wire", version.ref = "wire" }
+buildKonfig = { id = "com.codingfeline.buildkonfig", version.ref = "buildKonfig" }


### PR DESCRIPTION
## Goal

Adds the `User-Agent` header to OTLP exporters as described in [the spec](https://opentelemetry.io/docs/specs/otel/protocol/exporter/#user-agent). This uses the [BuildKonfig plugin](https://github.com/yshrsmz/BuildKonfig) to generate a Kotlin class containing the project's version string, which is then used in the user agent string.

Closes #43 

## Testing

Added unit tests.
