### PR TITLE
Alter processor/exporter APIs

### DIFF
--- a/examples/example-app/src/commonMain/kotlin/io/opentelemetry/example/app/TelemetryExamples.kt
+++ b/examples/example-app/src/commonMain/kotlin/io/opentelemetry/example/app/TelemetryExamples.kt
@@ -13,7 +13,6 @@ import io.opentelemetry.kotlin.semconv.UrlAttributes
 import io.opentelemetry.kotlin.semconv.UserAttributes
 import io.opentelemetry.kotlin.tracing.Tracer
 import io.opentelemetry.kotlin.tracing.model.SpanKind
-import io.opentelemetry.kotlin.tracing.model.SpanRelationships
 import kotlinx.coroutines.delay
 
 /**

--- a/exporters-core/api/jvm/exporters-core.api
+++ b/exporters-core/api/jvm/exporters-core.api
@@ -7,6 +7,10 @@ public final class io/opentelemetry/kotlin/export/BatchTelemetryDefaults {
 }
 
 public final class io/opentelemetry/kotlin/logging/export/CoreLogRecordExporterApiKt {
+	public static final fun batchLogRecordProcessor (Lio/opentelemetry/kotlin/init/LogExportConfigDsl;Lio/opentelemetry/kotlin/logging/export/LogRecordExporter;IJJILkotlinx/coroutines/CoroutineDispatcher;)Lio/opentelemetry/kotlin/logging/export/LogRecordProcessor;
+	public static synthetic fun batchLogRecordProcessor$default (Lio/opentelemetry/kotlin/init/LogExportConfigDsl;Lio/opentelemetry/kotlin/logging/export/LogRecordExporter;IJJILkotlinx/coroutines/CoroutineDispatcher;ILjava/lang/Object;)Lio/opentelemetry/kotlin/logging/export/LogRecordProcessor;
+	public static final fun compositeLogRecordExporter (Lio/opentelemetry/kotlin/init/LogExportConfigDsl;[Lio/opentelemetry/kotlin/logging/export/LogRecordExporter;)Lio/opentelemetry/kotlin/logging/export/LogRecordExporter;
+	public static final fun compositeLogRecordProcessor (Lio/opentelemetry/kotlin/init/LogExportConfigDsl;[Lio/opentelemetry/kotlin/logging/export/LogRecordProcessor;)Lio/opentelemetry/kotlin/logging/export/LogRecordProcessor;
 	public static final fun createBatchLogRecordProcessor (Lio/opentelemetry/kotlin/logging/export/LogRecordExporter;IJJILkotlinx/coroutines/CoroutineDispatcher;)Lio/opentelemetry/kotlin/logging/export/LogRecordProcessor;
 	public static synthetic fun createBatchLogRecordProcessor$default (Lio/opentelemetry/kotlin/logging/export/LogRecordExporter;IJJILkotlinx/coroutines/CoroutineDispatcher;ILjava/lang/Object;)Lio/opentelemetry/kotlin/logging/export/LogRecordProcessor;
 	public static final fun createCompositeLogRecordExporter (Ljava/util/List;)Lio/opentelemetry/kotlin/logging/export/LogRecordExporter;
@@ -20,6 +24,10 @@ public final class io/opentelemetry/kotlin/logging/export/CoreLogRecordExporterA
 }
 
 public final class io/opentelemetry/kotlin/tracing/export/CoreSpanExporterApiKt {
+	public static final fun batchSpanProcessor (Lio/opentelemetry/kotlin/init/TraceExportConfigDsl;Lio/opentelemetry/kotlin/tracing/export/SpanExporter;IJJI)Lio/opentelemetry/kotlin/tracing/export/SpanProcessor;
+	public static synthetic fun batchSpanProcessor$default (Lio/opentelemetry/kotlin/init/TraceExportConfigDsl;Lio/opentelemetry/kotlin/tracing/export/SpanExporter;IJJIILjava/lang/Object;)Lio/opentelemetry/kotlin/tracing/export/SpanProcessor;
+	public static final fun compositeSpanExporter (Lio/opentelemetry/kotlin/init/TraceExportConfigDsl;[Lio/opentelemetry/kotlin/tracing/export/SpanExporter;)Lio/opentelemetry/kotlin/tracing/export/SpanExporter;
+	public static final fun compositeSpanProcessor (Lio/opentelemetry/kotlin/init/TraceExportConfigDsl;[Lio/opentelemetry/kotlin/tracing/export/SpanProcessor;)Lio/opentelemetry/kotlin/tracing/export/SpanProcessor;
 	public static final fun createBatchSpanProcessor (Lio/opentelemetry/kotlin/tracing/export/SpanExporter;IJJI)Lio/opentelemetry/kotlin/tracing/export/SpanProcessor;
 	public static synthetic fun createBatchSpanProcessor$default (Lio/opentelemetry/kotlin/tracing/export/SpanExporter;IJJIILjava/lang/Object;)Lio/opentelemetry/kotlin/tracing/export/SpanProcessor;
 	public static final fun createCompositeSpanExporter (Ljava/util/List;)Lio/opentelemetry/kotlin/tracing/export/SpanExporter;

--- a/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/CoreLogRecordExporterApi.kt
+++ b/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/CoreLogRecordExporterApi.kt
@@ -16,6 +16,15 @@ import kotlinx.coroutines.SupervisorJob
  * Creates a composite log record processor that delegates to a list of processors.
  */
 @ExperimentalApi
