### PR TITLE
propagate read-only ShutdownState to TracerProviderImpl and TracerImpl

### DIFF
--- a/implementation/build.gradle.kts
+++ b/implementation/build.gradle.kts
@@ -17,6 +17,7 @@ kotlin {
                 implementation(project(":model"))
                 implementation(project(":platform-implementations"))
                 implementation(project(":exporters-core"))
+                implementation(project(":noop"))
                 implementation(libs.kotlinx.coroutines)
             }
         }

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/TracerImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/TracerImpl.kt
@@ -3,7 +3,9 @@ package io.opentelemetry.kotlin.tracing
 import io.opentelemetry.kotlin.Clock
 import io.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.kotlin.InstrumentationScopeInfo
+import io.opentelemetry.kotlin.NoopOpenTelemetry
 import io.opentelemetry.kotlin.context.Context
+import io.opentelemetry.kotlin.export.ShutdownState
 import io.opentelemetry.kotlin.factory.SdkFactory
 import io.opentelemetry.kotlin.init.config.SpanLimitConfig
 import io.opentelemetry.kotlin.resource.Resource
@@ -24,7 +26,10 @@ internal class TracerImpl(
     private val scope: InstrumentationScopeInfo,
     private val resource: Resource,
     private val spanLimitConfig: SpanLimitConfig,
+    private val shutdownState: ShutdownState,
 ) : Tracer {
+
+    private val noopSpan = NoopOpenTelemetry.tracerProvider.getTracer("").startSpan("")
 
     private val contextFactory = sdkFactory.contextFactory
     private val root = contextFactory.root()
@@ -53,34 +58,35 @@ internal class TracerImpl(
         spanKind: SpanKind,
         startTimestamp: Long?,
         action: (SpanRelationships.() -> Unit)?
-    ): Span {
-        val ctx = parentContext ?: contextFactory.implicitContext()
+    ): Span =
+        shutdownState.ifActiveOrElse(noopSpan) {
+            val ctx = parentContext ?: contextFactory.implicitContext()
 
-        val parentSpanContext = when (ctx) {
-            root -> invalidSpanContext
-            else -> spanFactory.fromContext(ctx).spanContext
+            val parentSpanContext = when (ctx) {
+                root -> invalidSpanContext
+                else -> spanFactory.fromContext(ctx).spanContext
+            }
+
+            val spanContext = calculateSpanContext(parentSpanContext)
+
+            val spanModel = SpanModel(
+                clock = clock,
+                processor = processor,
+                name = name,
+                spanKind = spanKind,
+                startTimestamp = startTimestamp ?: clock.now(),
+                instrumentationScopeInfo = scope,
+                resource = resource,
+                parent = parentSpanContext,
+                spanContext = spanContext,
+                spanLimitConfig = spanLimitConfig
+            )
+            if (action != null) {
+                action(spanModel)
+            }
+            processor?.onStart(ReadWriteSpanImpl(spanModel), ctx)
+            CreatedSpan(spanModel)
         }
-
-        val spanContext = calculateSpanContext(parentSpanContext)
-
-        val spanModel = SpanModel(
-            clock = clock,
-            processor = processor,
-            name = name,
-            spanKind = spanKind,
-            startTimestamp = startTimestamp ?: clock.now(),
-            instrumentationScopeInfo = scope,
-            resource = resource,
-            parent = parentSpanContext,
-            spanContext = spanContext,
-            spanLimitConfig = spanLimitConfig
-        )
-        if (action != null) {
-            action(spanModel)
-        }
-        processor?.onStart(ReadWriteSpanImpl(spanModel), ctx)
-        return CreatedSpan(spanModel)
-    }
 
     private fun calculateSpanContext(parent: SpanContext): SpanContext {
         val factory = tracingIdFactory

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/TracerProviderImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/TracerProviderImpl.kt
@@ -2,8 +2,10 @@ package io.opentelemetry.kotlin.tracing
 
 import io.opentelemetry.kotlin.Clock
 import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.NoopOpenTelemetry
 import io.opentelemetry.kotlin.attributes.MutableAttributeContainer
 import io.opentelemetry.kotlin.export.DelegatingTelemetryCloseable
+import io.opentelemetry.kotlin.export.ShutdownState
 import io.opentelemetry.kotlin.export.TelemetryCloseable
 import io.opentelemetry.kotlin.factory.SdkFactory
 import io.opentelemetry.kotlin.init.config.TracingConfig
@@ -15,8 +17,11 @@ internal class TracerProviderImpl(
     private val clock: Clock,
     tracingConfig: TracingConfig,
     sdkFactory: SdkFactory,
+    private val shutdownState: ShutdownState,
     private val closeable: DelegatingTelemetryCloseable = DelegatingTelemetryCloseable()
 ) : TracerProvider, TelemetryCloseable by closeable {
+
+    private val noopTracer = NoopOpenTelemetry.tracerProvider.getTracer("")
 
     private val apiProvider = ApiProviderImpl<Tracer> { key ->
         @Suppress("DEPRECATION")
@@ -33,7 +38,8 @@ internal class TracerProviderImpl(
             sdkFactory = sdkFactory,
             scope = key,
             resource = tracingConfig.resource,
-            spanLimitConfig = tracingConfig.spanLimits
+            spanLimitConfig = tracingConfig.spanLimits,
+            shutdownState = shutdownState,
         )
     }
 
@@ -42,13 +48,14 @@ internal class TracerProviderImpl(
         version: String?,
         schemaUrl: String?,
         attributes: (MutableAttributeContainer.() -> Unit)?
-    ): Tracer {
-        val key = apiProvider.createInstrumentationScopeInfo(
-            name = name,
-            version = version,
-            schemaUrl = schemaUrl,
-            attributes = attributes
-        )
-        return apiProvider.getOrCreate(key)
-    }
+    ): Tracer =
+        shutdownState.ifActiveOrElse(noopTracer) {
+            val key = apiProvider.createInstrumentationScopeInfo(
+                name = name,
+                version = version,
+                schemaUrl = schemaUrl,
+                attributes = attributes
+            )
+            apiProvider.getOrCreate(key)
+        }
 }

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/LogContextTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/LogContextTest.kt
@@ -3,6 +3,7 @@ package io.opentelemetry.kotlin.logging
 import io.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.kotlin.InstrumentationScopeInfoImpl
 import io.opentelemetry.kotlin.clock.FakeClock
+import io.opentelemetry.kotlin.export.MutableShutdownState
 import io.opentelemetry.kotlin.factory.SdkFactory
 import io.opentelemetry.kotlin.factory.createSdkFactory
 import io.opentelemetry.kotlin.logging.export.FakeLogRecordProcessor
@@ -40,12 +41,13 @@ internal class LogContextTest {
             fakeLogLimitsConfig
         )
         tracer = TracerImpl(
-            clock,
-            FakeSpanProcessor(),
-            sdkFactory,
-            key,
-            FakeResource(),
-            fakeSpanLimitsConfig
+            clock = clock,
+            processor = FakeSpanProcessor(),
+            sdkFactory = sdkFactory,
+            scope = key,
+            resource = FakeResource(),
+            spanLimitConfig = fakeSpanLimitsConfig,
+            shutdownState = MutableShutdownState(),
         )
     }
 

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/SpanAttributesTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/SpanAttributesTest.kt
@@ -4,6 +4,7 @@ import io.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.kotlin.InstrumentationScopeInfoImpl
 import io.opentelemetry.kotlin.attributes.MutableAttributeContainer
 import io.opentelemetry.kotlin.clock.FakeClock
