### PR TITLE
add shutdown compliance to persistence exporters

### DIFF
--- a/exporters-persistence/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/PersistingLogRecordExporter.kt
+++ b/exporters-persistence/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/PersistingLogRecordExporter.kt
@@ -1,6 +1,7 @@
 package io.opentelemetry.kotlin.logging.export
 
 import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.export.MutableShutdownState
 import io.opentelemetry.kotlin.export.OperationResultCode
 import io.opentelemetry.kotlin.export.OperationResultCode.Success
 import io.opentelemetry.kotlin.export.TelemetryRepository
@@ -14,17 +15,23 @@ internal class PersistingLogRecordExporter(
 
     @Suppress("DEPRECATION")
     private val exporter = createCompositeLogRecordExporter(exporters)
+    private val shutdownState = MutableShutdownState()
 
-    override suspend fun export(telemetry: List<ReadableLogRecord>): OperationResultCode {
-        val record = repository.store(telemetry)
-
-        val result = exporter.export(telemetry)
-        if (result == Success && record != null) {
-            repository.delete(record)
+    override suspend fun export(telemetry: List<ReadableLogRecord>): OperationResultCode =
+        shutdownState.ifActive {
+            val record = repository.store(telemetry)
+            val result = exporter.export(telemetry)
+            if (result == Success && record != null) {
+                repository.delete(record)
+            }
+            result
         }
-        return result
-    }
 
     override suspend fun forceFlush(): OperationResultCode = exporter.forceFlush()
-    override suspend fun shutdown(): OperationResultCode = exporter.shutdown()
+
+    override suspend fun shutdown(): OperationResultCode =
+        shutdownState.ifActive(OperationResultCode.Success) {
+            shutdownState.shutdown()
+            exporter.shutdown()
+        }
 }

--- a/exporters-persistence/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/PersistingLogRecordProcessor.kt
+++ b/exporters-persistence/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/PersistingLogRecordProcessor.kt
@@ -2,9 +2,11 @@ package io.opentelemetry.kotlin.logging.export
 
 import io.opentelemetry.kotlin.Clock
 import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.InstrumentationScopeInfo
 import io.opentelemetry.kotlin.context.Context
 import io.opentelemetry.kotlin.error.SdkErrorHandler
 import io.opentelemetry.kotlin.error.SdkErrorSeverity
+import io.opentelemetry.kotlin.export.MutableShutdownState
 import io.opentelemetry.kotlin.export.OperationResultCode
 import io.opentelemetry.kotlin.export.PersistedTelemetryConfig
 import io.opentelemetry.kotlin.export.PersistedTelemetryType
@@ -14,6 +16,7 @@ import io.opentelemetry.kotlin.export.TelemetryRepositoryImpl
 import io.opentelemetry.kotlin.export.TimeoutTelemetryCloseable
 import io.opentelemetry.kotlin.logging.model.ReadWriteLogRecord
 import io.opentelemetry.kotlin.logging.model.ReadableLogRecord
+import io.opentelemetry.kotlin.logging.model.SeverityNumber
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 
@@ -69,19 +72,34 @@ internal class PersistingLogRecordProcessor(
     @Suppress("DEPRECATION")
     private val processor = createCompositeLogRecordProcessor(processors + batchingProcessor)
     private val telemetryCloseable: TelemetryCloseable = TimeoutTelemetryCloseable(processor)
+    private val shutdownState = MutableShutdownState()
 
     override fun onEmit(log: ReadWriteLogRecord, context: Context) {
-        try {
-            processor.onEmit(log, context)
-        } catch (e: Throwable) {
-            sdkErrorHandler.onUserCodeError(
-                e,
-                "LogRecordProcessor.onEmit failed",
-                SdkErrorSeverity.WARNING
-            )
+        shutdownState.execute {
+            try {
+                processor.onEmit(log, context)
+            } catch (e: Throwable) {
+                sdkErrorHandler.onUserCodeError(
+                    e,
+                    "LogRecordProcessor.onEmit failed",
+                    SdkErrorSeverity.WARNING
+                )
+            }
         }
     }
 
+    override fun enabled(
+        context: Context,
+        instrumentationScopeInfo: InstrumentationScopeInfo,
+        severityNumber: SeverityNumber?,
+        eventName: String?,
+    ): Boolean = !shutdownState.isShutdown
+
     override suspend fun forceFlush(): OperationResultCode = telemetryCloseable.forceFlush()
-    override suspend fun shutdown(): OperationResultCode = telemetryCloseable.shutdown()
+
+    override suspend fun shutdown(): OperationResultCode =
+        shutdownState.ifActive(OperationResultCode.Success) {
+            shutdownState.shutdown()
+            telemetryCloseable.shutdown()
+        }
 }

--- a/exporters-persistence/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/export/PersistingLogRecordExporterTest.kt
+++ b/exporters-persistence/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/export/PersistingLogRecordExporterTest.kt
@@ -2,6 +2,7 @@ package io.opentelemetry.kotlin.logging.export
 
 import io.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.kotlin.export.FakeTelemetryRepository
+import io.opentelemetry.kotlin.export.OperationResultCode
 import io.opentelemetry.kotlin.export.OperationResultCode.Failure
 import io.opentelemetry.kotlin.export.OperationResultCode.Success
 import io.opentelemetry.kotlin.logging.model.FakeReadableLogRecord
@@ -72,5 +73,31 @@ internal class PersistingLogRecordExporterTest {
 
         val result = exporter.export(telemetry)
         assertEquals(Failure, result)
+    }
+
+    @Test
+    fun testExportReturnsFailureAfterShutdown() = runTest {
+        val repository = FakeTelemetryRepository<ReadableLogRecord>()
+        val exporter = PersistingLogRecordExporter(listOf(FakeLogRecordExporter()), repository)
+        exporter.shutdown()
+
+        val result = exporter.export(telemetry)
+        assertEquals(Failure, result)
+    }
+
+    @Test
+    fun testShutdownReturnsSuccessOnSecondCall() = runTest {
+        val repository = FakeTelemetryRepository<ReadableLogRecord>()
+        val exporter = PersistingLogRecordExporter(listOf(FakeLogRecordExporter()), repository)
+        assertEquals(Success, exporter.shutdown())
+        assertEquals(Success, exporter.shutdown())
+    }
+
+    @Test
+    fun testForceFlushWorksAfterShutdown() = runTest {
+        val repository = FakeTelemetryRepository<ReadableLogRecord>()
+        val exporter = PersistingLogRecordExporter(listOf(FakeLogRecordExporter()), repository)
+        exporter.shutdown()
+        assertEquals(OperationResultCode.Success, exporter.forceFlush())
     }
 }

--- a/exporters-persistence/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/export/PersistingLogRecordProcessorTest.kt
+++ b/exporters-persistence/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/export/PersistingLogRecordProcessorTest.kt
@@ -2,6 +2,7 @@ package io.opentelemetry.kotlin.logging.export
 
 import io.opentelemetry.kotlin.Clock
 import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.FakeInstrumentationScopeInfo
 import io.opentelemetry.kotlin.clock.FakeClock
 import io.opentelemetry.kotlin.context.Context
 import io.opentelemetry.kotlin.context.FakeContext
@@ -21,6 +22,7 @@ import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 @OptIn(ExperimentalApi::class, ExperimentalCoroutinesApi::class)
@@ -302,6 +304,43 @@ internal class PersistingLogRecordProcessorTest {
         val result = resultDeferred.await()
 
         assertEquals(Failure, result)
+    }
+
+    @Test
+    fun testShutdownReturnsSuccessOnSecondCall() = runTest {
+        val processor = createProcessor(
+            exporters = listOf(FakeLogRecordExporter()),
+        )
+
+        assertEquals(Success, processor.shutdown())
+        assertEquals(Success, processor.shutdown())
+    }
+
+    @Test
+    fun testEnabledReturnsFalseAfterShutdown() = runTest {
+        val processor = createProcessor(
+            exporters = listOf(FakeLogRecordExporter()),
+        )
+
+        processor.shutdown()
+        assertFalse(
+            processor.enabled(
+                FakeContext(),
+                FakeInstrumentationScopeInfo(),
+                null,
+                null,
+            )
+        )
+    }
+
+    @Test
+    fun testForceFlushWorksAfterShutdown() = runTest {
+        val processor = createProcessor(
+            exporters = listOf(FakeLogRecordExporter()),
+        )
+
+        processor.shutdown()
+        assertEquals(Success, processor.forceFlush())
     }
 
     private fun TestScope.createProcessor(


### PR DESCRIPTION
## Summary
- Phase 6 of 10: Shutdown compliance stack
- Adds `MutableShutdownState` to `PersistingLogRecordExporter` and `PersistingLogRecordProcessor`
- Persistence exporters respect shutdown state

🤖 Generated with [Claude Code](https://claude.com/claude-code)