+@ConfigDsl
+public fun LogExportConfigDsl.compositeLogRecordProcessor(vararg processors: LogRecordProcessor): LogRecordProcessor {
+    require(processors.isNotEmpty()) { "At least one processor must be provided" }
+    @Suppress("DEPRECATION")
+    return createCompositeLogRecordProcessor(processors.toList())
+}
+
+@ExperimentalApi
+@Deprecated("Deprecated.", ReplaceWith("compositeLogRecordProcessor(processors)"))
 public fun createCompositeLogRecordProcessor(processors: List<LogRecordProcessor>): LogRecordProcessor {
     return CompositeLogRecordProcessor(
         processors,
@@ -45,6 +54,15 @@ public fun createSimpleLogRecordProcessor(exporter: LogRecordExporter): LogRecor
  * Creates a composite log record exporter that delegates to a list of exporters.
  */
 @ExperimentalApi
+@ConfigDsl
+public fun LogExportConfigDsl.compositeLogRecordExporter(vararg exporters: LogRecordExporter): LogRecordExporter {
+    require(exporters.isNotEmpty()) { "At least one exporter must be provided" }
+    @Suppress("DEPRECATION")
+    return createCompositeLogRecordExporter(exporters.toList())
+}
+
+@ExperimentalApi
+@Deprecated("Deprecated.", ReplaceWith("compositeLogRecordExporter(exporters)"))
 public fun createCompositeLogRecordExporter(exporters: List<LogRecordExporter>): LogRecordExporter {
     return CompositeLogRecordExporter(
         exporters,
@@ -57,6 +75,24 @@ public fun createCompositeLogRecordExporter(exporters: List<LogRecordExporter>):
  * See https://opentelemetry.io/docs/specs/otel/logs/sdk/#batching-processor
  */
 @ExperimentalApi
+@ConfigDsl
+public fun LogExportConfigDsl.batchLogRecordProcessor(
+    exporter: LogRecordExporter,
+    maxQueueSize: Int = BatchTelemetryDefaults.MAX_QUEUE_SIZE,
+    scheduleDelayMs: Long = BatchTelemetryDefaults.SCHEDULE_DELAY_MS,
+    exportTimeoutMs: Long = BatchTelemetryDefaults.EXPORT_TIMEOUT_MS,
+    maxExportBatchSize: Int = BatchTelemetryDefaults.MAX_EXPORT_BATCH_SIZE,
+    dispatcher: CoroutineDispatcher = Dispatchers.Default,
+): LogRecordProcessor {
+    @Suppress("DEPRECATION")
+    return createBatchLogRecordProcessor(exporter, maxQueueSize, scheduleDelayMs, exportTimeoutMs, maxExportBatchSize, dispatcher)
+}
+
+@ExperimentalApi
+@Deprecated(
+    "Deprecated.",
+    ReplaceWith("batchLogRecordProcessor(exporter, maxQueueSize, scheduleDelayMs, exportTimeoutMs, maxExportBatchSize, dispatcher)")
+)
 public fun createBatchLogRecordProcessor(
     exporter: LogRecordExporter,
     maxQueueSize: Int = BatchTelemetryDefaults.MAX_QUEUE_SIZE,

--- a/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/CoreSpanExporterApi.kt
+++ b/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/CoreSpanExporterApi.kt
@@ -14,6 +14,15 @@ import kotlinx.coroutines.SupervisorJob
  * Creates a composite span processor that delegates to a list of processors.
  */
 @ExperimentalApi
+@ConfigDsl
+public fun TraceExportConfigDsl.compositeSpanProcessor(vararg processors: SpanProcessor): SpanProcessor {
+    require(processors.isNotEmpty()) { "At least one processor must be provided" }
+    @Suppress("DEPRECATION")
+    return createCompositeSpanProcessor(processors.toList())
+}
+
+@ExperimentalApi
+@Deprecated("Deprecated.", ReplaceWith("compositeSpanProcessor(processors)"))
 public fun createCompositeSpanProcessor(processors: List<SpanProcessor>): SpanProcessor {
     return CompositeSpanProcessor(
         processors,
@@ -43,6 +52,15 @@ public fun createSimpleSpanProcessor(exporter: SpanExporter): SpanProcessor {
  * Creates a composite span exporter that delegates to a list of exporters.
  */
 @ExperimentalApi
+@ConfigDsl
+public fun TraceExportConfigDsl.compositeSpanExporter(vararg exporters: SpanExporter): SpanExporter {
+    require(exporters.isNotEmpty()) { "At least one exporter must be provided" }
+    @Suppress("DEPRECATION")
+    return createCompositeSpanExporter(exporters.toList())
+}
+
+@ExperimentalApi
+@Deprecated("Deprecated.", ReplaceWith("compositeSpanExporter(exporters)"))
 public fun createCompositeSpanExporter(exporters: List<SpanExporter>): SpanExporter {
     return CompositeSpanExporter(
         exporters,
@@ -54,7 +72,21 @@ public fun createCompositeSpanExporter(exporters: List<SpanExporter>): SpanExpor
  * Creates a batching processor that sends telemetry in batches.
  * See https://opentelemetry.io/docs/specs/otel/logs/sdk/#batching-processor
  */
-@OptIn(ExperimentalApi::class)
+@ExperimentalApi
+@ConfigDsl
+public fun TraceExportConfigDsl.batchSpanProcessor(
+    exporter: SpanExporter,
+    maxQueueSize: Int = BatchTelemetryDefaults.MAX_QUEUE_SIZE,
+    scheduleDelayMs: Long = BatchTelemetryDefaults.SCHEDULE_DELAY_MS,
+    exportTimeoutMs: Long = BatchTelemetryDefaults.EXPORT_TIMEOUT_MS,
+    maxExportBatchSize: Int = BatchTelemetryDefaults.MAX_EXPORT_BATCH_SIZE
+): SpanProcessor {
+    @Suppress("DEPRECATION")
+    return createBatchSpanProcessor(exporter, maxQueueSize, scheduleDelayMs, exportTimeoutMs, maxExportBatchSize)
+}
+
+@ExperimentalApi
+@Deprecated("Deprecated.", ReplaceWith("batchSpanProcessor(exporter, maxQueueSize, scheduleDelayMs, exportTimeoutMs, maxExportBatchSize)"))
 public fun createBatchSpanProcessor(
     exporter: SpanExporter,
     maxQueueSize: Int = BatchTelemetryDefaults.MAX_QUEUE_SIZE,

--- a/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/export/CoreLogRecordExporterApiTest.kt
+++ b/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/export/CoreLogRecordExporterApiTest.kt
@@ -1,0 +1,26 @@
+package io.opentelemetry.kotlin.logging.export
+
+import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.export.FakeLogExportConfig
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+
+@OptIn(ExperimentalApi::class)
+internal class CoreLogRecordExporterApiTest {
+
+    private val config = FakeLogExportConfig()
+
+    @Test
+    fun compositeLogRecordProcessorEmpty() {
+        assertFailsWith<IllegalArgumentException> {
+            config.compositeLogRecordProcessor()
+        }
+    }
+
+    @Test
+    fun compositeLogRecordExporterEmpty() {
+        assertFailsWith<IllegalArgumentException> {
+            config.compositeLogRecordExporter()
+        }
+    }
+}

--- a/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/export/CoreSpanExporterApiTest.kt
+++ b/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/export/CoreSpanExporterApiTest.kt
@@ -1,0 +1,26 @@
+package io.opentelemetry.kotlin.tracing.export
+
+import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.export.FakeTraceExportConfig
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+
+@OptIn(ExperimentalApi::class)
+internal class CoreSpanExporterApiTest {
+
+    private val config = FakeTraceExportConfig()
+
+    @Test
+    fun compositeSpanProcessorEmpty() {
+        assertFailsWith<IllegalArgumentException> {
+            config.compositeSpanProcessor()
+        }
+    }
+
+    @Test
+    fun compositeSpanExporterEmpty() {
+        assertFailsWith<IllegalArgumentException> {
+            config.compositeSpanExporter()
+        }
+    }
+}

--- a/exporters-in-memory/api/jvm/exporters-in-memory.api
+++ b/exporters-in-memory/api/jvm/exporters-in-memory.api
@@ -4,6 +4,7 @@ public abstract interface class io/opentelemetry/kotlin/logging/export/InMemoryL
 
 public final class io/opentelemetry/kotlin/logging/export/InMemoryLogRecordExporterApiKt {
 	public static final fun createInMemoryLogRecordExporter ()Lio/opentelemetry/kotlin/logging/export/InMemoryLogRecordExporter;
+	public static final fun inMemoryLogRecordExporter (Lio/opentelemetry/kotlin/init/LogExportConfigDsl;)Lio/opentelemetry/kotlin/logging/export/InMemoryLogRecordExporter;
 }
 
 public abstract interface class io/opentelemetry/kotlin/tracing/export/InMemorySpanExporter : io/opentelemetry/kotlin/tracing/export/SpanExporter {
@@ -12,5 +13,6 @@ public abstract interface class io/opentelemetry/kotlin/tracing/export/InMemoryS
 
 public final class io/opentelemetry/kotlin/tracing/export/InMemorySpanExporterApiKt {
 	public static final fun createInMemorySpanExporter ()Lio/opentelemetry/kotlin/tracing/export/InMemorySpanExporter;
+	public static final fun inMemorySpanExporter (Lio/opentelemetry/kotlin/init/TraceExportConfigDsl;)Lio/opentelemetry/kotlin/tracing/export/InMemorySpanExporter;
 }
 

--- a/exporters-in-memory/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/InMemoryLogRecordExporterApi.kt
+++ b/exporters-in-memory/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/InMemoryLogRecordExporterApi.kt
@@ -3,11 +3,21 @@
 package io.opentelemetry.kotlin.logging.export
 
 import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.init.ConfigDsl
+import io.opentelemetry.kotlin.init.LogExportConfigDsl
 
 /**
  * Creates an in-memory log record exporter that stores telemetry in memory.
  * This is intended for development/testing rather than production use.
  */
 @ExperimentalApi
+@ConfigDsl
+public fun LogExportConfigDsl.inMemoryLogRecordExporter(): InMemoryLogRecordExporter {
+    @Suppress("DEPRECATION")
+    return createInMemoryLogRecordExporter()
+}
+
+@ExperimentalApi
+@Deprecated("Deprecated.", ReplaceWith("inMemoryLogRecordExporter()"))
 public fun createInMemoryLogRecordExporter(): InMemoryLogRecordExporter =
     InMemoryLogRecordExporterImpl()

--- a/exporters-in-memory/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/InMemorySpanExporterApi.kt
+++ b/exporters-in-memory/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/InMemorySpanExporterApi.kt
@@ -3,10 +3,20 @@
 package io.opentelemetry.kotlin.tracing.export
 
 import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.init.ConfigDsl
+import io.opentelemetry.kotlin.init.TraceExportConfigDsl
 
 /**
  * Creates an in-memory span exporter that stores telemetry in memory.
  * This is intended for development/testing rather than production use.
  */
 @ExperimentalApi
+@ConfigDsl
+public fun TraceExportConfigDsl.inMemorySpanExporter(): InMemorySpanExporter {
+    @Suppress("DEPRECATION")
+    return createInMemorySpanExporter()
+}
+
+@ExperimentalApi
+@Deprecated("Deprecated.", ReplaceWith("inMemorySpanExporter()"))
 public fun createInMemorySpanExporter(): InMemorySpanExporter = InMemorySpanExporterImpl()

--- a/exporters-in-memory/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/export/InMemoryLogRecordExporterTest.kt
+++ b/exporters-in-memory/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/export/InMemoryLogRecordExporterTest.kt
@@ -15,6 +15,7 @@ internal class InMemoryLogRecordExporterTest {
     private lateinit var exporter: InMemoryLogRecordExporter
 
     @BeforeTest
+    @Suppress("DEPRECATION")
     fun setUp() {
         exporter = createInMemoryLogRecordExporter()
     }

--- a/exporters-in-memory/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/export/InMemorySpanExporterTest.kt
+++ b/exporters-in-memory/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/export/InMemorySpanExporterTest.kt
@@ -15,6 +15,7 @@ internal class InMemorySpanExporterTest {
     private lateinit var exporter: InMemorySpanExporter
 
     @BeforeTest
+    @Suppress("DEPRECATION")
     fun setUp() {
         exporter = createInMemorySpanExporter()
     }

--- a/exporters-otlp/api/jvm/exporters-otlp.api
+++ b/exporters-otlp/api/jvm/exporters-otlp.api
@@ -1,10 +1,14 @@
 public final class io/opentelemetry/kotlin/logging/export/OtlpLogRecordExporterApiKt {
 	public static final fun createOtlpHttpLogRecordExporter (Ljava/lang/String;Lio/ktor/client/engine/HttpClientEngine;)Lio/opentelemetry/kotlin/logging/export/LogRecordExporter;
 	public static synthetic fun createOtlpHttpLogRecordExporter$default (Ljava/lang/String;Lio/ktor/client/engine/HttpClientEngine;ILjava/lang/Object;)Lio/opentelemetry/kotlin/logging/export/LogRecordExporter;
+	public static final fun otlpHttpLogRecordExporter (Lio/opentelemetry/kotlin/init/LogExportConfigDsl;Ljava/lang/String;Lio/ktor/client/engine/HttpClientEngine;)Lio/opentelemetry/kotlin/logging/export/LogRecordExporter;
+	public static synthetic fun otlpHttpLogRecordExporter$default (Lio/opentelemetry/kotlin/init/LogExportConfigDsl;Ljava/lang/String;Lio/ktor/client/engine/HttpClientEngine;ILjava/lang/Object;)Lio/opentelemetry/kotlin/logging/export/LogRecordExporter;
 }
 
 public final class io/opentelemetry/kotlin/tracing/export/OtlpSpanExporterApiKt {
 	public static final fun createOtlpHttpSpanExporter (Ljava/lang/String;Lio/ktor/client/engine/HttpClientEngine;)Lio/opentelemetry/kotlin/tracing/export/SpanExporter;
 	public static synthetic fun createOtlpHttpSpanExporter$default (Ljava/lang/String;Lio/ktor/client/engine/HttpClientEngine;ILjava/lang/Object;)Lio/opentelemetry/kotlin/tracing/export/SpanExporter;
+	public static final fun otlpHttpSpanExporter (Lio/opentelemetry/kotlin/init/TraceExportConfigDsl;Ljava/lang/String;Lio/ktor/client/engine/HttpClientEngine;)Lio/opentelemetry/kotlin/tracing/export/SpanExporter;
+	public static synthetic fun otlpHttpSpanExporter$default (Lio/opentelemetry/kotlin/init/TraceExportConfigDsl;Ljava/lang/String;Lio/ktor/client/engine/HttpClientEngine;ILjava/lang/Object;)Lio/opentelemetry/kotlin/tracing/export/SpanExporter;
 }
 

--- a/exporters-otlp/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/OtlpLogRecordExporterApi.kt
+++ b/exporters-otlp/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/OtlpLogRecordExporterApi.kt
@@ -10,18 +10,30 @@ import io.opentelemetry.kotlin.export.EXPORT_MAX_ATTEMPT_INTERVAL_MS
 import io.opentelemetry.kotlin.export.OtlpClient
 import io.opentelemetry.kotlin.export.createDefaultHttpClient
 import io.opentelemetry.kotlin.export.createHttpEngine
+import io.opentelemetry.kotlin.init.ConfigDsl
+import io.opentelemetry.kotlin.init.LogExportConfigDsl
 
 /**
  * Creates a log record exporter that sends telemetry to the specified URL over OTLP.
  */
 @ExperimentalApi
+@ConfigDsl
+public fun LogExportConfigDsl.otlpHttpLogRecordExporter(
+    baseUrl: String,
+    httpClientEngine: HttpClientEngine = createHttpEngine(),
+): LogRecordExporter {
+    @Suppress("DEPRECATION")
+    return createOtlpHttpLogRecordExporter(baseUrl, httpClientEngine)
+}
+
+@ExperimentalApi
+@Deprecated("Deprecated.", ReplaceWith("otlpHttpLogRecordExporter(baseUrl, httpClientEngine)"))
 public fun createOtlpHttpLogRecordExporter(
     baseUrl: String,
     httpClientEngine: HttpClientEngine = createHttpEngine(),
 ): LogRecordExporter =
     OtlpHttpLogRecordExporter(
         OtlpClient(baseUrl, createDefaultHttpClient(engine = httpClientEngine)),
-
         EXPORT_INITIAL_DELAY_MS,
         EXPORT_MAX_ATTEMPT_INTERVAL_MS,
         EXPORT_MAX_ATTEMPTS

--- a/exporters-otlp/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/OtlpSpanExporterApi.kt
+++ b/exporters-otlp/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/OtlpSpanExporterApi.kt
@@ -8,11 +8,24 @@ import io.opentelemetry.kotlin.export.EXPORT_MAX_ATTEMPT_INTERVAL_MS
 import io.opentelemetry.kotlin.export.OtlpClient
 import io.opentelemetry.kotlin.export.createDefaultHttpClient
 import io.opentelemetry.kotlin.export.createHttpEngine
+import io.opentelemetry.kotlin.init.ConfigDsl
+import io.opentelemetry.kotlin.init.TraceExportConfigDsl
 
 /**
  * Creates a span exporter that sends telemetry to the specified URL over OTLP.
  */
 @ExperimentalApi
+@ConfigDsl
+public fun TraceExportConfigDsl.otlpHttpSpanExporter(
+    baseUrl: String,
+    httpClientEngine: HttpClientEngine = createHttpEngine(),
+): SpanExporter {
+    @Suppress("DEPRECATION")
+    return createOtlpHttpSpanExporter(baseUrl, httpClientEngine)
+}
+
+@ExperimentalApi
+@Deprecated("Deprecated.", ReplaceWith("otlpHttpSpanExporter(baseUrl, httpClientEngine)"))
 public fun createOtlpHttpSpanExporter(
     baseUrl: String,
     httpClientEngine: HttpClientEngine = createHttpEngine(),

--- a/exporters-persistence/src/androidMain/kotlin/io/opentelemetry/kotlin/logging/export/PersistingLogRecordExporterApi.android.kt
+++ b/exporters-persistence/src/androidMain/kotlin/io/opentelemetry/kotlin/logging/export/PersistingLogRecordExporterApi.android.kt
@@ -10,19 +10,22 @@ import io.opentelemetry.kotlin.error.SdkErrorHandler
 import io.opentelemetry.kotlin.export.BatchTelemetryDefaults
 import io.opentelemetry.kotlin.export.TelemetryFileSystemImpl
 import io.opentelemetry.kotlin.export.getFileSystem
+import io.opentelemetry.kotlin.init.ConfigDsl
+import io.opentelemetry.kotlin.init.LogExportConfigDsl
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import okio.Path.Companion.toPath
 
 /**
- * See [createPersistingLogRecordProcessor].
+ * See [persistingLogRecordProcessor].
  */
 @ExperimentalApi
-internal fun createPersistingLogRecordProcessor(
+@ConfigDsl
+internal fun LogExportConfigDsl.persistingLogRecordProcessor(
     context: Context,
     processors: List<LogRecordProcessor>,
     exporters: List<LogRecordExporter>,
-    clock: Clock,
+    clock: Clock = this.clock,
     maxQueueSize: Int = BatchTelemetryDefaults.MAX_QUEUE_SIZE,
     scheduleDelayMs: Long = BatchTelemetryDefaults.SCHEDULE_DELAY_MS,
     exportTimeoutMs: Long = BatchTelemetryDefaults.EXPORT_TIMEOUT_MS,
@@ -37,11 +40,11 @@ internal fun createPersistingLogRecordProcessor(
         getFileSystem(),
         storagePath
     )
-    return createPersistingLogRecordProcessor(
+    return persistingLogRecordProcessor(
         processors = processors,
         exporters = exporters,
         fileSystem = fileSystem,
-        clock = clock,
+        clock = this.clock,
         maxQueueSize = maxQueueSize,
         scheduleDelayMs = scheduleDelayMs,
         exportTimeoutMs = exportTimeoutMs,

--- a/exporters-persistence/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/PersistingLogRecordExporter.kt
+++ b/exporters-persistence/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/PersistingLogRecordExporter.kt
@@ -12,6 +12,7 @@ internal class PersistingLogRecordExporter(
     private val repository: TelemetryRepository<ReadableLogRecord>,
 ) : LogRecordExporter {
 
+    @Suppress("DEPRECATION")
     private val exporter = createCompositeLogRecordExporter(exporters)
 
     override suspend fun export(telemetry: List<ReadableLogRecord>): OperationResultCode {

--- a/exporters-persistence/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/PersistingLogRecordExporterApi.kt
+++ b/exporters-persistence/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/PersistingLogRecordExporterApi.kt
@@ -12,6 +12,8 @@ import io.opentelemetry.kotlin.export.TelemetryFileSystem
 import io.opentelemetry.kotlin.export.TelemetryFileSystemImpl
 import io.opentelemetry.kotlin.export.getFileSystem
 import io.opentelemetry.kotlin.export.getTelemetryStorageDirectory
+import io.opentelemetry.kotlin.init.ConfigDsl
+import io.opentelemetry.kotlin.init.LogExportConfigDsl
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 
@@ -27,14 +29,15 @@ import kotlinx.coroutines.Dispatchers
  * This processor is not supported on JS platforms currently.
  */
 @ExperimentalApi
-internal fun createPersistingLogRecordProcessor(
+@ConfigDsl
+internal fun LogExportConfigDsl.persistingLogRecordProcessor(
     processors: List<LogRecordProcessor>,
     exporters: List<LogRecordExporter>,
     fileSystem: TelemetryFileSystem = TelemetryFileSystemImpl(
         getFileSystem(),
         getTelemetryStorageDirectory("logs"),
     ),
-    clock: Clock,
+    clock: Clock = this.clock,
     maxQueueSize: Int = BatchTelemetryDefaults.MAX_QUEUE_SIZE,
     scheduleDelayMs: Long = BatchTelemetryDefaults.SCHEDULE_DELAY_MS,
     exportTimeoutMs: Long = BatchTelemetryDefaults.EXPORT_TIMEOUT_MS,

--- a/exporters-persistence/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/PersistingLogRecordProcessor.kt
+++ b/exporters-persistence/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/PersistingLogRecordProcessor.kt
@@ -56,6 +56,7 @@ internal class PersistingLogRecordProcessor(
 
     private val exporter = PersistingLogRecordExporter(exporters, repository)
 
+    @Suppress("DEPRECATION")
     private val batchingProcessor = createBatchLogRecordProcessor(
         exporter,
         maxQueueSize,
@@ -64,6 +65,8 @@ internal class PersistingLogRecordProcessor(
         maxExportBatchSize,
         dispatcher,
     )
+
+    @Suppress("DEPRECATION")
     private val processor = createCompositeLogRecordProcessor(processors + batchingProcessor)
     private val telemetryCloseable: TelemetryCloseable = TimeoutTelemetryCloseable(processor)
 

--- a/exporters-persistence/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/export/PersistingLogRecordProcessorTest.kt
+++ b/exporters-persistence/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/export/PersistingLogRecordProcessorTest.kt
@@ -1,5 +1,6 @@
 package io.opentelemetry.kotlin.logging.export
 
+import io.opentelemetry.kotlin.Clock
 import io.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.kotlin.clock.FakeClock
 import io.opentelemetry.kotlin.context.Context
@@ -8,6 +9,7 @@ import io.opentelemetry.kotlin.export.FakeTelemetryFileSystem
 import io.opentelemetry.kotlin.export.OperationResultCode
 import io.opentelemetry.kotlin.export.OperationResultCode.Failure
 import io.opentelemetry.kotlin.export.OperationResultCode.Success
+import io.opentelemetry.kotlin.init.LogExportConfigDsl
 import io.opentelemetry.kotlin.logging.model.FakeReadWriteLogRecord
 import io.opentelemetry.kotlin.logging.model.ReadWriteLogRecord
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -309,7 +311,7 @@ internal class PersistingLogRecordProcessorTest {
         scheduleDelayMs: Long = 5000,
     ): LogRecordProcessor {
         val dispatcher = StandardTestDispatcher(testScheduler)
-        return createPersistingLogRecordProcessor(
+        return FakeLogExportConfig().persistingLogRecordProcessor(
             processors = processors,
             exporters = exporters,
             fileSystem = FakeTelemetryFileSystem(),
@@ -319,6 +321,8 @@ internal class PersistingLogRecordProcessorTest {
             dispatcher = dispatcher,
         )
     }
+
+    private class FakeLogExportConfig(override val clock: Clock = FakeClock()) : LogExportConfigDsl
 
     @OptIn(ExperimentalApi::class)
     private class DelayingLogRecordProcessor(

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/LoggerProviderImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/LoggerProviderImpl.kt
@@ -20,6 +20,7 @@ internal class LoggerProviderImpl(
 
     private val apiProvider by lazy {
         ApiProviderImpl<Logger> { key ->
+            @Suppress("DEPRECATION")
             val processor = when {
                 loggingConfig.processors.isEmpty() -> null
                 else -> createCompositeLogRecordProcessor(

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/TracerProviderImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/TracerProviderImpl.kt
@@ -19,6 +19,7 @@ internal class TracerProviderImpl(
 ) : TracerProvider, TelemetryCloseable by closeable {
 
     private val apiProvider = ApiProviderImpl<Tracer> { key ->
+        @Suppress("DEPRECATION")
         val processor = when {
             tracingConfig.processors.isEmpty() -> null
             else -> createCompositeSpanProcessor(

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/init/LoggerProviderConfigImplTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/init/LoggerProviderConfigImplTest.kt
@@ -4,7 +4,7 @@ import io.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.kotlin.attributes.DEFAULT_ATTRIBUTE_LIMIT
 import io.opentelemetry.kotlin.clock.FakeClock
 import io.opentelemetry.kotlin.logging.export.FakeLogRecordProcessor
-import io.opentelemetry.kotlin.logging.export.createCompositeLogRecordProcessor
+import io.opentelemetry.kotlin.logging.export.compositeLogRecordProcessor
 import io.opentelemetry.kotlin.logging.export.simpleLogRecordProcessor
 import io.opentelemetry.kotlin.logging.export.stdoutLogRecordExporter
 import kotlin.test.Test
@@ -41,7 +41,7 @@ internal class LoggerProviderConfigImplTest {
         val schemaUrl = "https://example.com/schema"
 
         val cfg = LoggerProviderConfigImpl(clock).apply {
-            export { createCompositeLogRecordProcessor(listOf(firstProcessor, secondProcessor)) }
+            export { compositeLogRecordProcessor(firstProcessor, secondProcessor) }
 
             resource(schemaUrl) {
                 setStringAttribute("key", "value")

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/init/TracerProviderConfigImplTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/init/TracerProviderConfigImplTest.kt
@@ -4,7 +4,7 @@ import io.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.kotlin.attributes.DEFAULT_ATTRIBUTE_LIMIT
 import io.opentelemetry.kotlin.clock.FakeClock
 import io.opentelemetry.kotlin.tracing.export.FakeSpanProcessor
-import io.opentelemetry.kotlin.tracing.export.createCompositeSpanProcessor
+import io.opentelemetry.kotlin.tracing.export.compositeSpanProcessor
 import io.opentelemetry.kotlin.tracing.export.simpleSpanProcessor
 import io.opentelemetry.kotlin.tracing.export.stdoutSpanExporter
 import kotlin.test.Test
@@ -47,7 +47,7 @@ internal class TracerProviderConfigImplTest {
         val schemaUrl = "https://example.com/schema"
 
         val cfg = TracerProviderConfigImpl(clock).apply {
-            export { createCompositeSpanProcessor(listOf(firstProcessor, secondProcessor)) }
+            export { compositeSpanProcessor(firstProcessor, secondProcessor) }
 
             resource(schemaUrl) {
                 setStringAttribute("key", "value")

--- a/integration-test/config/detekt/baseline.xml
+++ b/integration-test/config/detekt/baseline.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" ?>
+<SmellBaseline>
+  <ManuallySuppressedIssues/>
+  <CurrentIssues>
+    <ID>SpreadOperator:OtelKotlinTestRule.kt$OtelKotlinTestRule$( InMemoryLogRecordProcessor( logRecordExporter, scope, ), *config.logRecordProcessors.toTypedArray() )</ID>
+    <ID>SpreadOperator:OtelKotlinTestRule.kt$OtelKotlinTestRule$( InMemorySpanProcessor( spanExporter, scope, ), *config.spanProcessors.toTypedArray() )</ID>
+  </CurrentIssues>
+</SmellBaseline>

--- a/integration-test/src/commonMain/kotlin/io/opentelemetry/kotlin/framework/OtelKotlinTestRule.kt
+++ b/integration-test/src/commonMain/kotlin/io/opentelemetry/kotlin/framework/OtelKotlinTestRule.kt
@@ -8,12 +8,12 @@ import io.opentelemetry.kotlin.init.LoggerProviderConfigDsl
 import io.opentelemetry.kotlin.init.TracerProviderConfigDsl
 import io.opentelemetry.kotlin.logging.Logger
 import io.opentelemetry.kotlin.logging.LoggerProvider
-import io.opentelemetry.kotlin.logging.export.createCompositeLogRecordProcessor
+import io.opentelemetry.kotlin.logging.export.compositeLogRecordProcessor
 import io.opentelemetry.kotlin.logging.model.ReadableLogRecord
 import io.opentelemetry.kotlin.tracing.Tracer
 import io.opentelemetry.kotlin.tracing.TracerProvider
 import io.opentelemetry.kotlin.tracing.data.SpanData
-import io.opentelemetry.kotlin.tracing.export.createCompositeSpanProcessor
+import io.opentelemetry.kotlin.tracing.export.compositeSpanProcessor
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestCoroutineScheduler
@@ -52,13 +52,12 @@ abstract class OtelKotlinTestRule(context: TestCoroutineScheduler) {
     protected val loggerProviderConfig: LoggerProviderConfigDsl.() -> Unit = {
         config.attributes?.let { resource(config.schemaUrl, it) }
         export {
-            createCompositeLogRecordProcessor(
-                listOf(
-                    InMemoryLogRecordProcessor(
-                        logRecordExporter,
-                        scope,
-                    )
-                ) + config.logRecordProcessors
+            compositeLogRecordProcessor(
+                InMemoryLogRecordProcessor(
+                    logRecordExporter,
+                    scope,
+                ),
+                *config.logRecordProcessors.toTypedArray()
             )
         }
         logLimits(config.logLimits)
@@ -70,13 +69,12 @@ abstract class OtelKotlinTestRule(context: TestCoroutineScheduler) {
     protected val tracerProviderConfig: TracerProviderConfigDsl.() -> Unit = {
         config.attributes?.let { resource(config.schemaUrl, it) }
         export {
-            createCompositeSpanProcessor(
-                listOf(
-                    InMemorySpanProcessor(
-                        spanExporter,
-                        scope,
-                    )
-                ) + config.spanProcessors
+            compositeSpanProcessor(
+                InMemorySpanProcessor(
+                    spanExporter,
+                    scope,
+                ),
+                *config.spanProcessors.toTypedArray()
             )
         }
         spanLimits(config.spanLimits)

--- a/smoke-test/src/commonTest/kotlin/io/opentelemetry/kotlin/smoketest/OpenTelemetrySmokeTest.kt
+++ b/smoke-test/src/commonTest/kotlin/io/opentelemetry/kotlin/smoketest/OpenTelemetrySmokeTest.kt
@@ -3,9 +3,9 @@ package io.opentelemetry.kotlin.smoketest
 import io.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.kotlin.OpenTelemetry
 import io.opentelemetry.kotlin.createOpenTelemetry
-import io.opentelemetry.kotlin.logging.export.createOtlpHttpLogRecordExporter
+import io.opentelemetry.kotlin.logging.export.otlpHttpLogRecordExporter
 import io.opentelemetry.kotlin.logging.export.simpleLogRecordProcessor
-import io.opentelemetry.kotlin.tracing.export.createOtlpHttpSpanExporter
+import io.opentelemetry.kotlin.tracing.export.otlpHttpSpanExporter
 import io.opentelemetry.kotlin.tracing.export.simpleSpanProcessor
 import kotlinx.coroutines.test.runTest
 import kotlin.test.AfterTest
@@ -26,7 +26,7 @@ class OpenTelemetrySmokeTest {
             tracerProvider {
                 export {
                     simpleSpanProcessor(
-                        createOtlpHttpSpanExporter(
+                        otlpHttpSpanExporter(
                             server.baseUrl,
                             server.mockEngine
                         )
@@ -36,7 +36,7 @@ class OpenTelemetrySmokeTest {
             loggerProvider {
                 export {
                     simpleLogRecordProcessor(
-                        createOtlpHttpLogRecordExporter(
+                        otlpHttpLogRecordExporter(
                             server.baseUrl,
                             server.mockEngine
                         )

--- a/smoke-test/src/jvmTest/kotlin/io/opentelemetry/kotlin/smoketest/OpenTelemetryCompatSmokeTest.kt
+++ b/smoke-test/src/jvmTest/kotlin/io/opentelemetry/kotlin/smoketest/OpenTelemetryCompatSmokeTest.kt
@@ -3,9 +3,9 @@ package io.opentelemetry.kotlin.smoketest
 import io.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.kotlin.OpenTelemetry
 import io.opentelemetry.kotlin.createCompatOpenTelemetry
-import io.opentelemetry.kotlin.logging.export.createOtlpHttpLogRecordExporter
+import io.opentelemetry.kotlin.logging.export.otlpHttpLogRecordExporter
 import io.opentelemetry.kotlin.logging.export.simpleLogRecordProcessor
-import io.opentelemetry.kotlin.tracing.export.createOtlpHttpSpanExporter
+import io.opentelemetry.kotlin.tracing.export.otlpHttpSpanExporter
 import io.opentelemetry.kotlin.tracing.export.simpleSpanProcessor
 import kotlinx.coroutines.test.runTest
 import kotlin.test.AfterTest
@@ -26,7 +26,7 @@ class OpenTelemetryCompatSmokeTest {
             tracerProvider {
                 export {
                     simpleSpanProcessor(
-                        createOtlpHttpSpanExporter(
+                        otlpHttpSpanExporter(
                             server.baseUrl,
                             server.mockEngine
                         )
@@ -36,7 +36,7 @@ class OpenTelemetryCompatSmokeTest {
             loggerProvider {
                 export {
                     simpleLogRecordProcessor(
-                        createOtlpHttpLogRecordExporter(
+                        otlpHttpLogRecordExporter(
                             server.baseUrl,
                             server.mockEngine
                         )


### PR DESCRIPTION
## Goal

Further builds on #153 by altering the remaining APIs used to create exporters and processors.

## Testing

Relied on existing test coverage.
