### PR TITLE
add shutdown compliance to in-memory exporters

### DIFF
--- a/exporters-in-memory/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/InMemoryLogRecordExporterImpl.kt
+++ b/exporters-in-memory/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/InMemoryLogRecordExporterImpl.kt
@@ -1,6 +1,7 @@
 package io.opentelemetry.kotlin.logging.export
 
 import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.export.MutableShutdownState
 import io.opentelemetry.kotlin.export.OperationResultCode
 import io.opentelemetry.kotlin.logging.model.ReadableLogRecord
 
@@ -8,15 +9,22 @@ import io.opentelemetry.kotlin.logging.model.ReadableLogRecord
 internal class InMemoryLogRecordExporterImpl : InMemoryLogRecordExporter {
 
     private val impl = mutableListOf<ReadableLogRecord>()
+    private val shutdownState = MutableShutdownState()
 
     override val exportedLogRecords: List<ReadableLogRecord>
         get() = impl
 
-    override suspend fun export(telemetry: List<ReadableLogRecord>): OperationResultCode {
-        impl += telemetry
-        return OperationResultCode.Success
-    }
+    override suspend fun export(telemetry: List<ReadableLogRecord>): OperationResultCode =
+        shutdownState.ifActive {
+            impl += telemetry
+            OperationResultCode.Success
+        }
 
-    override suspend fun shutdown(): OperationResultCode = OperationResultCode.Success
     override suspend fun forceFlush(): OperationResultCode = OperationResultCode.Success
+
+    override suspend fun shutdown(): OperationResultCode =
+        shutdownState.ifActive(OperationResultCode.Success) {
+            shutdownState.shutdown()
+            OperationResultCode.Success
+        }
 }

--- a/exporters-in-memory/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/InMemorySpanExporterImpl.kt
+++ b/exporters-in-memory/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/InMemorySpanExporterImpl.kt
@@ -1,6 +1,7 @@
 package io.opentelemetry.kotlin.tracing.export
 
 import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.export.MutableShutdownState
 import io.opentelemetry.kotlin.export.OperationResultCode
 import io.opentelemetry.kotlin.tracing.data.SpanData
 
@@ -8,15 +9,22 @@ import io.opentelemetry.kotlin.tracing.data.SpanData
 internal class InMemorySpanExporterImpl : InMemorySpanExporter {
 
     private val impl = mutableListOf<SpanData>()
+    private val shutdownState = MutableShutdownState()
 
     override val exportedSpans: List<SpanData>
         get() = impl
 
-    override suspend fun export(telemetry: List<SpanData>): OperationResultCode {
-        impl += telemetry
-        return OperationResultCode.Success
-    }
+    override suspend fun export(telemetry: List<SpanData>): OperationResultCode =
+        shutdownState.ifActive {
+            impl += telemetry
+            OperationResultCode.Success
+        }
 
     override suspend fun forceFlush(): OperationResultCode = OperationResultCode.Success
-    override suspend fun shutdown(): OperationResultCode = OperationResultCode.Success
+
+    override suspend fun shutdown(): OperationResultCode =
+        shutdownState.ifActive(OperationResultCode.Success) {
+            shutdownState.shutdown()
+            OperationResultCode.Success
+        }
 }

--- a/exporters-in-memory/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/export/InMemoryLogRecordExporterTest.kt
+++ b/exporters-in-memory/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/export/InMemoryLogRecordExporterTest.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.test.runTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 @OptIn(ExperimentalApi::class)
 internal class InMemoryLogRecordExporterTest {
@@ -34,5 +35,25 @@ internal class InMemoryLogRecordExporterTest {
     fun testExport() = runTest {
         exporter.export(fakeTelemetry)
         assertEquals(fakeTelemetry, exporter.exportedLogRecords)
+    }
+
+    @Test
+    fun testExportReturnsFailureAfterShutdown() = runTest {
+        exporter.shutdown()
+        val result = exporter.export(fakeTelemetry)
+        assertEquals(OperationResultCode.Failure, result)
+        assertTrue(exporter.exportedLogRecords.isEmpty())
+    }
+
+    @Test
+    fun testShutdownReturnsSuccessOnSecondCall() = runTest {
+        assertEquals(OperationResultCode.Success, exporter.shutdown())
+        assertEquals(OperationResultCode.Success, exporter.shutdown())
+    }
+
+    @Test
+    fun testForceFlushWorksAfterShutdown() = runTest {
+        exporter.shutdown()
+        assertEquals(OperationResultCode.Success, exporter.forceFlush())
     }
 }

--- a/exporters-in-memory/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/export/InMemorySpanExporterTest.kt
+++ b/exporters-in-memory/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/export/InMemorySpanExporterTest.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.test.runTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 @OptIn(ExperimentalApi::class)
 internal class InMemorySpanExporterTest {
@@ -34,5 +35,25 @@ internal class InMemorySpanExporterTest {
     fun testExport() = runTest {
         exporter.export(fakeTelemetry)
         assertEquals(fakeTelemetry, exporter.exportedSpans)
+    }
+
+    @Test
+    fun testExportReturnsFailureAfterShutdown() = runTest {
+        exporter.shutdown()
+        val result = exporter.export(fakeTelemetry)
+        assertEquals(OperationResultCode.Failure, result)
+        assertTrue(exporter.exportedSpans.isEmpty())
+    }
+
+    @Test
+    fun testShutdownReturnsSuccessOnSecondCall() = runTest {
+        assertEquals(OperationResultCode.Success, exporter.shutdown())
+        assertEquals(OperationResultCode.Success, exporter.shutdown())
+    }
+
+    @Test
+    fun testForceFlushWorksAfterShutdown() = runTest {
+        exporter.shutdown()
+        assertEquals(OperationResultCode.Success, exporter.forceFlush())
     }
 }


### PR DESCRIPTION
## Summary
- Phase 5 of 10: Shutdown compliance stack
- Adds `MutableShutdownState` to `InMemorySpanExporterImpl` and `InMemoryLogRecordExporterImpl`
- In-memory exporters reject data after shutdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)