### PR TITLE
add shutdown compliance to span processors and exporters

### DIFF
--- a/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/BatchSpanProcessorImpl.kt
+++ b/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/BatchSpanProcessorImpl.kt
@@ -3,6 +3,7 @@ package io.opentelemetry.kotlin.tracing.export
 import io.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.kotlin.context.Context
 import io.opentelemetry.kotlin.export.BatchTelemetryProcessor
+import io.opentelemetry.kotlin.export.MutableShutdownState
 import io.opentelemetry.kotlin.export.OperationResultCode
 import io.opentelemetry.kotlin.tracing.model.ReadWriteSpan
 import io.opentelemetry.kotlin.tracing.model.ReadableSpan
@@ -16,6 +17,8 @@ internal class BatchSpanProcessorImpl(
     private val maxExportBatchSize: Int,
 ) : SpanProcessor {
 
+    private val shutdownState = MutableShutdownState()
+
     private val processor =
         BatchTelemetryProcessor(
             maxQueueSize = maxQueueSize,
@@ -25,7 +28,9 @@ internal class BatchSpanProcessorImpl(
             exportAction = exporter::export
         )
 
-    override fun onEnd(span: ReadableSpan) = processor.processTelemetry(span)
+    override fun onEnd(span: ReadableSpan) {
+        shutdownState.execute { processor.processTelemetry(span) }
+    }
 
     override fun isStartRequired(): Boolean = true
     override fun isEndRequired(): Boolean = true
@@ -40,5 +45,10 @@ internal class BatchSpanProcessorImpl(
     }
 
     override suspend fun forceFlush(): OperationResultCode = processor.forceFlush()
-    override suspend fun shutdown(): OperationResultCode = processor.shutdown()
+
+    override suspend fun shutdown(): OperationResultCode =
+        shutdownState.ifActive(OperationResultCode.Success) {
+            shutdownState.shutdown()
+            processor.shutdown()
+        }
 }

--- a/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/SimpleSpanProcessor.kt
+++ b/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/SimpleSpanProcessor.kt
@@ -3,6 +3,7 @@ package io.opentelemetry.kotlin.tracing.export
 import io.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.kotlin.ReentrantReadWriteLock
 import io.opentelemetry.kotlin.context.Context
+import io.opentelemetry.kotlin.export.MutableShutdownState
 import io.opentelemetry.kotlin.export.OperationResultCode
 import io.opentelemetry.kotlin.tracing.model.ReadWriteSpan
 import io.opentelemetry.kotlin.tracing.model.ReadableSpan
@@ -21,6 +22,7 @@ internal class SimpleSpanProcessor(
 ) : SpanProcessor {
 
     private val lock = ReentrantReadWriteLock()
+    private val shutdownState = MutableShutdownState()
 
     override fun onStart(
         span: ReadWriteSpan,
@@ -32,15 +34,22 @@ internal class SimpleSpanProcessor(
     }
 
     override fun onEnd(span: ReadableSpan) {
-        scope.launch {
-            lock.write {
-                exporter.export(listOf(span))
+        shutdownState.execute {
+            scope.launch {
+                lock.write {
+                    exporter.export(listOf(span))
+                }
             }
         }
     }
 
     override fun isStartRequired(): Boolean = true
     override fun isEndRequired(): Boolean = true
-    override suspend fun forceFlush(): OperationResultCode = OperationResultCode.Success
-    override suspend fun shutdown(): OperationResultCode = OperationResultCode.Success
+    override suspend fun forceFlush(): OperationResultCode = exporter.forceFlush()
+
+    override suspend fun shutdown(): OperationResultCode =
+        shutdownState.ifActive(OperationResultCode.Success) {
+            shutdownState.shutdown()
+            exporter.shutdown()
+        }
 }

--- a/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/StdoutSpanExporter.kt
+++ b/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/StdoutSpanExporter.kt
@@ -1,6 +1,7 @@
 package io.opentelemetry.kotlin.tracing.export
 
 import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.export.MutableShutdownState
 import io.opentelemetry.kotlin.export.OperationResultCode
 import io.opentelemetry.kotlin.platformLog
 import io.opentelemetry.kotlin.tracing.data.SpanData
@@ -14,15 +15,23 @@ internal class StdoutSpanExporter(
     private val logger: (String) -> Unit = ::platformLog
 ) : SpanExporter {
 
-    override suspend fun export(telemetry: List<SpanData>): OperationResultCode {
-        telemetry.forEach { span ->
-            logger(formatSpan(span))
+    private val shutdownState = MutableShutdownState()
+
+    override suspend fun export(telemetry: List<SpanData>): OperationResultCode =
+        shutdownState.ifActive {
+            telemetry.forEach { span ->
+                logger(formatSpan(span))
+            }
+            OperationResultCode.Success
         }
-        return OperationResultCode.Success
-    }
 
     override suspend fun forceFlush(): OperationResultCode = OperationResultCode.Success
-    override suspend fun shutdown(): OperationResultCode = OperationResultCode.Success
+
+    override suspend fun shutdown(): OperationResultCode =
+        shutdownState.ifActive(OperationResultCode.Success) {
+            shutdownState.shutdown()
+            OperationResultCode.Success
+        }
 
     /**
      * Formats a [SpanData] into a human-readable string representation.

--- a/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/export/BatchSpanProcessorImplTest.kt
+++ b/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/export/BatchSpanProcessorImplTest.kt
@@ -1,0 +1,56 @@
+package io.opentelemetry.kotlin.tracing.export
+
+import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.export.OperationResultCode
+import io.opentelemetry.kotlin.tracing.FakeReadWriteSpan
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalApi::class, ExperimentalCoroutinesApi::class)
+internal class BatchSpanProcessorImplTest {
+
+    private lateinit var exporter: FakeSpanExporter
+    private lateinit var processor: BatchSpanProcessorImpl
+
+    @BeforeTest
+    fun setup() {
+        exporter = FakeSpanExporter()
+        processor = BatchSpanProcessorImpl(
+            exporter = exporter,
+            maxQueueSize = 100,
+            scheduleDelayMs = 1,
+            exportTimeoutMs = 1000,
+            maxExportBatchSize = 10,
+        )
+    }
+
+    @Test
+    fun testOnEndNoOpAfterShutdown() = runTest {
+        processor.shutdown()
+        advanceUntilIdle()
+
+        val span = FakeReadWriteSpan()
+        processor.onEnd(span)
+        advanceUntilIdle()
+
+        assertTrue(exporter.exports.isEmpty())
+    }
+
+    @Test
+    fun testShutdownReturnsSuccessOnSecondCall() = runTest {
+        assertEquals(OperationResultCode.Success, processor.shutdown())
+        assertEquals(OperationResultCode.Success, processor.shutdown())
+    }
+
+    @Test
+    fun testForceFlushWorksAfterShutdown() = runTest {
+        processor.shutdown()
+        advanceUntilIdle()
+        assertEquals(OperationResultCode.Success, processor.forceFlush())
+    }
+}

--- a/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/export/SimpleSpanProcessorTest.kt
+++ b/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/export/SimpleSpanProcessorTest.kt
@@ -38,4 +38,39 @@ internal class SimpleSpanProcessorTest {
         val export = exporter.exports.single()
         assertEquals(span.name, export.name)
     }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun testOnEndNoOpAfterShutdown() = runTest {
+        val exporter = FakeSpanExporter()
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val processor = SimpleSpanProcessor(exporter, scope)
+        processor.shutdown()
+
+        val span = FakeReadWriteSpan()
+        processor.onEnd(span)
+        assertTrue(exporter.exports.isEmpty())
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun testShutdownReturnsSuccessOnSecondCall() = runTest {
+        val exporter = FakeSpanExporter()
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val processor = SimpleSpanProcessor(exporter, scope)
+
+        assertEquals(OperationResultCode.Success, processor.shutdown())
+        assertEquals(OperationResultCode.Success, processor.shutdown())
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun testForceFlushWorksAfterShutdown() = runTest {
+        val exporter = FakeSpanExporter()
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val processor = SimpleSpanProcessor(exporter, scope)
+        processor.shutdown()
+
+        assertEquals(OperationResultCode.Success, processor.forceFlush())
+    }
 }

--- a/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/export/StdoutSpanExporterTest.kt
+++ b/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/export/StdoutSpanExporterTest.kt
@@ -89,4 +89,30 @@ internal class StdoutSpanExporterTest {
         val exporter = StdoutSpanExporter()
         assertEquals(OperationResultCode.Success, exporter.shutdown())
     }
+
+    @Test
+    fun testExportReturnsFailureAfterShutdown() = runTest {
+        val output = mutableListOf<String>()
+        val exporter = StdoutSpanExporter(output::add)
+        exporter.shutdown()
+
+        val span = FakeReadWriteSpan(name = "test-span")
+        val result = exporter.export(listOf(span))
+        assertEquals(OperationResultCode.Failure, result)
+        assertEquals(0, output.size)
+    }
+
+    @Test
+    fun testShutdownReturnsSuccessOnSecondCall() = runTest {
+        val exporter = StdoutSpanExporter()
+        assertEquals(OperationResultCode.Success, exporter.shutdown())
+        assertEquals(OperationResultCode.Success, exporter.shutdown())
+    }
+
+    @Test
+    fun testForceFlushWorksAfterShutdown() = runTest {
+        val exporter = StdoutSpanExporter()
+        exporter.shutdown()
+        assertEquals(OperationResultCode.Success, exporter.forceFlush())
+    }
 }

--- a/exporters-core/src/jvmTest/kotlin/io/opentelemetry/kotlin/tracing/export/StdoutSpanExporterJvmTest.kt
+++ b/exporters-core/src/jvmTest/kotlin/io/opentelemetry/kotlin/tracing/export/StdoutSpanExporterJvmTest.kt
@@ -1,0 +1,49 @@
+package io.opentelemetry.kotlin.tracing.export
+
+import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.export.OperationResultCode
+import io.opentelemetry.kotlin.tracing.FakeReadWriteSpan
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+import java.util.concurrent.CountDownLatch
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalApi::class)
+internal class StdoutSpanExporterJvmTest {
+
+    @Suppress("InjectDispatcher")
+    @Test
+    fun testInFlightExportCompletesWhenShutdownCalled() = runBlocking {
+        val exportStarted = CountDownLatch(1)
+        val proceedWithExport = CountDownLatch(1)
+        val logOutput = mutableListOf<String>()
+
+        val exporter = StdoutSpanExporter { line ->
+            logOutput.add(line)
+            exportStarted.countDown()
+            proceedWithExport.await()
+        }
+
+        val span = FakeReadWriteSpan(name = "test-span")
+
+        val exportJob = async(Dispatchers.Default) {
+            exporter.export(listOf(span))
+        }
+
+        // Wait for the export to be inside the logger callback
+        exportStarted.await()
+
+        // Shutdown while the export is still inside the ifActive block
+        exporter.shutdown()
+        proceedWithExport.countDown()
+
+        // The in-flight export should complete successfully
+        assertEquals(OperationResultCode.Success, exportJob.await())
+        assertEquals(1, logOutput.size)
+
+        // New exports after shutdown should be rejected
+        assertEquals(OperationResultCode.Failure, exporter.export(listOf(span)))
+    }
+}


### PR DESCRIPTION
## Summary
- Phase 3 of 10: Shutdown compliance stack
- Adds `MutableShutdownState` to `SimpleSpanProcessor`, `BatchSpanProcessorImpl`, and `StdoutSpanExporter`
- All span processing/exporting respects shutdown state

🤖 Generated with [Claude Code](https://claude.com/claude-code)