### PR TITLE
Increase max heap size in gradle properties

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 #Gradle
-org.gradle.jvmargs=-Xmx4096M -XX:+UseParallelGC -XX:MaxMetaspaceSize=2g -Dfile.encoding=UTF-8 -Dkotlin.daemon.jvm.options\="-Xmx4096M"
+org.gradle.jvmargs=-Xmx8G -XX:+UseParallelGC -XX:MaxMetaspaceSize=4g -Dfile.encoding=UTF-8 -Dkotlin.daemon.jvm.options\="-Xmx8G"
 org.gradle.caching=true
 org.gradle.configuration-cache=true
 org.gradle.configuration-cache.problems=fail


### PR DESCRIPTION
## Goal

I was bumping into the max heap size on a clean build (presumably the new example app and additional modules are adding up). I've therefore increased the max allowable heap size in gradle.properties which allowed me to build without gradle refusing to allocate more memory.
