### PR TITLE
Upgrade to AGP 9

### DIFF
--- a/benchmark-android/build.gradle.kts
+++ b/benchmark-android/build.gradle.kts
@@ -2,7 +2,6 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     id("com.android.library")
-    kotlin("android")
     alias(libs.plugins.androidx.benchmark)
 }
 

--- a/buildSrc/src/main/kotlin/io/opentelemetry/kotlin/BuildPlugin.kt
+++ b/buildSrc/src/main/kotlin/io/opentelemetry/kotlin/BuildPlugin.kt
@@ -1,5 +1,6 @@
 package io.opentelemetry.kotlin
 
+import com.android.build.api.dsl.KotlinMultiplatformAndroidLibraryTarget
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension
@@ -9,19 +10,24 @@ class BuildPlugin : Plugin<Project> {
 
     override fun apply(project: Project) {
         project.pluginManager.withPlugin("org.jetbrains.kotlin.multiplatform") {
-            val kotlin = project.extensions.getByType(KotlinMultiplatformExtension::class.java)
-            project.configureKotlin(kotlin)
-            project.configureDetekt()
-            project.configureBinaryCompatValidation()
-            project.configureExplicitApiMode(kotlin)
-            project.configureTest()
+            project.pluginManager.withPlugin("com.android.kotlin.multiplatform.library") {
+                val kotlin = project.extensions.getByType(KotlinMultiplatformExtension::class.java)
+                // Configure the android target - it's registered as an extension on the kotlin extension
+                val androidTarget = kotlin.extensions.getByType(KotlinMultiplatformAndroidLibraryTarget::class.java)
+                project.configureKotlinAndroidTarget(androidTarget)
+                project.configureKotlin(kotlin)
+                project.configureDetekt()
+                project.configureBinaryCompatValidation()
+                project.configureExplicitApiMode(kotlin)
+                project.configureTest()
+            }
+            project.pluginManager.withPlugin("org.jetbrains.kotlin.jvm") {
+                val kotlin = project.extensions.getByType(KotlinJvmProjectExtension::class.java)
+                project.configureDetekt()
+                project.configureBinaryCompatValidation()
+                project.configureTest()
+            }
+            project.configurePublishing()
         }
-        project.pluginManager.withPlugin("org.jetbrains.kotlin.jvm") {
-            val kotlin = project.extensions.getByType(KotlinJvmProjectExtension::class.java)
-            project.configureDetekt()
-            project.configureBinaryCompatValidation()
-            project.configureTest()
-        }
-        project.configurePublishing()
     }
 }

--- a/buildSrc/src/main/kotlin/io/opentelemetry/kotlin/KotlinAndroidTargetConfig.kt
+++ b/buildSrc/src/main/kotlin/io/opentelemetry/kotlin/KotlinAndroidTargetConfig.kt
@@ -1,0 +1,19 @@
+package io.opentelemetry.kotlin
+
+import com.android.build.api.dsl.KotlinMultiplatformAndroidLibraryTarget
+import org.gradle.api.Project
+
+
+fun Project.configureKotlinAndroidTarget(kotlinAndroidTarget: KotlinMultiplatformAndroidLibraryTarget) {
+    kotlinAndroidTarget.apply {
+        namespace = "io.opentelemetry.kotlin.${project.name.replace("-", ".")}"
+        compileSdk = 36
+        minSdk = 21
+
+        compilations.configureEach {
+            compileTaskProvider.configure {
+                compilerOptions.configureCompiler()
+            }
+        }
+    }
+}

--- a/buildSrc/src/main/kotlin/io/opentelemetry/kotlin/KotlinConfig.kt
+++ b/buildSrc/src/main/kotlin/io/opentelemetry/kotlin/KotlinConfig.kt
@@ -1,6 +1,5 @@
 package io.opentelemetry.kotlin
 
-import com.android.build.api.dsl.androidLibrary
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.exclude
 import org.jetbrains.kotlin.gradle.dsl.KotlinCommonCompilerOptions