+import io.opentelemetry.kotlin.export.MutableShutdownState
 import io.opentelemetry.kotlin.factory.FakeSdkFactory
 import io.opentelemetry.kotlin.init.config.SpanLimitConfig
 import io.opentelemetry.kotlin.resource.FakeResource
@@ -42,12 +43,13 @@ internal class SpanAttributesTest {
             attributeCountPerLinkLimit = fakeSpanLimitsConfig.attributeCountPerLinkLimit
         )
         tracer = TracerImpl(
-            FakeClock(),
-            FakeSpanProcessor(),
-            FakeSdkFactory(),
-            key,
-            FakeResource(),
-            spanLimitConfig,
+            clock = FakeClock(),
+            processor = FakeSpanProcessor(),
+            sdkFactory = FakeSdkFactory(),
+            scope = key,
+            resource = FakeResource(),
+            spanLimitConfig = spanLimitConfig,
+            shutdownState = MutableShutdownState(),
         )
     }
 

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/SpanDataTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/SpanDataTest.kt
@@ -3,6 +3,7 @@ package io.opentelemetry.kotlin.tracing
 import io.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.kotlin.InstrumentationScopeInfoImpl
 import io.opentelemetry.kotlin.clock.FakeClock
+import io.opentelemetry.kotlin.export.MutableShutdownState
 import io.opentelemetry.kotlin.factory.FakeSdkFactory
 import io.opentelemetry.kotlin.resource.FakeResource
 import io.opentelemetry.kotlin.tracing.data.SpanData
