### PR TITLE
Implement stdout exporters

### DIFF
--- a/exporters-core/api/android/exporters-core.api
+++ b/exporters-core/api/android/exporters-core.api
@@ -4,6 +4,8 @@ public final class io/opentelemetry/kotlin/logging/export/CoreLogRecordExporterA
 	public static final fun createCompositeLogRecordExporter (Ljava/util/List;)Lio/opentelemetry/kotlin/logging/export/LogRecordExporter;
 	public static final fun createCompositeLogRecordProcessor (Ljava/util/List;)Lio/opentelemetry/kotlin/logging/export/LogRecordProcessor;
 	public static final fun createSimpleLogRecordProcessor (Lio/opentelemetry/kotlin/logging/export/LogRecordExporter;)Lio/opentelemetry/kotlin/logging/export/LogRecordProcessor;
+	public static final fun createStdoutLogRecordExporter (Lkotlin/jvm/functions/Function1;)Lio/opentelemetry/kotlin/logging/export/LogRecordExporter;
+	public static synthetic fun createStdoutLogRecordExporter$default (Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lio/opentelemetry/kotlin/logging/export/LogRecordExporter;
 }
 
 public final class io/opentelemetry/kotlin/tracing/export/CoreSpanExporterApiKt {
@@ -12,5 +14,7 @@ public final class io/opentelemetry/kotlin/tracing/export/CoreSpanExporterApiKt 
 	public static final fun createCompositeSpanExporter (Ljava/util/List;)Lio/opentelemetry/kotlin/tracing/export/SpanExporter;
 	public static final fun createCompositeSpanProcessor (Ljava/util/List;)Lio/opentelemetry/kotlin/tracing/export/SpanProcessor;
 	public static final fun createSimpleSpanProcessor (Lio/opentelemetry/kotlin/tracing/export/SpanExporter;)Lio/opentelemetry/kotlin/tracing/export/SpanProcessor;
+	public static final fun createStdoutSpanExporter (Lkotlin/jvm/functions/Function1;)Lio/opentelemetry/kotlin/tracing/export/SpanExporter;
+	public static synthetic fun createStdoutSpanExporter$default (Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lio/opentelemetry/kotlin/tracing/export/SpanExporter;
 }
 

--- a/exporters-core/api/jvm/exporters-core.api
+++ b/exporters-core/api/jvm/exporters-core.api
@@ -4,6 +4,8 @@ public final class io/opentelemetry/kotlin/logging/export/CoreLogRecordExporterA
 	public static final fun createCompositeLogRecordExporter (Ljava/util/List;)Lio/opentelemetry/kotlin/logging/export/LogRecordExporter;
 	public static final fun createCompositeLogRecordProcessor (Ljava/util/List;)Lio/opentelemetry/kotlin/logging/export/LogRecordProcessor;
 	public static final fun createSimpleLogRecordProcessor (Lio/opentelemetry/kotlin/logging/export/LogRecordExporter;)Lio/opentelemetry/kotlin/logging/export/LogRecordProcessor;
+	public static final fun createStdoutLogRecordExporter (Lkotlin/jvm/functions/Function1;)Lio/opentelemetry/kotlin/logging/export/LogRecordExporter;
+	public static synthetic fun createStdoutLogRecordExporter$default (Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lio/opentelemetry/kotlin/logging/export/LogRecordExporter;
 }
 
 public final class io/opentelemetry/kotlin/tracing/export/CoreSpanExporterApiKt {
@@ -12,5 +14,7 @@ public final class io/opentelemetry/kotlin/tracing/export/CoreSpanExporterApiKt 
 	public static final fun createCompositeSpanExporter (Ljava/util/List;)Lio/opentelemetry/kotlin/tracing/export/SpanExporter;
 	public static final fun createCompositeSpanProcessor (Ljava/util/List;)Lio/opentelemetry/kotlin/tracing/export/SpanProcessor;
 	public static final fun createSimpleSpanProcessor (Lio/opentelemetry/kotlin/tracing/export/SpanExporter;)Lio/opentelemetry/kotlin/tracing/export/SpanProcessor;
+	public static final fun createStdoutSpanExporter (Lkotlin/jvm/functions/Function1;)Lio/opentelemetry/kotlin/tracing/export/SpanExporter;
+	public static synthetic fun createStdoutSpanExporter$default (Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lio/opentelemetry/kotlin/tracing/export/SpanExporter;
 }
 

--- a/exporters-core/build.gradle.kts
+++ b/exporters-core/build.gradle.kts
@@ -19,6 +19,7 @@ kotlin {
         val commonTest by getting {
             dependencies {
                 implementation(project(":test-fakes"))
+                implementation(project(":integration-test"))
                 implementation(libs.kotlin.test)
                 implementation(libs.kotlinx.coroutines.test)
             }
@@ -29,4 +30,13 @@ kotlin {
             }
         }
     }
+}
+
+tasks.register<Copy>("copyiOSTestResources") {
+    from("src/commonTest/resources")
+    into("build/bin/iosSimulatorArm64/debugTest/resources")
+}
+
+tasks.named("iosSimulatorArm64Test").configure {
+    dependsOn("copyiOSTestResources")
 }

--- a/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/CoreLogRecordExporterApi.kt
+++ b/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/CoreLogRecordExporterApi.kt
@@ -59,3 +59,15 @@ public fun createBatchLogRecordProcessor(
         exportTimeoutMs,
         maxExportBatchSize
     )
+
+/**
+ * Creates a log record exporter that outputs log records to stdout. The destination is configurable
+ * via a parameter that defaults to [println].
+ *
+ * This exporter is intended for debugging and learning purposes. It is not recommended for
+ * production use. The output format is not standardized and can change at any time.
+ */
+@ExperimentalApi
+public fun createStdoutLogRecordExporter(
+    logger: (String) -> Unit = ::println
+): LogRecordExporter = StdoutLogRecordExporter(logger)

--- a/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/StdoutLogRecordExporter.kt
+++ b/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/StdoutLogRecordExporter.kt
@@ -1,0 +1,84 @@
+package io.opentelemetry.kotlin.logging.export
+
+import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.export.OperationResultCode
+import io.opentelemetry.kotlin.logging.model.ReadableLogRecord
+
+/**
+ * A [LogRecordExporter] that outputs log records to stdout.
+ */
+@OptIn(ExperimentalApi::class)
+internal class StdoutLogRecordExporter(
+    private val logger: (String) -> Unit = ::println
+) : LogRecordExporter {
+
+    override fun export(telemetry: List<ReadableLogRecord>): OperationResultCode {
+        telemetry.forEach { logRecord ->
+            logger(formatLogRecord(logRecord))
+        }
+        return OperationResultCode.Success
+    }
+
+    override fun forceFlush(): OperationResultCode = OperationResultCode.Success
+    override fun shutdown(): OperationResultCode = OperationResultCode.Success
+
+    private fun formatLogRecord(logRecord: ReadableLogRecord): String = buildString {
+        append("LogRecord")
+        logRecord.severityNumber?.let {
+            append(" [")
+            append(it)
+            append("]")
+        }
+        appendLine()
+
+        logRecord.timestamp?.let {
+            append("  Timestamp: ")
+            appendLine(it)
+        }
+
+        logRecord.observedTimestamp?.let {
+            append("  ObservedTimestamp: ")
+            appendLine(it)
+        }
+
+        logRecord.severityText?.let {
+            append("  SeverityText: ")
+            appendLine(it)
+        }
+
+        logRecord.body?.let {
+            append("  Body: ")
+            appendLine(it)
+        }
+
+        logRecord.eventName?.let {
+            append("  EventName: ")
+            appendLine(it)
+        }
+
+        append("  TraceId: ")
+        appendLine(logRecord.spanContext.traceId)
+        append("  SpanId: ")
+        appendLine(logRecord.spanContext.spanId)
+
+        if (logRecord.attributes.isNotEmpty()) {
+            appendLine("  Attributes:")
+            logRecord.attributes.forEach { (key, value) ->
+                append("    ")
+                append(key)
+                append(": ")
+                appendLine(value)
+            }
+        }
+
+        append("  Resource: ")
+        appendLine(logRecord.resource.attributes)
+
+        append("  InstrumentationScope: ")
+        append(logRecord.instrumentationScopeInfo.name)
+        logRecord.instrumentationScopeInfo.version?.let {
+            append(":")
+            append(it)
+        }
+    }
+}

--- a/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/CoreSpanExporterApi.kt
+++ b/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/CoreSpanExporterApi.kt
@@ -55,3 +55,15 @@ public fun createBatchSpanProcessor(
     exportTimeoutMs,
     maxExportBatchSize
 )
+
+/**
+ * Creates a span exporter that outputs span data to stdout. The destination is configurable
+ * via a parameter that defaults to [println].
+ *
+ * This exporter is intended for debugging and learning purposes. It is not recommended for
+ * production use. The output format is not standardized and can change at any time.
+ */
+@ExperimentalApi
+public fun createStdoutSpanExporter(
+    logger: (String) -> Unit = ::println
+): SpanExporter = StdoutSpanExporter(logger)

--- a/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/StdoutSpanExporter.kt
+++ b/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/StdoutSpanExporter.kt
@@ -1,0 +1,103 @@
+package io.opentelemetry.kotlin.tracing.export
+
+import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.export.OperationResultCode
+import io.opentelemetry.kotlin.tracing.data.SpanData
+import io.opentelemetry.kotlin.tracing.data.StatusData
+
+/**
+ * A [SpanExporter] that outputs span data to stdout.
+ */
+@OptIn(ExperimentalApi::class)
+internal class StdoutSpanExporter(
+    private val logger: (String) -> Unit = ::println
+) : SpanExporter {
+
+    override fun export(telemetry: List<SpanData>): OperationResultCode {
+        telemetry.forEach { span ->
+            logger(formatSpan(span))
+        }
+        return OperationResultCode.Success
+    }
+
+    override fun forceFlush(): OperationResultCode = OperationResultCode.Success
+    override fun shutdown(): OperationResultCode = OperationResultCode.Success
+
+    /**
+     * Formats a [SpanData] into a human-readable string representation.
+     *
+     * @param span The span data to format.
+     * @return A formatted string containing the span's key information.
+     */
+    private fun formatSpan(span: SpanData): String = buildString {
+        append("Span: ")
+        append(span.name)
+        append(" [")
+        append(span.spanKind)
+        append("]")
+        appendLine()
+
+        append("  TraceId: ")
+        appendLine(span.spanContext.traceId)
+
+        append("  SpanId: ")
+        appendLine(span.spanContext.spanId)
+
+        append("  ParentSpanId: ")
+        appendLine(span.parent.spanId)
+
+        append("  Status: ")
+        append(span.status.statusCode)
+        if (span.status is StatusData.Error && span.status.description != null) {
+            append(" - ")
+            append(span.status.description)
+        }
+        appendLine()
+
+        append("  StartTime: ")
+        appendLine(span.startTimestamp)
+
+        span.endTimestamp?.let {
+            append("  EndTime: ")
+            appendLine(it)
+            append("  Duration: ")
+            append(it - span.startTimestamp)
+            appendLine(" ns")
+        }
+
+        if (span.attributes.isNotEmpty()) {
+            appendLine("  Attributes:")
+            span.attributes.forEach { (key, value) ->
+                append("    ")
+                append(key)
+                append(": ")
+                appendLine(value)
+            }
+        }
+
+        if (span.events.isNotEmpty()) {
+            appendLine("  Events:")
+            span.events.forEach { event ->
+                append("    - ")
+                append(event.name)
+                append(" @ ")
+                appendLine(event.timestamp)
+            }
+        }
+
+        if (span.links.isNotEmpty()) {
+            append("  Links: ")
+            appendLine(span.links.size)
+        }
+
+        append("  Resource: ")
+        appendLine(span.resource.attributes)
+
+        append("  InstrumentationScope: ")
+        append(span.instrumentationScopeInfo.name)
+        span.instrumentationScopeInfo.version?.let {
+            append(":")
+            append(it)
+        }
+    }
+}

--- a/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/export/StdoutLogRecordExporterTest.kt
+++ b/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/export/StdoutLogRecordExporterTest.kt
@@ -1,0 +1,81 @@
+package io.opentelemetry.kotlin.logging.export
+
+import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.FakeInstrumentationScopeInfo
+import io.opentelemetry.kotlin.export.OperationResultCode
+import io.opentelemetry.kotlin.framework.loadTestFixture
+import io.opentelemetry.kotlin.logging.model.FakeReadableLogRecord
+import io.opentelemetry.kotlin.logging.model.SeverityNumber
+import io.opentelemetry.kotlin.resource.FakeResource
+import io.opentelemetry.kotlin.tracing.FakeSpanContext
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalApi::class)
+internal class StdoutLogRecordExporterTest {
+
+    @Test
+    fun testExportLogRecordMinimal() {
+        val output = mutableListOf<String>()
+        val exporter = createStdoutLogRecordExporter(logger = { output.add(it) })
+
+        val logRecord = FakeReadableLogRecord(
+            body = null,
+            timestamp = null,
+            observedTimestamp = null,
+            severityNumber = null,
+            severityText = null,
+            attributes = emptyMap(),
+            resource = FakeResource(emptyMap()),
+            instrumentationScopeInfo = FakeInstrumentationScopeInfo("0.1.0", null, null, emptyMap())
+        )
+
+        val result = exporter.export(listOf(logRecord))
+        assertEquals(OperationResultCode.Success, result)
+        assertEquals(1, output.size)
+
+        val expected = loadTestFixture("stdout_log_record_output_minimal.txt")
+        assertEquals(expected, output.single())
+    }
+
+    @Test
+    fun testExportLogRecord() {
+        val output = mutableListOf<String>()
+        val exporter = createStdoutLogRecordExporter(logger = { output.add(it) })
+
+        val logRecord = FakeReadableLogRecord(
+            timestamp = 1000000000L,
+            observedTimestamp = 1000000100L,
+            severityNumber = SeverityNumber.INFO,
+            severityText = "INFO",
+            body = "Application started successfully",
+            eventName = "my_event",
+            attributes = mapOf("thread.name" to "main", "code.function" to "start"),
+            spanContext = FakeSpanContext.VALID,
+            resource = FakeResource(attributes = mapOf("service.name" to "test-service")),
+            instrumentationScopeInfo = FakeInstrumentationScopeInfo(
+                name = "io.opentelemetry.test",
+                version = "1.0.0"
+            )
+        )
+
+        val result = exporter.export(listOf(logRecord))
+        assertEquals(OperationResultCode.Success, result)
+        assertEquals(1, output.size)
+
+        val expected = loadTestFixture("stdout_log_record_output.txt")
+        assertEquals(expected, output.single())
+    }
+
+    @Test
+    fun testForceFlush() {
+        val exporter = StdoutLogRecordExporter()
+        assertEquals(OperationResultCode.Success, exporter.forceFlush())
+    }
+
+    @Test
+    fun testShutdown() {
+        val exporter = StdoutLogRecordExporter()
+        assertEquals(OperationResultCode.Success, exporter.shutdown())
+    }
+}

