### PR TITLE
Alter `TelemetryCloseable` so that shutdown and forceFlush use suspend

### DIFF
--- a/api/api/android/api.api
+++ b/api/api/android/api.api
@@ -75,8 +75,8 @@ public final class io/opentelemetry/kotlin/export/OperationResultCode$Success : 
 }
 
 public abstract interface class io/opentelemetry/kotlin/export/TelemetryCloseable {
-	public abstract fun forceFlush ()Lio/opentelemetry/kotlin/export/OperationResultCode;
-	public abstract fun shutdown ()Lio/opentelemetry/kotlin/export/OperationResultCode;
+	public abstract fun forceFlush (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun shutdown (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public abstract interface class io/opentelemetry/kotlin/factory/ContextFactory {

--- a/api/api/jvm/api.api
+++ b/api/api/jvm/api.api
@@ -75,8 +75,8 @@ public final class io/opentelemetry/kotlin/export/OperationResultCode$Success : 
 }
 
 public abstract interface class io/opentelemetry/kotlin/export/TelemetryCloseable {
-	public abstract fun forceFlush ()Lio/opentelemetry/kotlin/export/OperationResultCode;
-	public abstract fun shutdown ()Lio/opentelemetry/kotlin/export/OperationResultCode;
+	public abstract fun forceFlush (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun shutdown (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public abstract interface class io/opentelemetry/kotlin/factory/ContextFactory {

--- a/api/src/commonMain/kotlin/io/opentelemetry/kotlin/export/TelemetryCloseable.kt
+++ b/api/src/commonMain/kotlin/io/opentelemetry/kotlin/export/TelemetryCloseable.kt
@@ -12,10 +12,10 @@ public interface TelemetryCloseable {
     /**
      * Requests the implementation to flush any buffered telemetry.
      */
-    public fun forceFlush(): OperationResultCode
+    public suspend fun forceFlush(): OperationResultCode
 
     /**
      * Shuts down the implementation and completes cleanup tasks necessary.
      */
-    public fun shutdown(): OperationResultCode
+    public suspend fun shutdown(): OperationResultCode
 }

--- a/compat/build.gradle.kts
+++ b/compat/build.gradle.kts
@@ -23,6 +23,7 @@ kotlin {
             dependencies {
                 implementation(project(":test-fakes"))
                 implementation(project(":integration-test"))
+                implementation(libs.kotlinx.coroutines.test)
             }
         }
     }

--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/logging/export/LogRecordExporterAdapter.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/logging/export/LogRecordExporterAdapter.kt
@@ -16,6 +16,6 @@ internal class LogRecordExporterAdapter(
         return code.toOperationResultCode()
     }
 
-    override fun shutdown(): OperationResultCode = impl.shutdown().toOperationResultCode()
-    override fun forceFlush(): OperationResultCode = impl.flush().toOperationResultCode()
+    override suspend fun shutdown(): OperationResultCode = impl.shutdown().toOperationResultCode()
+    override suspend fun forceFlush(): OperationResultCode = impl.flush().toOperationResultCode()
 }

--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/logging/export/LogRecordProcessorAdapter.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/logging/export/LogRecordProcessorAdapter.kt
@@ -22,6 +22,6 @@ internal class LogRecordProcessorAdapter(
         }
     }
 
-    override fun shutdown(): OperationResultCode = impl.shutdown().toOperationResultCode()
-    override fun forceFlush(): OperationResultCode = impl.forceFlush().toOperationResultCode()
+    override suspend fun shutdown(): OperationResultCode = impl.shutdown().toOperationResultCode()
+    override suspend fun forceFlush(): OperationResultCode = impl.forceFlush().toOperationResultCode()
 }

--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/tracing/export/SpanExporterAdapter.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/tracing/export/SpanExporterAdapter.kt
@@ -17,6 +17,6 @@ internal class SpanExporterAdapter(
         return code.toOperationResultCode()
     }
 
-    override fun shutdown(): OperationResultCode = impl.shutdown().toOperationResultCode()
-    override fun forceFlush(): OperationResultCode = impl.flush().toOperationResultCode()
+    override suspend fun shutdown(): OperationResultCode = impl.shutdown().toOperationResultCode()
+    override suspend fun forceFlush(): OperationResultCode = impl.flush().toOperationResultCode()
 }

--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/tracing/export/SpanProcessorAdapter.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/tracing/export/SpanProcessorAdapter.kt
@@ -37,6 +37,6 @@ internal class SpanProcessorAdapter(
 
     override fun isStartRequired(): Boolean = impl.isStartRequired
     override fun isEndRequired(): Boolean = impl.isEndRequired
-    override fun shutdown(): OperationResultCode = impl.shutdown().toOperationResultCode()
-    override fun forceFlush(): OperationResultCode = impl.forceFlush().toOperationResultCode()
+    override suspend fun shutdown(): OperationResultCode = impl.shutdown().toOperationResultCode()
+    override suspend fun forceFlush(): OperationResultCode = impl.forceFlush().toOperationResultCode()
 }

--- a/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/logging/LogExportTest.kt
+++ b/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/logging/LogExportTest.kt
@@ -150,8 +150,8 @@ internal class LogExportTest {
             capturedContext = context
         }
 
-        override fun shutdown(): OperationResultCode = OperationResultCode.Success
-        override fun forceFlush(): OperationResultCode = OperationResultCode.Success
+        override suspend fun shutdown(): OperationResultCode = OperationResultCode.Success
+        override suspend fun forceFlush(): OperationResultCode = OperationResultCode.Success
     }
 
     /**
@@ -180,7 +180,7 @@ internal class LogExportTest {
             }
         }
 
-        override fun shutdown(): OperationResultCode = OperationResultCode.Success
-        override fun forceFlush(): OperationResultCode = OperationResultCode.Success
+        override suspend fun shutdown(): OperationResultCode = OperationResultCode.Success
+        override suspend fun forceFlush(): OperationResultCode = OperationResultCode.Success
     }
 }

--- a/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/logging/OtelJavaLogExportTest.kt
+++ b/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/logging/OtelJavaLogExportTest.kt
@@ -112,7 +112,7 @@ internal class OtelJavaLogExportTest {
             capturedJavaContext = (context as ContextAdapter).impl
         }
 
-        override fun shutdown(): OperationResultCode = OperationResultCode.Success
-        override fun forceFlush(): OperationResultCode = OperationResultCode.Success
+        override suspend fun shutdown(): OperationResultCode = OperationResultCode.Success
+        override suspend fun forceFlush(): OperationResultCode = OperationResultCode.Success
     }
 }

--- a/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/logging/export/LogRecordExporterAdapterTest.kt
+++ b/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/logging/export/LogRecordExporterAdapterTest.kt
@@ -5,6 +5,7 @@ import io.opentelemetry.kotlin.attributes.convertToMap
 import io.opentelemetry.kotlin.export.OperationResultCode
 import io.opentelemetry.kotlin.fakes.otel.java.FakeOtelJavaLogRecordExporter
 import io.opentelemetry.kotlin.logging.model.FakeReadableLogRecord
+import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Test
 import kotlin.test.assertEquals
@@ -22,13 +23,13 @@ internal class LogRecordExporterAdapterTest {
     }
 
     @Test
-    fun `test flush`() {
+    fun `test flush`() = runTest {
         assertEquals(OperationResultCode.Success, wrapper.forceFlush())
         assertEquals(1, impl.flushCount)
     }
 
     @Test
-    fun `test shutdown`() {
+    fun `test shutdown`() = runTest {
         assertEquals(OperationResultCode.Success, wrapper.shutdown())
         assertEquals(1, impl.shutdownCount)
     }

--- a/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/logging/export/LogRecordProcessorExtTest.kt
+++ b/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/logging/export/LogRecordProcessorExtTest.kt
@@ -3,6 +3,7 @@ package io.opentelemetry.kotlin.logging.export
 import io.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.kotlin.fakes.otel.java.FakeOtelJavaLogRecordProcessor
 import io.opentelemetry.kotlin.framework.OtelKotlinHarness
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
@@ -27,7 +28,7 @@ internal class LogRecordProcessorExtTest {
     }
 
     @Test
-    fun testFlush() {
+    fun testFlush() = runTest {
         val impl = FakeOtelJavaLogRecordProcessor()
         val adapter = impl.toOtelKotlinLogRecordProcessor()
         adapter.forceFlush()
@@ -35,7 +36,7 @@ internal class LogRecordProcessorExtTest {
     }
 
     @Test
-    fun testShutdown() {
+    fun testShutdown() = runTest {
         val impl = FakeOtelJavaLogRecordProcessor()
         val adapter = impl.toOtelKotlinLogRecordProcessor()
         adapter.shutdown()

--- a/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/tracing/OtelJavaSpanExportTest.kt
+++ b/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/tracing/OtelJavaSpanExportTest.kt
@@ -342,8 +342,8 @@ internal class OtelJavaSpanExportTest {
         override fun onEnd(span: ReadableSpan) = Unit
         override fun isStartRequired(): Boolean = true
         override fun isEndRequired(): Boolean = false
-        override fun shutdown(): OperationResultCode = OperationResultCode.Success
-        override fun forceFlush(): OperationResultCode = OperationResultCode.Success
+        override suspend fun shutdown(): OperationResultCode = OperationResultCode.Success
+        override suspend fun forceFlush(): OperationResultCode = OperationResultCode.Success
     }
 
     private val attrs = OtelJavaAttributes.builder()

--- a/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/tracing/SpanExportTest.kt
+++ b/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/tracing/SpanExportTest.kt
@@ -483,8 +483,8 @@ internal class SpanExportTest {
         override fun onEnd(span: ReadableSpan) {}
         override fun isStartRequired(): Boolean = true
         override fun isEndRequired(): Boolean = false
-        override fun shutdown(): OperationResultCode = OperationResultCode.Success
-        override fun forceFlush(): OperationResultCode = OperationResultCode.Success
+        override suspend fun shutdown(): OperationResultCode = OperationResultCode.Success
+        override suspend fun forceFlush(): OperationResultCode = OperationResultCode.Success
     }
 
     /**
@@ -527,8 +527,8 @@ internal class SpanExportTest {
         override fun onEnd(span: ReadableSpan) {
         }
 
-        override fun shutdown(): OperationResultCode = OperationResultCode.Success
-        override fun forceFlush(): OperationResultCode = OperationResultCode.Success
+        override suspend fun shutdown(): OperationResultCode = OperationResultCode.Success
+        override suspend fun forceFlush(): OperationResultCode = OperationResultCode.Success
         override fun isStartRequired(): Boolean = true
         override fun isEndRequired(): Boolean = true
     }

--- a/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/tracing/export/SpanExporterAdapterTest.kt
+++ b/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/tracing/export/SpanExporterAdapterTest.kt
@@ -7,6 +7,7 @@ import io.opentelemetry.kotlin.fakes.otel.java.FakeOtelJavaSpanExporter
 import io.opentelemetry.kotlin.tracing.data.FakeSpanData
 import io.opentelemetry.kotlin.tracing.ext.toOtelJavaSpanKind
 import io.opentelemetry.kotlin.tracing.ext.toOtelJavaStatusCode
+import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Test
 import kotlin.test.assertEquals
@@ -24,13 +25,13 @@ internal class SpanExporterAdapterTest {
     }
 
     @Test
-    fun `test flush`() {
+    fun `test flush`() = runTest {
         assertEquals(OperationResultCode.Success, wrapper.forceFlush())
         assertEquals(1, impl.flushCount)
     }
 
     @Test
-    fun `test shutdown`() {
+    fun `test shutdown`() = runTest {
         assertEquals(OperationResultCode.Success, wrapper.shutdown())
         assertEquals(1, impl.shutdownCount)
     }
@@ -55,7 +56,10 @@ internal class SpanExporterAdapterTest {
         assertEquals(originalScope.name, observedScope.name)
         assertEquals(originalScope.version, observedScope.version)
         assertEquals(originalScope.schemaUrl, observedScope.schemaUrl)
-        assertEquals(emptyMap(), observedScope.attributes.convertToMap()) // otel-java don't support this
+        assertEquals(
+            emptyMap(),
+            observedScope.attributes.convertToMap()
+        ) // otel-java don't support this
 
         val originalEvent = original.events.single()
         val observedEvent = observed.events.single()

--- a/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/tracing/export/SpanProcessorExtTest.kt
+++ b/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/tracing/export/SpanProcessorExtTest.kt
@@ -3,6 +3,7 @@ package io.opentelemetry.kotlin.tracing.export
 import io.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.kotlin.fakes.otel.java.FakeOtelJavaSpanProcessor
 import io.opentelemetry.kotlin.framework.OtelKotlinHarness
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import kotlin.test.assertSame
@@ -35,7 +36,7 @@ internal class SpanProcessorExtTest {
     }
 
     @Test
-    fun testFlush() {
+    fun testFlush() = runTest {
         val impl = FakeOtelJavaSpanProcessor()
         val adapter = impl.toOtelKotlinSpanProcessor()
         adapter.forceFlush()
@@ -43,7 +44,7 @@ internal class SpanProcessorExtTest {
     }
 
     @Test
-    fun testShutdown() {
+    fun testShutdown() = runTest {
         val impl = FakeOtelJavaSpanProcessor()
         val adapter = impl.toOtelKotlinSpanProcessor()
         adapter.shutdown()

--- a/examples/example-common/src/commonMain/kotlin/io/opentelemetry/example/ExampleLogRecordExporter.kt
+++ b/examples/example-common/src/commonMain/kotlin/io/opentelemetry/example/ExampleLogRecordExporter.kt
@@ -15,6 +15,6 @@ internal class ExampleLogRecordExporter : LogRecordExporter {
         return OperationResultCode.Success
     }
 
-    override fun forceFlush(): OperationResultCode = OperationResultCode.Success
-    override fun shutdown(): OperationResultCode = OperationResultCode.Success
+    override suspend fun forceFlush(): OperationResultCode = OperationResultCode.Success
+    override suspend fun shutdown(): OperationResultCode = OperationResultCode.Success
 }

--- a/examples/example-common/src/commonMain/kotlin/io/opentelemetry/example/ExampleLogRecordProcessor.kt
+++ b/examples/example-common/src/commonMain/kotlin/io/opentelemetry/example/ExampleLogRecordProcessor.kt
@@ -18,6 +18,6 @@ internal class ExampleLogRecordProcessor : LogRecordProcessor {
         exporter.export(listOf(log))
     }
 
-    override fun forceFlush(): OperationResultCode = OperationResultCode.Success
-    override fun shutdown(): OperationResultCode = OperationResultCode.Success
+    override suspend fun forceFlush(): OperationResultCode = OperationResultCode.Success
+    override suspend fun shutdown(): OperationResultCode = OperationResultCode.Success
 }

--- a/examples/example-common/src/commonMain/kotlin/io/opentelemetry/example/ExampleSpanExporter.kt
+++ b/examples/example-common/src/commonMain/kotlin/io/opentelemetry/example/ExampleSpanExporter.kt
@@ -15,6 +15,6 @@ internal class ExampleSpanExporter : SpanExporter {
         return OperationResultCode.Success
     }
 
-    override fun forceFlush(): OperationResultCode = OperationResultCode.Success
-    override fun shutdown(): OperationResultCode = OperationResultCode.Success
+    override suspend fun forceFlush(): OperationResultCode = OperationResultCode.Success
+    override suspend fun shutdown(): OperationResultCode = OperationResultCode.Success
 }

--- a/examples/example-common/src/commonMain/kotlin/io/opentelemetry/example/ExampleSpanProcessor.kt
+++ b/examples/example-common/src/commonMain/kotlin/io/opentelemetry/example/ExampleSpanProcessor.kt
@@ -27,6 +27,6 @@ internal class ExampleSpanProcessor : SpanProcessor {
 
     override fun isStartRequired(): Boolean = true
     override fun isEndRequired(): Boolean = true
-    override fun forceFlush(): OperationResultCode = OperationResultCode.Success
-    override fun shutdown(): OperationResultCode = OperationResultCode.Success
+    override suspend fun forceFlush(): OperationResultCode = OperationResultCode.Success
+    override suspend fun shutdown(): OperationResultCode = OperationResultCode.Success
 }

--- a/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/export/BatchExportOperation.kt
+++ b/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/export/BatchExportOperation.kt
@@ -34,3 +34,34 @@ internal fun <T> batchExportOperation(
         else -> OperationResultCode.Failure
     }
 }
+
+/**
+ * Performs an export operation on each element in a List and returns a success code if each
+ * operation is successful, or a failure code if any operation fails.
+ */
+@OptIn(ExperimentalApi::class)
+internal suspend fun <T> batchExportOperationSuspend(
+    elements: List<T>,
+    sdkErrorHandler: SdkErrorHandler,
+    action: suspend (T) -> OperationResultCode
+): OperationResultCode {
+    var success = true
+
+    elements.forEach {
+        try {
+            val exportResult = action(it)
+            success = success && exportResult == OperationResultCode.Success
+        } catch (exc: Throwable) {
+            success = false
+            sdkErrorHandler.onUserCodeError(
+                exc,
+                "Export operation failed",
+                SdkErrorSeverity.WARNING
+            )
+        }
+    }
+    return when {
+        success -> OperationResultCode.Success
+        else -> OperationResultCode.Failure
+    }
+}

--- a/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/export/BatchTelemetryProcessor.kt
+++ b/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/export/BatchTelemetryProcessor.kt
@@ -55,7 +55,7 @@ internal class BatchTelemetryProcessor<T>(
         }
     }
 
