### PR TITLE
Alter location of hex on TraceFlags

### DIFF
--- a/api-ext/api/jvm/api-ext.api
+++ b/api-ext/api/jvm/api-ext.api
@@ -20,3 +20,7 @@ public final class io/opentelemetry/kotlin/tracing/SpanExtKt {
 	public static final fun wrapOperation (Lio/opentelemetry/kotlin/tracing/model/Span;Lkotlin/jvm/functions/Function0;)V
 }
 
+public final class io/opentelemetry/kotlin/tracing/model/TraceFlagsExtKt {
+	public static final fun getHex (Lio/opentelemetry/kotlin/tracing/model/TraceFlags;)Ljava/lang/String;
+}
+

--- a/api-ext/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/model/TraceFlagsExt.kt
+++ b/api-ext/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/model/TraceFlagsExt.kt
@@ -1,0 +1,23 @@
+package io.opentelemetry.kotlin.tracing.model
+
+import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.ThreadSafe
+
+/**
+ * Returns the hexadecimal representation of the trace flags as a 2-character lowercase string.
+ *
+ * Possible values:
+ * - "00" = no flags set (neither sampled nor random)
+ * - "01" = sampled only (0b000000001)
+ * - "02" = random only (0b000000010)
+ * - "03" = both sampled and random (0b000000011)
+ */
+@ThreadSafe
+@ExperimentalApi
+public val TraceFlags.hex: String
+    get() = when {
+        isRandom && isSampled -> "03"
+        isRandom && !isSampled -> "02"
+        !isRandom && isSampled -> "01"
+        else -> "00"
+    }

--- a/api-ext/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/model/TraceFlagsExtTest.kt
+++ b/api-ext/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/model/TraceFlagsExtTest.kt
@@ -1,0 +1,18 @@
+package io.opentelemetry.kotlin.tracing.model
+
+import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.tracing.FakeTraceFlags
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalApi::class)
+internal class TraceFlagsExtTest {
+
+    @Test
+    fun testEmptyString() {
+        assertEquals("00", FakeTraceFlags().hex)
+        assertEquals("01", FakeTraceFlags(isSampled = true).hex)
+        assertEquals("02", FakeTraceFlags(isRandom = true).hex)
+        assertEquals("03", FakeTraceFlags(isSampled = true, isRandom = true).hex)
+    }
+}

--- a/api/api/jvm/api.api
+++ b/api/api/jvm/api.api
@@ -274,7 +274,6 @@ public final class io/opentelemetry/kotlin/tracing/model/SpanRelationships$Defau
 }
 
 public abstract interface class io/opentelemetry/kotlin/tracing/model/TraceFlags {
-	public abstract fun getHex ()Ljava/lang/String;
 	public abstract fun isRandom ()Z
 	public abstract fun isSampled ()Z
 }

--- a/api/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/model/TraceFlags.kt
+++ b/api/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/model/TraceFlags.kt
@@ -23,16 +23,4 @@ public interface TraceFlags {
      */
     @ThreadSafe
     public val isRandom: Boolean
-
-    /**
-     * Returns the hexadecimal representation of the trace flags as a 2-character lowercase string.
-     *
-     * Possible values:
-     * - "00" = no flags set (neither sampled nor random)
-     * - "01" = sampled only (0b000000001)
-     * - "02" = random only (0b000000010)
-     * - "03" = both sampled and random (0b000000011)
-     */
-    @ThreadSafe
-    public val hex: String
 }

--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/tracing/model/TraceFlagsAdapter.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/tracing/model/TraceFlagsAdapter.kt
@@ -12,12 +12,4 @@ internal class TraceFlagsAdapter(
 
     // verify if the second bit (random flag) is set, using bitwise AND
     override val isRandom: Boolean = traceFlags.asByte().toInt() and 0b00000010 != 0
-
-    // opentelemetry-kotlin implementation of TraceFlags only exposes 00, 01, 02, 03 as valid hex values.
-    override val hex: String = when {
-        isSampled && isRandom -> "03"
-        !isSampled && isRandom -> "02"
-        isSampled && !isRandom -> "01"
-        else -> "00"
-    }
 }