@@ -32,12 +33,13 @@ internal class SpanDataTest {
         fakeResource = FakeResource()
         fakeSpanContext = FakeSpanContext.INVALID
         tracer = TracerImpl(
-            clock,
-            processor,
-            FakeSdkFactory(),
-            key,
-            fakeResource,
-            fakeSpanLimitsConfig
+            clock = clock,
+            processor = processor,
+            sdkFactory = FakeSdkFactory(),
+            scope = key,
+            resource = fakeResource,
+            spanLimitConfig = fakeSpanLimitsConfig,
+            shutdownState = MutableShutdownState(),
         )
     }
 

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/SpanEndTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/SpanEndTest.kt
@@ -3,6 +3,7 @@ package io.opentelemetry.kotlin.tracing
 import io.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.kotlin.InstrumentationScopeInfoImpl
 import io.opentelemetry.kotlin.clock.FakeClock
+import io.opentelemetry.kotlin.export.MutableShutdownState
 import io.opentelemetry.kotlin.factory.FakeSdkFactory
 import io.opentelemetry.kotlin.factory.SdkFactory
 import io.opentelemetry.kotlin.resource.FakeResource
@@ -28,12 +29,13 @@ internal class SpanEndTest {
         processor = FakeSpanProcessor()
         sdkFactory = FakeSdkFactory()
         tracer = TracerImpl(
-            clock,
-            processor,
-            sdkFactory,
-            key,
-            FakeResource(),
-            fakeSpanLimitsConfig
+            clock = clock,
+            processor = processor,
+            sdkFactory = sdkFactory,
+            scope = key,
+            resource = FakeResource(),
+            spanLimitConfig = fakeSpanLimitsConfig,
+            shutdownState = MutableShutdownState(),
         )
     }
 

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/SpanEventTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/SpanEventTest.kt
@@ -3,6 +3,7 @@ package io.opentelemetry.kotlin.tracing
 import io.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.kotlin.InstrumentationScopeInfoImpl
 import io.opentelemetry.kotlin.clock.FakeClock
+import io.opentelemetry.kotlin.export.MutableShutdownState
 import io.opentelemetry.kotlin.factory.FakeSdkFactory
 import io.opentelemetry.kotlin.init.config.SpanLimitConfig
 import io.opentelemetry.kotlin.resource.FakeResource
@@ -34,12 +35,13 @@ internal class SpanEventTest {
             attributeCountPerLinkLimit = fakeSpanLimitsConfig.attributeCountPerLinkLimit
         )
         tracer = TracerImpl(
-            clock,
-            processor,
-            FakeSdkFactory(),
-            key,
-            FakeResource(),
-            spanLimitConfig
+            clock = clock,
+            processor = processor,
+            sdkFactory = FakeSdkFactory(),
+            scope = key,
+            resource = FakeResource(),
+            spanLimitConfig = spanLimitConfig,
+            shutdownState = MutableShutdownState(),
         )
     }
 

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/SpanLinkTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/SpanLinkTest.kt
@@ -3,6 +3,7 @@ package io.opentelemetry.kotlin.tracing
 import io.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.kotlin.InstrumentationScopeInfoImpl
 import io.opentelemetry.kotlin.clock.FakeClock