@@ -9,23 +8,11 @@ import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.XCFramework
 
 fun Project.configureKotlin(
-    kotlin: KotlinMultiplatformExtension
+    kotlin: KotlinMultiplatformExtension,
 ) {
     kotlin.apply {
         jvmToolchain(11)
         compilerOptions.configureCompiler()
-
-        androidLibrary {
-            namespace = "io.opentelemetry.kotlin.${project.name.replace("-", ".")}"
-            compileSdk = 36
-            minSdk = 21
-
-            compilations.configureEach {
-                compileTaskProvider.configure {
-                    compilerOptions.configureCompiler()
-                }
-            }
-        }
         jvm {
             compilerOptions.configureCompiler()
         }
@@ -96,7 +83,7 @@ fun Project.configureKotlin(
     }
 }
 
-private fun KotlinCommonCompilerOptions.configureCompiler() {
+fun KotlinCommonCompilerOptions.configureCompiler() {
     allWarningsAsErrors.set(true)
     apiVersion.set(KotlinVersion.KOTLIN_2_0)
     languageVersion.set(KotlinVersion.KOTLIN_2_0)

--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/OpenTelemetryCompatEntrypoint.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/OpenTelemetryCompatEntrypoint.kt
@@ -4,7 +4,6 @@ import io.opentelemetry.kotlin.factory.SdkFactory
 import io.opentelemetry.kotlin.factory.createCompatSdkFactory
 import io.opentelemetry.kotlin.init.CompatOpenTelemetryConfig
 import io.opentelemetry.kotlin.init.OpenTelemetryConfigDsl
-import io.opentelemetry.kotlin.OpenTelemetryImpl
 
 /**
  * Constructs an [OpenTelemetry] instance that exposes OpenTelemetry as a Kotlin API. The SDK is

--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/OtelJavaOpenTelemetryExt.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/OtelJavaOpenTelemetryExt.kt
@@ -8,7 +8,6 @@ import io.opentelemetry.kotlin.factory.createCompatSdkFactory
 import io.opentelemetry.kotlin.init.CompatSpanLimitsConfig
 import io.opentelemetry.kotlin.logging.LoggerProviderAdapter
 import io.opentelemetry.kotlin.tracing.TracerProviderAdapter
-import io.opentelemetry.kotlin.OpenTelemetryImpl
 
 /**
  * Constructs an [OpenTelemetry] instance that exposes OpenTelemetry as a Kotlin API.

--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/factory/CompatSpanFactory.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/factory/CompatSpanFactory.kt
@@ -2,6 +2,7 @@
 
 package io.opentelemetry.kotlin.factory
 
+import io.opentelemetry.api.trace.otelJavaSpanContextKey
 import io.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.kotlin.aliases.OtelJavaContext
 import io.opentelemetry.kotlin.aliases.OtelJavaSpan
@@ -11,7 +12,6 @@ import io.opentelemetry.kotlin.tracing.NonRecordingSpan
 import io.opentelemetry.kotlin.tracing.model.Span
 import io.opentelemetry.kotlin.tracing.model.SpanContext
 import io.opentelemetry.kotlin.tracing.model.SpanContextAdapter
-import io.opentelemetry.api.trace.otelJavaSpanContextKey
 
 @OptIn(ExperimentalApi::class)
 internal class CompatSpanFactory(spanContextFactory: SpanContextFactory) : SpanFactory {

--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/tracing/OtelJavaSpanBuilderAdapter.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/tracing/OtelJavaSpanBuilderAdapter.kt
@@ -9,6 +9,7 @@ import io.opentelemetry.kotlin.aliases.OtelJavaSpan
 import io.opentelemetry.kotlin.aliases.OtelJavaSpanBuilder
 import io.opentelemetry.kotlin.aliases.OtelJavaSpanContext
 import io.opentelemetry.kotlin.aliases.OtelJavaSpanKind
+import io.opentelemetry.kotlin.attributes.convertToMap
 import io.opentelemetry.kotlin.attributes.setAttributes
 import io.opentelemetry.kotlin.context.ContextAdapter
 import io.opentelemetry.kotlin.tracing.ext.toOtelKotlinSpanContext
@@ -17,7 +18,6 @@ import io.opentelemetry.kotlin.tracing.model.OtelJavaSpanAdapter
 import java.util.Queue
 import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.TimeUnit
-import io.opentelemetry.kotlin.attributes.convertToMap
 
 @OptIn(ExperimentalApi::class)
 internal class OtelJavaSpanBuilderAdapter(

--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/tracing/model/OtelJavaSpanAdapter.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/tracing/model/OtelJavaSpanAdapter.kt
@@ -9,11 +9,11 @@ import io.opentelemetry.kotlin.aliases.OtelJavaScope
 import io.opentelemetry.kotlin.aliases.OtelJavaSpan
 import io.opentelemetry.kotlin.aliases.OtelJavaSpanContext
 import io.opentelemetry.kotlin.aliases.OtelJavaStatusCode
+import io.opentelemetry.kotlin.attributes.convertToMap
 import io.opentelemetry.kotlin.tracing.ext.toOtelJavaSpanContext
 import io.opentelemetry.kotlin.tracing.ext.toOtelKotlinStatusData
 import io.opentelemetry.kotlin.tracing.recordException
 import java.util.concurrent.TimeUnit
-import io.opentelemetry.kotlin.attributes.convertToMap
 
 @OptIn(ExperimentalApi::class)
 internal class OtelJavaSpanAdapter(private val span: Span) : OtelJavaSpan, OtelJavaImplicitContextKeyed {

--- a/examples/android-app/build.gradle.kts
+++ b/examples/android-app/build.gradle.kts
@@ -1,7 +1,6 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
-    id("org.jetbrains.kotlin.android")
     id("com.android.application")
 }
 

--- a/examples/telescope-app/app/build.gradle.kts
+++ b/examples/telescope-app/app/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     alias(libs.plugins.android.application)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
 }
 
@@ -27,9 +26,6 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
-    }
-    kotlinOptions {
-        jvmTarget = "11"
     }
     buildFeatures {
         compose = true

--- a/examples/telescope-app/build.gradle.kts
+++ b/examples/telescope-app/build.gradle.kts
@@ -1,6 +1,5 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
     alias(libs.plugins.android.application) apply false
-    alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.kotlin.compose) apply false
 }

--- a/examples/telescope-app/gradle/libs.versions.toml
+++ b/examples/telescope-app/gradle/libs.versions.toml
@@ -49,6 +49,5 @@ androidx-navigation-compose = { group = "androidx.navigation", name = "navigatio
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 

--- a/exporters-otlp/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/logging/export/OtlpHttpLogRecordExporterApi.jvm.kt
+++ b/exporters-otlp/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/logging/export/OtlpHttpLogRecordExporterApi.jvm.kt
@@ -5,7 +5,6 @@ import io.opentelemetry.kotlin.export.EXPORT_INITIAL_DELAY_MS
 import io.opentelemetry.kotlin.export.EXPORT_MAX_ATTEMPTS
 import io.opentelemetry.kotlin.export.EXPORT_MAX_ATTEMPT_INTERVAL_MS
 import io.opentelemetry.kotlin.export.OtlpClient
-import io.opentelemetry.kotlin.logging.export.LogRecordExporter
 
 @OptIn(ExperimentalApi::class)
 public actual fun createOtlpHttpLogRecordExporter(baseUrl: String): LogRecordExporter =

--- a/exporters-otlp/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/tracing/export/OtlpHttpSpanExporterApi.jvm.kt
+++ b/exporters-otlp/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/tracing/export/OtlpHttpSpanExporterApi.jvm.kt
@@ -5,7 +5,6 @@ import io.opentelemetry.kotlin.export.EXPORT_INITIAL_DELAY_MS
 import io.opentelemetry.kotlin.export.EXPORT_MAX_ATTEMPTS
 import io.opentelemetry.kotlin.export.EXPORT_MAX_ATTEMPT_INTERVAL_MS
 import io.opentelemetry.kotlin.export.OtlpClient
-import io.opentelemetry.kotlin.tracing.export.SpanExporter
 
 @OptIn(ExperimentalApi::class)
 public actual fun createOtlpHttpSpanExporter(baseUrl: String): SpanExporter = OtlpHttpSpanExporter(

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.13.2"
+agp = "9.0.0"
 kotlin = "2.3.0"
 android-minSdk = "21"
 android-compileSdk = "36"
@@ -18,7 +18,7 @@ koverGradlePlugin = "0.9.4"
 downloadPlugin = "5.6.0"
 #noinspection GradleDependency
 kotlinExposed = "2.0.0"
-androidxBenchmark = "1.4.1"
+androidxBenchmark = "1.5.0-alpha01"
 kotlinxBenchmark = "0.4.15"
 androidxTest = "1.7.0"
 androidxRunner = "1.7.0"
@@ -64,8 +64,8 @@ protobuf-kotlin = { module = "com.google.protobuf:protobuf-kotlin", version.ref 
 wire-runtime = { module = "com.squareup.wire:wire-runtime", version.ref = "wire" }
 
 [plugins]
-androidLibrary = { id = "com.android.kotlin.multiplatform.library", version.ref = "agp" }
-kotlinMultiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
+android-kotlin-multiplatform-library = { id = "com.android.kotlin.multiplatform.library", version.ref = "agp" }
+kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 vanniktech-mavenPublish = { id = "com.vanniktech.maven.publish", version.ref = "mavenPublish" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }


### PR DESCRIPTION
## Goal

Upgrade Android Gradle Plugin from 8.13.2 to 9.0.0.

## Changes

- Bump AGP version to 9.0.0
- Bump androidx-benchmark to 1.5.0-alpha01 for AGP 9 compatibility
- Rename plugins in libs.versions.toml (`androidLibrary` → `android-kotlin-multiplatform-library`, `kotlinMultiplatform` → `kotlin-multiplatform`)
- Extract Android target configuration to KotlinAndroidTargetConfig.kt
- Restructure BuildPlugin to keep common multiplatform config separate from android-specific config
- Fix BuildPlugin to ensure `configurePublishing()` runs for all modules (fixes compat-bom publishing)
- Fix compat-bom to properly import OpenTelemetry Java BOM version constraints
- Restore kotlin.android plugin in telescope-app example