### PR TITLE
add ShutdownState abstract class and MutableShutdownState

### DIFF
--- a/sdk-api/api/jvm/sdk-api.api
+++ b/sdk-api/api/jvm/sdk-api.api
@@ -6,6 +6,12 @@ public abstract interface class io/opentelemetry/kotlin/OpenTelemetrySdk : io/op
 	public abstract fun getClock ()Lio/opentelemetry/kotlin/Clock;
 }
 
+public final class io/opentelemetry/kotlin/export/MutableShutdownState : io/opentelemetry/kotlin/export/ShutdownState {
+	public fun <init> ()V
+	public fun isShutdown ()Z
+	public final fun shutdown ()V
+}
+
 public abstract class io/opentelemetry/kotlin/export/OperationResultCode {
 }
 
@@ -15,6 +21,15 @@ public final class io/opentelemetry/kotlin/export/OperationResultCode$Failure : 
 
 public final class io/opentelemetry/kotlin/export/OperationResultCode$Success : io/opentelemetry/kotlin/export/OperationResultCode {
 	public static final field INSTANCE Lio/opentelemetry/kotlin/export/OperationResultCode$Success;
+}
+
+public abstract class io/opentelemetry/kotlin/export/ShutdownState {
+	public fun <init> ()V
+	public final fun execute (Lkotlin/jvm/functions/Function0;)V
+	public final fun ifActive (Lio/opentelemetry/kotlin/export/OperationResultCode;Lkotlin/jvm/functions/Function0;)Lio/opentelemetry/kotlin/export/OperationResultCode;
+	public static synthetic fun ifActive$default (Lio/opentelemetry/kotlin/export/ShutdownState;Lio/opentelemetry/kotlin/export/OperationResultCode;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)Lio/opentelemetry/kotlin/export/OperationResultCode;
+	public final fun ifActiveOrElse (Ljava/lang/Object;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+	public abstract fun isShutdown ()Z
 }
 
 public abstract interface class io/opentelemetry/kotlin/export/TelemetryCloseable {

--- a/sdk-api/src/commonMain/kotlin/io/opentelemetry/kotlin/export/MutableShutdownState.kt
+++ b/sdk-api/src/commonMain/kotlin/io/opentelemetry/kotlin/export/MutableShutdownState.kt
@@ -1,0 +1,19 @@
+package io.opentelemetry.kotlin.export
+
+import io.opentelemetry.kotlin.ExperimentalApi
+import kotlin.concurrent.Volatile
+
+/**
+ * Non-locking but thread-safe implementation of [ShutdownState]. Objects that can read but not modify
+ * the shutdown state should use [ShutdownState] instead of this.
+ */
+@OptIn(ExperimentalApi::class)
+public class MutableShutdownState : ShutdownState() {
+    @Volatile
+    override var isShutdown: Boolean = false
+        private set
+
+    public fun shutdown() {
+        isShutdown = true
+    }
+}

--- a/sdk-api/src/commonMain/kotlin/io/opentelemetry/kotlin/export/ShutdownState.kt
+++ b/sdk-api/src/commonMain/kotlin/io/opentelemetry/kotlin/export/ShutdownState.kt
@@ -1,0 +1,37 @@
+package io.opentelemetry.kotlin.export
+
+import io.opentelemetry.kotlin.ExperimentalApi
+
+/**
+ * Execute code or return defaults depending on whether this is shutdown or not, respectively.
+ */
+@OptIn(ExperimentalApi::class)
+public abstract class ShutdownState {
+    public abstract val isShutdown: Boolean
+
+    /**
+     * Run the given [action] if this isn't shutdown. Otherwise, return [default]
+     */
+    public inline fun <T> ifActiveOrElse(default: T, action: () -> T): T =
+        if (isShutdown) {
+            default
+        } else {
+            action()
+        }
+
+    /**
+     * Run the given [action] and return the resulting [OperationResultCode] if this isn't shutdown. Otherwise, return [default]
+     */
+    public inline fun ifActive(
+        default: OperationResultCode = OperationResultCode.Failure,
+        action: () -> OperationResultCode,
+    ): OperationResultCode =
+        ifActiveOrElse(default, action)
+
+    /**
+     * Run the given [action] if this isn't shutdown. Do nothing otherwise.
+     */
+    public inline fun execute(action: () -> Unit) {
+        ifActiveOrElse(Unit, action)
+    }
+}

--- a/sdk-api/src/commonTest/kotlin/io/opentelemetry/kotlin/export/ShutdownStateTest.kt
+++ b/sdk-api/src/commonTest/kotlin/io/opentelemetry/kotlin/export/ShutdownStateTest.kt
@@ -1,0 +1,128 @@
+package io.opentelemetry.kotlin.export
+
+import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.export.OperationResultCode.Failure
+import io.opentelemetry.kotlin.export.OperationResultCode.Success
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalApi::class)
+internal class ShutdownStateTest {
+
+    private lateinit var state: MutableShutdownState
+
+    @BeforeTest
+    fun setup() {
+        state = MutableShutdownState()
+    }
+
+    @Test
+    fun testInitialStateIsNotShutdown() {
+        assertFalse(state.isShutdown)
+    }
+
+    @Test
+    fun testShutdownTransitionsState() {
+        state.shutdown()
+        assertTrue(state.isShutdown)
+    }
+
+    @Test
+    fun testIsShutdownRemainsTrue() {
+        state.shutdown()
+        assertTrue(state.isShutdown)
+        state.shutdown()
+        assertTrue(state.isShutdown)
+    }
+
+    @Test
+    fun testIfActiveOrElseRunsActionWhenActive() {
+        val result = state.ifActiveOrElse("default") { "active" }
+        assertEquals("active", result)
+    }
+
+    @Test
+    fun testIfActiveOrElseReturnsDefaultWhenShutdown() {
+        state.shutdown()
+        val result = state.ifActiveOrElse("default") { "active" }
+        assertEquals("default", result)
+    }
+
+    @Test
+    fun testExecuteRunsActionWhenActive() {
+        var called = false
+        state.execute { called = true }
+        assertTrue(called)
+    }
+
+    @Test
+    fun testExecuteSkipsActionWhenShutdown() {
+        state.shutdown()
+        var called = false
+        state.execute { called = true }
+        assertFalse(called)
+    }
+
+    @Test
+    fun testIfActiveResultReturnsSuccessWhenActive() {
+        val result = state.ifActive { Success }
+        assertEquals(Success, result)
+    }
+
+    @Test
+    fun testIfActiveResultReturnsFailureWhenShutdown() {
+        state.shutdown()
+        val result = state.ifActive { Success }
+        assertEquals(Failure, result)
+    }
+
+    @Test
+    fun testReadOnlyIfActiveOrElseRunsActionWhenActive() {
+        val readOnly: ShutdownState = state
+        val result = readOnly.ifActiveOrElse("default") { "active" }
+        assertEquals("active", result)
+    }
+
+    @Test
+    fun testReadOnlyIfActiveOrElseReturnsDefaultWhenShutdown() {
+        val readOnly: ShutdownState = state
+        state.shutdown()
+        val result = readOnly.ifActiveOrElse("default") { "active" }
+        assertEquals("default", result)
+    }
+
+    @Test
+    fun testReadOnlyExecuteRunsActionWhenActive() {
+        val readOnly: ShutdownState = state
+        var called = false
+        readOnly.execute { called = true }
+        assertTrue(called)
+    }
+
+    @Test
+    fun testReadOnlyExecuteSkipsActionWhenShutdown() {
+        val readOnly: ShutdownState = state
+        state.shutdown()
+        var called = false
+        readOnly.execute { called = true }
+        assertFalse(called)
+    }
+
+    @Test
+    fun testReadOnlyIfActiveReturnsSuccessWhenActive() {
+        val readOnly: ShutdownState = state
+        val result = readOnly.ifActive { Success }
+        assertEquals(Success, result)
+    }
+
+    @Test
+    fun testReadOnlyIfActiveReturnsFailureWhenShutdown() {
+        val readOnly: ShutdownState = state
+        state.shutdown()
+        val result = readOnly.ifActive { Success }
+        assertEquals(Failure, result)
+    }
+}


### PR DESCRIPTION
## Summary
- Phase 1 of 10: Shutdown compliance stack
- Adds `ShutdownState` abstract class with inline helper methods (`ifActiveOrElse`, `ifActive`, `execute`) and `MutableShutdownState` concrete class with `@Volatile` boolean flag
- Read-only base class supports suspend lambdas via inline members on abstract class

## Stack
1. **add ShutdownState abstract class and MutableShutdownState** (this PR) → `main`
2. add shutdown compliance to BatchTelemetryProcessor and TelemetryExporter
3. add shutdown compliance to span processors and exporters
4. add shutdown compliance to log processors and exporters
5. add shutdown compliance to in-memory exporters
6. add shutdown compliance to persistence exporters
7. add shutdown compliance to Java interop adapters
8. propagate read-only ShutdownState to TracerProviderImpl and TracerImpl
9. propagate read-only ShutdownState to LoggerProviderImpl and LoggerImpl
10. wire shared MutableShutdownState through CloseableOpenTelemetryImpl

🤖 Generated with [Claude Code](https://claude.com/claude-code)