-    fun forceFlush(): OperationResultCode {
+    suspend fun forceFlush(): OperationResultCode {
         scope.launch {
             flushInternal()
         }

--- a/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/export/CompositeTelemetryCloseable.kt
+++ b/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/export/CompositeTelemetryCloseable.kt
@@ -9,15 +9,15 @@ internal class CompositeTelemetryCloseable(
     private val sdkErrorHandler: SdkErrorHandler,
 ) : TelemetryCloseable {
 
-    override fun forceFlush(): OperationResultCode =
-        batchExportOperation(
+    override suspend fun forceFlush(): OperationResultCode =
+        batchExportOperationSuspend(
             closeables,
             sdkErrorHandler,
             TelemetryCloseable::forceFlush
         )
 
-    override fun shutdown(): OperationResultCode =
-        batchExportOperation(
+    override suspend fun shutdown(): OperationResultCode =
+        batchExportOperationSuspend(
             closeables,
             sdkErrorHandler,
             TelemetryCloseable::shutdown

--- a/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/BatchLogRecordProcessorImpl.kt
+++ b/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/BatchLogRecordProcessorImpl.kt
@@ -29,6 +29,6 @@ internal class BatchLogRecordProcessorImpl(
         context: Context
     ) = processor.processTelemetry(log)
 
-    override fun forceFlush(): OperationResultCode = processor.forceFlush()
-    override fun shutdown(): OperationResultCode = processor.shutdown()
+    override suspend fun forceFlush(): OperationResultCode = processor.forceFlush()
+    override suspend fun shutdown(): OperationResultCode = processor.shutdown()
 }

--- a/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/SimpleLogRecordProcessor.kt
+++ b/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/SimpleLogRecordProcessor.kt
@@ -27,6 +27,6 @@ internal class SimpleLogRecordProcessor(
         }
     }
 
-    override fun forceFlush(): OperationResultCode = OperationResultCode.Success
-    override fun shutdown(): OperationResultCode = OperationResultCode.Success
+    override suspend fun forceFlush(): OperationResultCode = OperationResultCode.Success
+    override suspend fun shutdown(): OperationResultCode = OperationResultCode.Success
 }

--- a/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/StdoutLogRecordExporter.kt
+++ b/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/StdoutLogRecordExporter.kt
@@ -19,8 +19,8 @@ internal class StdoutLogRecordExporter(
         return OperationResultCode.Success
     }
 
-    override fun forceFlush(): OperationResultCode = OperationResultCode.Success
-    override fun shutdown(): OperationResultCode = OperationResultCode.Success
+    override suspend fun forceFlush(): OperationResultCode = OperationResultCode.Success
+    override suspend fun shutdown(): OperationResultCode = OperationResultCode.Success
 
     private fun formatLogRecord(logRecord: ReadableLogRecord): String = buildString {
         append("LogRecord")

--- a/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/BatchSpanProcessorImpl.kt
+++ b/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/BatchSpanProcessorImpl.kt
@@ -39,6 +39,6 @@ internal class BatchSpanProcessorImpl(
     override fun onEnding(span: ReadWriteSpan) {
     }
 
-    override fun forceFlush(): OperationResultCode = processor.forceFlush()
-    override fun shutdown(): OperationResultCode = processor.shutdown()
+    override suspend fun forceFlush(): OperationResultCode = processor.forceFlush()
+    override suspend fun shutdown(): OperationResultCode = processor.shutdown()
 }

--- a/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/SimpleSpanProcessor.kt
+++ b/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/SimpleSpanProcessor.kt
@@ -36,6 +36,6 @@ internal class SimpleSpanProcessor(
 
     override fun isStartRequired(): Boolean = true
     override fun isEndRequired(): Boolean = true
-    override fun forceFlush(): OperationResultCode = OperationResultCode.Success
-    override fun shutdown(): OperationResultCode = OperationResultCode.Success
+    override suspend fun forceFlush(): OperationResultCode = OperationResultCode.Success
+    override suspend fun shutdown(): OperationResultCode = OperationResultCode.Success
 }

--- a/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/StdoutSpanExporter.kt
+++ b/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/StdoutSpanExporter.kt
@@ -20,8 +20,8 @@ internal class StdoutSpanExporter(
         return OperationResultCode.Success
     }
 
-    override fun forceFlush(): OperationResultCode = OperationResultCode.Success
-    override fun shutdown(): OperationResultCode = OperationResultCode.Success
+    override suspend fun forceFlush(): OperationResultCode = OperationResultCode.Success
+    override suspend fun shutdown(): OperationResultCode = OperationResultCode.Success
 
     /**
      * Formats a [SpanData] into a human-readable string representation.

--- a/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/export/BatchTelemetryProcessorTest.kt
+++ b/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/export/BatchTelemetryProcessorTest.kt
@@ -180,7 +180,7 @@ internal class BatchTelemetryProcessorTest {
         assertEquals(emptyList(), exports)
     }
 
-    private fun <T> TestScope.assertTelemetryBatched(
+    private suspend fun <T> TestScope.assertTelemetryBatched(
         telemetry: List<T>,
         batchSize: Int = 3,
         exportTimeoutMs: Long = 1000,

--- a/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/export/CompositeLogRecordExporterTest.kt
+++ b/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/export/CompositeLogRecordExporterTest.kt
@@ -6,6 +6,7 @@ import io.opentelemetry.kotlin.export.OperationResultCode
 import io.opentelemetry.kotlin.export.OperationResultCode.Failure
 import io.opentelemetry.kotlin.export.OperationResultCode.Success
 import io.opentelemetry.kotlin.logging.model.FakeReadableLogRecord
+import kotlinx.coroutines.test.runTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -25,7 +26,7 @@ internal class CompositeLogRecordExporterTest {
     }
 
     @Test
-    fun testNoSpanExporters() {
+    fun testNoSpanExporters() = runTest {
         val exporter =
             CompositeLogRecordExporter(
                 emptyList(),
@@ -40,7 +41,7 @@ internal class CompositeLogRecordExporterTest {
     }
 
     @Test
-    fun testMultipleSpanExporters() {
+    fun testMultipleSpanExporters() = runTest {
         val first = FakeLogRecordExporter()
         val second = FakeLogRecordExporter()
         val exporter =
@@ -57,7 +58,7 @@ internal class CompositeLogRecordExporterTest {
     }
 
     @Test
-    fun testOneExporterExportFails() {
+    fun testOneExporterExportFails() = runTest {
         val first = FakeLogRecordExporter(action = { Failure })
         val second = FakeLogRecordExporter()
         val exporter =
@@ -74,7 +75,7 @@ internal class CompositeLogRecordExporterTest {
     }
 
     @Test
-    fun testOneExporterFlushFails() {
+    fun testOneExporterFlushFails() = runTest {
         val first = FakeLogRecordExporter(flushCode = { Failure })
         val second = FakeLogRecordExporter()
         val exporter =
@@ -91,7 +92,7 @@ internal class CompositeLogRecordExporterTest {
     }
 
     @Test
-    fun testOneExporterShutdownFails() {
+    fun testOneExporterShutdownFails() = runTest {
         val first = FakeLogRecordExporter(shutdownCode = { Failure })
         val second = FakeLogRecordExporter()
         val exporter =
@@ -108,7 +109,7 @@ internal class CompositeLogRecordExporterTest {
     }
 
     @Test
-    fun testOneExporterThrowsInExport() {
+    fun testOneExporterThrowsInExport() = runTest {
         val first = FakeLogRecordExporter(action = { throw IllegalStateException() })
         val second = FakeLogRecordExporter()
         val exporter =
@@ -125,7 +126,7 @@ internal class CompositeLogRecordExporterTest {
     }
 
     @Test
-    fun testOneExporterThrowsInFlush() {
+    fun testOneExporterThrowsInFlush() = runTest {
         val first = FakeLogRecordExporter(flushCode = { throw IllegalStateException() })
         val second = FakeLogRecordExporter()
         val exporter =
@@ -142,7 +143,7 @@ internal class CompositeLogRecordExporterTest {
     }
 
     @Test
-    fun testOneExporterThrowsInShutdown() {
+    fun testOneExporterThrowsInShutdown() = runTest {
         val first = FakeLogRecordExporter(shutdownCode = { throw IllegalStateException() })
         val second = FakeLogRecordExporter()
         val exporter =
@@ -158,7 +159,7 @@ internal class CompositeLogRecordExporterTest {
         assertTelemetryCapturedFailure(first, second)
     }
 
-    private fun CompositeLogRecordExporter.assertReturnValuesMatch(
+    private suspend fun CompositeLogRecordExporter.assertReturnValuesMatch(
         export: OperationResultCode,
         flush: OperationResultCode,
         shutdown: OperationResultCode

--- a/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/export/CompositeLogRecordProcessorTest.kt
+++ b/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/export/CompositeLogRecordProcessorTest.kt
@@ -7,6 +7,7 @@ import io.opentelemetry.kotlin.export.OperationResultCode
 import io.opentelemetry.kotlin.export.OperationResultCode.Failure
 import io.opentelemetry.kotlin.export.OperationResultCode.Success
 import io.opentelemetry.kotlin.logging.model.FakeReadWriteLogRecord
+import kotlinx.coroutines.test.runTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -27,7 +28,7 @@ internal class CompositeLogRecordProcessorTest {
     }
 
     @Test
-    fun testNoSpanProcessors() {
+    fun testNoSpanProcessors() = runTest {
         val processor =
             CompositeLogRecordProcessor(
                 emptyList(),
@@ -41,7 +42,7 @@ internal class CompositeLogRecordProcessorTest {
     }
 
     @Test
-    fun testMultipleSpanProcessors() {
+    fun testMultipleSpanProcessors() = runTest {
         val first = FakeLogRecordProcessor()
         val second = FakeLogRecordProcessor()
         val processor =
@@ -57,7 +58,7 @@ internal class CompositeLogRecordProcessorTest {
     }
 
     @Test
-    fun testOneProcessorFlushFails() {
+    fun testOneProcessorFlushFails() = runTest {
         val first = FakeLogRecordProcessor(flushCode = { Failure })
         val second = FakeLogRecordProcessor()
         val processor =
@@ -73,7 +74,7 @@ internal class CompositeLogRecordProcessorTest {
     }
 
     @Test
-    fun testOneProcessorShutdownFails() {
+    fun testOneProcessorShutdownFails() = runTest {
         val first = FakeLogRecordProcessor(shutdownCode = { Failure })
         val second = FakeLogRecordProcessor()
         val processor =
@@ -89,7 +90,7 @@ internal class CompositeLogRecordProcessorTest {
     }
 
     @Test
-    fun testOneProcessorThrowsInOnEmit() {
+    fun testOneProcessorThrowsInOnEmit() = runTest {
         val first = FakeLogRecordProcessor(action = { _, _ -> throw IllegalStateException() })
         val second = FakeLogRecordProcessor()
         val processor =
@@ -105,7 +106,7 @@ internal class CompositeLogRecordProcessorTest {
     }
 
     @Test
-    fun testOneProcessorThrowsInFlush() {
+    fun testOneProcessorThrowsInFlush() = runTest {
         val first = FakeLogRecordProcessor(flushCode = { throw IllegalStateException() })
         val second = FakeLogRecordProcessor()
         val processor =
@@ -121,7 +122,7 @@ internal class CompositeLogRecordProcessorTest {
     }
 
     @Test
-    fun testOneProcessorThrowsInShutdown() {
+    fun testOneProcessorThrowsInShutdown() = runTest {
         val first = FakeLogRecordProcessor(shutdownCode = { throw IllegalStateException() })
         val second = FakeLogRecordProcessor()
         val processor =
@@ -136,7 +137,7 @@ internal class CompositeLogRecordProcessorTest {
         assertTelemetryCapturedFailure(first, second)
     }
 
-    private fun CompositeLogRecordProcessor.assertReturnValuesMatch(
+    private suspend fun CompositeLogRecordProcessor.assertReturnValuesMatch(
         flush: OperationResultCode,
         shutdown: OperationResultCode
     ) {

--- a/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/export/SimpleLogRecordProcessorTest.kt
+++ b/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/export/SimpleLogRecordProcessorTest.kt
@@ -4,6 +4,7 @@ import io.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.kotlin.context.FakeContext
 import io.opentelemetry.kotlin.export.OperationResultCode
 import io.opentelemetry.kotlin.logging.model.FakeReadWriteLogRecord
+import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -11,7 +12,7 @@ import kotlin.test.assertEquals
 internal class SimpleLogRecordProcessorTest {
 
     @Test
-    fun testSpanProcessorDefaults() {
+    fun testSpanProcessorDefaults() = runTest {
         val processor =
             SimpleLogRecordProcessor(
                 FakeLogRecordExporter()

--- a/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/export/StdoutLogRecordExporterTest.kt
+++ b/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/export/StdoutLogRecordExporterTest.kt
@@ -8,6 +8,7 @@ import io.opentelemetry.kotlin.logging.model.FakeReadableLogRecord
 import io.opentelemetry.kotlin.logging.model.SeverityNumber
 import io.opentelemetry.kotlin.resource.FakeResource
 import io.opentelemetry.kotlin.tracing.FakeSpanContext
+import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -68,13 +69,13 @@ internal class StdoutLogRecordExporterTest {
     }
 
     @Test
-    fun testForceFlush() {
+    fun testForceFlush() = runTest {
         val exporter = StdoutLogRecordExporter()
         assertEquals(OperationResultCode.Success, exporter.forceFlush())
     }
 
     @Test
-    fun testShutdown() {
+    fun testShutdown() = runTest {
         val exporter = StdoutLogRecordExporter()
         assertEquals(OperationResultCode.Success, exporter.shutdown())
     }

--- a/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/export/CompositeSpanExporterTest.kt
+++ b/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/export/CompositeSpanExporterTest.kt
@@ -6,6 +6,7 @@ import io.opentelemetry.kotlin.export.OperationResultCode
 import io.opentelemetry.kotlin.export.OperationResultCode.Failure
 import io.opentelemetry.kotlin.export.OperationResultCode.Success
 import io.opentelemetry.kotlin.tracing.data.FakeSpanData
+import kotlinx.coroutines.test.runTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -25,7 +26,7 @@ internal class CompositeSpanExporterTest {
     }
 
     @Test
-    fun testNoSpanExporters() {
+    fun testNoSpanExporters() = runTest {
         val exporter =
             CompositeSpanExporter(
                 emptyList(),
@@ -40,7 +41,7 @@ internal class CompositeSpanExporterTest {
     }
 
     @Test
-    fun testMultipleSpanExporters() {
+    fun testMultipleSpanExporters() = runTest {
         val first = FakeSpanExporter()
         val second = FakeSpanExporter()
         val exporter =
@@ -60,7 +61,7 @@ internal class CompositeSpanExporterTest {
     }
 
     @Test
-    fun testOneExporterExportFails() {
+    fun testOneExporterExportFails() = runTest {
         val first = FakeSpanExporter(exportReturnValue = { Failure })
         val second = FakeSpanExporter()
         val exporter =
@@ -80,7 +81,7 @@ internal class CompositeSpanExporterTest {
     }
 
     @Test
-    fun testOneExporterFlushFails() {
+    fun testOneExporterFlushFails() = runTest {
         val first = FakeSpanExporter(forceFlushReturnValue = { Failure })
         val second = FakeSpanExporter()
         val exporter =
@@ -100,7 +101,7 @@ internal class CompositeSpanExporterTest {
     }
 
     @Test
-    fun testOneExporterShutdownFails() {
+    fun testOneExporterShutdownFails() = runTest {
         val first = FakeSpanExporter(shutdownReturnValue = { Failure })
         val second = FakeSpanExporter()
         val exporter =
@@ -120,7 +121,7 @@ internal class CompositeSpanExporterTest {
     }
 
     @Test
-    fun testOneExporterThrowsInExport() {
+    fun testOneExporterThrowsInExport() = runTest {
         val first = FakeSpanExporter(exportReturnValue = { throw IllegalStateException() })
         val second = FakeSpanExporter()
         val exporter =
@@ -140,7 +141,7 @@ internal class CompositeSpanExporterTest {
     }
 
     @Test
-    fun testOneExporterThrowsInFlush() {
+    fun testOneExporterThrowsInFlush() = runTest {
         val first = FakeSpanExporter(forceFlushReturnValue = { throw IllegalStateException() })
         val second = FakeSpanExporter()
         val exporter =
@@ -160,7 +161,7 @@ internal class CompositeSpanExporterTest {
     }
 
     @Test
-    fun testOneExporterThrowsInShutdown() {
+    fun testOneExporterThrowsInShutdown() = runTest {
         val first = FakeSpanExporter(shutdownReturnValue = { throw IllegalStateException() })
         val second = FakeSpanExporter()
         val exporter =
@@ -179,7 +180,7 @@ internal class CompositeSpanExporterTest {
         assertTelemetryCapturedFailure(first, second)
     }
 
-    private fun CompositeSpanExporter.assertReturnValuesMatch(
+    private suspend fun CompositeSpanExporter.assertReturnValuesMatch(
         export: OperationResultCode,
         flush: OperationResultCode,
         shutdown: OperationResultCode

--- a/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/export/CompositeSpanProcessorTest.kt
+++ b/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/export/CompositeSpanProcessorTest.kt
@@ -7,6 +7,7 @@ import io.opentelemetry.kotlin.export.OperationResultCode
 import io.opentelemetry.kotlin.export.OperationResultCode.Failure
 import io.opentelemetry.kotlin.export.OperationResultCode.Success
 import io.opentelemetry.kotlin.tracing.FakeReadWriteSpan
+import kotlinx.coroutines.test.runTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -27,7 +28,7 @@ internal class CompositeSpanProcessorTest {
     }
 
     @Test
-    fun testNoSpanProcessors() {
+    fun testNoSpanProcessors() = runTest {
         val processor =
             CompositeSpanProcessor(
                 emptyList(),
@@ -43,7 +44,7 @@ internal class CompositeSpanProcessorTest {
     }
 
     @Test
-    fun testProcessorNotInvoked() {
+    fun testProcessorNotInvoked() = runTest {
         val impl = FakeSpanProcessor(startRequired = false, endRequired = false)
         val other = FakeSpanProcessor()
         val processor =
@@ -67,7 +68,7 @@ internal class CompositeSpanProcessorTest {
     }
 
     @Test
-    fun testMultipleSpanProcessors() {
+    fun testMultipleSpanProcessors() = runTest {
         val first = FakeSpanProcessor()
         val second = FakeSpanProcessor()
         val processor =
@@ -86,7 +87,7 @@ internal class CompositeSpanProcessorTest {
     }
 
     @Test
-    fun testOneProcessorFlushFails() {
+    fun testOneProcessorFlushFails() = runTest {
         val first = FakeSpanProcessor(flushCode = { Failure })
         val second = FakeSpanProcessor()
         val processor =
@@ -105,7 +106,7 @@ internal class CompositeSpanProcessorTest {
     }
 
     @Test
-    fun testOneProcessorShutdownFails() {
+    fun testOneProcessorShutdownFails() = runTest {
         val first = FakeSpanProcessor(shutdownCode = { Failure })
         val second = FakeSpanProcessor()
         val processor =
@@ -124,7 +125,7 @@ internal class CompositeSpanProcessorTest {
     }
 
     @Test
-    fun testOneProcessorsThrowsInOnStart() {
+    fun testOneProcessorsThrowsInOnStart() = runTest {
         val first = FakeSpanProcessor(startAction = { _, _ -> throw IllegalStateException() })
         val second = FakeSpanProcessor()
         val processor =
@@ -143,7 +144,7 @@ internal class CompositeSpanProcessorTest {
     }
 
     @Test
-    fun testOneProcessorsThrowsInOnEnding() {
+    fun testOneProcessorsThrowsInOnEnding() = runTest {
         val first = FakeSpanProcessor(endingAction = { throw IllegalStateException() })
         val second = FakeSpanProcessor()
         val processor =
@@ -162,7 +163,7 @@ internal class CompositeSpanProcessorTest {
     }
 
     @Test
-    fun testOneProcessorsThrowsInOnEnd() {
+    fun testOneProcessorsThrowsInOnEnd() = runTest {
         val first = FakeSpanProcessor(endAction = { throw IllegalStateException() })
         val second = FakeSpanProcessor()
         val processor =
@@ -181,7 +182,7 @@ internal class CompositeSpanProcessorTest {
     }
 
     @Test
-    fun testOneProcessorsThrowsInFlush() {
+    fun testOneProcessorsThrowsInFlush() = runTest {
         val first = FakeSpanProcessor(flushCode = { throw IllegalStateException() })
         val second = FakeSpanProcessor()
         val processor =
@@ -200,7 +201,7 @@ internal class CompositeSpanProcessorTest {
     }
 
     @Test
-    fun testOneProcessorsThrowsInShutdown() {
+    fun testOneProcessorsThrowsInShutdown() = runTest {
         val first = FakeSpanProcessor(shutdownCode = { throw IllegalStateException() })
         val second = FakeSpanProcessor()
         val processor =
@@ -218,7 +219,7 @@ internal class CompositeSpanProcessorTest {
         assertTelemetryCapturedFailure(first, second)
     }
 
-    private fun CompositeSpanProcessor.assertReturnValuesMatch(
+    private suspend fun CompositeSpanProcessor.assertReturnValuesMatch(
         flush: OperationResultCode,
         shutdown: OperationResultCode
     ) {

--- a/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/export/SimpleSpanProcessorTest.kt
+++ b/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/export/SimpleSpanProcessorTest.kt
@@ -4,6 +4,7 @@ import io.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.kotlin.context.FakeContext
 import io.opentelemetry.kotlin.export.OperationResultCode
 import io.opentelemetry.kotlin.tracing.FakeReadWriteSpan
+import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -12,7 +13,7 @@ import kotlin.test.assertTrue
 internal class SimpleSpanProcessorTest {
 
     @Test
-    fun testSpanProcessorDefaults() {
+    fun testSpanProcessorDefaults() = runTest {
         val processor =
             SimpleSpanProcessor(
                 FakeSpanExporter()

--- a/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/export/StdoutSpanExporterTest.kt
+++ b/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/export/StdoutSpanExporterTest.kt
@@ -11,6 +11,7 @@ import io.opentelemetry.kotlin.tracing.data.FakeEventData
 import io.opentelemetry.kotlin.tracing.data.FakeLinkData
 import io.opentelemetry.kotlin.tracing.data.StatusData
 import io.opentelemetry.kotlin.tracing.model.SpanKind
+import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -75,13 +76,13 @@ internal class StdoutSpanExporterTest {
     }
 
     @Test
-    fun testForceFlush() {
+    fun testForceFlush() = runTest {
         val exporter = StdoutSpanExporter()
         assertEquals(OperationResultCode.Success, exporter.forceFlush())
     }
 
     @Test
-    fun testShutdown() {
+    fun testShutdown() = runTest {
         val exporter = StdoutSpanExporter()
         assertEquals(OperationResultCode.Success, exporter.shutdown())
     }

--- a/exporters-otlp/src/commonMain/kotlin/io/opentelemetry/kotlin/export/TelemetryExporter.kt
+++ b/exporters-otlp/src/commonMain/kotlin/io/opentelemetry/kotlin/export/TelemetryExporter.kt
@@ -49,9 +49,9 @@ internal class TelemetryExporter<T>(
         }
     }
 
-    override fun forceFlush(): OperationResultCode = Success
+    override suspend fun forceFlush(): OperationResultCode = Success
 
-    override fun shutdown(): OperationResultCode {
+    override suspend fun shutdown(): OperationResultCode {
         scope.cancel()
         return Success
     }

--- a/exporters-otlp/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/OtlpHttpLogRecordExporter.kt
+++ b/exporters-otlp/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/OtlpHttpLogRecordExporter.kt
@@ -24,6 +24,6 @@ internal class OtlpHttpLogRecordExporter(
         return exporter.export(telemetry)
     }
 
-    override fun forceFlush(): OperationResultCode = exporter.forceFlush()
-    override fun shutdown(): OperationResultCode = exporter.shutdown()
+    override suspend fun forceFlush(): OperationResultCode = exporter.forceFlush()
+    override suspend fun shutdown(): OperationResultCode = exporter.shutdown()
 }

--- a/exporters-otlp/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/OtlpHttpSpanExporter.kt
+++ b/exporters-otlp/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/OtlpHttpSpanExporter.kt
@@ -24,6 +24,6 @@ internal class OtlpHttpSpanExporter(
         return exporter.export(telemetry)
     }
 
-    override fun forceFlush(): OperationResultCode = exporter.forceFlush()
-    override fun shutdown(): OperationResultCode = exporter.shutdown()
+    override suspend fun forceFlush(): OperationResultCode = exporter.forceFlush()
+    override suspend fun shutdown(): OperationResultCode = exporter.shutdown()
 }

--- a/exporters-otlp/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/export/OtlpHttpLogRecordExporterTest.kt
+++ b/exporters-otlp/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/export/OtlpHttpLogRecordExporterTest.kt
@@ -61,7 +61,7 @@ internal class OtlpHttpLogRecordExporterTest {
     }
 
     @Test
-    fun testExportForceFlush() {
+    fun testExportForceFlush() = runTest {
         val code = exporter.forceFlush()
         assertEquals(OperationResultCode.Success, code)
     }

--- a/exporters-otlp/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/export/OtlpHttpSpanExporterTest.kt
+++ b/exporters-otlp/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/export/OtlpHttpSpanExporterTest.kt
@@ -61,7 +61,7 @@ internal class OtlpHttpSpanExporterTest {
     }
 
     @Test
-    fun testExportForceFlush() {
+    fun testExportForceFlush() = runTest {
         val code = exporter.forceFlush()
         assertEquals(OperationResultCode.Success, code)
     }

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/integration/test/logging/LogProcessorNaughtyExportTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/integration/test/logging/LogProcessorNaughtyExportTest.kt
@@ -80,7 +80,7 @@ internal class LogProcessorNaughtyExportTest {
             }
         }
 
-        override fun forceFlush(): OperationResultCode = OperationResultCode.Success
-        override fun shutdown(): OperationResultCode = OperationResultCode.Success
+        override suspend fun forceFlush(): OperationResultCode = OperationResultCode.Success
+        override suspend fun shutdown(): OperationResultCode = OperationResultCode.Success
     }
 }

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/integration/test/logging/LogProcessorOnEmitTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/integration/test/logging/LogProcessorOnEmitTest.kt
@@ -91,7 +91,7 @@ internal class LogProcessorOnEmitTest {
             setStringAttribute("key", "value")
         }
 
-        override fun forceFlush(): OperationResultCode = OperationResultCode.Success
-        override fun shutdown(): OperationResultCode = OperationResultCode.Success
+        override suspend fun forceFlush(): OperationResultCode = OperationResultCode.Success
+        override suspend fun shutdown(): OperationResultCode = OperationResultCode.Success
     }
 }

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/integration/test/tracing/SpanProcessNaughtyOnEndTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/integration/test/tracing/SpanProcessNaughtyOnEndTest.kt
@@ -90,7 +90,7 @@ internal class SpanProcessNaughtyOnEndTest {
 
         override fun isStartRequired(): Boolean = true
         override fun isEndRequired(): Boolean = true
-        override fun forceFlush(): OperationResultCode = OperationResultCode.Success
-        override fun shutdown(): OperationResultCode = OperationResultCode.Success
+        override suspend fun forceFlush(): OperationResultCode = OperationResultCode.Success
+        override suspend fun shutdown(): OperationResultCode = OperationResultCode.Success
     }
 }

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/integration/test/tracing/SpanProcessOnEndReadTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/integration/test/tracing/SpanProcessOnEndReadTest.kt
@@ -78,7 +78,7 @@ internal class SpanProcessOnEndReadTest {
 
         override fun isStartRequired(): Boolean = true
         override fun isEndRequired(): Boolean = true
-        override fun forceFlush(): OperationResultCode = OperationResultCode.Success
-        override fun shutdown(): OperationResultCode = OperationResultCode.Success
+        override suspend fun forceFlush(): OperationResultCode = OperationResultCode.Success
+        override suspend fun shutdown(): OperationResultCode = OperationResultCode.Success
     }
 }

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/integration/test/tracing/SpanProcessOnEndingReadTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/integration/test/tracing/SpanProcessOnEndingReadTest.kt
@@ -91,7 +91,7 @@ internal class SpanProcessOnEndingReadTest {
 
         override fun isStartRequired(): Boolean = true
         override fun isEndRequired(): Boolean = true
-        override fun forceFlush(): OperationResultCode = OperationResultCode.Success
-        override fun shutdown(): OperationResultCode = OperationResultCode.Success
+        override suspend fun forceFlush(): OperationResultCode = OperationResultCode.Success
+        override suspend fun shutdown(): OperationResultCode = OperationResultCode.Success
     }
 }

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/integration/test/tracing/SpanProcessOnStartOverrideTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/integration/test/tracing/SpanProcessOnStartOverrideTest.kt
@@ -87,7 +87,7 @@ internal class SpanProcessOnStartOverrideTest {
 
         override fun isStartRequired(): Boolean = true
         override fun isEndRequired(): Boolean = true
-        override fun forceFlush(): OperationResultCode = OperationResultCode.Success
-        override fun shutdown(): OperationResultCode = OperationResultCode.Success
+        override suspend fun forceFlush(): OperationResultCode = OperationResultCode.Success
+        override suspend fun shutdown(): OperationResultCode = OperationResultCode.Success
     }
 }

--- a/integration-test/src/commonMain/kotlin/io/opentelemetry/kotlin/framework/InMemoryLogRecordExporter.kt
+++ b/integration-test/src/commonMain/kotlin/io/opentelemetry/kotlin/framework/InMemoryLogRecordExporter.kt
@@ -19,6 +19,6 @@ internal class InMemoryLogRecordExporter : LogRecordExporter {
         return OperationResultCode.Success
     }
 
-    override fun shutdown(): OperationResultCode = OperationResultCode.Success
-    override fun forceFlush(): OperationResultCode = OperationResultCode.Success
+    override suspend fun shutdown(): OperationResultCode = OperationResultCode.Success
+    override suspend fun forceFlush(): OperationResultCode = OperationResultCode.Success
 }

--- a/integration-test/src/commonMain/kotlin/io/opentelemetry/kotlin/framework/InMemoryLogRecordProcessor.kt
+++ b/integration-test/src/commonMain/kotlin/io/opentelemetry/kotlin/framework/InMemoryLogRecordProcessor.kt
@@ -15,6 +15,6 @@ internal class InMemoryLogRecordProcessor(
         exporter.export(listOf(log))
     }
 
-    override fun shutdown(): OperationResultCode = OperationResultCode.Success
-    override fun forceFlush(): OperationResultCode = OperationResultCode.Success
+    override suspend fun shutdown(): OperationResultCode = OperationResultCode.Success
+    override suspend fun forceFlush(): OperationResultCode = OperationResultCode.Success
 }

--- a/integration-test/src/commonMain/kotlin/io/opentelemetry/kotlin/framework/InMemorySpanExporter.kt
+++ b/integration-test/src/commonMain/kotlin/io/opentelemetry/kotlin/framework/InMemorySpanExporter.kt
@@ -19,6 +19,6 @@ internal class InMemorySpanExporter : SpanExporter {
         return OperationResultCode.Success
     }
 
-    override fun forceFlush(): OperationResultCode = OperationResultCode.Success
-    override fun shutdown(): OperationResultCode = OperationResultCode.Success
+    override suspend fun forceFlush(): OperationResultCode = OperationResultCode.Success
+    override suspend fun shutdown(): OperationResultCode = OperationResultCode.Success
 }

--- a/integration-test/src/commonMain/kotlin/io/opentelemetry/kotlin/framework/InMemorySpanProcessor.kt
+++ b/integration-test/src/commonMain/kotlin/io/opentelemetry/kotlin/framework/InMemorySpanProcessor.kt
@@ -20,8 +20,8 @@ internal class InMemorySpanProcessor(private val exporter: InMemorySpanExporter)
         exporter.export(listOf(span.toSpanData()))
     }
 
-    override fun forceFlush(): OperationResultCode = OperationResultCode.Success
-    override fun shutdown(): OperationResultCode = OperationResultCode.Success
+    override suspend fun forceFlush(): OperationResultCode = OperationResultCode.Success
+    override suspend fun shutdown(): OperationResultCode = OperationResultCode.Success
     override fun isStartRequired(): Boolean = true
     override fun isEndRequired(): Boolean = true
 }

--- a/test-fakes/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/FakeLogRecordExporter.kt
+++ b/test-fakes/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/FakeLogRecordExporter.kt
@@ -18,6 +18,6 @@ class FakeLogRecordExporter(
         return action(telemetry)
     }
 
-    override fun forceFlush(): OperationResultCode = flushCode()
-    override fun shutdown(): OperationResultCode = shutdownCode()
+    override suspend fun forceFlush(): OperationResultCode = flushCode()
+    override suspend fun shutdown(): OperationResultCode = shutdownCode()
 }

--- a/test-fakes/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/FakeLogRecordProcessor.kt
+++ b/test-fakes/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/FakeLogRecordProcessor.kt
@@ -22,6 +22,6 @@ class FakeLogRecordProcessor(
         action(log, context)
     }
 
-    override fun forceFlush(): OperationResultCode = flushCode()
-    override fun shutdown(): OperationResultCode = shutdownCode()
+    override suspend fun forceFlush(): OperationResultCode = flushCode()
+    override suspend fun shutdown(): OperationResultCode = shutdownCode()
 }

--- a/test-fakes/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/FakeSpanExporter.kt
+++ b/test-fakes/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/FakeSpanExporter.kt
@@ -18,6 +18,6 @@ class FakeSpanExporter(
         return exportReturnValue(telemetry)
     }
 
-    override fun forceFlush(): OperationResultCode = forceFlushReturnValue()
-    override fun shutdown(): OperationResultCode = shutdownReturnValue()
+    override suspend fun forceFlush(): OperationResultCode = forceFlushReturnValue()
+    override suspend fun shutdown(): OperationResultCode = shutdownReturnValue()
 }

--- a/test-fakes/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/FakeSpanProcessor.kt
+++ b/test-fakes/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/FakeSpanProcessor.kt
@@ -41,6 +41,6 @@ class FakeSpanProcessor(
 
     override fun isStartRequired(): Boolean = startRequired
     override fun isEndRequired(): Boolean = endRequired
-    override fun forceFlush(): OperationResultCode = flushCode()
-    override fun shutdown(): OperationResultCode = shutdownCode()
+    override suspend fun forceFlush(): OperationResultCode = flushCode()
+    override suspend fun shutdown(): OperationResultCode = shutdownCode()
 }


### PR DESCRIPTION
## Goal

Alters `TelemetryCloseable` so that `shutdown()` and `forceFlush()` use [suspend](https://kotlinlang.org/docs/composing-suspending-functions.html). This partially addresses #5 as it uses coroutines to make the operation behave more like Java's `CompleteableResultCode`. 