--- a/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/export/StdoutSpanExporterTest.kt
+++ b/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/export/StdoutSpanExporterTest.kt
@@ -1,0 +1,88 @@
+package io.opentelemetry.kotlin.tracing.export
+
+import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.FakeInstrumentationScopeInfo
+import io.opentelemetry.kotlin.export.OperationResultCode
+import io.opentelemetry.kotlin.framework.loadTestFixture
+import io.opentelemetry.kotlin.resource.FakeResource
+import io.opentelemetry.kotlin.tracing.FakeReadWriteSpan
+import io.opentelemetry.kotlin.tracing.FakeSpanContext
+import io.opentelemetry.kotlin.tracing.data.FakeEventData
+import io.opentelemetry.kotlin.tracing.data.FakeLinkData
+import io.opentelemetry.kotlin.tracing.data.StatusData
+import io.opentelemetry.kotlin.tracing.model.SpanKind
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalApi::class)
+internal class StdoutSpanExporterTest {
+
+    @Test
+    fun testExportMinimalSpan() {
+        val output = mutableListOf<String>()
+        val exporter = createStdoutSpanExporter(logger = { output.add(it) })
+
+        val span = FakeReadWriteSpan(
+            name = "test-span",
+            endTimestamp = null,
+            status = StatusData.Error("Whoops"),
+            instrumentationScopeInfo = FakeInstrumentationScopeInfo("0.1.0", null, null, emptyMap())
+        )
+
+        val result = exporter.export(listOf(span))
+        assertEquals(OperationResultCode.Success, result)
+        assertEquals(1, output.size)
+
+        val expected = loadTestFixture("stdout_span_output_minimal.txt")
+        assertEquals(expected, output.single())
+    }
+
+    @Test
+    fun testExportSpan() {
+        val output = mutableListOf<String>()
+        val exporter = createStdoutSpanExporter(logger = { output.add(it) })
+
+        val span = FakeReadWriteSpan(
+            name = "test-span",
+            spanKind = SpanKind.SERVER,
+            status = StatusData.Ok,
+            spanContext = FakeSpanContext.VALID,
+            parent = FakeSpanContext.INVALID,
+            startTimestamp = 1000000000L,
+            endTimestamp = 2000000000L,
+            attributes = mapOf("http.method" to "GET", "http.status_code" to 200),
+            events = listOf(
+                FakeEventData(name = "request.started", timestamp = 1100000000L),
+                FakeEventData(name = "request.completed", timestamp = 1900000000L)
+            ),
+            links = listOf(
+                FakeLinkData()
+            ),
+            resource = FakeResource(attributes = mapOf("service.name" to "test-service")),
+            instrumentationScopeInfo = FakeInstrumentationScopeInfo(
+                name = "io.opentelemetry.test",
+                version = "1.0.0"
+            ),
+            hasEnded = true
+        )
+
+        val result = exporter.export(listOf(span))
+        assertEquals(OperationResultCode.Success, result)
+        assertEquals(1, output.size)
+
+        val expected = loadTestFixture("stdout_span_output.txt")
+        assertEquals(expected, output.single())
+    }
+
+    @Test
+    fun testForceFlush() {
+        val exporter = StdoutSpanExporter()
+        assertEquals(OperationResultCode.Success, exporter.forceFlush())
+    }
+
+    @Test
+    fun testShutdown() {
+        val exporter = StdoutSpanExporter()
+        assertEquals(OperationResultCode.Success, exporter.shutdown())
+    }
+}

