### PR TITLE
Configure signing information into envars for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,13 @@
 ---
 name: Release
 
+env:
+  ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.ORG_GRADLE_PROJECT_MAVENCENTRALUSERNAME }}
+  ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.ORG_GRADLE_PROJECT_MAVENCENTRALPASSWORD }}
+  ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGINMEMORYKEYID }}
+  ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGINMEMORYKEY }}
+  ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGINMEMORYKEYPASSWORD }}
+
 on:
   workflow_dispatch:
 


### PR DESCRIPTION
## Goal

The [Vanniktech publishing plugin](https://vanniktech.github.io/gradle-maven-publish-plugin/central/#secrets) requires signing information as envars but currently they're supplied as Github secrets (which also doesn't seem to allow underscores). Therefore we need to add an explicit mapping to the release workflow only to fix the [workflow failure](https://github.com/open-telemetry/opentelemetry-kotlin/actions/runs/22228757526/job/64302695719#step:9:132).