### PR TITLE
propagate read-only ShutdownState to LoggerProviderImpl and LoggerImpl

### DIFF
--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/LoggerImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/LoggerImpl.kt
@@ -5,6 +5,7 @@ import io.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.kotlin.InstrumentationScopeInfo
 import io.opentelemetry.kotlin.attributes.MutableAttributeContainer
 import io.opentelemetry.kotlin.context.Context
+import io.opentelemetry.kotlin.export.ShutdownState
 import io.opentelemetry.kotlin.factory.SdkFactory
 import io.opentelemetry.kotlin.init.config.LogLimitConfig
 import io.opentelemetry.kotlin.logging.export.LogRecordProcessor
@@ -21,6 +22,7 @@ internal class LoggerImpl(
     private val key: InstrumentationScopeInfo,
     private val resource: Resource,
     private val logLimitConfig: LogLimitConfig,
+    private val shutdownState: ShutdownState,
 ) : Logger {
 
     private val contextFactory = sdkFactory.contextFactory
@@ -32,13 +34,13 @@ internal class LoggerImpl(
         context: Context?,
         severityNumber: SeverityNumber?,
         eventName: String?,
-    ): Boolean {
-        if (processor == null) {
-            return false
+    ): Boolean =
+        if (shutdownState.isShutdown || processor == null) {
+            false
+        } else {
+            val ctx = context ?: contextFactory.implicitContext()
+            processor.enabled(ctx, key, severityNumber, eventName)
         }
-        val ctx = context ?: contextFactory.implicitContext()
-        return processor.enabled(ctx, key, severityNumber, eventName)
-    }
 
     @Deprecated(
         "Deprecated",
@@ -129,28 +131,30 @@ internal class LoggerImpl(
         severityNumber: SeverityNumber?,
         attributes: (MutableAttributeContainer.() -> Unit)?
     ) {
-        val ctx = context ?: contextFactory.implicitContext()
-        val spanContext = when (ctx) {
-            root -> invalidSpanContext
-            else -> spanFactory.fromContext(ctx).spanContext
-        }
+        shutdownState.execute {
+            val ctx = context ?: contextFactory.implicitContext()
+            val spanContext = when (ctx) {
+                root -> invalidSpanContext
+                else -> spanFactory.fromContext(ctx).spanContext
+            }
 
-        val now = clock.now()
-        val log = LogRecordModel(
-            resource = resource,
-            instrumentationScopeInfo = key,
-            timestamp = timestamp ?: now,
-            observedTimestamp = observedTimestamp ?: now,
-            body = body,
-            severityText = severityText,
-            severityNumber = severityNumber ?: SeverityNumber.UNKNOWN,
-            spanContext = spanContext,
-            logLimitConfig = logLimitConfig,
-            eventName = eventName,
-        )
-        if (attributes != null) {
-            attributes(log)
+            val now = clock.now()
+            val log = LogRecordModel(
+                resource = resource,
+                instrumentationScopeInfo = key,
+                timestamp = timestamp ?: now,
+                observedTimestamp = observedTimestamp ?: now,
+                body = body,
+                severityText = severityText,
+                severityNumber = severityNumber ?: SeverityNumber.UNKNOWN,
+                spanContext = spanContext,
+                logLimitConfig = logLimitConfig,
+                eventName = eventName,
+            )
+            if (attributes != null) {
+                attributes(log)
+            }
+            processor?.onEmit(ReadWriteLogRecordImpl(log), ctx)
         }
-        processor?.onEmit(ReadWriteLogRecordImpl(log), ctx)
     }
 }

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/LoggerProviderImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/LoggerProviderImpl.kt
@@ -2,8 +2,10 @@ package io.opentelemetry.kotlin.logging
 
 import io.opentelemetry.kotlin.Clock
 import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.NoopOpenTelemetry
 import io.opentelemetry.kotlin.attributes.MutableAttributeContainer
 import io.opentelemetry.kotlin.export.DelegatingTelemetryCloseable
+import io.opentelemetry.kotlin.export.ShutdownState
 import io.opentelemetry.kotlin.export.TelemetryCloseable
 import io.opentelemetry.kotlin.factory.SdkFactory
 import io.opentelemetry.kotlin.init.config.LoggingConfig
@@ -15,8 +17,11 @@ internal class LoggerProviderImpl(
     private val clock: Clock,
     loggingConfig: LoggingConfig,
     sdkFactory: SdkFactory,
+    private val shutdownState: ShutdownState,
     private val closeable: DelegatingTelemetryCloseable = DelegatingTelemetryCloseable()
 ) : LoggerProvider, TelemetryCloseable by closeable {
+
+    private val noopLogger = NoopOpenTelemetry.loggerProvider.getLogger("")
 
     private val apiProvider by lazy {
         ApiProviderImpl<Logger> { key ->
@@ -29,12 +34,13 @@ internal class LoggerProviderImpl(
             }
             processor?.let(closeable::add)
             LoggerImpl(
-                clock,
-                processor,
-                sdkFactory,
-                key,
-                loggingConfig.resource,
-                loggingConfig.logLimits
+                clock = clock,
+                processor = processor,
+                sdkFactory = sdkFactory,
+                key = key,
+                resource = loggingConfig.resource,
+                logLimitConfig = loggingConfig.logLimits,
+                shutdownState = shutdownState,
             )
         }
     }
@@ -44,8 +50,9 @@ internal class LoggerProviderImpl(
         version: String?,
         schemaUrl: String?,
         attributes: (MutableAttributeContainer.() -> Unit)?
-    ): Logger {
-        val key = apiProvider.createInstrumentationScopeInfo(name, version, schemaUrl, attributes)
-        return apiProvider.getOrCreate(key)
-    }
+    ): Logger =
+        shutdownState.ifActiveOrElse(noopLogger) {
+            val key = apiProvider.createInstrumentationScopeInfo(name, version, schemaUrl, attributes)
+            apiProvider.getOrCreate(key)
+        }
 }

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/LogAttributesTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/LogAttributesTest.kt
@@ -4,6 +4,7 @@ import io.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.kotlin.InstrumentationScopeInfoImpl
 import io.opentelemetry.kotlin.attributes.MutableAttributeContainer
 import io.opentelemetry.kotlin.clock.FakeClock
+import io.opentelemetry.kotlin.export.MutableShutdownState
 import io.opentelemetry.kotlin.factory.FakeSdkFactory
 import io.opentelemetry.kotlin.init.config.LogLimitConfig
 import io.opentelemetry.kotlin.logging.export.FakeLogRecordProcessor
@@ -35,15 +36,16 @@ internal class LogAttributesTest {
     @BeforeTest
     fun setUp() {
         logger = LoggerImpl(
-            FakeClock(),
-            processor,
-            FakeSdkFactory(),
-            key,
-            FakeResource(),
-            LogLimitConfig(
+            clock = FakeClock(),
+            processor = processor,
+            sdkFactory = FakeSdkFactory(),
+            key = key,
+            resource = FakeResource(),
+            logLimitConfig = LogLimitConfig(
                 attributeCountLimit = 8,
                 attributeValueLengthLimit = fakeLogLimitsConfig.attributeValueLengthLimit
-            )
+            ),
+            shutdownState = MutableShutdownState(),
         )
     }
 

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/LogContextTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/LogContextTest.kt
@@ -33,12 +33,13 @@ internal class LogContextTest {
         processor = FakeLogRecordProcessor()
         sdkFactory = createSdkFactory()
         logger = LoggerImpl(
-            clock,
-            processor,
-            sdkFactory,
-            key,
-            FakeResource(),
-            fakeLogLimitsConfig
+            clock = clock,
+            processor = processor,
+            sdkFactory = sdkFactory,
+            key = key,
+            resource = FakeResource(),
+            logLimitConfig = fakeLogLimitsConfig,
+            shutdownState = MutableShutdownState(),
         )
         tracer = TracerImpl(
             clock = clock,

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/LogMetaPropertiesTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/LogMetaPropertiesTest.kt
@@ -3,6 +3,7 @@ package io.opentelemetry.kotlin.logging
 import io.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.kotlin.InstrumentationScopeInfoImpl
 import io.opentelemetry.kotlin.clock.FakeClock
+import io.opentelemetry.kotlin.export.MutableShutdownState
 import io.opentelemetry.kotlin.factory.FakeSdkFactory
 import io.opentelemetry.kotlin.logging.export.FakeLogRecordProcessor
 import io.opentelemetry.kotlin.resource.FakeResource
@@ -25,12 +26,13 @@ internal class LogMetaPropertiesTest {
         clock = FakeClock()
         processor = FakeLogRecordProcessor()
         logger = LoggerImpl(
-            clock,
-            processor,
-            FakeSdkFactory(),
-            key,
-            fakeResource,
-            fakeLogLimitsConfig
+            clock = clock,
+            processor = processor,
+            sdkFactory = FakeSdkFactory(),
+            key = key,
+            resource = fakeResource,
+            logLimitConfig = fakeLogLimitsConfig,
+            shutdownState = MutableShutdownState(),
         )
     }
 

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/LogSimplePropertiesTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/LogSimplePropertiesTest.kt
@@ -3,6 +3,7 @@ package io.opentelemetry.kotlin.logging
 import io.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.kotlin.InstrumentationScopeInfoImpl
 import io.opentelemetry.kotlin.clock.FakeClock
+import io.opentelemetry.kotlin.export.MutableShutdownState
 import io.opentelemetry.kotlin.factory.FakeSdkFactory
 import io.opentelemetry.kotlin.factory.SdkFactory
 import io.opentelemetry.kotlin.logging.export.FakeLogRecordProcessor
@@ -29,12 +30,13 @@ internal class LogSimplePropertiesTest {
         processor = FakeLogRecordProcessor()
         sdkFactory = FakeSdkFactory()
         logger = LoggerImpl(
-            clock,
-            processor,
-            sdkFactory,
-            key,
-            FakeResource(),
-            fakeLogLimitsConfig
+            clock = clock,
+            processor = processor,
+            sdkFactory = sdkFactory,
+            key = key,
+            resource = FakeResource(),
+            logLimitConfig = fakeLogLimitsConfig,
+            shutdownState = MutableShutdownState(),
         )
     }
 

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/LoggerEnabledTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/LoggerEnabledTest.kt
@@ -4,6 +4,7 @@ import io.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.kotlin.InstrumentationScopeInfoImpl
 import io.opentelemetry.kotlin.clock.FakeClock
 import io.opentelemetry.kotlin.context.FakeContext
+import io.opentelemetry.kotlin.export.MutableShutdownState
 import io.opentelemetry.kotlin.factory.FakeSdkFactory
 import io.opentelemetry.kotlin.factory.SdkFactory
 import io.opentelemetry.kotlin.logging.export.FakeLogRecordProcessor
@@ -56,12 +57,13 @@ internal class LoggerEnabledTest {
 
     private fun createLogger(processor: FakeLogRecordProcessor?): LoggerImpl {
         val logger = LoggerImpl(
-            clock,
-            processor,
-            sdkFactory,
-            key,
-            FakeResource(),
-            fakeLogLimitsConfig
+            clock = clock,
+            processor = processor,
+            sdkFactory = sdkFactory,
+            key = key,
+            resource = FakeResource(),
+            logLimitConfig = fakeLogLimitsConfig,
+            shutdownState = MutableShutdownState(),
         )
         return logger
     }

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/LoggerProviderImplTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/LoggerProviderImplTest.kt
@@ -3,6 +3,7 @@ package io.opentelemetry.kotlin.logging
 import io.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.kotlin.attributes.MutableAttributeContainerImpl
 import io.opentelemetry.kotlin.clock.FakeClock
+import io.opentelemetry.kotlin.export.MutableShutdownState
 import io.opentelemetry.kotlin.export.OperationResultCode
 import io.opentelemetry.kotlin.factory.createSdkFactory
 import io.opentelemetry.kotlin.init.config.LogLimitConfig
@@ -11,8 +12,10 @@ import io.opentelemetry.kotlin.logging.export.FakeLogRecordProcessor
 import io.opentelemetry.kotlin.resource.FakeResource
 import io.opentelemetry.kotlin.resource.ResourceImpl
 import kotlinx.coroutines.test.runTest
+import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNotEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertSame
@@ -27,16 +30,25 @@ internal class LoggerProviderImplTest {
         ResourceImpl(MutableAttributeContainerImpl(), null)
     )
     private val factory = createSdkFactory()
+    private lateinit var impl: LoggerProviderImpl
+
+    @BeforeTest
+    fun setup() {
+        impl = LoggerProviderImpl(
+            clock = clock,
+            loggingConfig = loggingConfig,
+            sdkFactory = factory,
+            shutdownState = MutableShutdownState(),
+        )
+    }
 
     @Test
     fun testMinimalLoggerProvider() {
-        val impl = LoggerProviderImpl(clock, loggingConfig, factory)
         assertNotNull(impl.getLogger(name = ""))
     }
 
     @Test
     fun testFullLoggerProvider() {
-        val impl = LoggerProviderImpl(clock, loggingConfig, factory)
         val first = impl.getLogger(
             name = "name",
             version = "0.1.0",
@@ -49,7 +61,6 @@ internal class LoggerProviderImplTest {
 
     @Test
     fun testDupeLoggerProviderName() {
-        val impl = LoggerProviderImpl(clock, loggingConfig, factory)
         val first = impl.getLogger(name = "name")
         val second = impl.getLogger(name = "name")
         val third = impl.getLogger(name = "other")
@@ -59,7 +70,6 @@ internal class LoggerProviderImplTest {
 
     @Test
     fun testDupeLoggerProviderVersion() {
-        val impl = LoggerProviderImpl(clock, loggingConfig, factory)
         val first = impl.getLogger(name = "name", version = "0.1.0")
         val second = impl.getLogger(name = "name", version = "0.1.0")
         val third = impl.getLogger(name = "name", version = "0.2.0")
@@ -69,7 +79,6 @@ internal class LoggerProviderImplTest {
 
     @Test
     fun testDupeLoggerProviderSchemaUrl() {
-        val impl = LoggerProviderImpl(clock, loggingConfig, factory)
         val first = impl.getLogger(name = "name", schemaUrl = "https://example.com/foo")
         val second = impl.getLogger(name = "name", schemaUrl = "https://example.com/foo")
         val third = impl.getLogger(name = "name", schemaUrl = "https://example.com/bar")
@@ -79,7 +88,6 @@ internal class LoggerProviderImplTest {
 
     @Test
     fun testDupeLoggerProviderAttributes() {
-        val impl = LoggerProviderImpl(clock, loggingConfig, factory)
         val first = impl.getLogger(name = "name") {
             setStringAttribute("key", "value")
         }
@@ -95,14 +103,12 @@ internal class LoggerProviderImplTest {
 
     @Test
     fun testForceFlushEmptyProcessors() = runTest {
-        val impl = LoggerProviderImpl(clock, loggingConfig, factory)
         val result = impl.forceFlush()
         assertEquals(OperationResultCode.Success, result)
     }
 
     @Test
     fun testShutdownEmptyProcessors() = runTest {
-        val impl = LoggerProviderImpl(clock, loggingConfig, factory)
         val result = impl.shutdown()
         assertEquals(OperationResultCode.Success, result)
     }
@@ -121,7 +127,12 @@ internal class LoggerProviderImplTest {
             LogLimitConfig(100, 100),
             FakeResource(),
         )
-        val impl = LoggerProviderImpl(clock, config, factory)
+        val impl = LoggerProviderImpl(
+            clock = clock,
+            loggingConfig = config,
+            sdkFactory = factory,
+            shutdownState = MutableShutdownState(),
+        )
         impl.getLogger(name = "test")
 
         val result = impl.forceFlush()
@@ -143,11 +154,51 @@ internal class LoggerProviderImplTest {
             LogLimitConfig(100, 100),
             FakeResource(),
         )
-        val impl = LoggerProviderImpl(clock, config, factory)
+        val impl = LoggerProviderImpl(
+            clock = clock,
+            loggingConfig = config,
+            sdkFactory = factory,
+            shutdownState = MutableShutdownState(),
+        )
         impl.getLogger(name = "test")
 
         val result = impl.shutdown()
         assertEquals(OperationResultCode.Success, result)
         assertEquals(true, shutdownCalled)
+    }
+
+    @Test
+    fun testGetLoggerAfterShutdownReturnsNoopLogger() = runTest {
+        val shutdownState = MutableShutdownState()
+        val provider = LoggerProviderImpl(
+            clock = clock,
+            loggingConfig = loggingConfig,
+            sdkFactory = factory,
+            shutdownState = shutdownState,
+        )
+        shutdownState.shutdown()
+        val logger = provider.getLogger(name = "test")
+        assertFalse(logger.enabled())
+    }
+
+    @Test
+    fun testExistingLoggerDoesNotEmitAfterShutdown() = runTest {
+        val shutdownState = MutableShutdownState()
+        val processor = FakeLogRecordProcessor()
+        val config = LoggingConfig(
+            listOf(processor),
+            LogLimitConfig(100, 100),
+            FakeResource(),
+        )
+        val provider = LoggerProviderImpl(
+            clock = clock,
+            loggingConfig = config,
+            sdkFactory = factory,
+            shutdownState = shutdownState,
+        )
+        val logger = provider.getLogger(name = "test")
+        shutdownState.shutdown()
+        logger.emit(body = "should not emit")
+        assertEquals(0, processor.logs.size)
     }
 }


### PR DESCRIPTION
## Summary
- Phase 9 of 10: Shutdown compliance stack
- `LoggerProviderImpl` and `LoggerImpl` accept `ShutdownState` (read-only abstract class) as a required parameter with no default
- After shutdown, `getLogger()` returns a noop logger, `enabled()` returns false, and `emit()` becomes a no-op
- Noop instances are eagerly initialized (singletons, negligible cost)

🤖 Generated with [Claude Code](https://claude.com/claude-code)