### PR TITLE
Preparations for initial release attempt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # opentelemetry-kotlin changelog
 
+## Unreleased
+
+## Legacy release notes made under io.embrace coordinates
+
 # 0.7.0
 *Oct 15, 2025*
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Other targets compile but are not considered sufficiently tested to count as 'su
 
 ```
 dependencies {
-    val otelKotlinVersion = "0.8.0"
+    val otelKotlinVersion = "0.1.0-alpha"
     implementation("io.opentelemetry.kotlin:core:$otelKotlinVersion")
     implementation("io.opentelemetry.kotlin:implementation:$otelKotlinVersion")
 }
@@ -54,7 +54,7 @@ This can be helpful if you already use the Java implementation or don't want to 
 
 ```
 dependencies {
-    val otelKotlinVersion = "0.8.0"
+    val otelKotlinVersion = "0.1.0-alpha"
     implementation("io.opentelemetry.kotlin:core:$otelKotlinVersion")
     implementation("io.opentelemetry.kotlin:compat:$otelKotlinVersion")
 }

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -2,9 +2,6 @@
 
 ## Checklist
 
-1. Run `pre-release-workflow.yml` on GitHub Actions
-2. Sign into Sonatype and ensure the artifacts have been validated
-3. Publish the artifacts
-4. Open a PR with a changelog entry that describes what changed in the new version
-5. Create a release on GitHub's UI using the tag
-6. Merge the version bump PR created by the CI bot
+1. Run [draft-change-log-entries.yml](.github/workflows/draft-change-log-entries.yaml) on GitHub Actions
+2. Run [prepare-release-branch.yml](.github/workflows/prepare-release-branch.yml) on GitHub Actions
+3. Run [release.yml](.github/workflows/release.yml) on GitHub Actions

--- a/examples/telescope-app/gradle/libs.versions.toml
+++ b/examples/telescope-app/gradle/libs.versions.toml
@@ -10,7 +10,7 @@ lifecycleRuntimeKtx = "2.8.7"
 activityCompose = "1.10.1"
 composeBom = "2025.02.00"
 opentelemetry-bom = "1.46.0"
-opentelemetry-kotlin = "0.8.0-SNAPSHOT"
+opentelemetry-kotlin = "0.1.0-SNAPSHOT"
 opentelemetry-semconv = "1.28.0-alpha"
 navigationCompose = "2.8.8"
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,4 +16,4 @@ android.builtInKotlin=false
 android.newDsl=false
 
 #Custom
-version=0.8.0-SNAPSHOT
+version=0.1.0-SNAPSHOT


### PR DESCRIPTION
## Goal

Makes some initial preparations for attempting the release process. This changeset:

- Adds 'unreleased' into the changelog as a header as this seems to be a pre-requisite of the release workflows
- Resets the version to 0.1.0-alpha
- Tweaks the release checklist somewhat

### Remaining alterations to repository

I copied the release workflows from [opentelemetry-android](https://github.com/open-telemetry/opentelemetry-android) and it looks like some additional setup is required to setup these secrets in the repository:

```
secrets.GITHUB_TOKEN
secrets.OTELBOT_PRIVATE_KEY
secrets.SONATYPE_USER
secrets.SONATYPE_KEY
secrets.GPG_PRIVATE_KEY
secrets.GPG_PASSWORD
```

Additionally we will need to set this one variable:

```
vars.OTELBOT_APP_ID
```