### PR TITLE
Alter API for spec compliance

### DIFF
--- a/api-ext/api/jvm/api-ext.api
+++ b/api-ext/api/jvm/api-ext.api
@@ -20,3 +20,7 @@ public final class io/opentelemetry/kotlin/tracing/SpanExtKt {
 	public static final fun wrapOperation (Lio/opentelemetry/kotlin/tracing/model/Span;Lkotlin/jvm/functions/Function0;)V
 }
 
+public final class io/opentelemetry/kotlin/tracing/model/TraceFlagsExtKt {
+	public static final fun getHex (Lio/opentelemetry/kotlin/tracing/model/TraceFlags;)Ljava/lang/String;
+}
+

--- a/api-ext/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/model/TraceFlagsExt.kt
+++ b/api-ext/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/model/TraceFlagsExt.kt
@@ -1,0 +1,23 @@
+package io.opentelemetry.kotlin.tracing.model
+
+import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.ThreadSafe
+
+/**
+ * Returns the hexadecimal representation of the trace flags as a 2-character lowercase string.
+ *
+ * Possible values:
+ * - "00" = no flags set (neither sampled nor random)
+ * - "01" = sampled only (0b000000001)
+ * - "02" = random only (0b000000010)
+ * - "03" = both sampled and random (0b000000011)
+ */
+@ThreadSafe
+@ExperimentalApi
+public val TraceFlags.hex: String
+    get() = when {
+        isRandom && isSampled -> "03"
+        isRandom && !isSampled -> "02"
+        !isRandom && isSampled -> "01"
+        else -> "00"
+    }

--- a/api-ext/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/model/TraceFlagsExtTest.kt
+++ b/api-ext/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/model/TraceFlagsExtTest.kt
@@ -1,0 +1,18 @@
+package io.opentelemetry.kotlin.tracing.model
+
+import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.tracing.FakeTraceFlags
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalApi::class)
+internal class TraceFlagsExtTest {
+
+    @Test
+    fun testEmptyString() {
+        assertEquals("00", FakeTraceFlags().hex)
+        assertEquals("01", FakeTraceFlags(isSampled = true).hex)
+        assertEquals("02", FakeTraceFlags(isRandom = true).hex)
+        assertEquals("03", FakeTraceFlags(isSampled = true, isRandom = true).hex)
+    }
+}

