### PR TITLE
Allows using compatibility mode in example app

### DIFF
--- a/examples/example-app/README.md
+++ b/examples/example-app/README.md
@@ -3,7 +3,9 @@
 A Kotlin Multiplatform example app that demonstrates the OpenTelemetry Kotlin API. It emits
 spans and logs that are then sent to OpenTelemetry exporters that by default print the telemetry.
 
-## Exporting to a Collector
+## Configuring the example app
+
+### Exporting telemetry to an OpenTelemetry collector
 
 By default, the example app prints telemetry to stdout. You can optionally export telemetry to an
 OpenTelemetry collector by setting the `url` property in `AppConfig.kt`:
@@ -14,6 +16,21 @@ val url: String? = "http://localhost:4318"
 
 To run a collector locally,
 see [opentelemetry-collector](https://github.com/open-telemetry/opentelemetry-collector).
+
+### Altering the SDK mode
+
+opentelemetry-kotlin has 1 API with 3 implementations. By default the KMP implementation will be
+used but you can change to the compat (uses opentelemetry-java under the hood) or no-op
+implementation by setting the `sdkMode` property in `AppConfig.kt`:
+
+```kotlin
+val sdkMode = SdkMode.COMPAT
+```
+
+### Using custom processors
+
+You can supply your own processors by altering `spanProcessor` and logRecordProcessor on
+`AppConfig`.
 
 ## Example app targets
 

--- a/examples/example-app/build.gradle.kts
+++ b/examples/example-app/build.gradle.kts
@@ -61,6 +61,7 @@ kotlin {
             dependsOn(composeMain)
             dependencies {
                 implementation(libs.androidx.activity.compose)
+                implementation(project(":compat"))
             }
         }
 
@@ -68,6 +69,7 @@ kotlin {
             dependsOn(composeMain)
             dependencies {
                 implementation(compose.desktop.currentOs)
+                implementation(project(":compat"))
             }
         }
 

--- a/examples/example-app/src/androidMain/kotlin/io/opentelemetry/example/app/PlatformOpenTelemetry.android.kt
+++ b/examples/example-app/src/androidMain/kotlin/io/opentelemetry/example/app/PlatformOpenTelemetry.android.kt
@@ -1,0 +1,20 @@
+package io.opentelemetry.example.app
+
+import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.NoopOpenTelemetry
+import io.opentelemetry.kotlin.OpenTelemetry
+import io.opentelemetry.kotlin.createCompatOpenTelemetry
+import io.opentelemetry.kotlin.createOpenTelemetry
+import io.opentelemetry.kotlin.init.OpenTelemetryConfigDsl
+
+@ExperimentalApi
+internal actual fun createPlatformOpenTelemetry(
+    sdkMode: AppConfig.SdkMode,
+    config: OpenTelemetryConfigDsl.() -> Unit
+): OpenTelemetry {
+    return when (sdkMode) {
+        AppConfig.SdkMode.IMPLEMENTATION -> createOpenTelemetry(config)
+        AppConfig.SdkMode.COMPAT -> createCompatOpenTelemetry(config)
+        AppConfig.SdkMode.NOOP -> NoopOpenTelemetry
+    }
+}

--- a/examples/example-app/src/commonMain/kotlin/io/opentelemetry/example/app/AppConfig.kt
+++ b/examples/example-app/src/commonMain/kotlin/io/opentelemetry/example/app/AppConfig.kt
@@ -22,6 +22,12 @@ object AppConfig {
         IMPLEMENTATION,
 
         /**
+         * Kotlin API that wraps the opentelemetry-java SDK.
+         * Only available on JVM/Android platforms.
+         */
+        COMPAT,
+
+        /**
          * No-op implementation (KMP).
          */
         NOOP

--- a/examples/example-app/src/commonMain/kotlin/io/opentelemetry/example/app/PlatformOpenTelemetry.kt
+++ b/examples/example-app/src/commonMain/kotlin/io/opentelemetry/example/app/PlatformOpenTelemetry.kt
@@ -1,0 +1,17 @@
+package io.opentelemetry.example.app
+
+import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.OpenTelemetry
+import io.opentelemetry.kotlin.init.OpenTelemetryConfigDsl
+
+/**
+ * Creates an OpenTelemetry instance using platform-specific implementation.
+ * On JVM/Android, this respects [sdkMode] to choose between
+ * KMP SDK, Java SDK (via compat module), or no-op.
+ * On other platforms, COMPAT mode is not supported and will throw an exception.
+ */
+@ExperimentalApi
+internal expect fun createPlatformOpenTelemetry(
+    sdkMode: AppConfig.SdkMode,
+    config: OpenTelemetryConfigDsl.() -> Unit
+): OpenTelemetry

--- a/examples/example-app/src/commonMain/kotlin/io/opentelemetry/example/app/TelemetryEntrypoint.kt
+++ b/examples/example-app/src/commonMain/kotlin/io/opentelemetry/example/app/TelemetryEntrypoint.kt
@@ -3,9 +3,7 @@
 package io.opentelemetry.example.app
 
 import io.opentelemetry.kotlin.ExperimentalApi
-import io.opentelemetry.kotlin.NoopOpenTelemetry
 import io.opentelemetry.kotlin.OpenTelemetry
-import io.opentelemetry.kotlin.createOpenTelemetry
 import io.opentelemetry.kotlin.init.OpenTelemetryConfigDsl
 
 /**
@@ -20,8 +18,5 @@ fun initializeOtelSdk(): OpenTelemetry {
             addLogRecordProcessor(AppConfig.logRecordProcessor)
         }
     }
-    return when (AppConfig.sdkMode) {
-        AppConfig.SdkMode.IMPLEMENTATION -> createOpenTelemetry(config)
-        AppConfig.SdkMode.NOOP -> NoopOpenTelemetry
-    }
+    return createPlatformOpenTelemetry(AppConfig.sdkMode, config)
 }

--- a/examples/example-app/src/iosMain/kotlin/io/opentelemetry/example/app/PlatformOpenTelemetry.ios.kt
+++ b/examples/example-app/src/iosMain/kotlin/io/opentelemetry/example/app/PlatformOpenTelemetry.ios.kt
@@ -1,0 +1,23 @@
+package io.opentelemetry.example.app
+
+import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.NoopOpenTelemetry
+import io.opentelemetry.kotlin.OpenTelemetry
+import io.opentelemetry.kotlin.createOpenTelemetry
+import io.opentelemetry.kotlin.init.OpenTelemetryConfigDsl
+
+@ExperimentalApi
+internal actual fun createPlatformOpenTelemetry(
+    sdkMode: AppConfig.SdkMode,
+    config: OpenTelemetryConfigDsl.() -> Unit
+): OpenTelemetry {
+    return when (sdkMode) {
+        AppConfig.SdkMode.IMPLEMENTATION -> createOpenTelemetry(config)
+        AppConfig.SdkMode.COMPAT -> {
+            throw UnsupportedOperationException(
+                "COMPAT mode is unsupported on JS. Use IMPLEMENTATION or NOOP instead."
+            )
+        }
+        AppConfig.SdkMode.NOOP -> NoopOpenTelemetry
+    }
+}

--- a/examples/example-app/src/jsMain/kotlin/io/opentelemetry/example/app/PlatformOpenTelemetry.js.kt
+++ b/examples/example-app/src/jsMain/kotlin/io/opentelemetry/example/app/PlatformOpenTelemetry.js.kt
@@ -1,0 +1,23 @@
+package io.opentelemetry.example.app
+
+import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.NoopOpenTelemetry
+import io.opentelemetry.kotlin.OpenTelemetry
+import io.opentelemetry.kotlin.createOpenTelemetry
+import io.opentelemetry.kotlin.init.OpenTelemetryConfigDsl
+
+@ExperimentalApi
+internal actual fun createPlatformOpenTelemetry(
+    sdkMode: AppConfig.SdkMode,
+    config: OpenTelemetryConfigDsl.() -> Unit
+): OpenTelemetry {
+    return when (sdkMode) {
+        AppConfig.SdkMode.IMPLEMENTATION -> createOpenTelemetry(config)
+        AppConfig.SdkMode.COMPAT -> {
+            throw UnsupportedOperationException(
+                "COMPAT mode is unsupported on JS. Use IMPLEMENTATION or NOOP instead."
+            )
+        }
+        AppConfig.SdkMode.NOOP -> NoopOpenTelemetry
+    }
+}

--- a/examples/example-app/src/jvmMain/kotlin/io/opentelemetry/example/app/PlatformOpenTelemetry.jvm.kt
+++ b/examples/example-app/src/jvmMain/kotlin/io/opentelemetry/example/app/PlatformOpenTelemetry.jvm.kt
@@ -1,0 +1,20 @@
+package io.opentelemetry.example.app
+
+import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.NoopOpenTelemetry
+import io.opentelemetry.kotlin.OpenTelemetry
+import io.opentelemetry.kotlin.createCompatOpenTelemetry
+import io.opentelemetry.kotlin.createOpenTelemetry
+import io.opentelemetry.kotlin.init.OpenTelemetryConfigDsl
+
+@ExperimentalApi
+internal actual fun createPlatformOpenTelemetry(
+    sdkMode: AppConfig.SdkMode,
+    config: OpenTelemetryConfigDsl.() -> Unit
+): OpenTelemetry {
+    return when (sdkMode) {
+        AppConfig.SdkMode.IMPLEMENTATION -> createOpenTelemetry(config)
+        AppConfig.SdkMode.COMPAT -> createCompatOpenTelemetry(config)
+        AppConfig.SdkMode.NOOP -> NoopOpenTelemetry
+    }
+}


### PR DESCRIPTION
## Goal

Alters the example app to allow using the compat mode in the example app for JVM/Android. This is stacked on top of #144 - the relevant changes are in the last commit.