--- a/exporters-core/src/commonTest/resources/stdout_log_record_output.txt
+++ b/exporters-core/src/commonTest/resources/stdout_log_record_output.txt
@@ -1,0 +1,13 @@
+LogRecord [INFO]
+  Timestamp: 1000000000
+  ObservedTimestamp: 1000000100
+  SeverityText: INFO
+  Body: Application started successfully
+  EventName: my_event
+  TraceId: 12345678901234567890123456789012
+  SpanId: 1234567890123456
+  Attributes:
+    thread.name: main
+    code.function: start
+  Resource: {service.name=test-service}
+  InstrumentationScope: io.opentelemetry.test:1.0.0

--- a/exporters-core/src/commonTest/resources/stdout_log_record_output_minimal.txt
+++ b/exporters-core/src/commonTest/resources/stdout_log_record_output_minimal.txt
@@ -1,0 +1,5 @@
+LogRecord
+  TraceId: 00000000000000000000000000000000
+  SpanId: 0000000000000000
+  Resource: {}
+  InstrumentationScope: 0.1.0

--- a/exporters-core/src/commonTest/resources/stdout_span_output.txt
+++ b/exporters-core/src/commonTest/resources/stdout_span_output.txt
@@ -1,0 +1,17 @@
+Span: test-span [SERVER]
+  TraceId: 12345678901234567890123456789012
+  SpanId: 1234567890123456
+  ParentSpanId: 0000000000000000
+  Status: OK
+  StartTime: 1000000000
+  EndTime: 2000000000
+  Duration: 1000000000 ns
+  Attributes:
+    http.method: GET
+    http.status_code: 200
+  Events:
+    - request.started @ 1100000000
+    - request.completed @ 1900000000
+  Links: 1
+  Resource: {service.name=test-service}
+  InstrumentationScope: io.opentelemetry.test:1.0.0