--- a/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/assertions/SpanContextAssertions.kt
+++ b/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/assertions/SpanContextAssertions.kt
@@ -14,7 +14,6 @@ internal fun assertSpanContextsMatch(lhs: SpanContext, rhs: SpanContext) {
     // trace flags
     assertEquals(lhs.traceFlags.isSampled, rhs.traceFlags.isSampled)
     assertEquals(lhs.traceFlags.isRandom, rhs.traceFlags.isRandom)
-    assertEquals(lhs.traceFlags.hex, rhs.traceFlags.hex)
 
     // trace flags
     assertEquals(lhs.traceState.asMap(), rhs.traceState.asMap())

--- a/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/factory/TraceFlagsFactoryTest.kt
+++ b/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/factory/TraceFlagsFactoryTest.kt
@@ -2,7 +2,6 @@ package io.opentelemetry.kotlin.factory
 
 import io.opentelemetry.kotlin.ExperimentalApi
 import org.junit.Test
-import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
@@ -14,46 +13,36 @@ internal class TraceFlagsFactoryTest {
     @Test
     fun `default property`() {
         val flags = factory.default
-
         assertFalse(flags.isSampled)
         assertFalse(flags.isRandom)
-        assertEquals("00", flags.hex)
     }
 
     @Test
     fun `create sampled only`() {
         val flags = factory.create(sampled = true, random = false)
-
         assertTrue(flags.isSampled)
         assertFalse(flags.isRandom)
-        assertEquals("01", flags.hex)
     }
 
     @Test
     fun `create random only`() {
         val flags = factory.create(sampled = false, random = true)
-
         assertFalse(flags.isSampled)
         assertTrue(flags.isRandom)
-        assertEquals("02", flags.hex)
     }
 
     @Test
     fun `create sampled and random`() {
         val flags = factory.create(sampled = true, random = true)
-
         assertTrue(flags.isSampled)
         assertTrue(flags.isRandom)
-        assertEquals("03", flags.hex)
     }
 
     @Test
     fun `create default via function`() {
         val flags = factory.create(sampled = false, random = false)
-
         assertFalse(flags.isSampled)
         assertFalse(flags.isRandom)
-        assertEquals("00", flags.hex)
     }
 
     @Test
@@ -61,22 +50,18 @@ internal class TraceFlagsFactoryTest {
         val default = factory.fromHex("00")
         assertFalse(default.isSampled)
         assertFalse(default.isRandom)
-        assertEquals("00", default.hex)
 
         val sampled = factory.fromHex("01")
         assertTrue(sampled.isSampled)
         assertFalse(sampled.isRandom)
-        assertEquals("01", sampled.hex)
 
         val random = factory.fromHex("02")
         assertFalse(random.isSampled)
         assertTrue(random.isRandom)
-        assertEquals("02", random.hex)
 
         val both = factory.fromHex("03")
         assertTrue(both.isSampled)
         assertTrue(both.isRandom)
-        assertEquals("03", both.hex)
     }
 
     @Test
@@ -84,22 +69,18 @@ internal class TraceFlagsFactoryTest {
         val default = factory.fromHex("04")
         assertFalse(default.isSampled)
         assertFalse(default.isRandom)
-        assertEquals("00", default.hex)
 
         val sampled = factory.fromHex("05")
         assertTrue(sampled.isSampled)
         assertFalse(sampled.isRandom)
-        assertEquals("01", sampled.hex)
 
         val random = factory.fromHex("06")
         assertFalse(random.isSampled)
         assertTrue(random.isRandom)
-        assertEquals("02", random.hex)
 
         val both = factory.fromHex("07")
         assertTrue(both.isSampled)
         assertTrue(both.isRandom)
-        assertEquals("03", both.hex)
     }
 
     @Test
@@ -107,16 +88,13 @@ internal class TraceFlagsFactoryTest {
         val emptyString = factory.fromHex("")
         assertFalse(emptyString.isSampled)
         assertFalse(emptyString.isRandom)
-        assertEquals("00", emptyString.hex)
 
         val shortString = factory.fromHex("1")
         assertFalse(shortString.isSampled)
         assertFalse(shortString.isRandom)
-        assertEquals("00", shortString.hex)
 
         val invalidHex = factory.fromHex("zz")
         assertFalse(invalidHex.isSampled)
         assertFalse(invalidHex.isRandom)
-        assertEquals("00", invalidHex.hex)
     }
 }

--- a/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/tracing/ext/TraceFlagsExtTest.kt
+++ b/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/tracing/ext/TraceFlagsExtTest.kt
@@ -2,6 +2,7 @@ package io.opentelemetry.kotlin.tracing.ext
 
 import io.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.kotlin.tracing.FakeTraceFlags
+import io.opentelemetry.kotlin.tracing.model.hex
 import org.junit.Assert.assertEquals
 import org.junit.Test
 

--- a/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/tracing/model/TraceFlagsAdapterTest.kt
+++ b/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/tracing/model/TraceFlagsAdapterTest.kt
@@ -3,7 +3,6 @@ package io.opentelemetry.kotlin.tracing.model
 import io.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.kotlin.aliases.OtelJavaTraceFlags
 import org.junit.Test
-import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
@@ -13,37 +12,29 @@ internal class TraceFlagsAdapterTest {
     @Test
     fun `default flags`() {
         val adapter = TraceFlagsAdapter(OtelJavaTraceFlags.getDefault())
-
         assertFalse(adapter.isSampled)
         assertFalse(adapter.isRandom)
-        assertEquals("00", adapter.hex)
     }
 
     @Test
     fun `sampled flags`() {
         val adapter = TraceFlagsAdapter(OtelJavaTraceFlags.getSampled())
-
         assertTrue(adapter.isSampled)
         assertFalse(adapter.isRandom)
-        assertEquals("01", adapter.hex)
     }
 
     @Test
     fun `random flags`() {
         val adapter = TraceFlagsAdapter(OtelJavaTraceFlags.fromByte(0b00000010))
-
         assertFalse(adapter.isSampled)
         assertTrue(adapter.isRandom)
-        assertEquals("02", adapter.hex)
     }
 
     @Test
     fun `sampled and random flags`() {
         val adapter = TraceFlagsAdapter(OtelJavaTraceFlags.fromByte(0b00000011))
-
         assertTrue(adapter.isSampled)
         assertTrue(adapter.isRandom)
-        assertEquals("03", adapter.hex)
     }
 
     @Test
@@ -51,21 +42,17 @@ internal class TraceFlagsAdapterTest {
         val sampledAndRandom = TraceFlagsAdapter(OtelJavaTraceFlags.fromByte(0b01100011))
         assertTrue(sampledAndRandom.isSampled)
         assertTrue(sampledAndRandom.isRandom)
-        assertEquals("03", sampledAndRandom.hex)
 
         val random = TraceFlagsAdapter(OtelJavaTraceFlags.fromByte(0b01100010))
         assertFalse(random.isSampled)
         assertTrue(random.isRandom)
-        assertEquals("02", random.hex)
 
         val sampled = TraceFlagsAdapter(OtelJavaTraceFlags.fromByte(0b01110001))
         assertTrue(sampled.isSampled)
         assertFalse(sampled.isRandom)
-        assertEquals("01", sampled.hex)
 
         val default = TraceFlagsAdapter(OtelJavaTraceFlags.fromByte(0b01110000))
         assertFalse(default.isSampled)
         assertFalse(default.isRandom)
-        assertEquals("00", default.hex)
     }
 }

--- a/exporters-protobuf/src/commonMain/kotlin/io/opentelemetry/kotlin/export/conversion/CommonProtobufConversion.kt
+++ b/exporters-protobuf/src/commonMain/kotlin/io/opentelemetry/kotlin/export/conversion/CommonProtobufConversion.kt
@@ -8,6 +8,7 @@ import io.opentelemetry.kotlin.resource.Resource
 import io.opentelemetry.kotlin.tracing.model.SpanContext
 import io.opentelemetry.kotlin.tracing.model.TraceFlags
 import io.opentelemetry.kotlin.tracing.model.TraceState
+import io.opentelemetry.kotlin.tracing.model.hex
 import io.opentelemetry.proto.common.v1.InstrumentationScope
 
 @OptIn(ExperimentalApi::class)
@@ -79,7 +80,6 @@ internal class DeserializedSpanContext(
 private class DeserializedTraceFlags(private val value: Int) : TraceFlags {
     override val isSampled: Boolean = (value and 0x01) != 0
     override val isRandom: Boolean = (value and 0x02) != 0
-    override val hex: String = "0${value.toString(16)}"
 }
 
 @OptIn(ExperimentalApi::class)

--- a/exporters-protobuf/src/commonTest/kotlin/io/opentelemetry/kotlin/export/conversion/CommonProtobufConversionTest.kt
+++ b/exporters-protobuf/src/commonTest/kotlin/io/opentelemetry/kotlin/export/conversion/CommonProtobufConversionTest.kt
@@ -6,7 +6,6 @@ import io.opentelemetry.kotlin.factory.hexToByteArray
 import io.opentelemetry.kotlin.resource.FakeResource
 import io.opentelemetry.kotlin.tracing.FakeTraceFlags
 import io.opentelemetry.proto.common.v1.InstrumentationScope
-import kotlin.collections.get
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -123,7 +122,7 @@ class CommonProtobufConversionTest {
 
     @Test
     fun testTraceFlagsConversion() {
-        val flags = FakeTraceFlags(isSampled = true, isRandom = false, hex = "01")
+        val flags = FakeTraceFlags(isSampled = true, isRandom = false)
         assertEquals(1, flags.toFlagsInt())
     }
 

--- a/exporters-protobuf/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/export/ExportLogsServiceRequestTest.kt
+++ b/exporters-protobuf/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/export/ExportLogsServiceRequestTest.kt
@@ -21,7 +21,7 @@ class ExportLogsServiceRequestTest {
         spanContext = FakeSpanContext(
             traceIdBytes = "12345678901234567890123456789012".hexToByteArray(),
             spanIdBytes = "1234567890123456".hexToByteArray(),
-            traceFlags = FakeTraceFlags(isSampled = true, hex = "01"),
+            traceFlags = FakeTraceFlags(isSampled = true),
             traceState = FakeTraceState(emptyMap())
         )
     )
@@ -118,7 +118,6 @@ class ExportLogsServiceRequestTest {
         assertEquals(expectedContext.spanId, actualContext.spanId)
         assertEquals(expectedContext.traceFlags.isSampled, actualContext.traceFlags.isSampled)
         assertEquals(expectedContext.traceFlags.isRandom, actualContext.traceFlags.isRandom)
-        assertEquals(expectedContext.traceFlags.hex, actualContext.traceFlags.hex)
         assertEquals(expectedContext.traceState.asMap(), actualContext.traceState.asMap())
     }
 

--- a/exporters-protobuf/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/export/ExportTraceServiceRequestCreatorTest.kt
+++ b/exporters-protobuf/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/export/ExportTraceServiceRequestCreatorTest.kt
@@ -26,7 +26,7 @@ class ExportTraceServiceRequestCreatorTest {
         parent = FakeSpanContext(
             traceIdBytes = "12345678901234567890123456789012".hexToByteArray(),
             spanIdBytes = "1234567890123456".hexToByteArray(),
-            traceFlags = FakeTraceFlags(isSampled = true, hex = "01"),
+            traceFlags = FakeTraceFlags(isSampled = true),
             traceState = FakeTraceState(mapOf("foo" to "bar"))
         ),
         spanContext = FakeSpanContext(
@@ -177,7 +177,6 @@ class ExportTraceServiceRequestCreatorTest {
         assertEquals(expectedContext.spanId, actualContext.spanId)
         assertEquals(expectedContext.traceFlags.isSampled, actualContext.traceFlags.isSampled)
         assertEquals(expectedContext.traceFlags.isRandom, actualContext.traceFlags.isRandom)
-        assertEquals(expectedContext.traceFlags.hex, actualContext.traceFlags.hex)
         assertEquals(expectedContext.traceState.asMap(), actualContext.traceState.asMap())
     }
 

--- a/implementation/build.gradle.kts
+++ b/implementation/build.gradle.kts
@@ -22,6 +22,7 @@ kotlin {
         }
         val commonTest by getting {
             dependencies {
+                implementation(project(":api-ext"))
                 implementation(project(":test-fakes"))
                 implementation(project(":integration-test"))
                 implementation(libs.kotlinx.coroutines.test)

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/TraceFlagsImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/TraceFlagsImpl.kt
@@ -7,14 +7,4 @@ import io.opentelemetry.kotlin.tracing.model.TraceFlags
 internal class TraceFlagsImpl(
     override val isSampled: Boolean,
     override val isRandom: Boolean
-) : TraceFlags {
-
-    override val hex: String by lazy {
-        when {
-            isRandom && isSampled -> "03"
-            isRandom && !isSampled -> "02"
-            !isRandom && isSampled -> "01"
-            else -> "00"
-        }
-    }
-}
+) : TraceFlags

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/factory/TraceFlagsFactoryImplTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/factory/TraceFlagsFactoryImplTest.kt
@@ -2,7 +2,6 @@ package io.opentelemetry.kotlin.factory
 
 import io.opentelemetry.kotlin.ExperimentalApi
 import kotlin.test.Test
-import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
@@ -17,7 +16,6 @@ internal class TraceFlagsFactoryImplTest {
 
         assertTrue(flags.isSampled)
         assertFalse(flags.isRandom)
-        assertEquals("01", flags.hex)
     }
 
     @Test
@@ -26,7 +24,6 @@ internal class TraceFlagsFactoryImplTest {
 
         assertTrue(flags.isSampled)
         assertFalse(flags.isRandom)
-        assertEquals("01", flags.hex)
     }
 
     @Test
@@ -35,7 +32,6 @@ internal class TraceFlagsFactoryImplTest {
 
         assertFalse(flags.isSampled)
         assertTrue(flags.isRandom)
-        assertEquals("02", flags.hex)
     }
 
     @Test
@@ -44,7 +40,6 @@ internal class TraceFlagsFactoryImplTest {
 
         assertTrue(flags.isSampled)
         assertTrue(flags.isRandom)
-        assertEquals("03", flags.hex)
     }
 
     @Test
@@ -53,7 +48,6 @@ internal class TraceFlagsFactoryImplTest {
 
         assertFalse(flags.isSampled)
         assertFalse(flags.isRandom)
-        assertEquals("00", flags.hex)
     }
 
     @Test
@@ -61,27 +55,22 @@ internal class TraceFlagsFactoryImplTest {
         val default = factory.fromHex("00")
         assertFalse(default.isSampled)
         assertFalse(default.isRandom)
-        assertEquals("00", default.hex)
 
         val sampled = factory.fromHex("01")
         assertTrue(sampled.isSampled)
         assertFalse(sampled.isRandom)
-        assertEquals("01", sampled.hex)
 
         val random = factory.fromHex("02")
         assertFalse(random.isSampled)
         assertTrue(random.isRandom)
-        assertEquals("02", random.hex)
 
         val both = factory.fromHex("03")
         assertTrue(both.isSampled)
         assertTrue(both.isRandom)
-        assertEquals("03", both.hex)
 
         val anotherBoth = factory.fromHex("2f") // 00101111
         assertTrue(anotherBoth.isSampled)
         assertTrue(anotherBoth.isRandom)
-        assertEquals("03", anotherBoth.hex)
     }
 
     @Test
@@ -89,16 +78,13 @@ internal class TraceFlagsFactoryImplTest {
         val emptyString = factory.fromHex("")
         assertFalse(emptyString.isSampled)
         assertFalse(emptyString.isRandom)
-        assertEquals("00", emptyString.hex)
 
         val shortString = factory.fromHex("1")
         assertFalse(shortString.isSampled)
         assertFalse(shortString.isRandom)
-        assertEquals("00", shortString.hex)
 
         val notHex = factory.fromHex("2g")
         assertFalse(notHex.isSampled)
         assertFalse(notHex.isRandom)
-        assertEquals("00", notHex.hex)
     }
 }

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/integration/test/model/ReadableSpanConversionTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/integration/test/model/ReadableSpanConversionTest.kt
@@ -11,6 +11,7 @@ import io.opentelemetry.kotlin.tracing.data.FakeLinkData
 import io.opentelemetry.kotlin.tracing.data.StatusData
 import io.opentelemetry.kotlin.tracing.model.SpanContext
 import io.opentelemetry.kotlin.tracing.model.SpanKind
+import io.opentelemetry.kotlin.tracing.model.hex
 import kotlin.test.Test
 import kotlin.test.assertEquals
 

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/integration/test/model/ReadableSpanExt.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/integration/test/model/ReadableSpanExt.kt
@@ -15,6 +15,7 @@ import io.opentelemetry.kotlin.tracing.data.LinkData
 import io.opentelemetry.kotlin.tracing.data.StatusData
 import io.opentelemetry.kotlin.tracing.model.ReadableSpan
 import io.opentelemetry.kotlin.tracing.model.SpanContext
+import io.opentelemetry.kotlin.tracing.model.hex
 
 @OptIn(ExperimentalApi::class)
 internal fun ReadableSpan.toSerializable(): SerializableSpanData =

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/TraceFlagsImplTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/TraceFlagsImplTest.kt
@@ -3,7 +3,6 @@ package io.opentelemetry.kotlin.tracing
 import io.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.kotlin.factory.TraceFlagsFactoryImpl
 import kotlin.test.Test
-import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
@@ -15,19 +14,15 @@ internal class TraceFlagsImplTest {
     @Test
     fun testEmptyString() {
         val flags = factory.fromHex("")
-
         assertFalse(flags.isSampled)
         assertFalse(flags.isRandom)
-        assertEquals("00", flags.hex)
     }
 
     @Test
     fun testSingleChar() {
         val flags = factory.fromHex("1")
-
         assertFalse(flags.isSampled)
         assertFalse(flags.isRandom)
-        assertEquals("00", flags.hex)
     }
 
     @Test
@@ -35,21 +30,17 @@ internal class TraceFlagsImplTest {
         val default = factory.fromHex("00")
         assertFalse(default.isRandom)
         assertFalse(default.isSampled)
-        assertEquals("00", default.hex)
 
         val sampled = factory.fromHex("01")
         assertFalse(sampled.isRandom)
         assertTrue(sampled.isSampled)
-        assertEquals("01", sampled.hex)
 
         val random = factory.fromHex("02")
         assertTrue(random.isRandom)
         assertFalse(random.isSampled)
-        assertEquals("02", random.hex)
 
         val sampledAndRandom = factory.fromHex("03")
         assertTrue(sampledAndRandom.isRandom)
         assertTrue(sampledAndRandom.isSampled)
-        assertEquals("03", sampledAndRandom.hex)
     }
 }

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/TracerSpanContextTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/TracerSpanContextTest.kt
@@ -9,6 +9,7 @@ import io.opentelemetry.kotlin.factory.toHexString
 import io.opentelemetry.kotlin.resource.FakeResource
 import io.opentelemetry.kotlin.tracing.export.FakeSpanProcessor
 import io.opentelemetry.kotlin.tracing.model.SpanContext
+import io.opentelemetry.kotlin.tracing.model.hex
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/integration-test/build.gradle.kts
+++ b/integration-test/build.gradle.kts
@@ -9,6 +9,7 @@ kotlin {
     sourceSets {
         val commonMain by getting {
             dependencies {
+                implementation(project(":api-ext"))
                 implementation(project(":sdk"))
                 implementation(project(":test-fakes"))
                 implementation(project(":semconv"))

--- a/integration-test/src/commonMain/kotlin/io/opentelemetry/kotlin/framework/serialization/conversion/SerializableSpanContext.kt
+++ b/integration-test/src/commonMain/kotlin/io/opentelemetry/kotlin/framework/serialization/conversion/SerializableSpanContext.kt
@@ -3,6 +3,7 @@ package io.opentelemetry.kotlin.framework.serialization.conversion
 import io.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.kotlin.framework.serialization.SerializableSpanContext
 import io.opentelemetry.kotlin.tracing.model.SpanContext
+import io.opentelemetry.kotlin.tracing.model.hex
 
 @OptIn(ExperimentalApi::class)
 fun SpanContext.toSerializable() =

--- a/integration-test/src/commonTest/kotlin/io/opentelemetry/kotlin/framework/serialization/SerializableLogRecordDataTest.kt
+++ b/integration-test/src/commonTest/kotlin/io/opentelemetry/kotlin/framework/serialization/SerializableLogRecordDataTest.kt
@@ -6,6 +6,7 @@ import io.opentelemetry.kotlin.framework.serialization.conversion.toSerializable
 import io.opentelemetry.kotlin.logging.model.FakeReadableLogRecord
 import io.opentelemetry.kotlin.resource.Resource
 import io.opentelemetry.kotlin.tracing.model.SpanContext
+import io.opentelemetry.kotlin.tracing.model.hex
 import kotlin.test.Test
 import kotlin.test.assertEquals
 

--- a/integration-test/src/commonTest/kotlin/io/opentelemetry/kotlin/framework/serialization/SerializableSpanDataTest.kt
+++ b/integration-test/src/commonTest/kotlin/io/opentelemetry/kotlin/framework/serialization/SerializableSpanDataTest.kt
@@ -8,6 +8,7 @@ import io.opentelemetry.kotlin.tracing.data.FakeSpanData
 import io.opentelemetry.kotlin.tracing.data.LinkData
 import io.opentelemetry.kotlin.tracing.data.StatusData
 import io.opentelemetry.kotlin.tracing.model.SpanContext
+import io.opentelemetry.kotlin.tracing.model.hex
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue

--- a/noop/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/NoopTraceFlags.kt
+++ b/noop/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/NoopTraceFlags.kt
@@ -7,5 +7,4 @@ import io.opentelemetry.kotlin.tracing.model.TraceFlags
 internal object NoopTraceFlags : TraceFlags {
     override val isSampled: Boolean = false
     override val isRandom: Boolean = false
-    override val hex: String = "00"
 }

--- a/noop/src/commonTest/kotlin/io/opentelemetry/kotlin/NoopTests.kt
+++ b/noop/src/commonTest/kotlin/io/opentelemetry/kotlin/NoopTests.kt
@@ -47,7 +47,6 @@ internal class NoopTests {
         val traceFlags = context.traceFlags
         assertFalse(traceFlags.isSampled)
         assertFalse(traceFlags.isRandom)
-        assertEquals("00", traceFlags.hex)
 
         // Test trace state default values
         val traceState = context.traceState

--- a/test-fakes/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/FakeTraceFlags.kt
+++ b/test-fakes/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/FakeTraceFlags.kt
@@ -7,5 +7,4 @@ import io.opentelemetry.kotlin.tracing.model.TraceFlags
 class FakeTraceFlags(
     override val isSampled: Boolean = false,
     override val isRandom: Boolean = false,
-    override val hex: String = "00"
 ) : TraceFlags


### PR DESCRIPTION
## Goal

Moves `hex` on `TraceFlags` to `api-ext` as it's not part of the API package in the OpenTelemetry specification.

## Testing

Updated existing unit tests.
