### PR TITLE
Improve release script error handling

### DIFF
--- a/.github/scripts/draft-change-log-entries.sh
+++ b/.github/scripts/draft-change-log-entries.sh
@@ -1,9 +1,15 @@
 #!/bin/bash -e
 
 version=$("$(dirname "$0")/get-version.sh")
-prior_version=$("$(dirname "$0")/get-prior-version.sh" "$version")
+[[ -z "$version" ]] && { echo "Error: failed to get version" >&2; exit 1; }
 
-range="v$prior_version..HEAD"
+if prior_version=$("$(dirname "$0")/get-prior-version.sh" "$version" 2>/dev/null); then
+  range="v$prior_version..HEAD"
+else
+  # No prior version tag exists, use initial commit
+  initial_commit=$(git rev-list --max-parents=0 HEAD)
+  range="$initial_commit..HEAD"
+fi
 
 echo "## Unreleased"
 echo

--- a/.github/scripts/generate-release-contributors.sh
+++ b/.github/scripts/generate-release-contributors.sh
@@ -7,6 +7,9 @@
 #   git push origin upstream/main:main
 #   export GITHUB_REPOSITORY=open-telemetry/opentelemetry-kotlin
 
+[[ -z "$1" ]] && { echo "Error: missing from_version argument"; exit 1; }
+[[ -z "$GITHUB_REPOSITORY" ]] && { echo "Error: GITHUB_REPOSITORY not set"; exit 1; }
+
 from_version=$1
 
 # get the date of the first commit that was not in the from_version

--- a/.github/scripts/generate-release-notes.sh
+++ b/.github/scripts/generate-release-notes.sh
@@ -2,6 +2,10 @@
 
 # Generates release notes, like what appears in GitHub release pages.
 
+[[ -z "$1" ]] && { echo "Error: missing VERSION argument"; exit 1; }
+[[ -z "$2" ]] && { echo "Error: missing PRIOR_VERSION argument"; exit 1; }
+[[ ! -f "CHANGELOG.md" ]] && { echo "Error: CHANGELOG.md not found"; exit 1; }
+
 VERSION=$1
 PRIOR_VERSION=$2
 

--- a/.github/scripts/get-prior-version.sh
+++ b/.github/scripts/get-prior-version.sh
@@ -1,5 +1,7 @@
 #!/bin/bash -e
 
+[[ -z "$1" ]] && { echo "Error: missing version argument" >&2; exit 1; }
+
 from_version_json=$("$(dirname "$0")/parse-version.sh" "$1")
 major=$(echo "$from_version_json" | jq -r '.major')
 minor=$(echo "$from_version_json" | jq -r '.minor')
@@ -20,6 +22,11 @@ else
   else
     prior_version="$major.$minor.$((patch - 1))"
   fi
+fi
+
+if ! git rev-parse "v$prior_version" >/dev/null 2>&1; then
+  echo "Error: prior version tag 'v$prior_version' does not exist" >&2
+  exit 1
 fi
 
 echo "$prior_version"

--- a/.github/scripts/get-version.sh
+++ b/.github/scripts/get-version.sh
@@ -1,3 +1,8 @@
 #!/bin/bash -e
 
-grep ^version= gradle.properties | sed s/version=// | tr -d '\r'
+[[ ! -f "gradle.properties" ]] && { echo "Error: gradle.properties not found" >&2; exit 1; }
+
+version=$(grep ^version= gradle.properties | sed s/version=// | tr -d '\r')
+[[ -z "$version" ]] && { echo "Error: version not found in gradle.properties" >&2; exit 1; }
+
+echo "$version"

--- a/.github/scripts/parse-version.sh
+++ b/.github/scripts/parse-version.sh
@@ -3,8 +3,8 @@
 version=$1
 
 if [[ -z "$version" ]]; then
- echo "Unexpected version argument: $version"
- exit 1
+  echo "Error: missing version argument" >&2
+  exit 1
 fi
 
 if [[ $version =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)(-(rc\.([0-9]+)))?$ ]]; then
@@ -13,7 +13,7 @@ if [[ $version =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)(-(rc\.([0-9]+)))?$ ]]; then
   version_patch="${BASH_REMATCH[3]}"
   version_rc="${BASH_REMATCH[6]}"
 else
-  echo "unexpected version: '$version'"
+  echo "Error: invalid version format '$version' (expected: X.Y.Z or X.Y.Z-rc.N)" >&2
   exit 1
 fi
 

--- a/.github/scripts/update-version.sh
+++ b/.github/scripts/update-version.sh
@@ -1,5 +1,8 @@
 #!/bin/bash -e
 
+[[ -z "$1" ]] && { echo "Error: missing version argument"; exit 1; }
+[[ ! -f "gradle.properties" ]] && { echo "Error: gradle.properties not found"; exit 1; }
+
 version=$1
 alpha_version=${version}-alpha
 

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -43,5 +43,3 @@ jobs:
 
       - name: Build Example Apps
         run: ./gradlew :examples:jvm-app:run :examples:android-app:assembleRelease :examples:js-app:jsNodeDevelopmentRun --stacktrace
-      - name: Build Telescope App
-        run: ./gradlew pTML && cd examples/telescope-app && ./gradlew assembleRelease --stacktrace

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,4 +16,4 @@ android.builtInKotlin=false
 android.newDsl=false
 
 #Custom
-version=0.1.0-SNAPSHOT
+version=0.1.0


### PR DESCRIPTION
## Goal

Improves the error handling in the release scripts by erroring out early if variables aren't set or if directories cannot be found. This should help make it easier to debug when things go wrong in CI.

I've tested this out by checking that the changelog draft [workflow passes](https://github.com/fractalwrench/opentelemetry-kotlin/actions/runs/21670028295/job/62475244537). I also needed to disable building the telescope app in CI because the publish action fails for workflows not ending in `-SNAPSHOT` as no signing is currently configured. Stopping building this app in CI feels ok given that there was discussion about removing this specific app entirely in #102 