--- a/exporters-core/src/commonTest/resources/stdout_span_output_minimal.txt
+++ b/exporters-core/src/commonTest/resources/stdout_span_output_minimal.txt
@@ -1,0 +1,8 @@
+Span: test-span [INTERNAL]
+  TraceId: 00000000000000000000000000000000
+  SpanId: 0000000000000000
+  ParentSpanId: 0000000000000000
+  Status: ERROR - Whoops
+  StartTime: 0
+  Resource: {foo=bar}
+  InstrumentationScope: 0.1.0

--- a/integration-test/src/androidMain/kotlin/io/opentelemetry/kotlin/framework/GoldenFileDataLoader.jvm.kt
+++ b/integration-test/src/androidMain/kotlin/io/opentelemetry/kotlin/framework/GoldenFileDataLoader.jvm.kt
@@ -1,6 +1,6 @@
 package io.opentelemetry.kotlin.framework
 
-internal actual fun loadTestFixture(fixtureName: String): String {
+actual fun loadTestFixture(fixtureName: String): String {
     val stream = checkNotNull(ClassLoader.getSystemResourceAsStream(fixtureName)) {
         "Resource '$fixtureName' not found"
     }

--- a/integration-test/src/appleMain/kotlin/io/opentelemetry/kotlin/framework/GoldenFileDataLoader.apple.kt
+++ b/integration-test/src/appleMain/kotlin/io/opentelemetry/kotlin/framework/GoldenFileDataLoader.apple.kt
@@ -9,7 +9,7 @@ import platform.Foundation.dataWithContentsOfFile
 import platform.posix.memcpy
 
 // see https://developer.squareup.com/blog/kotlin-multiplatform-shared-test-resources/
-internal actual fun loadTestFixture(fixtureName: String): String {
+actual fun loadTestFixture(fixtureName: String): String {
     val mainBundle = NSBundle.mainBundle.bundlePath()
     val path = "$mainBundle/resources/$fixtureName"
     val data = checkNotNull(NSData.dataWithContentsOfFile(path)) {

--- a/integration-test/src/commonMain/kotlin/io/opentelemetry/kotlin/framework/GoldenFileDataLoader.kt
+++ b/integration-test/src/commonMain/kotlin/io/opentelemetry/kotlin/framework/GoldenFileDataLoader.kt
@@ -2,7 +2,7 @@ package io.opentelemetry.kotlin.framework
 
 import kotlinx.serialization.json.Json
 
-internal expect fun loadTestFixture(fixtureName: String): String
+expect fun loadTestFixture(fixtureName: String): String
 
 internal inline fun <reified T> compareGoldenFile(
     observed: List<T>,

--- a/integration-test/src/jsMain/kotlin/io/opentelemetry/kotlin/framework/GoldenFileDataLoader.js.kt
+++ b/integration-test/src/jsMain/kotlin/io/opentelemetry/kotlin/framework/GoldenFileDataLoader.js.kt
@@ -1,6 +1,6 @@
 package io.opentelemetry.kotlin.framework
 
-internal actual fun loadTestFixture(fixtureName: String): String {
+actual fun loadTestFixture(fixtureName: String): String {
     val fs = js("require('fs')")
     val path = js("require('path')")
     val fixturePath = path.resolve("kotlin/$fixtureName")

--- a/integration-test/src/jvmMain/kotlin/io/opentelemetry/kotlin/framework/GoldenFileDataLoader.jvm.kt
+++ b/integration-test/src/jvmMain/kotlin/io/opentelemetry/kotlin/framework/GoldenFileDataLoader.jvm.kt
@@ -1,6 +1,6 @@
 package io.opentelemetry.kotlin.framework
 
-internal actual fun loadTestFixture(fixtureName: String): String {
+actual fun loadTestFixture(fixtureName: String): String {
     val stream = checkNotNull(ClassLoader.getSystemResourceAsStream(fixtureName)) {
         "Resource '$fixtureName' not found"
     }


### PR DESCRIPTION
## Goal

Implements log/span exporters that print to stdout. This defaults to `println` but the actual destination is configurable via the API to create the exporter.

Closes #38.

## Testing

Added unit tests.
