### PR TITLE
add shutdown compliance to log processors and exporters

### DIFF
--- a/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/BatchLogRecordProcessorImpl.kt
+++ b/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/BatchLogRecordProcessorImpl.kt
@@ -1,10 +1,13 @@
 package io.opentelemetry.kotlin.logging.export
 
 import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.InstrumentationScopeInfo
 import io.opentelemetry.kotlin.context.Context
 import io.opentelemetry.kotlin.export.BatchTelemetryProcessor
+import io.opentelemetry.kotlin.export.MutableShutdownState
 import io.opentelemetry.kotlin.export.OperationResultCode
 import io.opentelemetry.kotlin.logging.model.ReadWriteLogRecord
+import io.opentelemetry.kotlin.logging.model.SeverityNumber
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 
@@ -17,6 +20,8 @@ internal class BatchLogRecordProcessorImpl(
     private val maxExportBatchSize: Int,
     dispatcher: CoroutineDispatcher = Dispatchers.Default,
 ) : LogRecordProcessor {
+
+    private val shutdownState = MutableShutdownState()
 
     private val processor =
         BatchTelemetryProcessor(
@@ -31,8 +36,22 @@ internal class BatchLogRecordProcessorImpl(
     override fun onEmit(
         log: ReadWriteLogRecord,
         context: Context
-    ) = processor.processTelemetry(log)
+    ) {
+        shutdownState.execute { processor.processTelemetry(log) }
+    }
+
+    override fun enabled(
+        context: Context,
+        instrumentationScopeInfo: InstrumentationScopeInfo,
+        severityNumber: SeverityNumber?,
+        eventName: String?,
+    ): Boolean = !shutdownState.isShutdown
 
     override suspend fun forceFlush(): OperationResultCode = processor.forceFlush()
-    override suspend fun shutdown(): OperationResultCode = processor.shutdown()
+
+    override suspend fun shutdown(): OperationResultCode =
+        shutdownState.ifActive(OperationResultCode.Success) {
+            shutdownState.shutdown()
+            processor.shutdown()
+        }
 }

--- a/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/SimpleLogRecordProcessor.kt
+++ b/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/SimpleLogRecordProcessor.kt
@@ -1,10 +1,13 @@
 package io.opentelemetry.kotlin.logging.export
 
 import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.InstrumentationScopeInfo
 import io.opentelemetry.kotlin.ReentrantReadWriteLock
 import io.opentelemetry.kotlin.context.Context
+import io.opentelemetry.kotlin.export.MutableShutdownState
 import io.opentelemetry.kotlin.export.OperationResultCode
 import io.opentelemetry.kotlin.logging.model.ReadWriteLogRecord
+import io.opentelemetry.kotlin.logging.model.SeverityNumber
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
@@ -20,18 +23,33 @@ internal class SimpleLogRecordProcessor(
 ) : LogRecordProcessor {
 
     private val lock = ReentrantReadWriteLock()
+    private val shutdownState = MutableShutdownState()
 
     override fun onEmit(
         log: ReadWriteLogRecord,
         context: Context
     ) {
-        scope.launch {
-            lock.write {
-                exporter.export(listOf(log))
+        shutdownState.execute {
+            scope.launch {
+                lock.write {
+                    exporter.export(listOf(log))
+                }
             }
         }
     }
 
-    override suspend fun forceFlush(): OperationResultCode = OperationResultCode.Success
-    override suspend fun shutdown(): OperationResultCode = OperationResultCode.Success
+    override fun enabled(
+        context: Context,
+        instrumentationScopeInfo: InstrumentationScopeInfo,
+        severityNumber: SeverityNumber?,
+        eventName: String?,
+    ): Boolean = !shutdownState.isShutdown
+
+    override suspend fun forceFlush(): OperationResultCode = exporter.forceFlush()
+
+    override suspend fun shutdown(): OperationResultCode =
+        shutdownState.ifActive(OperationResultCode.Success) {
+            shutdownState.shutdown()
+            exporter.shutdown()
+        }
 }

--- a/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/StdoutLogRecordExporter.kt
+++ b/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/StdoutLogRecordExporter.kt
@@ -1,6 +1,7 @@
 package io.opentelemetry.kotlin.logging.export
 
 import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.export.MutableShutdownState
 import io.opentelemetry.kotlin.export.OperationResultCode
 import io.opentelemetry.kotlin.logging.model.ReadableLogRecord
 import io.opentelemetry.kotlin.platformLog
@@ -13,15 +14,23 @@ internal class StdoutLogRecordExporter(
     private val logger: (String) -> Unit = ::platformLog
 ) : LogRecordExporter {
 
-    override suspend fun export(telemetry: List<ReadableLogRecord>): OperationResultCode {
-        telemetry.forEach { logRecord ->
-            logger(formatLogRecord(logRecord))
+    private val shutdownState = MutableShutdownState()
+
+    override suspend fun export(telemetry: List<ReadableLogRecord>): OperationResultCode =
+        shutdownState.ifActive {
+            telemetry.forEach { logRecord ->
+                logger(formatLogRecord(logRecord))
+            }
+            OperationResultCode.Success
         }
-        return OperationResultCode.Success
-    }
 
     override suspend fun forceFlush(): OperationResultCode = OperationResultCode.Success
-    override suspend fun shutdown(): OperationResultCode = OperationResultCode.Success
+
+    override suspend fun shutdown(): OperationResultCode =
+        shutdownState.ifActive(OperationResultCode.Success) {
+            shutdownState.shutdown()
+            OperationResultCode.Success
+        }
 
     private fun formatLogRecord(logRecord: ReadableLogRecord): String = buildString {
         append("LogRecord")

--- a/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/export/BatchLogRecordProcessorImplTest.kt
+++ b/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/export/BatchLogRecordProcessorImplTest.kt
@@ -1,0 +1,67 @@
+package io.opentelemetry.kotlin.logging.export
+
+import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.FakeInstrumentationScopeInfo
+import io.opentelemetry.kotlin.context.FakeContext
+import io.opentelemetry.kotlin.export.OperationResultCode
+import io.opentelemetry.kotlin.logging.model.FakeReadWriteLogRecord
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalApi::class, ExperimentalCoroutinesApi::class)
+internal class BatchLogRecordProcessorImplTest {
+
+    private lateinit var exporter: FakeLogRecordExporter
+    private lateinit var processor: BatchLogRecordProcessorImpl
+
+    @BeforeTest
+    fun setup() {
+        exporter = FakeLogRecordExporter()
+        processor = BatchLogRecordProcessorImpl(
+            exporter = exporter,
+            maxQueueSize = 100,
+            scheduleDelayMs = 1,
+            exportTimeoutMs = 1000,
+            maxExportBatchSize = 10,
+        )
+    }
+
+    @Test
+    fun testOnEmitNoOpAfterShutdown() = runTest {
+        processor.shutdown()
+        advanceUntilIdle()
+
+        val log = FakeReadWriteLogRecord()
+        processor.onEmit(log, FakeContext())
+        advanceUntilIdle()
+
+        assertTrue(exporter.logs.isEmpty())
+    }
+
+    @Test
+    fun testShutdownReturnsSuccessOnSecondCall() = runTest {
+        assertEquals(OperationResultCode.Success, processor.shutdown())
+        assertEquals(OperationResultCode.Success, processor.shutdown())
+    }
+
+    @Test
+    fun testEnabledReturnsFalseAfterShutdown() = runTest {
+        assertTrue(processor.enabled(FakeContext(), FakeInstrumentationScopeInfo(), null, null))
+
+        processor.shutdown()
+        assertFalse(processor.enabled(FakeContext(), FakeInstrumentationScopeInfo(), null, null))
+    }
+
+    @Test
+    fun testForceFlushWorksAfterShutdown() = runTest {
+        processor.shutdown()
+        advanceUntilIdle()
+        assertEquals(OperationResultCode.Success, processor.forceFlush())
+    }
+}

--- a/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/export/SimpleLogRecordProcessorTest.kt
+++ b/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/export/SimpleLogRecordProcessorTest.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 @OptIn(ExperimentalApi::class, ExperimentalCoroutinesApi::class)
@@ -20,9 +21,9 @@ internal class SimpleLogRecordProcessorTest {
     @Test
     fun testSpanProcessorDefaults() = runTest {
         val processor = FakeLogExportConfig().simpleLogRecordProcessor(FakeLogRecordExporter())
+        assertTrue(processor.enabled(FakeContext(), FakeInstrumentationScopeInfo(), null, null))
         assertEquals(OperationResultCode.Success, processor.shutdown())
         assertEquals(OperationResultCode.Success, processor.forceFlush())
-        assertTrue(processor.enabled(FakeContext(), FakeInstrumentationScopeInfo(), null, null))
     }
 
     @Test
@@ -38,5 +39,52 @@ internal class SimpleLogRecordProcessorTest {
 
         val export = exporter.logs.single()
         assertEquals(log.body, export.body)
+    }
+
+    @Test
+    fun testOnEmitNoOpAfterShutdown() = runTest {
+        val exporter = FakeLogRecordExporter()
+        val processor = SimpleLogRecordProcessor(
+            exporter,
+            CoroutineScope(UnconfinedTestDispatcher(testScheduler)),
+        )
+        processor.shutdown()
+
+        val log = FakeReadWriteLogRecord()
+        processor.onEmit(log, FakeContext())
+        assertTrue(exporter.logs.isEmpty())
+    }
+
+    @Test
+    fun testShutdownReturnsSuccessOnSecondCall() = runTest {
+        val processor = SimpleLogRecordProcessor(
+            FakeLogRecordExporter(),
+            CoroutineScope(UnconfinedTestDispatcher(testScheduler)),
+        )
+
+        assertEquals(OperationResultCode.Success, processor.shutdown())
+        assertEquals(OperationResultCode.Success, processor.shutdown())
+    }
+
+    @Test
+    fun testEnabledReturnsFalseAfterShutdown() = runTest {
+        val processor = SimpleLogRecordProcessor(
+            FakeLogRecordExporter(),
+            CoroutineScope(UnconfinedTestDispatcher(testScheduler)),
+        )
+        processor.shutdown()
+
+        assertFalse(processor.enabled(FakeContext(), FakeInstrumentationScopeInfo(), null, null))
+    }
+
+    @Test
+    fun testForceFlushWorksAfterShutdown() = runTest {
+        val processor = SimpleLogRecordProcessor(
+            FakeLogRecordExporter(),
+            CoroutineScope(UnconfinedTestDispatcher(testScheduler)),
+        )
+        processor.shutdown()
+
+        assertEquals(OperationResultCode.Success, processor.forceFlush())
     }
 }

--- a/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/export/StdoutLogRecordExporterTest.kt
+++ b/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/export/StdoutLogRecordExporterTest.kt
@@ -84,4 +84,30 @@ internal class StdoutLogRecordExporterTest {
         val exporter = StdoutLogRecordExporter()
         assertEquals(OperationResultCode.Success, exporter.shutdown())
     }
+
+    @Test
+    fun testExportReturnsFailureAfterShutdown() = runTest {
+        val output = mutableListOf<String>()
+        val exporter = StdoutLogRecordExporter(output::add)
+        exporter.shutdown()
+
+        val logRecord = FakeReadableLogRecord()
+        val result = exporter.export(listOf(logRecord))
+        assertEquals(OperationResultCode.Failure, result)
+        assertEquals(0, output.size)
+    }
+
+    @Test
+    fun testShutdownReturnsSuccessOnSecondCall() = runTest {
+        val exporter = StdoutLogRecordExporter()
+        assertEquals(OperationResultCode.Success, exporter.shutdown())
+        assertEquals(OperationResultCode.Success, exporter.shutdown())
+    }
+
+    @Test
+    fun testForceFlushWorksAfterShutdown() = runTest {
+        val exporter = StdoutLogRecordExporter()
+        exporter.shutdown()
+        assertEquals(OperationResultCode.Success, exporter.forceFlush())
+    }
 }

--- a/exporters-core/src/jvmTest/kotlin/io/opentelemetry/kotlin/logging/export/StdoutLogRecordExporterJvmTest.kt
+++ b/exporters-core/src/jvmTest/kotlin/io/opentelemetry/kotlin/logging/export/StdoutLogRecordExporterJvmTest.kt
@@ -1,0 +1,49 @@
+package io.opentelemetry.kotlin.logging.export
+
+import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.export.OperationResultCode
+import io.opentelemetry.kotlin.logging.model.FakeReadableLogRecord
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+import java.util.concurrent.CountDownLatch
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalApi::class)
+internal class StdoutLogRecordExporterJvmTest {
+
+    @Suppress("InjectDispatcher")
+    @Test
+    fun testInFlightExportCompletesWhenShutdownCalled() = runBlocking {
+        val exportStarted = CountDownLatch(1)
+        val proceedWithExport = CountDownLatch(1)
+        val logOutput = mutableListOf<String>()
+
+        val exporter = StdoutLogRecordExporter { line ->
+            logOutput.add(line)
+            exportStarted.countDown()
+            proceedWithExport.await()
+        }
+
+        val logRecord = FakeReadableLogRecord()
+
+        val exportJob = async(Dispatchers.Default) {
+            exporter.export(listOf(logRecord))
+        }
+
+        // Wait for the export to be inside the logger callback
+        exportStarted.await()
+
+        // Shutdown while the export is still inside the ifActive block
+        exporter.shutdown()
+        proceedWithExport.countDown()
+
+        // The in-flight export should complete successfully
+        assertEquals(OperationResultCode.Success, exportJob.await())
+        assertEquals(1, logOutput.size)
+
+        // New exports after shutdown should be rejected
+        assertEquals(OperationResultCode.Failure, exporter.export(listOf(logRecord)))
+    }
+}


### PR DESCRIPTION
## Summary
- Phase 4 of 10: Shutdown compliance stack
- Adds `MutableShutdownState` to `SimpleLogRecordProcessor`, `BatchLogRecordProcessorImpl`, and `StdoutLogRecordExporter`
- All log processing/exporting respects shutdown state

🤖 Generated with [Claude Code](https://claude.com/claude-code)