+import io.opentelemetry.kotlin.export.MutableShutdownState
 import io.opentelemetry.kotlin.factory.FakeSdkFactory
 import io.opentelemetry.kotlin.factory.hexToByteArray
 import io.opentelemetry.kotlin.init.config.SpanLimitConfig
@@ -39,12 +40,13 @@ internal class SpanLinkTest {
             attributeCountPerLinkLimit = fakeSpanLimitsConfig.attributeCountPerLinkLimit
         )
         tracer = TracerImpl(
-            clock,
-            processor,
-            FakeSdkFactory(),
-            key,
-            FakeResource(),
-            spanLimitConfig
+            clock = clock,
+            processor = processor,
+            sdkFactory = FakeSdkFactory(),
+            scope = key,
+            resource = FakeResource(),
+            spanLimitConfig = spanLimitConfig,
+            shutdownState = MutableShutdownState(),
         )
     }
 

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/SpanMetaPropertiesTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/SpanMetaPropertiesTest.kt
@@ -3,6 +3,7 @@ package io.opentelemetry.kotlin.tracing
 import io.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.kotlin.InstrumentationScopeInfoImpl
 import io.opentelemetry.kotlin.clock.FakeClock
+import io.opentelemetry.kotlin.export.MutableShutdownState
 import io.opentelemetry.kotlin.factory.FakeSdkFactory
 import io.opentelemetry.kotlin.resource.FakeResource
 import io.opentelemetry.kotlin.tracing.export.FakeSpanProcessor
@@ -24,12 +25,13 @@ internal class SpanMetaPropertiesTest {
         clock = FakeClock()
         processor = FakeSpanProcessor()
         tracer = TracerImpl(
-            clock,
-            processor,
-            FakeSdkFactory(),
-            key,
-            fakeResource,
-            fakeSpanLimitsConfig,
+            clock = clock,
+            processor = processor,
+            sdkFactory = FakeSdkFactory(),
+            scope = key,
+            resource = fakeResource,
+            spanLimitConfig = fakeSpanLimitsConfig,
+            shutdownState = MutableShutdownState(),
         )
     }
 

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/SpanSimplePropertiesTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/SpanSimplePropertiesTest.kt
@@ -3,6 +3,7 @@ package io.opentelemetry.kotlin.tracing
 import io.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.kotlin.InstrumentationScopeInfoImpl
 import io.opentelemetry.kotlin.clock.FakeClock
+import io.opentelemetry.kotlin.export.MutableShutdownState
 import io.opentelemetry.kotlin.factory.FakeSdkFactory
 import io.opentelemetry.kotlin.resource.FakeResource
 import io.opentelemetry.kotlin.tracing.data.StatusData