--- a/api/api/jvm/api.api
+++ b/api/api/jvm/api.api
@@ -108,12 +108,14 @@ public final class io/opentelemetry/kotlin/factory/TracingIdFactoryKt {
 }
 
 public abstract interface class io/opentelemetry/kotlin/logging/Logger {
+	public abstract fun emit (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Lio/opentelemetry/kotlin/context/Context;Lio/opentelemetry/kotlin/logging/model/SeverityNumber;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
 	public abstract fun enabled (Lio/opentelemetry/kotlin/context/Context;Lio/opentelemetry/kotlin/logging/model/SeverityNumber;Ljava/lang/String;)Z
 	public abstract fun log (Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Lio/opentelemetry/kotlin/context/Context;Lio/opentelemetry/kotlin/logging/model/SeverityNumber;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
 	public abstract fun logEvent (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Lio/opentelemetry/kotlin/context/Context;Lio/opentelemetry/kotlin/logging/model/SeverityNumber;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
 }
 
 public final class io/opentelemetry/kotlin/logging/Logger$DefaultImpls {
+	public static synthetic fun emit$default (Lio/opentelemetry/kotlin/logging/Logger;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Lio/opentelemetry/kotlin/context/Context;Lio/opentelemetry/kotlin/logging/model/SeverityNumber;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
 	public static synthetic fun enabled$default (Lio/opentelemetry/kotlin/logging/Logger;Lio/opentelemetry/kotlin/context/Context;Lio/opentelemetry/kotlin/logging/model/SeverityNumber;Ljava/lang/String;ILjava/lang/Object;)Z
 	public static synthetic fun log$default (Lio/opentelemetry/kotlin/logging/Logger;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Lio/opentelemetry/kotlin/context/Context;Lio/opentelemetry/kotlin/logging/model/SeverityNumber;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
 	public static synthetic fun logEvent$default (Lio/opentelemetry/kotlin/logging/Logger;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Lio/opentelemetry/kotlin/context/Context;Lio/opentelemetry/kotlin/logging/model/SeverityNumber;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
@@ -170,10 +172,12 @@ public final class io/opentelemetry/kotlin/tracing/StatusCode : java/lang/Enum {
 
 public abstract interface class io/opentelemetry/kotlin/tracing/Tracer {
 	public abstract fun createSpan (Ljava/lang/String;Lio/opentelemetry/kotlin/context/Context;Lio/opentelemetry/kotlin/tracing/model/SpanKind;Ljava/lang/Long;Lkotlin/jvm/functions/Function1;)Lio/opentelemetry/kotlin/tracing/model/Span;
+	public abstract fun startSpan (Ljava/lang/String;Lio/opentelemetry/kotlin/context/Context;Lio/opentelemetry/kotlin/tracing/model/SpanKind;Ljava/lang/Long;Lkotlin/jvm/functions/Function1;)Lio/opentelemetry/kotlin/tracing/model/Span;
 }
 
 public final class io/opentelemetry/kotlin/tracing/Tracer$DefaultImpls {
 	public static synthetic fun createSpan$default (Lio/opentelemetry/kotlin/tracing/Tracer;Ljava/lang/String;Lio/opentelemetry/kotlin/context/Context;Lio/opentelemetry/kotlin/tracing/model/SpanKind;Ljava/lang/Long;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lio/opentelemetry/kotlin/tracing/model/Span;
+	public static synthetic fun startSpan$default (Lio/opentelemetry/kotlin/tracing/Tracer;Ljava/lang/String;Lio/opentelemetry/kotlin/context/Context;Lio/opentelemetry/kotlin/tracing/model/SpanKind;Ljava/lang/Long;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lio/opentelemetry/kotlin/tracing/model/Span;
 }
 
 public abstract interface class io/opentelemetry/kotlin/tracing/TracerProvider {
@@ -274,7 +278,6 @@ public final class io/opentelemetry/kotlin/tracing/model/SpanRelationships$Defau
 }
 
 public abstract interface class io/opentelemetry/kotlin/tracing/model/TraceFlags {
-	public abstract fun getHex ()Ljava/lang/String;
 	public abstract fun isRandom ()Z
 	public abstract fun isSampled ()Z
 }

--- a/api/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/Logger.kt
+++ b/api/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/Logger.kt
@@ -33,8 +33,9 @@ public interface Logger {
     ): Boolean
 
     /**
-     * Emits a log record with the given optional parameters:
+     * Emits an event with a name and the given optional parameters:
      *
+     * - [eventName] - the name of the event, or null if it has no name
      * - [body] - the body of the log message
      * - [timestamp] - the timestamp at which the event occurred
      * - [observedTimestamp] - the timestamp at which the event was entered into the OpenTelemetry API
@@ -43,6 +44,21 @@ public interface Logger {
      * - [severityText] - a string representation of the severity at the point it was captured
      * - [attributes] - additional attributes to associate with the log
      */
+    public fun emit(
+        body: String? = null,
+        eventName: String? = null,
+        timestamp: Long? = null,
+        observedTimestamp: Long? = null,
+        context: Context? = null,
+        severityNumber: SeverityNumber? = null,
+        severityText: String? = null,
+        attributes: (MutableAttributeContainer.() -> Unit)? = null,
+    )
+
+    @Deprecated(
+        "Deprecated",
+        ReplaceWith("emit(body, null, timestamp, observedTimestamp, context, severityNumber, severityText, attributes)")
+    )
     public fun log(
         body: String? = null,
         timestamp: Long? = null,
@@ -53,17 +69,10 @@ public interface Logger {
         attributes: (MutableAttributeContainer.() -> Unit)? = null,
     )
 
-    /**
-     * Emits an event with a name and the given optional parameters:
-     *
-     * - [body] - the body of the log message
-     * - [timestamp] - the timestamp at which the event occurred
-     * - [observedTimestamp] - the timestamp at which the event was entered into the OpenTelemetry API
-     * - [context] - the context in which the log was emitted
-     * - [severityNumber] - the severity of the log
-     * - [severityText] - a string representation of the severity at the point it was captured
-     * - [attributes] - additional attributes to associate with the log
-     */
+    @Deprecated(
+        "Deprecated",
+        ReplaceWith("emit(body, eventName, timestamp, observedTimestamp, context, severityNumber, severityText, attributes)")
+    )
     public fun logEvent(
         eventName: String,
         body: String? = null,

--- a/api/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/Tracer.kt
+++ b/api/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/Tracer.kt
@@ -17,7 +17,7 @@ import io.opentelemetry.kotlin.tracing.model.SpanRelationships
 public interface Tracer {
 
     /**
-     * Creates a new span. A span must have a non-empty name, and can optionally include:
+     * Creates and starts a new span. A span must have a non-empty name, and can optionally include:
      *
      * @param parentContext - a context object containing the parent span. If this is not set
      * explicitly, the implicit context via [io.opentelemetry.kotlin.factory.ContextFactory.implicitContext] will be used.
@@ -29,6 +29,18 @@ public interface Tracer {
      * https://opentelemetry.io/docs/specs/otel/trace/api/#span
      */
     @ThreadSafe
+    public fun startSpan(
+        name: String,
+        parentContext: Context? = null,
+        spanKind: SpanKind = SpanKind.INTERNAL,
+        startTimestamp: Long? = null,
+        action: (SpanRelationships.() -> Unit)? = null
+    ): Span
+
+    @Deprecated(
+        "Deprecated.",
+        ReplaceWith("startSpan(name, parentContext, spanKind, startTimestamp, action)")
+    )
     public fun createSpan(
         name: String,
         parentContext: Context? = null,

--- a/api/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/model/TraceFlags.kt
+++ b/api/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/model/TraceFlags.kt
@@ -23,16 +23,4 @@ public interface TraceFlags {
      */
     @ThreadSafe
     public val isRandom: Boolean
-
-    /**
-     * Returns the hexadecimal representation of the trace flags as a 2-character lowercase string.
-     *
-     * Possible values:
-     * - "00" = no flags set (neither sampled nor random)
-     * - "01" = sampled only (0b000000001)
-     * - "02" = random only (0b000000010)
-     * - "03" = both sampled and random (0b000000011)
-     */
-    @ThreadSafe
-    public val hex: String
 }

--- a/benchmark-fixtures/src/commonMain/kotlin/io/opentelemetry/kotlin/benchmark/fixtures/logging/ComplexLoggingFixture.kt
+++ b/benchmark-fixtures/src/commonMain/kotlin/io/opentelemetry/kotlin/benchmark/fixtures/logging/ComplexLoggingFixture.kt
@@ -14,13 +14,13 @@ class ComplexLoggingFixture(
     private val logger: Logger = otel.loggerProvider.getLogger("logger")
 
     override fun execute() {
-        logger.log(
-            "Hello world!",
-            500,
-            1000,
-            otel.contextFactory.root(),
-            SeverityNumber.DEBUG3,
-            "debug3"
+        logger.emit(
+            body = "Hello world!",
+            timestamp = 500,
+            observedTimestamp = 1000,
+            context = otel.contextFactory.root(),
+            severityNumber = SeverityNumber.DEBUG3,
+            severityText = "debug3"
         ) {
             setStringAttribute("key", "value")
         }

--- a/benchmark-fixtures/src/commonMain/kotlin/io/opentelemetry/kotlin/benchmark/fixtures/logging/SimpleLoggingFixture.kt
+++ b/benchmark-fixtures/src/commonMain/kotlin/io/opentelemetry/kotlin/benchmark/fixtures/logging/SimpleLoggingFixture.kt
@@ -13,6 +13,6 @@ class SimpleLoggingFixture(
     private val logger: Logger = otel.loggerProvider.getLogger("logger")
 
     override fun execute() {
-        logger.log("Hello world!")
+        logger.emit("Hello world!")
     }
 }

--- a/benchmark-fixtures/src/commonMain/kotlin/io/opentelemetry/kotlin/benchmark/fixtures/tracing/AddSpanAttributeFixture.kt
+++ b/benchmark-fixtures/src/commonMain/kotlin/io/opentelemetry/kotlin/benchmark/fixtures/tracing/AddSpanAttributeFixture.kt
@@ -10,7 +10,7 @@ class AddSpanAttributeFixture(
 ) : BenchmarkFixture {
 
     private val tracer = otel.tracerProvider.getTracer("test")
-    private val span = tracer.createSpan("new_span")
+    private val span = tracer.startSpan("new_span")
 
     override fun execute() {
         span.setStringAttribute("key", "value")

--- a/benchmark-fixtures/src/commonMain/kotlin/io/opentelemetry/kotlin/benchmark/fixtures/tracing/AddSpanEventFixture.kt
+++ b/benchmark-fixtures/src/commonMain/kotlin/io/opentelemetry/kotlin/benchmark/fixtures/tracing/AddSpanEventFixture.kt
@@ -10,7 +10,7 @@ class AddSpanEventFixture(
 ) : BenchmarkFixture {
 
     private val tracer = otel.tracerProvider.getTracer("test")
-    private val span = tracer.createSpan("new_span")
+    private val span = tracer.startSpan("new_span")
 
     override fun execute() {
         span.addEvent("my_event") {

--- a/benchmark-fixtures/src/commonMain/kotlin/io/opentelemetry/kotlin/benchmark/fixtures/tracing/AddSpanLinkFixture.kt
+++ b/benchmark-fixtures/src/commonMain/kotlin/io/opentelemetry/kotlin/benchmark/fixtures/tracing/AddSpanLinkFixture.kt
@@ -11,8 +11,8 @@ class AddSpanLinkFixture(
 ) : BenchmarkFixture {
 
     private val tracer = otel.tracerProvider.getTracer("test")
-    private val other = tracer.createSpan("other")
-    private val span = tracer.createSpan("new_span")
+    private val other = tracer.startSpan("other")
+    private val span = tracer.startSpan("new_span")
 
     override fun execute() {
         span.addLink(other) {

--- a/benchmark-fixtures/src/commonMain/kotlin/io/opentelemetry/kotlin/benchmark/fixtures/tracing/ComplexSpanCreationFixture.kt
+++ b/benchmark-fixtures/src/commonMain/kotlin/io/opentelemetry/kotlin/benchmark/fixtures/tracing/ComplexSpanCreationFixture.kt
@@ -11,10 +11,10 @@ class ComplexSpanCreationFixture(
 ) : BenchmarkFixture {
 
     private val tracer = otel.tracerProvider.getTracer("test")
-    private val other = tracer.createSpan("other")
+    private val other = tracer.startSpan("other")
 
     override fun execute() {
-        tracer.createSpan(
+        tracer.startSpan(
             "new_span",
             otel.contextFactory.root(),
             SpanKind.CLIENT,

--- a/benchmark-fixtures/src/commonMain/kotlin/io/opentelemetry/kotlin/benchmark/fixtures/tracing/SpanCreationFixture.kt
+++ b/benchmark-fixtures/src/commonMain/kotlin/io/opentelemetry/kotlin/benchmark/fixtures/tracing/SpanCreationFixture.kt
@@ -12,6 +12,6 @@ class SpanCreationFixture(
     private val tracer = otel.tracerProvider.getTracer("test")
 
     override fun execute() {
-        tracer.createSpan("new_span")
+        tracer.startSpan("new_span")
     }
 }

--- a/benchmark-fixtures/src/commonMain/kotlin/io/opentelemetry/kotlin/benchmark/fixtures/tracing/SpanEndFixture.kt
+++ b/benchmark-fixtures/src/commonMain/kotlin/io/opentelemetry/kotlin/benchmark/fixtures/tracing/SpanEndFixture.kt
@@ -10,7 +10,7 @@ class SpanEndFixture(
 ) : BenchmarkFixture {
 
     private val tracer = otel.tracerProvider.getTracer("test")
-    private val span = tracer.createSpan("new_span")
+    private val span = tracer.startSpan("new_span")
 
     override fun execute() {
         span.end()

--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/logging/LoggerAdapter.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/logging/LoggerAdapter.kt
@@ -25,6 +25,10 @@ internal class LoggerAdapter(
         return true
     }
 
+    @Deprecated(
+        "Deprecated",
+        replaceWith = ReplaceWith("emit(body, null, timestamp, observedTimestamp, context, severityNumber, severityText, attributes)")
+    )
     override fun log(
         body: String?,
         timestamp: Long?,
@@ -34,8 +38,7 @@ internal class LoggerAdapter(
         severityText: String?,
         attributes: (MutableAttributeContainer.() -> Unit)?
     ) {
-        processTelemetry(
-            eventName = null,
+        emit(
             body = body,
             timestamp = timestamp,
             observedTimestamp = observedTimestamp,
@@ -46,6 +49,10 @@ internal class LoggerAdapter(
         )
     }
 
+    @Deprecated(
+        "Deprecated",
+        replaceWith = ReplaceWith("emit(body, eventName, timestamp, observedTimestamp, context, severityNumber, severityText, attributes)")
+    )
     override fun logEvent(
         eventName: String,
         body: String?,
@@ -56,9 +63,9 @@ internal class LoggerAdapter(
         severityText: String?,
         attributes: (MutableAttributeContainer.() -> Unit)?
     ) {
-        processTelemetry(
-            eventName = eventName,
+        emit(
             body = body,
+            eventName = eventName,
             timestamp = timestamp,
             observedTimestamp = observedTimestamp,
             context = context,
@@ -68,9 +75,9 @@ internal class LoggerAdapter(
         )
     }
 
-    private fun processTelemetry(
-        eventName: String?,
+    override fun emit(
         body: String?,
+        eventName: String?,
         timestamp: Long?,
         observedTimestamp: Long?,
         context: Context?,

--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/logging/OtelJavaLogRecordBuilderAdapter.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/logging/OtelJavaLogRecordBuilderAdapter.kt
@@ -75,7 +75,7 @@ internal class OtelJavaLogRecordBuilderAdapter(private val impl: Logger) :
     }
 
     override fun emit() {
-        impl.log(
+        impl.emit(
             body = body,
             timestamp = timestamp,
             observedTimestamp = observedTimestamp,

--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/tracing/OtelJavaSpanBuilderAdapter.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/tracing/OtelJavaSpanBuilderAdapter.kt
@@ -93,7 +93,7 @@ internal class OtelJavaSpanBuilderAdapter(
     }
 
     override fun startSpan(): OtelJavaSpan {
-        val span = tracer.createSpan(
+        val span = tracer.startSpan(
             name = spanName,
             spanKind = kind.toOtelKotlinSpanKind(),
             startTimestamp = start,

--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/tracing/TracerAdapter.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/tracing/TracerAdapter.kt
@@ -22,7 +22,19 @@ internal class TracerAdapter(
     private val spanLimitsConfig: CompatSpanLimitsConfig
 ) : Tracer {
 
+    @Deprecated(
+        "Deprecated.",
+        replaceWith = ReplaceWith("startSpan(name, parentContext, spanKind, startTimestamp, action)")
+    )
     override fun createSpan(
+        name: String,
+        parentContext: Context?,
+        spanKind: SpanKind,
+        startTimestamp: Long?,
+        action: (SpanRelationships.() -> Unit)?
+    ): Span = startSpan(name, parentContext, spanKind, startTimestamp, action)
+
+    override fun startSpan(
         name: String,
         parentContext: Context?,
         spanKind: SpanKind,

--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/tracing/model/TraceFlagsAdapter.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/tracing/model/TraceFlagsAdapter.kt
@@ -12,12 +12,4 @@ internal class TraceFlagsAdapter(
 
     // verify if the second bit (random flag) is set, using bitwise AND
     override val isRandom: Boolean = traceFlags.asByte().toInt() and 0b00000010 != 0
-
-    // opentelemetry-kotlin implementation of TraceFlags only exposes 00, 01, 02, 03 as valid hex values.
-    override val hex: String = when {
-        isSampled && isRandom -> "03"
-        !isSampled && isRandom -> "02"
-        isSampled && !isRandom -> "01"
-        else -> "00"
-    }
 }

--- a/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/assertions/SpanContextAssertions.kt
+++ b/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/assertions/SpanContextAssertions.kt
@@ -14,7 +14,6 @@ internal fun assertSpanContextsMatch(lhs: SpanContext, rhs: SpanContext) {
     // trace flags
     assertEquals(lhs.traceFlags.isSampled, rhs.traceFlags.isSampled)
     assertEquals(lhs.traceFlags.isRandom, rhs.traceFlags.isRandom)
-    assertEquals(lhs.traceFlags.hex, rhs.traceFlags.hex)
 
     // trace flags
     assertEquals(lhs.traceState.asMap(), rhs.traceState.asMap())

--- a/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/factory/ContextFactoryImplTest.kt
+++ b/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/factory/ContextFactoryImplTest.kt
@@ -21,7 +21,7 @@ internal class ContextFactoryImplTest {
     @Test
     fun `test store span`() {
         val tracer = createCompatOpenTelemetry().tracerProvider.getTracer("tracer")
-        val span = tracer.createSpan("span")
+        val span = tracer.startSpan("span")
         val contextFactory = factory.contextFactory
         val ctx = contextFactory.storeSpan(contextFactory.root(), span)
         val retrievedSpan = factory.spanFactory.fromContext(ctx)

--- a/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/factory/TraceFlagsFactoryTest.kt
+++ b/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/factory/TraceFlagsFactoryTest.kt
@@ -2,7 +2,6 @@ package io.opentelemetry.kotlin.factory
 
 import io.opentelemetry.kotlin.ExperimentalApi
 import org.junit.Test
-import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
@@ -17,7 +16,6 @@ internal class TraceFlagsFactoryTest {
 
         assertFalse(flags.isSampled)
         assertFalse(flags.isRandom)
-        assertEquals("00", flags.hex)
     }
 
     @Test
@@ -26,7 +24,6 @@ internal class TraceFlagsFactoryTest {
 
         assertTrue(flags.isSampled)
         assertFalse(flags.isRandom)
-        assertEquals("01", flags.hex)
     }
 
     @Test
@@ -35,7 +32,6 @@ internal class TraceFlagsFactoryTest {
 
         assertFalse(flags.isSampled)
         assertTrue(flags.isRandom)
-        assertEquals("02", flags.hex)
     }
 
     @Test
@@ -44,7 +40,6 @@ internal class TraceFlagsFactoryTest {
 
         assertTrue(flags.isSampled)
         assertTrue(flags.isRandom)
-        assertEquals("03", flags.hex)
     }
 
     @Test
@@ -53,7 +48,6 @@ internal class TraceFlagsFactoryTest {
 
         assertFalse(flags.isSampled)
         assertFalse(flags.isRandom)
-        assertEquals("00", flags.hex)
     }
 
     @Test
@@ -61,22 +55,18 @@ internal class TraceFlagsFactoryTest {
         val default = factory.fromHex("00")
         assertFalse(default.isSampled)
         assertFalse(default.isRandom)
-        assertEquals("00", default.hex)
 
         val sampled = factory.fromHex("01")
         assertTrue(sampled.isSampled)
         assertFalse(sampled.isRandom)
-        assertEquals("01", sampled.hex)
 
         val random = factory.fromHex("02")
         assertFalse(random.isSampled)
         assertTrue(random.isRandom)
-        assertEquals("02", random.hex)
 
         val both = factory.fromHex("03")
         assertTrue(both.isSampled)
         assertTrue(both.isRandom)
-        assertEquals("03", both.hex)
     }
 
     @Test
@@ -84,22 +74,18 @@ internal class TraceFlagsFactoryTest {
         val default = factory.fromHex("04")
         assertFalse(default.isSampled)
         assertFalse(default.isRandom)
-        assertEquals("00", default.hex)
 
         val sampled = factory.fromHex("05")
         assertTrue(sampled.isSampled)
         assertFalse(sampled.isRandom)
-        assertEquals("01", sampled.hex)
 
         val random = factory.fromHex("06")
         assertFalse(random.isSampled)
         assertTrue(random.isRandom)
-        assertEquals("02", random.hex)
 
         val both = factory.fromHex("07")
         assertTrue(both.isSampled)
         assertTrue(both.isRandom)
-        assertEquals("03", both.hex)
     }
 
     @Test
@@ -107,16 +93,13 @@ internal class TraceFlagsFactoryTest {
         val emptyString = factory.fromHex("")
         assertFalse(emptyString.isSampled)
         assertFalse(emptyString.isRandom)
-        assertEquals("00", emptyString.hex)
 
         val shortString = factory.fromHex("1")
         assertFalse(shortString.isSampled)
         assertFalse(shortString.isRandom)
-        assertEquals("00", shortString.hex)
 
         val invalidHex = factory.fromHex("zz")
         assertFalse(invalidHex.isSampled)
         assertFalse(invalidHex.isRandom)
-        assertEquals("00", invalidHex.hex)
     }
 }

--- a/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/logging/LogExportTest.kt
+++ b/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/logging/LogExportTest.kt
@@ -32,7 +32,7 @@ internal class LogExportTest {
     @Test
     fun `test minimal log export`() = runTest {
         // logging without a body is allowed by the OTel spec, so we assert the MVP log here
-        harness.logger.log()
+        harness.logger.emit()
 
         harness.assertLogRecords(
             expectedCount = 1,
@@ -49,7 +49,7 @@ internal class LogExportTest {
         ) {
             setStringAttribute("key1", "value1")
         }
-        logger.log(
+        logger.emit(
             body = "Hello, world!",
             timestamp = 100L,
             observedTimestamp = 50L,
@@ -77,7 +77,7 @@ internal class LogExportTest {
         }
 
         val logger = harness.kotlinApi.loggerProvider.getLogger("test_logger")
-        logger.log(body = "Test log with custom resource")
+        logger.emit(body = "Test log with custom resource")
 
         harness.assertLogRecords(
             expectedCount = 1,
@@ -98,7 +98,7 @@ internal class LogExportTest {
         val testContext = currentContext.set(contextKey, testContextValue)
 
         // Log a message with the created context
-        harness.logger.log(body = "Test log with context", context = testContext)
+        harness.logger.emit(body = "Test log with context", context = testContext)
 
         // Verify context was captured and contains expected value
         val actualValue = contextCapturingProcessor.capturedContext?.get(contextKey)
@@ -111,7 +111,7 @@ internal class LogExportTest {
             attributeCountLimit = 2
             attributeValueLengthLimit = 3
         }
-        harness.logger.log(body = "Test log limits") {
+        harness.logger.emit(body = "Test log limits") {
             setStringAttribute("key1", "max")
             setStringAttribute("key2", "over_max")
             setStringAttribute("key3", "another")
@@ -122,7 +122,7 @@ internal class LogExportTest {
     @Test
     fun `test log export with custom processor`() = runTest {
         harness.config.logRecordProcessors.add(CustomLogRecordProcessor())
-        harness.logger.log("Test")
+        harness.logger.emit("Test")
 
         harness.assertLogRecords(
             expectedCount = 1,
@@ -133,9 +133,9 @@ internal class LogExportTest {
     @Test
     fun `test event export`() = runTest {
         val logger = harness.kotlinApi.loggerProvider.getLogger("test_logger")
-        logger.logEvent(
-            eventName = "my_event_name",
+        logger.emit(
             body = "Some Event",
+            eventName = "my_event_name",
             severityNumber = SeverityNumber.WARN4
         ) {
             setStringAttribute("key1", "value1")

--- a/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/tracing/SpanExportTest.kt
+++ b/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/tracing/SpanExportTest.kt
@@ -45,7 +45,7 @@ internal class SpanExportTest {
     @Test
     fun `test minimal span export`() = runTest {
         val spanName = "my_span"
-        harness.tracer.createSpan(spanName).end()
+        harness.tracer.startSpan(spanName).end()
 
         harness.assertSpans(
             expectedCount = 1,
@@ -56,7 +56,7 @@ internal class SpanExportTest {
     @Test
     fun `test span properties export`() = runTest {
         val spanName = "my_span"
-        val span = harness.tracer.createSpan(
+        val span = harness.tracer.startSpan(
             name = spanName,
             spanKind = SpanKind.CLIENT,
             startTimestamp = 500
@@ -86,7 +86,7 @@ internal class SpanExportTest {
     @Test
     fun `test span attributes export`() = runTest {
         val spanName = "span_attrs"
-        val span = harness.tracer.createSpan(spanName)
+        val span = harness.tracer.startSpan(spanName)
         span.assertAttributes()
         span.end()
 
@@ -99,7 +99,7 @@ internal class SpanExportTest {
     @Test
     fun `test span events export`() = runTest {
         val spanName = "span_events"
-        val span = harness.tracer.createSpan(spanName).apply {
+        val span = harness.tracer.startSpan(spanName).apply {
             assertTrue(events.isEmpty())
 
             val eventName = "my_event"
@@ -124,13 +124,13 @@ internal class SpanExportTest {
     fun `test span context parent`() = runTest {
         val root = harness.kotlinApi.contextFactory.root()
 
-        val a = harness.tracer.createSpan("a", parentContext = root)
+        val a = harness.tracer.startSpan("a", parentContext = root)
         val ctxa = a.storeInContext(root)
 
-        val b = harness.tracer.createSpan("b", parentContext = ctxa)
+        val b = harness.tracer.startSpan("b", parentContext = ctxa)
         val ctxb = b.storeInContext(ctxa)
 
-        val c = harness.tracer.createSpan("c", parentContext = ctxb)
+        val c = harness.tracer.startSpan("c", parentContext = ctxb)
 
         assertSpanContextsMatch(harness.kotlinApi.spanContextFactory.invalid, a.parent)
         assertNotNull(a.spanContext)
@@ -157,7 +157,7 @@ internal class SpanExportTest {
 
     @Test
     fun `test span trace flags`() = runTest {
-        val span = harness.tracer.createSpan("my_span")
+        val span = harness.tracer.startSpan("my_span")
         val flags = span.spanContext.traceFlags
         assertEquals("01", flags.toOtelJavaTraceFlags().asHex())
         assertTrue(flags.isSampled)
@@ -174,7 +174,7 @@ internal class SpanExportTest {
         assertEquals("0000000000000000", invalidContext.spanId)
 
         // Test span creation with invalid parent
-        val span = harness.tracer.createSpan(
+        val span = harness.tracer.startSpan(
             "test_span",
             parentContext = harness.kotlinApi.contextFactory.root()
         )
@@ -189,8 +189,8 @@ internal class SpanExportTest {
 
     @Test
     fun `test span links export`() = runTest {
-        val linkedSpan = harness.tracer.createSpan("linked_span")
-        val span = harness.tracer.createSpan("span_links").apply {
+        val linkedSpan = harness.tracer.startSpan("linked_span")
+        val span = harness.tracer.startSpan("span_links").apply {
             assertTrue(events.isEmpty())
 
             addLink(linkedSpan.spanContext) {
@@ -221,7 +221,7 @@ internal class SpanExportTest {
             setLongAttribute("tracer_id", 123)
         }
 
-        val span = tracerWithSchemaUrl.createSpan("schema_url_span")
+        val span = tracerWithSchemaUrl.startSpan("schema_url_span")
         span.end()
 
         harness.assertSpans(expectedCount = 1, goldenFileName = "span_schema_url.json")
@@ -230,11 +230,11 @@ internal class SpanExportTest {
     @Test
     fun `test multiple operations`() = runTest {
         // create multiple spans, with multiple links and events
-        val linkedSpan1 = harness.tracer.createSpan("linked_span_1")
-        val linkedSpan2 = harness.tracer.createSpan("linked_span_2")
-        val linkedSpan3 = harness.tracer.createSpan("linked_span_3")
+        val linkedSpan1 = harness.tracer.startSpan("linked_span_1")
+        val linkedSpan2 = harness.tracer.startSpan("linked_span_2")
+        val linkedSpan3 = harness.tracer.startSpan("linked_span_3")
 
-        val span = harness.tracer.createSpan("multi_operations_span").apply {
+        val span = harness.tracer.startSpan("multi_operations_span").apply {
             // Add multiple events
             addEvent("event_1", 100L)
             addEvent("event_2", 200L) {
@@ -264,7 +264,7 @@ internal class SpanExportTest {
 
     @Test
     fun `test attributes edge cases`() = runTest {
-        val span = harness.tracer.createSpan("edge_case_attributes").apply {
+        val span = harness.tracer.startSpan("edge_case_attributes").apply {
             // Test empty string
             setStringAttribute("empty_string", "")
 
@@ -288,10 +288,10 @@ internal class SpanExportTest {
 
     @Test
     fun `test trace and span id validation without sanitization`() = runTest {
-        val span1 = harness.tracer.createSpan("validation_span_1")
-        val span2 = harness.tracer.createSpan("validation_span_2")
+        val span1 = harness.tracer.startSpan("validation_span_1")
+        val span2 = harness.tracer.startSpan("validation_span_2")
         val ctx = span1.storeInContext(harness.kotlinApi.contextFactory.root())
-        val span3 = harness.tracer.createSpan("validation_span_3", ctx)
+        val span3 = harness.tracer.startSpan("validation_span_3", ctx)
 
         span1.end()
         span2.end()
@@ -382,7 +382,7 @@ internal class SpanExportTest {
         }
 
         val tracer = harness.kotlinApi.tracerProvider.getTracer("test_tracer")
-        tracer.createSpan("test_span").end()
+        tracer.startSpan("test_span").end()
 
         harness.assertSpans(
             expectedCount = 1,
@@ -404,7 +404,7 @@ internal class SpanExportTest {
 
         // Create a span with the created context
         val tracer = harness.kotlinApi.tracerProvider.getTracer("test_tracer")
-        tracer.createSpan("Test span with context", parentContext = testContext).end()
+        tracer.startSpan("Test span with context", parentContext = testContext).end()
 
         // Verify context was captured and contains expected value
         val actualValue = contextCapturingProcessor.capturedContext?.get(contextKey)
@@ -420,9 +420,9 @@ internal class SpanExportTest {
             attributeCountPerLinkLimit = 1
             attributeCountPerEventLimit
         }
-        val a = harness.tracer.createSpan("a")
-        val b = harness.tracer.createSpan("b")
-        val c = harness.tracer.createSpan("span") {
+        val a = harness.tracer.startSpan("a")
+        val b = harness.tracer.startSpan("b")
+        val c = harness.tracer.startSpan("span") {
             addMultipleAttrs()
 
             addLink(a.spanContext) {
@@ -452,10 +452,10 @@ internal class SpanExportTest {
                 link
             }
         )
-        val other = harness.tracer.createSpan("other")
+        val other = harness.tracer.startSpan("other")
         link = other.spanContext
         other.end()
-        harness.tracer.createSpan("my_span").end()
+        harness.tracer.startSpan("my_span").end()
 
         harness.assertSpans(
             expectedCount = 2,

--- a/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/tracing/export/OtelJavaSpanProcessorAdapterTest.kt
+++ b/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/tracing/export/OtelJavaSpanProcessorAdapterTest.kt
@@ -34,7 +34,7 @@ internal class OtelJavaSpanProcessorAdapterTest {
     fun `span propagated correctly`() {
         with(harness) {
             val fakeTime = 5_000_000L
-            val span = tracer.createSpan(
+            val span = tracer.startSpan(
                 name = "test",
                 spanKind = SpanKind.CLIENT,
                 startTimestamp = fakeTime,
@@ -70,8 +70,8 @@ internal class OtelJavaSpanProcessorAdapterTest {
     @Test
     fun `parent context propagated correctly`() {
         with(harness) {
-            val parentSpan = tracer.createSpan("parent")
-            val childSpan = tracer.createSpan(
+            val parentSpan = tracer.startSpan("parent")
+            val childSpan = tracer.startSpan(
                 name = "name",
                 parentContext = parentSpan.storeInContext(rootContext)
             )

--- a/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/tracing/ext/TraceFlagsExtTest.kt
+++ b/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/tracing/ext/TraceFlagsExtTest.kt
@@ -12,6 +12,6 @@ internal class TraceFlagsExtTest {
     fun toOtelJavaTraceFlags() {
         val expected = FakeTraceFlags()
         val observed = expected.toOtelJavaTraceFlags()
-        assertEquals(expected.hex, observed.asHex())
+        assertEquals(expected.isSampled, observed.isSampled)
     }
 }

--- a/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/tracing/model/ReadWriteSpanAdapterTest.kt
+++ b/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/tracing/model/ReadWriteSpanAdapterTest.kt
@@ -101,7 +101,7 @@ internal class ReadWriteSpanAdapterTest {
             ),
         )
         harness.config.spanProcessors.add(processor)
-        harness.tracer.createSpan("name").end()
+        harness.tracer.startSpan("name").end()
         harness.assertSpans(
             expectedCount = 1,
             assertions = { spans ->

--- a/examples/example-app/src/commonMain/kotlin/io/opentelemetry/example/app/TelemetryExamples.kt
+++ b/examples/example-app/src/commonMain/kotlin/io/opentelemetry/example/app/TelemetryExamples.kt
@@ -53,7 +53,7 @@ suspend fun runAllExamples(platform: String) {
  * Creates a basic span with no attributes.
  */
 private fun demonstrateBasicSpan(tracer: Tracer) {
-    val span = tracer.createSpan("basic-span")
+    val span = tracer.startSpan("basic-span")
     span.end()
 }
 
@@ -61,7 +61,7 @@ private fun demonstrateBasicSpan(tracer: Tracer) {
  * Creates a complex span with attributes and events.
  */
 private fun demonstrateComplexSpan(tracer: Tracer) {
-    val span = tracer.createSpan(
+    val span = tracer.startSpan(
         name = "http-request",
         spanKind = SpanKind.CLIENT
     ) {
@@ -90,12 +90,12 @@ private fun demonstrateComplexSpan(tracer: Tracer) {
  * Creates nested spans that represent parent-child relationships.
  */
 private fun demonstrateSpanNesting(tracer: Tracer) {
-    val parentSpan = tracer.createSpan("parent-operation") {
+    val parentSpan = tracer.startSpan("parent-operation") {
         setStringAttribute("operation.type", "database-transaction")
     }
 
     // Create first child span (database query)
-    val childSpan1 = tracer.createSpan(
+    val childSpan1 = tracer.startSpan(
         name = "database-query",
         spanKind = SpanKind.INTERNAL
     ) {
@@ -106,7 +106,7 @@ private fun demonstrateSpanNesting(tracer: Tracer) {
     childSpan1.end()
 
     // Create second child span (cache lookup)
-    val childSpan2 = tracer.createSpan("cache-lookup") {
+    val childSpan2 = tracer.startSpan("cache-lookup") {
         setStringAttribute("cache.type", "redis")
     }
     childSpan2.end()
@@ -118,7 +118,7 @@ private fun demonstrateSpanNesting(tracer: Tracer) {
  * Emits a basic log.
  */
 private fun demonstrateBasicLogging(logger: Logger) {
-    logger.log("Application started successfully")
+    logger.emit("Application started successfully")
 }
 
 /**
@@ -136,7 +136,7 @@ private fun demonstrateComplexLogging(logger: Logger) {
     }
 
     // Warning log
-    logger.log(
+    logger.emit(
         body = "Request rate limit approaching threshold",
         severityNumber = SeverityNumber.WARN,
         severityText = "WARN"
@@ -146,7 +146,7 @@ private fun demonstrateComplexLogging(logger: Logger) {
     }
 
     // Error log
-    logger.log(
+    logger.emit(
         body = "Failed to connect to database",
         severityNumber = SeverityNumber.ERROR,
         severityText = "ERROR"

--- a/examples/example-app/src/composeMain/kotlin/io/opentelemetry/example/app/ui/LogScreen.kt
+++ b/examples/example-app/src/composeMain/kotlin/io/opentelemetry/example/app/ui/LogScreen.kt
@@ -119,7 +119,7 @@ fun LogScreen(otel: OpenTelemetry) {
 }
 
 private fun emitLog(otel: OpenTelemetry, form: LogFormState) {
-    otel.loggerProvider.getLogger(AppConfig.APP_NAME).log(
+    otel.loggerProvider.getLogger(AppConfig.APP_NAME).emit(
         body = form.body.ifBlank { null },
         timestamp = form.timestamp.toLongOrNull(),
         observedTimestamp = form.observedTimestamp.toLongOrNull(),

--- a/examples/example-app/src/composeMain/kotlin/io/opentelemetry/example/app/ui/SpanScreen.kt
+++ b/examples/example-app/src/composeMain/kotlin/io/opentelemetry/example/app/ui/SpanScreen.kt
@@ -179,7 +179,7 @@ fun SpanScreen(
 @ExperimentalApi
 private fun createSpan(otel: OpenTelemetry, form: SpanFormState): Pair<Span, Scope?> {
     val startTs = form.startTimestamp.toLongOrNull()
-    val span = otel.tracerProvider.getTracer(AppConfig.APP_NAME).createSpan(
+    val span = otel.tracerProvider.getTracer(AppConfig.APP_NAME).startSpan(
         name = form.name,
         spanKind = parseSpanKind(form.spanKind),
         startTimestamp = startTs,

--- a/exporters-protobuf/src/commonMain/kotlin/io/opentelemetry/kotlin/export/conversion/CommonProtobufConversion.kt
+++ b/exporters-protobuf/src/commonMain/kotlin/io/opentelemetry/kotlin/export/conversion/CommonProtobufConversion.kt
@@ -8,6 +8,7 @@ import io.opentelemetry.kotlin.resource.Resource
 import io.opentelemetry.kotlin.tracing.model.SpanContext
 import io.opentelemetry.kotlin.tracing.model.TraceFlags
 import io.opentelemetry.kotlin.tracing.model.TraceState
+import io.opentelemetry.kotlin.tracing.model.hex
 import io.opentelemetry.proto.common.v1.InstrumentationScope
 
 @OptIn(ExperimentalApi::class)
@@ -79,7 +80,6 @@ internal class DeserializedSpanContext(
 private class DeserializedTraceFlags(private val value: Int) : TraceFlags {
     override val isSampled: Boolean = (value and 0x01) != 0
     override val isRandom: Boolean = (value and 0x02) != 0
-    override val hex: String = "0${value.toString(16)}"
 }
 
 @OptIn(ExperimentalApi::class)

--- a/exporters-protobuf/src/commonTest/kotlin/io/opentelemetry/kotlin/export/conversion/CommonProtobufConversionTest.kt
+++ b/exporters-protobuf/src/commonTest/kotlin/io/opentelemetry/kotlin/export/conversion/CommonProtobufConversionTest.kt
@@ -6,7 +6,6 @@ import io.opentelemetry.kotlin.factory.hexToByteArray
 import io.opentelemetry.kotlin.resource.FakeResource
 import io.opentelemetry.kotlin.tracing.FakeTraceFlags
 import io.opentelemetry.proto.common.v1.InstrumentationScope
-import kotlin.collections.get
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -123,7 +122,7 @@ class CommonProtobufConversionTest {
 
     @Test
     fun testTraceFlagsConversion() {
-        val flags = FakeTraceFlags(isSampled = true, isRandom = false, hex = "01")
+        val flags = FakeTraceFlags(isSampled = true, isRandom = false)
         assertEquals(1, flags.toFlagsInt())
     }
 

--- a/exporters-protobuf/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/export/ExportLogsServiceRequestTest.kt
+++ b/exporters-protobuf/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/export/ExportLogsServiceRequestTest.kt
@@ -21,7 +21,7 @@ class ExportLogsServiceRequestTest {
         spanContext = FakeSpanContext(
             traceIdBytes = "12345678901234567890123456789012".hexToByteArray(),
             spanIdBytes = "1234567890123456".hexToByteArray(),
-            traceFlags = FakeTraceFlags(isSampled = true, hex = "01"),
+            traceFlags = FakeTraceFlags(isSampled = true),
             traceState = FakeTraceState(emptyMap())
         )
     )
@@ -118,7 +118,6 @@ class ExportLogsServiceRequestTest {
         assertEquals(expectedContext.spanId, actualContext.spanId)
         assertEquals(expectedContext.traceFlags.isSampled, actualContext.traceFlags.isSampled)
         assertEquals(expectedContext.traceFlags.isRandom, actualContext.traceFlags.isRandom)
-        assertEquals(expectedContext.traceFlags.hex, actualContext.traceFlags.hex)
         assertEquals(expectedContext.traceState.asMap(), actualContext.traceState.asMap())
     }
 

--- a/exporters-protobuf/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/export/ExportTraceServiceRequestCreatorTest.kt
+++ b/exporters-protobuf/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/export/ExportTraceServiceRequestCreatorTest.kt
@@ -26,7 +26,7 @@ class ExportTraceServiceRequestCreatorTest {
         parent = FakeSpanContext(
             traceIdBytes = "12345678901234567890123456789012".hexToByteArray(),
             spanIdBytes = "1234567890123456".hexToByteArray(),
-            traceFlags = FakeTraceFlags(isSampled = true, hex = "01"),
+            traceFlags = FakeTraceFlags(isSampled = true),
             traceState = FakeTraceState(mapOf("foo" to "bar"))
         ),
         spanContext = FakeSpanContext(
@@ -177,7 +177,6 @@ class ExportTraceServiceRequestCreatorTest {
         assertEquals(expectedContext.spanId, actualContext.spanId)
         assertEquals(expectedContext.traceFlags.isSampled, actualContext.traceFlags.isSampled)
         assertEquals(expectedContext.traceFlags.isRandom, actualContext.traceFlags.isRandom)
-        assertEquals(expectedContext.traceFlags.hex, actualContext.traceFlags.hex)
         assertEquals(expectedContext.traceState.asMap(), actualContext.traceState.asMap())
     }
 

--- a/implementation/build.gradle.kts
+++ b/implementation/build.gradle.kts
@@ -22,6 +22,7 @@ kotlin {
         }
         val commonTest by getting {
             dependencies {
+                implementation(project(":api-ext"))
                 implementation(project(":test-fakes"))
                 implementation(project(":integration-test"))
                 implementation(libs.kotlinx.coroutines.test)

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/LoggerImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/LoggerImpl.kt
@@ -40,6 +40,10 @@ internal class LoggerImpl(
         return processor.enabled(ctx, key, severityNumber, eventName)
     }
 
+    @Deprecated(
+        "Deprecated",
+        replaceWith = ReplaceWith("emit(body, null, timestamp, observedTimestamp, context, severityNumber, severityText, attributes)")
+    )
     override fun log(
         body: String?,
         timestamp: Long?,
@@ -49,18 +53,21 @@ internal class LoggerImpl(
         severityText: String?,
         attributes: (MutableAttributeContainer.() -> Unit)?
     ) {
-        processTelemetry(
-            context = context,
+        emit(
+            body = body,
             timestamp = timestamp,
             observedTimestamp = observedTimestamp,
-            body = body,
-            eventName = null,
-            severityText = severityText,
+            context = context,
             severityNumber = severityNumber,
+            severityText = severityText,
             attributes = attributes
         )
     }
 
+    @Deprecated(
+        "Deprecated",
+        replaceWith = ReplaceWith("emit(body, eventName, timestamp, observedTimestamp, context, severityNumber, severityText, attributes)")
+    )
     override fun logEvent(
         eventName: String,
         body: String?,
@@ -71,26 +78,26 @@ internal class LoggerImpl(
         severityText: String?,
         attributes: (MutableAttributeContainer.() -> Unit)?
     ) {
-        processTelemetry(
-            context = context,
-            timestamp = timestamp,
-            observedTimestamp = observedTimestamp,
+        emit(
             body = body,
             eventName = eventName,
-            severityText = severityText,
+            timestamp = timestamp,
+            observedTimestamp = observedTimestamp,
+            context = context,
             severityNumber = severityNumber,
+            severityText = severityText,
             attributes = attributes
         )
     }
 
-    private fun processTelemetry(
-        context: Context?,
-        timestamp: Long?,
-        observedTimestamp: Long?,
+    override fun emit(
         body: String?,
         eventName: String?,
-        severityText: String?,
+        timestamp: Long?,
+        observedTimestamp: Long?,
+        context: Context?,
         severityNumber: SeverityNumber?,
+        severityText: String?,
         attributes: (MutableAttributeContainer.() -> Unit)?
     ) {
         val ctx = context ?: contextFactory.implicitContext()
@@ -98,7 +105,6 @@ internal class LoggerImpl(
             root -> invalidSpanContext
             else -> spanFactory.fromContext(ctx).spanContext
         }
-
         val now = clock.now()
         val log = LogRecordModel(
             resource = resource,

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/TraceFlagsImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/TraceFlagsImpl.kt
@@ -7,14 +7,4 @@ import io.opentelemetry.kotlin.tracing.model.TraceFlags
 internal class TraceFlagsImpl(
     override val isSampled: Boolean,
     override val isRandom: Boolean
-) : TraceFlags {
-
-    override val hex: String by lazy {
-        when {
-            isRandom && isSampled -> "03"
-            isRandom && !isSampled -> "02"
-            !isRandom && isSampled -> "01"
-            else -> "00"
-        }
-    }
-}
+) : TraceFlags

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/TracerImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/TracerImpl.kt
@@ -34,7 +34,19 @@ internal class TracerImpl(
     private val spanFactory = sdkFactory.spanFactory
     private val tracingIdFactory = sdkFactory.tracingIdFactory
 
+    @Deprecated(
+        "Deprecated.",
+        replaceWith = ReplaceWith("startSpan(name, parentContext, spanKind, startTimestamp, action)")
+    )
     override fun createSpan(
+        name: String,
+        parentContext: Context?,
+        spanKind: SpanKind,
+        startTimestamp: Long?,
+        action: (SpanRelationships.() -> Unit)?
+    ): Span = startSpan(name, parentContext, spanKind, startTimestamp, action)
+
+    override fun startSpan(
         name: String,
         parentContext: Context?,
         spanKind: SpanKind,

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/factory/TraceFlagsFactoryImplTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/factory/TraceFlagsFactoryImplTest.kt
@@ -2,7 +2,6 @@ package io.opentelemetry.kotlin.factory
 
 import io.opentelemetry.kotlin.ExperimentalApi
 import kotlin.test.Test
-import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
@@ -17,7 +16,6 @@ internal class TraceFlagsFactoryImplTest {
 
         assertTrue(flags.isSampled)
         assertFalse(flags.isRandom)
-        assertEquals("01", flags.hex)
     }
 
     @Test
@@ -26,7 +24,6 @@ internal class TraceFlagsFactoryImplTest {
 
         assertTrue(flags.isSampled)
         assertFalse(flags.isRandom)
-        assertEquals("01", flags.hex)
     }
 
     @Test
@@ -35,7 +32,6 @@ internal class TraceFlagsFactoryImplTest {
 
         assertFalse(flags.isSampled)
         assertTrue(flags.isRandom)
-        assertEquals("02", flags.hex)
     }
 
     @Test
@@ -44,7 +40,6 @@ internal class TraceFlagsFactoryImplTest {
 
         assertTrue(flags.isSampled)
         assertTrue(flags.isRandom)
-        assertEquals("03", flags.hex)
     }
 
     @Test
@@ -53,7 +48,6 @@ internal class TraceFlagsFactoryImplTest {
 
         assertFalse(flags.isSampled)
         assertFalse(flags.isRandom)
-        assertEquals("00", flags.hex)
     }
 
     @Test
@@ -61,27 +55,22 @@ internal class TraceFlagsFactoryImplTest {
         val default = factory.fromHex("00")
         assertFalse(default.isSampled)
         assertFalse(default.isRandom)
-        assertEquals("00", default.hex)
 
         val sampled = factory.fromHex("01")
         assertTrue(sampled.isSampled)
         assertFalse(sampled.isRandom)
-        assertEquals("01", sampled.hex)
 
         val random = factory.fromHex("02")
         assertFalse(random.isSampled)
         assertTrue(random.isRandom)
-        assertEquals("02", random.hex)
 
         val both = factory.fromHex("03")
         assertTrue(both.isSampled)
         assertTrue(both.isRandom)
-        assertEquals("03", both.hex)
 
         val anotherBoth = factory.fromHex("2f") // 00101111
         assertTrue(anotherBoth.isSampled)
         assertTrue(anotherBoth.isRandom)
-        assertEquals("03", anotherBoth.hex)
     }
 
     @Test
@@ -89,16 +78,13 @@ internal class TraceFlagsFactoryImplTest {
         val emptyString = factory.fromHex("")
         assertFalse(emptyString.isSampled)
         assertFalse(emptyString.isRandom)
-        assertEquals("00", emptyString.hex)
 
         val shortString = factory.fromHex("1")
         assertFalse(shortString.isSampled)
         assertFalse(shortString.isRandom)
-        assertEquals("00", shortString.hex)
 
         val notHex = factory.fromHex("2g")
         assertFalse(notHex.isSampled)
         assertFalse(notHex.isRandom)
-        assertEquals("00", notHex.hex)
     }
 }

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/integration/test/logging/LogProcessorNaughtyExportTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/integration/test/logging/LogProcessorNaughtyExportTest.kt
@@ -28,13 +28,13 @@ internal class LogProcessorNaughtyExportTest {
         prepareConfig(processor)
         val ctx = prepareContext()
 
-        harness.logger.log(
+        harness.logger.emit(
             body = "custom_log",
             timestamp = 500,
             observedTimestamp = 600,
+            context = ctx,
             severityNumber = SeverityNumber.WARN2,
             severityText = "warn2",
-            context = ctx,
         ) {
             setStringAttribute("foo", "bar")
             setBooleanAttribute("experiment_enabled", true)
@@ -53,7 +53,7 @@ internal class LogProcessorNaughtyExportTest {
     }
 
     private fun prepareContext(): Context {
-        val span = harness.tracer.createSpan("span")
+        val span = harness.tracer.startSpan("span")
         val contextFactory = harness.kotlinApi.contextFactory
         val ctx = contextFactory.storeSpan(contextFactory.root(), span)
         return ctx

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/integration/test/logging/LogProcessorOnEmitTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/integration/test/logging/LogProcessorOnEmitTest.kt
@@ -29,14 +29,14 @@ internal class LogProcessorOnEmitTest {
         prepareConfig()
         val ctx = prepareContext()
 
-        harness.logger.logEvent(
-            eventName = "my_event",
+        harness.logger.emit(
             body = "custom_log",
+            eventName = "my_event",
             timestamp = 500,
             observedTimestamp = 600,
+            context = ctx,
             severityNumber = SeverityNumber.WARN2,
             severityText = "warn2",
-            context = ctx,
         ) {
             setStringAttribute("foo", "bar")
             setBooleanAttribute("experiment_enabled", true)
@@ -53,7 +53,7 @@ internal class LogProcessorOnEmitTest {
     }
 
     private fun prepareContext(): Context {
-        val span = harness.tracer.createSpan("span")
+        val span = harness.tracer.startSpan("span")
         val contextFactory = harness.kotlinApi.contextFactory
         val ctx = contextFactory.storeSpan(contextFactory.root(), span)
         return ctx

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/integration/test/logging/LoggerExportTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/integration/test/logging/LoggerExportTest.kt
@@ -26,7 +26,7 @@ internal class LoggerExportTest {
 
     @Test
     fun testMinimalLogExported() = runTest {
-        harness.logger.log("test") {
+        harness.logger.emit("test") {
             setStringAttribute("foo", "bar")
         }
         harness.assertLogRecords(1, "log_minimal.json")
@@ -34,7 +34,7 @@ internal class LoggerExportTest {
 
     @Test
     fun testLogWithBasicPropertiesExported() = runTest {
-        harness.logger.log(
+        harness.logger.emit(
             body = "custom_log",
             timestamp = 500,
             observedTimestamp = 600,
@@ -46,7 +46,7 @@ internal class LoggerExportTest {
 
     @Test
     fun testLogWithAttributesExported() = runTest {
-        harness.logger.log("test") {
+        harness.logger.emit("test") {
             setStringAttribute("foo", "bar")
             setBooleanAttribute("experiment_enabled", true)
         }
@@ -62,16 +62,16 @@ internal class LoggerExportTest {
         val logger = harness.loggerProvider.getLogger("test", "0.1.0", "https://example.com/bar/") {
             setStringAttribute("instrumentation_scope.foo", "bar")
         }
-        logger.log("test")
+        logger.emit("test")
         harness.assertLogRecords(1, "log_resource_scope.json")
     }
 
     @Test
     fun testLogWithParentSpanInContext() = runTest {
-        val span = harness.tracer.createSpan("span")
+        val span = harness.tracer.startSpan("span")
         val contextFactory = harness.kotlinApi.contextFactory
         val ctx = contextFactory.storeSpan(contextFactory.root(), span)
-        harness.logger.log("test", context = ctx)
+        harness.logger.emit("test", context = ctx)
         harness.assertLogRecords(1, "log_span_context.json")
     }
 
@@ -79,13 +79,13 @@ internal class LoggerExportTest {
     fun testLogWithRootContext() = runTest {
         val contextFactory = harness.kotlinApi.contextFactory
         val ctx = contextFactory.root()
-        harness.logger.log("test", context = ctx)
+        harness.logger.emit("test", context = ctx)
         harness.assertLogRecords(1, "log_root_context.json")
     }
 
     @Test
     fun testAttributeLimitsOnLogExport() = runTest {
-        harness.logger.log("test") {
+        harness.logger.emit("test") {
             repeat(logAttributeLimit + 1) {
                 setStringAttribute("key-$it", "value")
             }
@@ -98,9 +98,9 @@ internal class LoggerExportTest {
     @Test
     fun testEventExport() = runTest {
         val logger = harness.kotlinApi.loggerProvider.getLogger("test_logger")
-        logger.logEvent(
-            eventName = "my_event_name",
+        logger.emit(
             body = "Some Event",
+            eventName = "my_event_name",
             severityNumber = SeverityNumber.WARN4
         ) {
             setStringAttribute("key1", "value1")

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/integration/test/model/ReadableSpanConversionTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/integration/test/model/ReadableSpanConversionTest.kt
@@ -11,6 +11,7 @@ import io.opentelemetry.kotlin.tracing.data.FakeLinkData
 import io.opentelemetry.kotlin.tracing.data.StatusData
 import io.opentelemetry.kotlin.tracing.model.SpanContext
 import io.opentelemetry.kotlin.tracing.model.SpanKind
+import io.opentelemetry.kotlin.tracing.model.hex
 import kotlin.test.Test
 import kotlin.test.assertEquals
 

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/integration/test/model/ReadableSpanExt.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/integration/test/model/ReadableSpanExt.kt
@@ -15,6 +15,7 @@ import io.opentelemetry.kotlin.tracing.data.LinkData
 import io.opentelemetry.kotlin.tracing.data.StatusData
 import io.opentelemetry.kotlin.tracing.model.ReadableSpan
 import io.opentelemetry.kotlin.tracing.model.SpanContext
+import io.opentelemetry.kotlin.tracing.model.hex
 
 @OptIn(ExperimentalApi::class)
 internal fun ReadableSpan.toSerializable(): SerializableSpanData =

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/integration/test/tracing/SpanProcessNaughtyOnEndTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/integration/test/tracing/SpanProcessNaughtyOnEndTest.kt
@@ -32,7 +32,7 @@ internal class SpanProcessNaughtyOnEndTest {
     @Test
     fun testSpanProcessorOnEndOverrideIgnored() = runTest {
         harness.config.spanProcessors.add(NaughtySpanProcessor())
-        harness.tracer.createSpan("span") {
+        harness.tracer.startSpan("span") {
             setStringAttribute("key", "value")
             addEvent("test")
             addLink(FakeSpanContext.INVALID)

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/integration/test/tracing/SpanProcessOnEndReadTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/integration/test/tracing/SpanProcessOnEndReadTest.kt
@@ -32,7 +32,7 @@ internal class SpanProcessOnEndReadTest {
     @Test
     fun testReadPropertiesInProcessor() = runTest {
         harness.config.spanProcessors.add(OnEndSpanProcessor())
-        harness.tracer.createSpan("span") {
+        harness.tracer.startSpan("span") {
             setStringAttribute("key", "value")
             addEvent("test")
             addLink(FakeSpanContext.INVALID) {

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/integration/test/tracing/SpanProcessOnEndingReadTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/integration/test/tracing/SpanProcessOnEndingReadTest.kt
@@ -32,7 +32,7 @@ internal class SpanProcessOnEndingReadTest {
     @Test
     fun testReadPropertiesInProcessor() = runTest {
         harness.config.spanProcessors.add(OnEndingSpanProcessor())
-        harness.tracer.createSpan("span") {
+        harness.tracer.startSpan("span") {
             setStringAttribute("key", "value")
             addEvent("test")
             addLink(FakeSpanContext.INVALID) {

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/integration/test/tracing/SpanProcessOnStartOverrideTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/integration/test/tracing/SpanProcessOnStartOverrideTest.kt
@@ -32,7 +32,7 @@ internal class SpanProcessOnStartOverrideTest {
     @Test
     fun testOverridePropertiesInProcessor() = runTest {
         harness.config.spanProcessors.add(OnStartSpanProcessor())
-        harness.tracer.createSpan("span") {
+        harness.tracer.startSpan("span") {
             setStringAttribute("key", "value")
             addEvent("test")
             addLink(FakeSpanContext.INVALID)

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/integration/test/tracing/TracerExportTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/integration/test/tracing/TracerExportTest.kt
@@ -35,7 +35,7 @@ internal class TracerExportTest {
 
     @Test
     fun testMinimalSpanExport() = runTest {
-        val span = harness.tracer.createSpan("test") {
+        val span = harness.tracer.startSpan("test") {
             setStringAttribute("foo", "bar")
         }
         span.end()
@@ -44,7 +44,7 @@ internal class TracerExportTest {
 
     @Test
     fun testBasicPropertiesExport() = runTest {
-        harness.tracer.createSpan(
+        harness.tracer.startSpan(
             name = "custom_span",
             spanKind = SpanKind.PRODUCER,
             startTimestamp = 500
@@ -57,7 +57,7 @@ internal class TracerExportTest {
 
     @Test
     fun testAttributesExport() = runTest {
-        val span = harness.tracer.createSpan("test") {
+        val span = harness.tracer.startSpan("test") {
             setStringAttribute("foo", "bar")
             setBooleanAttribute("experiment_enabled", true)
         }
@@ -67,7 +67,7 @@ internal class TracerExportTest {
 
     @Test
     fun testAttributesAfterCreationExport() = runTest {
-        val span = harness.tracer.createSpan("test")
+        val span = harness.tracer.startSpan("test")
         span.apply {
             setStringAttribute("foo", "bar")
             setBooleanAttribute("experiment_enabled", true)
@@ -78,7 +78,7 @@ internal class TracerExportTest {
 
     @Test
     fun testSpanEventExport() = runTest {
-        harness.tracer.createSpan("test") {
+        harness.tracer.startSpan("test") {
             addEvent("my_event", 500) {
                 setStringAttribute("foo", "bar")
             }
@@ -88,7 +88,7 @@ internal class TracerExportTest {
 
     @Test
     fun testSpanEventAfterCreationExport() = runTest {
-        harness.tracer.createSpan("test").apply {
+        harness.tracer.startSpan("test").apply {
             addEvent("my_event", 500) {
                 setStringAttribute("foo", "bar")
             }
@@ -101,8 +101,8 @@ internal class TracerExportTest {
     fun testSpanLinkExport() = runTest {
         val linkName = "link"
         val otherName = "other"
-        val link = harness.tracer.createSpan(linkName)
-        val other = harness.tracer.createSpan(otherName) {
+        val link = harness.tracer.startSpan(linkName)
+        val other = harness.tracer.startSpan(otherName) {
             addLink(link.spanContext) {
                 setStringAttribute("foo", "bar")
             }
@@ -124,8 +124,8 @@ internal class TracerExportTest {
     fun testSpanLinkAfterCreationExport() = runTest {
         val linkName = "link"
         val otherName = "other"
-        val link = harness.tracer.createSpan(linkName)
-        val other = harness.tracer.createSpan(otherName)
+        val link = harness.tracer.startSpan(linkName)
+        val other = harness.tracer.startSpan(otherName)
         other.addLink(link.spanContext) {
             setStringAttribute("foo", "bar")
         }
@@ -146,10 +146,10 @@ internal class TracerExportTest {
     fun testSpanWithParentExport() = runTest {
         val parentName = "parent"
         val childName = "child"
-        val parentSpan = harness.tracer.createSpan(parentName)
+        val parentSpan = harness.tracer.startSpan(parentName)
         val contextFactory = harness.kotlinApi.contextFactory
         val parentCtx = contextFactory.storeSpan(contextFactory.root(), parentSpan)
-        val childSpan = harness.tracer.createSpan(childName, parentContext = parentCtx)
+        val childSpan = harness.tracer.startSpan(childName, parentContext = parentCtx)
         parentSpan.end()
         childSpan.end()
 
@@ -167,7 +167,7 @@ internal class TracerExportTest {
 
     @Test
     fun testSpanLimitExport() = runTest {
-        harness.tracer.createSpan("test") {
+        harness.tracer.startSpan("test") {
             repeat(spanAttributeLimit + 1) {
                 setStringAttribute("key-$it", "value")
             }
@@ -179,7 +179,7 @@ internal class TracerExportTest {
                 }
             }
             repeat(linkLimit + 1) {
-                val linkedSpan = harness.tracer.createSpan("linkedSpan")
+                val linkedSpan = harness.tracer.startSpan("linkedSpan")
                 addLink(linkedSpan.spanContext) {
                     repeat(spanAttributeLimit + 1) {
                         setStringAttribute("key-$it", "value")

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/LogAttributesTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/LogAttributesTest.kt
@@ -49,7 +49,7 @@ internal class LogAttributesTest {
 
     @Test
     fun testDefaultLogAttributes() {
-        logger.log("test")
+        logger.emit(eventName = "test")
         val log = processor.logs.single()
         assertTrue(log.attributes.isEmpty())
 
@@ -59,7 +59,7 @@ internal class LogAttributesTest {
 
     @Test
     fun testAddAttributesDuringLogCreation() {
-        logger.log("test") {
+        logger.emit(eventName = "test") {
             addTestAttributes()
         }
         val log = processor.logs.single()
@@ -68,7 +68,7 @@ internal class LogAttributesTest {
 
     @Test
     fun testAddAttributesAfterLogCreation() {
-        logger.log("test")
+        logger.emit(eventName = "test")
         val log = processor.logs.single()
         log.addTestAttributes()
         assertEquals(expected, log.attributes)
@@ -76,7 +76,7 @@ internal class LogAttributesTest {
 
     @Test
     fun testAttributesLimitNotExceeded() {
-        logger.log("test") {
+        logger.emit(eventName = "test") {
             addTestAttributesAlternateValues()
             addTestAttributes()
             addTestAttributes("xyz")
@@ -87,7 +87,7 @@ internal class LogAttributesTest {
 
     @Test
     fun testAttributesLimitNotExceeded2() {
-        logger.log("test")
+        logger.emit(eventName = "test")
         val log = processor.logs.single()
         log.addTestAttributesAlternateValues()
         log.addTestAttributes()

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/LogContextTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/LogContextTest.kt
@@ -51,7 +51,7 @@ internal class LogContextTest {
 
     @Test
     fun testDefaultContext() {
-        logger.log()
+        logger.emit()
         val log = processor.logs.single()
         val root = sdkFactory.spanFactory.fromContext(sdkFactory.contextFactory.root()).spanContext
         assertSame(root, log.spanContext)
@@ -59,9 +59,9 @@ internal class LogContextTest {
 
     @Test
     fun testOverrideContext() {
-        val span = tracer.createSpan("span")
+        val span = tracer.startSpan("span")
         val ctx = sdkFactory.contextFactory.storeSpan(sdkFactory.contextFactory.root(), span)
-        logger.log(context = ctx)
+        logger.emit(context = ctx)
 
         val log = processor.logs.single()
         assertSame(span.spanContext, log.spanContext)
@@ -69,13 +69,13 @@ internal class LogContextTest {
 
     @Test
     fun testImplicitContext() {
-        val span = tracer.createSpan("span")
+        val span = tracer.startSpan("span")
         val ctx = sdkFactory.contextFactory.storeSpan(sdkFactory.contextFactory.root(), span)
         val scope = ctx.attach()
-        logger.log()
+        logger.emit()
 
         scope.detach()
-        logger.log()
+        logger.emit()
 
         assertEquals(2, processor.logs.size)
         assertSame(span.spanContext, processor.logs[0].spanContext)

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/LogMetaPropertiesTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/LogMetaPropertiesTest.kt
@@ -36,14 +36,14 @@ internal class LogMetaPropertiesTest {
 
     @Test
     fun testLogInstrumentationScope() {
-        logger.log()
+        logger.emit()
         val log = processor.logs.single()
         assertSame(key, log.instrumentationScopeInfo)
     }
 
     @Test
     fun testLogResource() {
-        logger.log()
+        logger.emit()
         val log = processor.logs.single()
         assertSame(fakeResource, log.resource)
     }

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/LogSimplePropertiesTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/LogSimplePropertiesTest.kt
@@ -42,7 +42,7 @@ internal class LogSimplePropertiesTest {
     fun testMinimalLog() {
         val now = 5L
         clock.time = now
-        logger.log()
+        logger.emit()
 
         val log = processor.logs.single()
         assertNull(log.body)
@@ -56,7 +56,7 @@ internal class LogSimplePropertiesTest {
     fun testLogProperties() {
         val body = "Hello, World!"
         val severityText = "INFO"
-        logger.log(
+        logger.emit(
             body = body,
             timestamp = 2,
             observedTimestamp = 3,

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/SpanAttributesTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/SpanAttributesTest.kt
@@ -53,7 +53,7 @@ internal class SpanAttributesTest {
 
     @Test
     fun testSpanDefaultAttributes() {
-        val span = tracer.createSpan("test")
+        val span = tracer.startSpan("test")
         assertTrue(span.attributes.isEmpty())
 
         // ensure returned values is immutable, and not the underlying implementation
@@ -62,7 +62,7 @@ internal class SpanAttributesTest {
 
     @Test
     fun testSpanAddAttributesDuringCreation() {
-        val span = tracer.createSpan("test") {
+        val span = tracer.startSpan("test") {
             addTestAttributes()
         }
         assertEquals(expected, span.attributes)
@@ -70,14 +70,14 @@ internal class SpanAttributesTest {
 
     @Test
     fun testSpanAddAttributesAfterCreation() {
-        val span = tracer.createSpan("test")
+        val span = tracer.startSpan("test")
         span.addTestAttributes()
         assertEquals(expected, span.attributes)
     }
 
     @Test
     fun testSpanAddAttributesAfterEnd() {
-        val span = tracer.createSpan("test")
+        val span = tracer.startSpan("test")
         span.addTestAttributes()
         assertEquals(expected, span.attributes)
         span.end()
@@ -87,7 +87,7 @@ internal class SpanAttributesTest {
 
     @Test
     fun testAttributesLimitNotExceeded() {
-        val span = tracer.createSpan("test", action = {
+        val span = tracer.startSpan("test", action = {
             addTestAttributesAlternateValues()
             addTestAttributes("xyz")
             addTestAttributes()
@@ -100,7 +100,7 @@ internal class SpanAttributesTest {
 
     @Test
     fun testAttributesLimitNotExceeded2() {
-        val span = tracer.createSpan("test").apply {
+        val span = tracer.startSpan("test").apply {
             addTestAttributesAlternateValues()
             addTestAttributes("xyz")
             addTestAttributes()

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/SpanDataTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/SpanDataTest.kt
@@ -56,7 +56,7 @@ internal class SpanDataTest {
     }
 
     private fun simulateSpan(): Span {
-        return tracer.createSpan(
+        return tracer.startSpan(
             name = "test",
             startTimestamp = 5,
             spanKind = SpanKind.CLIENT,

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/SpanEndTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/SpanEndTest.kt
@@ -40,7 +40,7 @@ internal class SpanEndTest {
     @Test
     fun testSpanEndWithExplicitTimestamp() {
         val timestamp = 100L
-        val span = tracer.createSpan("test")
+        val span = tracer.startSpan("test")
         span.end(timestamp)
         assertSpanTimestamp(timestamp)
     }
@@ -49,14 +49,14 @@ internal class SpanEndTest {
     fun testSpanEndWithImplicitTimestamp() {
         val timestamp = 50L
         clock.time = timestamp
-        val span = tracer.createSpan("test")
+        val span = tracer.startSpan("test")
         span.end()
         assertSpanTimestamp(timestamp)
     }
 
     @Test
     fun testSpanIsRecording() {
-        val span = tracer.createSpan("test")
+        val span = tracer.startSpan("test")
         assertTrue(span.isRecording())
         span.end()
         assertFalse(span.isRecording())
@@ -64,7 +64,7 @@ internal class SpanEndTest {
 
     @Test
     fun testMultipleEndCalls() {
-        val span = tracer.createSpan("test")
+        val span = tracer.startSpan("test")
         assertTrue(span.isRecording())
 
         val timestamp = 100L
@@ -95,7 +95,7 @@ internal class SpanEndTest {
             assertTrue(rSpan.hasEnded)
         }
 
-        val span = tracer.createSpan("test")
+        val span = tracer.startSpan("test")
         assertFalse(span.isRecording())
         span.end()
         assertFalse(span.isRecording())

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/SpanEventTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/SpanEventTest.kt
@@ -46,7 +46,7 @@ internal class SpanEventTest {
     @Test
     fun testSpanEvent() {
         clock.time = 2
-        tracer.createSpan("test").apply {
+        tracer.startSpan("test").apply {
             addEvent("event")
             addEvent("event2", 5)
             addEvent("event3", 10) {
@@ -63,7 +63,7 @@ internal class SpanEventTest {
 
     @Test
     fun testTwoEventsWithSameKey() {
-        tracer.createSpan("test").apply {
+        tracer.startSpan("test").apply {
             addEvent("event")
             addEvent("event")
             end()
@@ -75,7 +75,7 @@ internal class SpanEventTest {
 
     @Test
     fun testSpanEventAfterEnd() {
-        tracer.createSpan("test").apply {
+        tracer.startSpan("test").apply {
             end()
             addEvent("event")
         }
@@ -85,7 +85,7 @@ internal class SpanEventTest {
     @Test
     fun testSpanEventDuringCreation() {
         clock.time = 2
-        tracer.createSpan("test", action = {
+        tracer.startSpan("test", action = {
             addEvent("event")
             addEvent("event2", 5)
             addEvent("event3", 10) {
@@ -103,7 +103,7 @@ internal class SpanEventTest {
 
     @Test
     fun testEventsLimitNotExceeded() {
-        tracer.createSpan("test", action = {
+        tracer.startSpan("test", action = {
             repeat(eventLimit + 1) {
                 addEvent("event")
             }
@@ -116,7 +116,7 @@ internal class SpanEventTest {
 
     @Test
     fun testEventsLimitNotExceeded2() {
-        tracer.createSpan("test").apply {
+        tracer.startSpan("test").apply {
             repeat(eventLimit + 1) {
                 addEvent("event")
             }
@@ -128,7 +128,7 @@ internal class SpanEventTest {
 
     @Test
     fun testSpanEventAttributesLimit() {
-        val span = tracer.createSpan("test", action = {
+        val span = tracer.startSpan("test", action = {
             addEvent("event") {
                 repeat(fakeSpanLimitsConfig.attributeCountLimit + 1) {
                     setStringAttribute("foo$it", "bar")
@@ -141,7 +141,7 @@ internal class SpanEventTest {
 
     @Test
     fun testSpanEventAttributesLimit2() {
-        val span = tracer.createSpan("test").apply {
+        val span = tracer.startSpan("test").apply {
             addEvent("event", attributes = {
                 repeat(fakeSpanLimitsConfig.attributeCountLimit + 1) {
                     setStringAttribute("foo$it", "bar")

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/SpanLinkTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/SpanLinkTest.kt
@@ -50,7 +50,7 @@ internal class SpanLinkTest {
 
     @Test
     fun testSpanLink() {
-        tracer.createSpan("test").apply {
+        tracer.startSpan("test").apply {
             addLink(fakeSpanContext)
             addLink(otherFakeSpanContext) {
                 setStringAttribute("foo", "bar")
@@ -65,7 +65,7 @@ internal class SpanLinkTest {
 
     @Test
     fun testTwoSpanLinksWithSameKey() {
-        tracer.createSpan("test").apply {
+        tracer.startSpan("test").apply {
             addLink(fakeSpanContext)
             addLink(fakeSpanContext)
             end()
@@ -76,7 +76,7 @@ internal class SpanLinkTest {
 
     @Test
     fun testSpanLinkAfterEnd() {
-        tracer.createSpan("test").apply {
+        tracer.startSpan("test").apply {
             end()
             addLink(fakeSpanContext)
         }
@@ -85,7 +85,7 @@ internal class SpanLinkTest {
 
     @Test
     fun testSpanLinkDuringCreation() {
-        tracer.createSpan("test", action = {
+        tracer.startSpan("test", action = {
             addLink(fakeSpanContext)
             addLink(otherFakeSpanContext) {
                 setStringAttribute("foo", "bar")
@@ -101,7 +101,7 @@ internal class SpanLinkTest {
 
     @Test
     fun testLinksLimitNotExceeded() {
-        tracer.createSpan("test", action = {
+        tracer.startSpan("test", action = {
             repeat(linkLimit + 1) {
                 addLink(
                     FakeSpanContext(
@@ -119,7 +119,7 @@ internal class SpanLinkTest {
 
     @Test
     fun testLinksLimitNotExceeded2() {
-        tracer.createSpan("test").apply {
+        tracer.startSpan("test").apply {
             repeat(linkLimit + 1) {
                 addLink(
                     FakeSpanContext(
@@ -136,7 +136,7 @@ internal class SpanLinkTest {
 
     @Test
     fun testSpanLinkAttributesLimit() {
-        val span = tracer.createSpan("test", action = {
+        val span = tracer.startSpan("test", action = {
             addLink(FakeSpanContext()) {
                 repeat(fakeSpanLimitsConfig.attributeCountLimit + 1) {
                     setStringAttribute("foo$it", "bar")
@@ -149,7 +149,7 @@ internal class SpanLinkTest {
 
     @Test
     fun testSpanLinkAttributesLimit2() {
-        val span = tracer.createSpan("test").apply {
+        val span = tracer.startSpan("test").apply {
             addLink(FakeSpanContext(), attributes = {
                 repeat(fakeSpanLimitsConfig.attributeCountLimit + 1) {
                     setStringAttribute("foo$it", "bar")

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/SpanMetaPropertiesTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/SpanMetaPropertiesTest.kt
@@ -35,14 +35,14 @@ internal class SpanMetaPropertiesTest {
 
     @Test
     fun testSpanInstrumentationScope() {
-        tracer.createSpan("test").end()
+        tracer.startSpan("test").end()
         val scope = processor.endCalls.single().instrumentationScopeInfo
         assertSame(key, scope)
     }
 
     @Test
     fun testSpanResource() {
-        tracer.createSpan("test").end()
+        tracer.startSpan("test").end()
         val resource = processor.endCalls.single().resource
         assertSame(fakeResource, resource)
     }

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/SpanSimplePropertiesTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/SpanSimplePropertiesTest.kt
@@ -35,13 +35,13 @@ internal class SpanSimplePropertiesTest {
     @Test
     fun testSpanName() {
         val name = "test"
-        val span = tracer.createSpan(name)
+        val span = tracer.startSpan(name)
         assertEquals(name, span.name)
     }
 
     @Test
     fun testSpanNameOverride() {
-        val span = tracer.createSpan("test")
+        val span = tracer.startSpan("test")
         val override = "another"
         span.name = override
         assertEquals(override, span.name)
@@ -50,7 +50,7 @@ internal class SpanSimplePropertiesTest {
     @Test
     fun testSpanNameAfterEnd() {
         val name = "test"
-        val span = tracer.createSpan(name)
+        val span = tracer.startSpan(name)
         span.end()
         span.name = "another"
         assertEquals(name, span.name)
@@ -58,20 +58,20 @@ internal class SpanSimplePropertiesTest {
 
     @Test
     fun testSpanStatus() {
-        val span = tracer.createSpan("test")
+        val span = tracer.startSpan("test")
         assertEquals(StatusData.Unset, span.status)
     }
 
     @Test
     fun testSpanStatusOverride() {
-        val span = tracer.createSpan("test")
+        val span = tracer.startSpan("test")
         span.status = StatusData.Ok
         assertEquals(StatusData.Ok, span.status)
     }
 
     @Test
     fun testSpanStatusAfterEnd() {
-        val span = tracer.createSpan("test")
+        val span = tracer.startSpan("test")
         span.end()
         span.status = StatusData.Ok
         assertEquals(StatusData.Unset, span.status)
@@ -79,27 +79,27 @@ internal class SpanSimplePropertiesTest {
 
     @Test
     fun testSpanKind() {
-        val span = tracer.createSpan("test")
+        val span = tracer.startSpan("test")
         assertEquals(SpanKind.INTERNAL, span.spanKind)
     }
 
     @Test
     fun testSpanKindOverride() {
-        val span = tracer.createSpan("test", spanKind = SpanKind.CLIENT)
+        val span = tracer.startSpan("test", spanKind = SpanKind.CLIENT)
         assertEquals(SpanKind.CLIENT, span.spanKind)
     }
 
     @Test
     fun testSpanStartTimestamp() {
         clock.time = 5
-        val span = tracer.createSpan("test")
+        val span = tracer.startSpan("test")
         assertEquals(clock.time, span.startTimestamp)
     }
 
     @Test
     fun testSpanStartTimestampExplicit() {
         val now = 9L
-        val span = tracer.createSpan("test", startTimestamp = now)
+        val span = tracer.startSpan("test", startTimestamp = now)
         assertEquals(now, span.startTimestamp)
     }
 }

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/TraceFlagsImplTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/TraceFlagsImplTest.kt
@@ -3,7 +3,6 @@ package io.opentelemetry.kotlin.tracing
 import io.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.kotlin.factory.TraceFlagsFactoryImpl
 import kotlin.test.Test
-import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
@@ -18,7 +17,6 @@ internal class TraceFlagsImplTest {
 
         assertFalse(flags.isSampled)
         assertFalse(flags.isRandom)
-        assertEquals("00", flags.hex)
     }
 
     @Test
@@ -27,7 +25,6 @@ internal class TraceFlagsImplTest {
 
         assertFalse(flags.isSampled)
         assertFalse(flags.isRandom)
-        assertEquals("00", flags.hex)
     }
 
     @Test
@@ -35,21 +32,17 @@ internal class TraceFlagsImplTest {
         val default = factory.fromHex("00")
         assertFalse(default.isRandom)
         assertFalse(default.isSampled)
-        assertEquals("00", default.hex)
 
         val sampled = factory.fromHex("01")
         assertFalse(sampled.isRandom)
         assertTrue(sampled.isSampled)
-        assertEquals("01", sampled.hex)
 
         val random = factory.fromHex("02")
         assertTrue(random.isRandom)
         assertFalse(random.isSampled)
-        assertEquals("02", random.hex)
 
         val sampledAndRandom = factory.fromHex("03")
         assertTrue(sampledAndRandom.isRandom)
         assertTrue(sampledAndRandom.isSampled)
-        assertEquals("03", sampledAndRandom.hex)
     }
 }

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/TracerSpanContextTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/TracerSpanContextTest.kt
@@ -43,7 +43,7 @@ internal class TracerSpanContextTest {
 
     @Test
     fun testNoExplicitParentContext() {
-        val span = tracer.createSpan("test")
+        val span = tracer.startSpan("test")
         assertFalse(span.parent.isValid)
         val spanContext = span.spanContext
         assertValidSpanContext(spanContext)
@@ -54,7 +54,7 @@ internal class TracerSpanContextTest {
         val invalidSpan = sdkFactory.spanFactory.invalid
         assertFalse(invalidSpan.spanContext.isValid)
         val parentCtx = sdkFactory.contextFactory.storeSpan(sdkFactory.contextFactory.root(), invalidSpan)
-        val span = tracer.createSpan("test", parentContext = parentCtx)
+        val span = tracer.startSpan("test", parentContext = parentCtx)
 
         assertFalse(span.parent.isValid)
         val spanContext = span.spanContext
@@ -63,9 +63,9 @@ internal class TracerSpanContextTest {
 
     @Test
     fun testExplicitParentContextOfValidSpan() {
-        val parentSpan = tracer.createSpan("parent")
+        val parentSpan = tracer.startSpan("parent")
         val parentCtx = sdkFactory.contextFactory.storeSpan(sdkFactory.contextFactory.root(), parentSpan)
-        val span = tracer.createSpan("test", parentContext = parentCtx)
+        val span = tracer.startSpan("test", parentContext = parentCtx)
 
         assertTrue(span.parent.isValid)
         val spanContext = span.spanContext
@@ -76,16 +76,16 @@ internal class TracerSpanContextTest {
 
     @Test
     fun testImplicitContext() {
-        val span = tracer.createSpan("span")
+        val span = tracer.startSpan("span")
         val ctx = sdkFactory.contextFactory.storeSpan(sdkFactory.contextFactory.root(), span)
         val scope = ctx.attach()
 
-        val first = tracer.createSpan("first")
+        val first = tracer.startSpan("first")
         first.end()
 
         scope.detach()
 
-        val second = tracer.createSpan("second")
+        val second = tracer.startSpan("second")
         second.end()
 
         assertSame(span.spanContext, first.parent)
@@ -98,6 +98,7 @@ internal class TracerSpanContextTest {
         assertNotEquals(sdkFactory.tracingIdFactory.invalidTraceId.toHexString(), spanContext.traceId)
         assertNotEquals(sdkFactory.tracingIdFactory.invalidSpanId.toHexString(), spanContext.spanId)
         assertEquals(emptyMap(), spanContext.traceState.asMap())
-        assertEquals("01", spanContext.traceFlags.hex)
+        assertTrue(spanContext.traceFlags.isSampled)
+        assertFalse(spanContext.traceFlags.isRandom)
     }
 }

--- a/integration-test/build.gradle.kts
+++ b/integration-test/build.gradle.kts
@@ -9,6 +9,7 @@ kotlin {
     sourceSets {
         val commonMain by getting {
             dependencies {
+                implementation(project(":api-ext"))
                 implementation(project(":sdk"))
                 implementation(project(":test-fakes"))
                 implementation(project(":semconv"))

--- a/integration-test/src/commonMain/kotlin/io/opentelemetry/kotlin/framework/serialization/conversion/SerializableSpanContext.kt
+++ b/integration-test/src/commonMain/kotlin/io/opentelemetry/kotlin/framework/serialization/conversion/SerializableSpanContext.kt
@@ -3,6 +3,7 @@ package io.opentelemetry.kotlin.framework.serialization.conversion
 import io.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.kotlin.framework.serialization.SerializableSpanContext
 import io.opentelemetry.kotlin.tracing.model.SpanContext
+import io.opentelemetry.kotlin.tracing.model.hex
 
 @OptIn(ExperimentalApi::class)
 fun SpanContext.toSerializable() =

--- a/integration-test/src/commonTest/kotlin/io/opentelemetry/kotlin/framework/serialization/SerializableLogRecordDataTest.kt
+++ b/integration-test/src/commonTest/kotlin/io/opentelemetry/kotlin/framework/serialization/SerializableLogRecordDataTest.kt
@@ -6,6 +6,7 @@ import io.opentelemetry.kotlin.framework.serialization.conversion.toSerializable
 import io.opentelemetry.kotlin.logging.model.FakeReadableLogRecord
 import io.opentelemetry.kotlin.resource.Resource
 import io.opentelemetry.kotlin.tracing.model.SpanContext
+import io.opentelemetry.kotlin.tracing.model.hex
 import kotlin.test.Test
 import kotlin.test.assertEquals
 

--- a/integration-test/src/commonTest/kotlin/io/opentelemetry/kotlin/framework/serialization/SerializableSpanDataTest.kt
+++ b/integration-test/src/commonTest/kotlin/io/opentelemetry/kotlin/framework/serialization/SerializableSpanDataTest.kt
@@ -8,6 +8,7 @@ import io.opentelemetry.kotlin.tracing.data.FakeSpanData
 import io.opentelemetry.kotlin.tracing.data.LinkData
 import io.opentelemetry.kotlin.tracing.data.StatusData
 import io.opentelemetry.kotlin.tracing.model.SpanContext
+import io.opentelemetry.kotlin.tracing.model.hex
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue

--- a/noop/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/NoopLogger.kt
+++ b/noop/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/NoopLogger.kt
@@ -13,6 +13,22 @@ internal object NoopLogger : Logger {
         eventName: String?,
     ): Boolean = false
 
+    override fun emit(
+        body: String?,
+        eventName: String?,
+        timestamp: Long?,
+        observedTimestamp: Long?,
+        context: Context?,
+        severityNumber: SeverityNumber?,
+        severityText: String?,
+        attributes: (MutableAttributeContainer.() -> Unit)?
+    ) {
+    }
+
+    @Deprecated(
+        "Deprecated",
+        replaceWith = ReplaceWith("emit(body, null, timestamp, observedTimestamp, context, severityNumber, severityText, attributes)")
+    )
     override fun log(
         body: String?,
         timestamp: Long?,
@@ -24,6 +40,10 @@ internal object NoopLogger : Logger {
     ) {
     }
 
+    @Deprecated(
+        "Deprecated",
+        replaceWith = ReplaceWith("emit(body, eventName, timestamp, observedTimestamp, context, severityNumber, severityText, attributes)")
+    )
     override fun logEvent(
         eventName: String,
         body: String?,

--- a/noop/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/NoopTraceFlags.kt
+++ b/noop/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/NoopTraceFlags.kt
@@ -7,5 +7,4 @@ import io.opentelemetry.kotlin.tracing.model.TraceFlags
 internal object NoopTraceFlags : TraceFlags {
     override val isSampled: Boolean = false
     override val isRandom: Boolean = false
-    override val hex: String = "00"
 }

--- a/noop/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/NoopTracer.kt
+++ b/noop/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/NoopTracer.kt
@@ -8,6 +8,18 @@ import io.opentelemetry.kotlin.tracing.model.SpanRelationships
 
 @ExperimentalApi
 internal object NoopTracer : Tracer {
+    override fun startSpan(
+        name: String,
+        parentContext: Context?,
+        spanKind: SpanKind,
+        startTimestamp: Long?,
+        action: (SpanRelationships.() -> Unit)?
+    ): Span = NoopSpan
+
+    @Deprecated(
+        "Deprecated.",
+        replaceWith = ReplaceWith("startSpan(name, parentContext, spanKind, startTimestamp, action)")
+    )
     override fun createSpan(
         name: String,
         parentContext: Context?,

--- a/noop/src/commonTest/kotlin/io/opentelemetry/kotlin/NoopTests.kt
+++ b/noop/src/commonTest/kotlin/io/opentelemetry/kotlin/NoopTests.kt
@@ -25,8 +25,8 @@ internal class NoopTests {
         val tracer = tracerProvider.getTracer("test-tracer")
 
         // All created spans are the same noop instance
-        val span = tracer.createSpan("span")
-        val anotherSpan = tracer.createSpan("span2", spanKind = SpanKind.CLIENT)
+        val span = tracer.startSpan("span")
+        val anotherSpan = tracer.startSpan("span2", spanKind = SpanKind.CLIENT)
         assertSame(span, anotherSpan)
         assertTrue(span is NoopSpan)
 
@@ -47,7 +47,6 @@ internal class NoopTests {
         val traceFlags = context.traceFlags
         assertFalse(traceFlags.isSampled)
         assertFalse(traceFlags.isRandom)
-        assertEquals("00", traceFlags.hex)
 
         // Test trace state default values
         val traceState = context.traceState
@@ -65,11 +64,10 @@ internal class NoopTests {
         val logger = loggerProvider.getLogger("test-logger")
 
         // Logging does nothing
-        logger.log(
+        logger.emit(
             body = "Complex message",
             timestamp = 1000000L,
             observedTimestamp = 2000000L,
-            context = null,
             severityNumber = SeverityNumber.ERROR,
             severityText = "ERROR"
         ) {
@@ -93,12 +91,11 @@ internal class NoopTests {
         val logger = loggerProvider.getLogger("test-logger")
 
         // Logging does nothing
-        logger.logEvent(
-            eventName = "my_event",
+        logger.emit(
             body = "Complex message",
+            eventName = "my_event",
             timestamp = 1000000L,
             observedTimestamp = 2000000L,
-            context = null,
             severityNumber = SeverityNumber.ERROR,
             severityText = "ERROR"
         ) {
@@ -167,7 +164,7 @@ internal class NoopTests {
     @Test
     fun testStoreSpan() {
         val otel = NoopOpenTelemetry
-        val span = otel.tracerProvider.getTracer("tracer").createSpan("span")
+        val span = otel.tracerProvider.getTracer("tracer").startSpan("span")
         val ctx = otel.contextFactory.storeSpan(otel.contextFactory.root(), span)
         assertTrue(ctx is NoopContext)
     }

--- a/smoke-test/src/commonTest/kotlin/io/opentelemetry/kotlin/smoketest/OpenTelemetryNoopSmokeTest.kt
+++ b/smoke-test/src/commonTest/kotlin/io/opentelemetry/kotlin/smoketest/OpenTelemetryNoopSmokeTest.kt
@@ -31,11 +31,11 @@ class OpenTelemetryNoopSmokeTest {
     @Test
     fun exportsSpansAndLogs() = runTest {
         val tracer = otel.tracerProvider.getTracer("test-tracer")
-        val span = tracer.createSpan("test-span")
+        val span = tracer.startSpan("test-span")
         span.end()
 
         val logger = otel.loggerProvider.getLogger("test-logger")
-        logger.log(body = "test-log")
+        logger.emit(body = "test-log")
 
         // assert nothing sent after 1s
         delay(1.seconds)

--- a/smoke-test/src/commonTest/kotlin/io/opentelemetry/kotlin/smoketest/OpenTelemetrySmokeTest.kt
+++ b/smoke-test/src/commonTest/kotlin/io/opentelemetry/kotlin/smoketest/OpenTelemetrySmokeTest.kt
@@ -55,12 +55,12 @@ class OpenTelemetrySmokeTest {
     fun exportsSpansAndLogs() = runTest {
         val spanName = "test-span"
         val tracer = otel.tracerProvider.getTracer("test-tracer")
-        val span = tracer.createSpan(spanName)
+        val span = tracer.startSpan(spanName)
         span.end()
 
         val logBody = "test-log-message"
         val logger = otel.loggerProvider.getLogger("test-logger")
-        logger.log(body = logBody)
+        logger.emit(body = logBody)
 
         // assert span received
         val receivedSpan = server.awaitSpan { it.name == spanName }

--- a/smoke-test/src/jvmTest/kotlin/io/opentelemetry/kotlin/smoketest/OpenTelemetryCompatSmokeTest.kt
+++ b/smoke-test/src/jvmTest/kotlin/io/opentelemetry/kotlin/smoketest/OpenTelemetryCompatSmokeTest.kt
@@ -55,12 +55,12 @@ class OpenTelemetryCompatSmokeTest {
     fun exportsSpansAndLogs() = runTest {
         val spanName = "test-span"
         val tracer = otel.tracerProvider.getTracer("test-tracer")
-        val span = tracer.createSpan(spanName)
+        val span = tracer.startSpan(spanName)
         span.end()
 
         val logBody = "test-log-message"
         val logger = otel.loggerProvider.getLogger("test-logger")
-        logger.log(body = logBody)
+        logger.emit(body = logBody)
 
         // assert span received
         val receivedSpan = server.awaitSpan { it.name == spanName }

--- a/test-fakes/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/FakeLogger.kt
+++ b/test-fakes/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/FakeLogger.kt
@@ -20,40 +20,16 @@ class FakeLogger(
         eventName: String?,
     ): Boolean = enabledResult()
 
-    override fun log(
+    override fun emit(
         body: String?,
-        timestamp: Long?,
-        observedTimestamp: Long?,
-        context: Context?,
-        severityNumber: SeverityNumber?,
-        severityText: String?,
-        attributes: (MutableAttributeContainer.() -> Unit)?
-    ) {
-        processTelemetry(null, timestamp, observedTimestamp, severityNumber, severityText, body)
-    }
-
-    override fun logEvent(
-        eventName: String,
-        body: String?,
-        timestamp: Long?,
-        observedTimestamp: Long?,
-        context: Context?,
-        severityNumber: SeverityNumber?,
-        severityText: String?,
-        attributes: (MutableAttributeContainer.() -> Unit)?
-    ) {
-        processTelemetry(eventName, timestamp, observedTimestamp, severityNumber, severityText, body)
-    }
-
-    private fun processTelemetry(
         eventName: String?,
         timestamp: Long?,
         observedTimestamp: Long?,
+        context: Context?,
         severityNumber: SeverityNumber?,
         severityText: String?,
-        body: String?
+        attributes: (MutableAttributeContainer.() -> Unit)?
     ) {
-        eventName.toString()
         logs.add(
             FakeReadableLogRecord(
                 timestamp,
@@ -64,5 +40,38 @@ class FakeLogger(
                 eventName,
             )
         )
+    }
+
+    @Deprecated(
+        "Deprecated",
+        replaceWith = ReplaceWith("emit(body, null, timestamp, observedTimestamp, context, severityNumber, severityText, attributes)")
+    )
+    override fun log(
+        body: String?,
+        timestamp: Long?,
+        observedTimestamp: Long?,
+        context: Context?,
+        severityNumber: SeverityNumber?,
+        severityText: String?,
+        attributes: (MutableAttributeContainer.() -> Unit)?
+    ) {
+        throw UnsupportedOperationException()
+    }
+
+    @Deprecated(
+        "Deprecated",
+        replaceWith = ReplaceWith("emit(body, eventName, timestamp, observedTimestamp, context, severityNumber, severityText, attributes)")
+    )
+    override fun logEvent(
+        eventName: String,
+        body: String?,
+        timestamp: Long?,
+        observedTimestamp: Long?,
+        context: Context?,
+        severityNumber: SeverityNumber?,
+        severityText: String?,
+        attributes: (MutableAttributeContainer.() -> Unit)?
+    ) {
+        throw UnsupportedOperationException()
     }
 }

--- a/test-fakes/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/FakeTraceFlags.kt
+++ b/test-fakes/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/FakeTraceFlags.kt
@@ -7,5 +7,4 @@ import io.opentelemetry.kotlin.tracing.model.TraceFlags
 class FakeTraceFlags(
     override val isSampled: Boolean = false,
     override val isRandom: Boolean = false,
-    override val hex: String = "00"
 ) : TraceFlags

--- a/test-fakes/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/FakeTracer.kt
+++ b/test-fakes/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/FakeTracer.kt
@@ -11,11 +11,25 @@ class FakeTracer(
     val name: String
 ) : Tracer {
 
-    override fun createSpan(
+    override fun startSpan(
         name: String,
         parentContext: Context?,
         spanKind: SpanKind,
         startTimestamp: Long?,
         action: (SpanRelationships.() -> Unit)?
     ): Span = FakeSpan()
+
+    @Deprecated(
+        "Deprecated.",
+        replaceWith = ReplaceWith("startSpan(name, parentContext, spanKind, startTimestamp, action)")
+    )
+    override fun createSpan(
+        name: String,
+        parentContext: Context?,
+        spanKind: SpanKind,
+        startTimestamp: Long?,
+        action: (SpanRelationships.() -> Unit)?
+    ): Span {
+        throw UnsupportedOperationException()
+    }
 }


### PR DESCRIPTION
## Goal

Makes a few tweaks to the API to better comply with the spec:

1. Renamed `createSpan` to `startSpan` as this better pairs with the `end()` concept, and what opentelemetry-java follows
2. Renamed `log` and `logEvent` to `emit` for parity with the spec and opentelemetry-java implementation
3. Moved `hex` on `TraceFlags` to `api-ext` as it's not part of the API or SDK interfaces

## Testing

Updated existing test coverage