@@ -23,12 +24,13 @@ internal class SpanSimplePropertiesTest {
     fun setUp() {
         clock = FakeClock()
         tracer = TracerImpl(
-            clock,
-            FakeSpanProcessor(),
-            FakeSdkFactory(),
-            key,
-            FakeResource(),
-            fakeSpanLimitsConfig
+            clock = clock,
+            processor = FakeSpanProcessor(),
+            sdkFactory = FakeSdkFactory(),
+            scope = key,
+            resource = FakeResource(),
+            spanLimitConfig = fakeSpanLimitsConfig,
+            shutdownState = MutableShutdownState(),
         )
     }
 

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/TracerProviderImplTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/TracerProviderImplTest.kt
@@ -3,6 +3,7 @@ package io.opentelemetry.kotlin.tracing
 import io.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.kotlin.attributes.MutableAttributeContainerImpl
 import io.opentelemetry.kotlin.clock.FakeClock
+import io.opentelemetry.kotlin.export.MutableShutdownState
 import io.opentelemetry.kotlin.export.OperationResultCode
 import io.opentelemetry.kotlin.factory.FakeSdkFactory
 import io.opentelemetry.kotlin.init.config.TracingConfig
@@ -13,6 +14,7 @@ import kotlinx.coroutines.test.runTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNotEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertSame
@@ -30,7 +32,12 @@ internal class TracerProviderImplTest {
 
     @BeforeTest
     fun setUp() {
-        impl = TracerProviderImpl(FakeClock(), tracingConfig, FakeSdkFactory())
+        impl = TracerProviderImpl(
+            clock = FakeClock(),
+            tracingConfig = tracingConfig,
+            sdkFactory = FakeSdkFactory(),
+            shutdownState = MutableShutdownState(),
+        )
     }
 
     @Test
@@ -118,7 +125,12 @@ internal class TracerProviderImplTest {
             fakeSpanLimitsConfig,
             FakeResource(),
         )
-        val provider = TracerProviderImpl(FakeClock(), config, FakeSdkFactory())
+        val provider = TracerProviderImpl(
+            clock = FakeClock(),
+            tracingConfig = config,
+            sdkFactory = FakeSdkFactory(),
+            shutdownState = MutableShutdownState(),
+        )
         provider.getTracer(name = "test")
 
         val result = provider.forceFlush()
@@ -140,11 +152,47 @@ internal class TracerProviderImplTest {
             fakeSpanLimitsConfig,
             FakeResource(),
         )
-        val provider = TracerProviderImpl(FakeClock(), config, FakeSdkFactory())
+        val provider = TracerProviderImpl(
+            clock = FakeClock(),
+            tracingConfig = config,
+            sdkFactory = FakeSdkFactory(),
+            shutdownState = MutableShutdownState(),
+        )
         provider.getTracer(name = "test")
 
         val result = provider.shutdown()
         assertEquals(OperationResultCode.Success, result)
         assertEquals(true, shutdownCalled)
+    }
+
+    @Test
+    fun testGetTracerAfterShutdownReturnsNoopTracer() = runTest {
+        val shutdownState = MutableShutdownState()
+        val provider = TracerProviderImpl(
+            clock = FakeClock(),
+            tracingConfig = tracingConfig,
+            sdkFactory = FakeSdkFactory(),
+            shutdownState = shutdownState,
+        )
+        shutdownState.shutdown()
+        val tracer = provider.getTracer(name = "test")
+        val span = tracer.startSpan("test-span")
+        assertFalse(span.isRecording())
+    }
+
+    @Test
+    fun testExistingTracerReturnsNoopSpanAfterShutdown() = runTest {
+        val shutdownState = MutableShutdownState()
+        val provider = TracerProviderImpl(
+            clock = FakeClock(),
+            tracingConfig = tracingConfig,
+            sdkFactory = FakeSdkFactory(),
+            shutdownState = shutdownState,
+        )
+        val tracer = provider.getTracer(name = "test")
+        shutdownState.shutdown()
+        val span = tracer.startSpan("test-span")
+        assertFalse(span.isRecording())
+        assertFalse(span.spanContext.isValid)
     }
 }

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/TracerSpanContextTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/TracerSpanContextTest.kt
@@ -3,6 +3,7 @@ package io.opentelemetry.kotlin.tracing
 import io.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.kotlin.InstrumentationScopeInfoImpl
 import io.opentelemetry.kotlin.clock.FakeClock
+import io.opentelemetry.kotlin.export.MutableShutdownState
 import io.opentelemetry.kotlin.factory.SdkFactory
 import io.opentelemetry.kotlin.factory.createSdkFactory
 import io.opentelemetry.kotlin.factory.toHexString
@@ -33,12 +34,13 @@ internal class TracerSpanContextTest {
         processor = FakeSpanProcessor()
         sdkFactory = createSdkFactory()
         tracer = TracerImpl(
-            clock,
-            processor,
-            sdkFactory,
-            key,
-            FakeResource(),
-            fakeSpanLimitsConfig,
+            clock = clock,
+            processor = processor,
+            sdkFactory = sdkFactory,
+            scope = key,
+            resource = FakeResource(),
+            spanLimitConfig = fakeSpanLimitsConfig,
+            shutdownState = MutableShutdownState(),
         )
     }
 


### PR DESCRIPTION
## Summary
- Phase 8 of 10: Shutdown compliance stack
- `TracerProviderImpl` and `TracerImpl` accept `ShutdownState` (read-only abstract class) as a required parameter with no default
- After shutdown, `getTracer()` returns a noop tracer and `startSpan()` returns noop spans
- Noop instances are eagerly initialized (singletons, negligible cost)

🤖 Generated with [Claude Code](https://claude.com/claude-code)