### PR TITLE
add shutdown compliance to log pipeline, in-memory exporters, and persistence layer

### DIFF
--- a/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/BatchLogRecordProcessorImpl.kt
+++ b/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/BatchLogRecordProcessorImpl.kt
@@ -1,10 +1,13 @@
 package io.opentelemetry.kotlin.logging.export
 
 import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.InstrumentationScopeInfo
 import io.opentelemetry.kotlin.context.Context
 import io.opentelemetry.kotlin.export.BatchTelemetryProcessor
+import io.opentelemetry.kotlin.export.MutableShutdownState
 import io.opentelemetry.kotlin.export.OperationResultCode
 import io.opentelemetry.kotlin.logging.model.ReadWriteLogRecord
+import io.opentelemetry.kotlin.logging.model.SeverityNumber
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 
@@ -17,6 +20,8 @@ internal class BatchLogRecordProcessorImpl(
     private val maxExportBatchSize: Int,
     dispatcher: CoroutineDispatcher = Dispatchers.Default,
 ) : LogRecordProcessor {
+
+    private val shutdownState = MutableShutdownState()
 
     private val processor =
         BatchTelemetryProcessor(
@@ -31,8 +36,22 @@ internal class BatchLogRecordProcessorImpl(
     override fun onEmit(
         log: ReadWriteLogRecord,
         context: Context
-    ) = processor.processTelemetry(log)
+    ) {
+        shutdownState.execute { processor.processTelemetry(log) }
+    }
+
+    override fun enabled(
+        context: Context,
+        instrumentationScopeInfo: InstrumentationScopeInfo,
+        severityNumber: SeverityNumber?,
+        eventName: String?,
+    ): Boolean = !shutdownState.isShutdown
 
     override suspend fun forceFlush(): OperationResultCode = processor.forceFlush()
-    override suspend fun shutdown(): OperationResultCode = processor.shutdown()
+
+    override suspend fun shutdown(): OperationResultCode =
+        shutdownState.ifActive(OperationResultCode.Success) {
+            shutdownState.shutdown()
+            processor.shutdown()
+        }
 }

--- a/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/SimpleLogRecordProcessor.kt
+++ b/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/SimpleLogRecordProcessor.kt
@@ -1,10 +1,13 @@
 package io.opentelemetry.kotlin.logging.export
 
 import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.InstrumentationScopeInfo
 import io.opentelemetry.kotlin.ReentrantReadWriteLock
 import io.opentelemetry.kotlin.context.Context
+import io.opentelemetry.kotlin.export.MutableShutdownState
 import io.opentelemetry.kotlin.export.OperationResultCode
 import io.opentelemetry.kotlin.logging.model.ReadWriteLogRecord
+import io.opentelemetry.kotlin.logging.model.SeverityNumber
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
@@ -20,18 +23,33 @@ internal class SimpleLogRecordProcessor(
 ) : LogRecordProcessor {
 
     private val lock = ReentrantReadWriteLock()
+    private val shutdownState = MutableShutdownState()
 
     override fun onEmit(
         log: ReadWriteLogRecord,
         context: Context
     ) {
-        scope.launch {
-            lock.write {
-                exporter.export(listOf(log))
+        shutdownState.execute {
+            scope.launch {
+                lock.write {
+                    exporter.export(listOf(log))
+                }
             }
         }
     }
 
-    override suspend fun forceFlush(): OperationResultCode = OperationResultCode.Success
-    override suspend fun shutdown(): OperationResultCode = OperationResultCode.Success
+    override fun enabled(
+        context: Context,
+        instrumentationScopeInfo: InstrumentationScopeInfo,
+        severityNumber: SeverityNumber?,
+        eventName: String?,
+    ): Boolean = !shutdownState.isShutdown
+
+    override suspend fun forceFlush(): OperationResultCode = exporter.forceFlush()
+
+    override suspend fun shutdown(): OperationResultCode =
+        shutdownState.ifActive(OperationResultCode.Success) {
+            shutdownState.shutdown()
+            exporter.shutdown()
+        }
 }

--- a/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/StdoutLogRecordExporter.kt
+++ b/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/StdoutLogRecordExporter.kt
@@ -1,6 +1,7 @@
 package io.opentelemetry.kotlin.logging.export
 
 import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.export.MutableShutdownState
 import io.opentelemetry.kotlin.export.OperationResultCode
 import io.opentelemetry.kotlin.logging.model.ReadableLogRecord
 import io.opentelemetry.kotlin.platformLog
@@ -13,15 +14,23 @@ internal class StdoutLogRecordExporter(
     private val logger: (String) -> Unit = ::platformLog
 ) : LogRecordExporter {
 
-    override suspend fun export(telemetry: List<ReadableLogRecord>): OperationResultCode {
-        telemetry.forEach { logRecord ->
-            logger(formatLogRecord(logRecord))
+    private val shutdownState = MutableShutdownState()
+
+    override suspend fun export(telemetry: List<ReadableLogRecord>): OperationResultCode =
+        shutdownState.ifActive {
+            telemetry.forEach { logRecord ->
+                logger(formatLogRecord(logRecord))
+            }
+            OperationResultCode.Success
         }
-        return OperationResultCode.Success
-    }
 
     override suspend fun forceFlush(): OperationResultCode = OperationResultCode.Success
-    override suspend fun shutdown(): OperationResultCode = OperationResultCode.Success
+
+    override suspend fun shutdown(): OperationResultCode =
+        shutdownState.ifActive(OperationResultCode.Success) {
+            shutdownState.shutdown()
+            OperationResultCode.Success
+        }
 
     private fun formatLogRecord(logRecord: ReadableLogRecord): String = buildString {
         append("LogRecord")

--- a/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/export/BatchLogRecordProcessorImplTest.kt
+++ b/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/export/BatchLogRecordProcessorImplTest.kt
@@ -1,0 +1,67 @@
+package io.opentelemetry.kotlin.logging.export
+
+import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.FakeInstrumentationScopeInfo
+import io.opentelemetry.kotlin.context.FakeContext
+import io.opentelemetry.kotlin.export.OperationResultCode
+import io.opentelemetry.kotlin.logging.model.FakeReadWriteLogRecord
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalApi::class, ExperimentalCoroutinesApi::class)
+internal class BatchLogRecordProcessorImplTest {
+
+    private lateinit var exporter: FakeLogRecordExporter
+    private lateinit var processor: BatchLogRecordProcessorImpl
+
+    @BeforeTest
+    fun setup() {
+        exporter = FakeLogRecordExporter()
+        processor = BatchLogRecordProcessorImpl(
+            exporter = exporter,
+            maxQueueSize = 100,
+            scheduleDelayMs = 1,
+            exportTimeoutMs = 1000,
+            maxExportBatchSize = 10,
+        )
+    }
+
+    @Test
+    fun testOnEmitNoOpAfterShutdown() = runTest {
+        processor.shutdown()
+        advanceUntilIdle()
+
+        val log = FakeReadWriteLogRecord()
+        processor.onEmit(log, FakeContext())
+        advanceUntilIdle()
+
+        assertTrue(exporter.logs.isEmpty())
+    }
+
+    @Test
+    fun testShutdownReturnsSuccessOnSecondCall() = runTest {
+        assertEquals(OperationResultCode.Success, processor.shutdown())
+        assertEquals(OperationResultCode.Success, processor.shutdown())
+    }
+
+    @Test
+    fun testEnabledReturnsFalseAfterShutdown() = runTest {
+        assertTrue(processor.enabled(FakeContext(), FakeInstrumentationScopeInfo(), null, null))
+
+        processor.shutdown()
+        assertFalse(processor.enabled(FakeContext(), FakeInstrumentationScopeInfo(), null, null))
+    }
+
+    @Test
+    fun testForceFlushWorksAfterShutdown() = runTest {
+        processor.shutdown()
+        advanceUntilIdle()
+        assertEquals(OperationResultCode.Success, processor.forceFlush())
+    }
+}

--- a/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/export/SimpleLogRecordProcessorTest.kt
+++ b/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/export/SimpleLogRecordProcessorTest.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 @OptIn(ExperimentalApi::class, ExperimentalCoroutinesApi::class)
@@ -20,9 +21,9 @@ internal class SimpleLogRecordProcessorTest {
     @Test
     fun testSpanProcessorDefaults() = runTest {
         val processor = FakeLogExportConfig().simpleLogRecordProcessor(FakeLogRecordExporter())
+        assertTrue(processor.enabled(FakeContext(), FakeInstrumentationScopeInfo(), null, null))
         assertEquals(OperationResultCode.Success, processor.shutdown())
         assertEquals(OperationResultCode.Success, processor.forceFlush())
-        assertTrue(processor.enabled(FakeContext(), FakeInstrumentationScopeInfo(), null, null))
     }
 
     @Test
@@ -38,5 +39,52 @@ internal class SimpleLogRecordProcessorTest {
 
         val export = exporter.logs.single()
         assertEquals(log.body, export.body)
+    }
+
+    @Test
+    fun testOnEmitNoOpAfterShutdown() = runTest {
+        val exporter = FakeLogRecordExporter()
+        val processor = SimpleLogRecordProcessor(
+            exporter,
+            CoroutineScope(UnconfinedTestDispatcher(testScheduler)),
+        )
+        processor.shutdown()
+
+        val log = FakeReadWriteLogRecord()
+        processor.onEmit(log, FakeContext())
+        assertTrue(exporter.logs.isEmpty())
+    }
+
+    @Test
+    fun testShutdownReturnsSuccessOnSecondCall() = runTest {
+        val processor = SimpleLogRecordProcessor(
+            FakeLogRecordExporter(),
+            CoroutineScope(UnconfinedTestDispatcher(testScheduler)),
+        )
+
+        assertEquals(OperationResultCode.Success, processor.shutdown())
+        assertEquals(OperationResultCode.Success, processor.shutdown())
+    }
+
+    @Test
+    fun testEnabledReturnsFalseAfterShutdown() = runTest {
+        val processor = SimpleLogRecordProcessor(
+            FakeLogRecordExporter(),
+            CoroutineScope(UnconfinedTestDispatcher(testScheduler)),
+        )
+        processor.shutdown()
+
+        assertFalse(processor.enabled(FakeContext(), FakeInstrumentationScopeInfo(), null, null))
+    }
+
+    @Test
+    fun testForceFlushWorksAfterShutdown() = runTest {
+        val processor = SimpleLogRecordProcessor(
+            FakeLogRecordExporter(),
+            CoroutineScope(UnconfinedTestDispatcher(testScheduler)),
+        )
+        processor.shutdown()
+
+        assertEquals(OperationResultCode.Success, processor.forceFlush())
     }
 }

--- a/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/export/StdoutLogRecordExporterTest.kt
+++ b/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/export/StdoutLogRecordExporterTest.kt
@@ -84,4 +84,30 @@ internal class StdoutLogRecordExporterTest {
         val exporter = StdoutLogRecordExporter()
         assertEquals(OperationResultCode.Success, exporter.shutdown())
     }
+
+    @Test
+    fun testExportReturnsFailureAfterShutdown() = runTest {
+        val output = mutableListOf<String>()
+        val exporter = StdoutLogRecordExporter(output::add)
+        exporter.shutdown()
+
+        val logRecord = FakeReadableLogRecord()
+        val result = exporter.export(listOf(logRecord))
+        assertEquals(OperationResultCode.Failure, result)
+        assertEquals(0, output.size)
+    }
+
+    @Test
+    fun testShutdownReturnsSuccessOnSecondCall() = runTest {
+        val exporter = StdoutLogRecordExporter()
+        assertEquals(OperationResultCode.Success, exporter.shutdown())
+        assertEquals(OperationResultCode.Success, exporter.shutdown())
+    }
+
+    @Test
+    fun testForceFlushWorksAfterShutdown() = runTest {
+        val exporter = StdoutLogRecordExporter()
+        exporter.shutdown()
+        assertEquals(OperationResultCode.Success, exporter.forceFlush())
+    }
 }

--- a/exporters-core/src/jvmTest/kotlin/io/opentelemetry/kotlin/logging/export/StdoutLogRecordExporterJvmTest.kt
+++ b/exporters-core/src/jvmTest/kotlin/io/opentelemetry/kotlin/logging/export/StdoutLogRecordExporterJvmTest.kt
@@ -1,0 +1,49 @@
+package io.opentelemetry.kotlin.logging.export
+
+import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.export.OperationResultCode
+import io.opentelemetry.kotlin.logging.model.FakeReadableLogRecord
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+import java.util.concurrent.CountDownLatch
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalApi::class)
+internal class StdoutLogRecordExporterJvmTest {
+
+    @Suppress("InjectDispatcher")
+    @Test
+    fun testInFlightExportCompletesWhenShutdownCalled() = runBlocking {
+        val exportStarted = CountDownLatch(1)
+        val proceedWithExport = CountDownLatch(1)
+        val logOutput = mutableListOf<String>()
+
+        val exporter = StdoutLogRecordExporter { line ->
+            logOutput.add(line)
+            exportStarted.countDown()
+            proceedWithExport.await()
+        }
+
+        val logRecord = FakeReadableLogRecord()
+
+        val exportJob = async(Dispatchers.Default) {
+            exporter.export(listOf(logRecord))
+        }
+
+        // Wait for the export to be inside the logger callback
+        exportStarted.await()
+
+        // Shutdown while the export is still inside the ifActive block
+        exporter.shutdown()
+        proceedWithExport.countDown()
+
+        // The in-flight export should complete successfully
+        assertEquals(OperationResultCode.Success, exportJob.await())
+        assertEquals(1, logOutput.size)
+
+        // New exports after shutdown should be rejected
+        assertEquals(OperationResultCode.Failure, exporter.export(listOf(logRecord)))
+    }
+}

--- a/exporters-in-memory/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/InMemoryLogRecordExporterImpl.kt
+++ b/exporters-in-memory/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/InMemoryLogRecordExporterImpl.kt
@@ -1,6 +1,7 @@
 package io.opentelemetry.kotlin.logging.export
 
 import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.export.MutableShutdownState
 import io.opentelemetry.kotlin.export.OperationResultCode
 import io.opentelemetry.kotlin.logging.model.ReadableLogRecord
 
@@ -8,15 +9,22 @@ import io.opentelemetry.kotlin.logging.model.ReadableLogRecord
 internal class InMemoryLogRecordExporterImpl : InMemoryLogRecordExporter {
 
     private val impl = mutableListOf<ReadableLogRecord>()
+    private val shutdownState = MutableShutdownState()
 
     override val exportedLogRecords: List<ReadableLogRecord>
         get() = impl
 
-    override suspend fun export(telemetry: List<ReadableLogRecord>): OperationResultCode {
-        impl += telemetry
-        return OperationResultCode.Success
-    }
+    override suspend fun export(telemetry: List<ReadableLogRecord>): OperationResultCode =
+        shutdownState.ifActive {
+            impl += telemetry
+            OperationResultCode.Success
+        }
 
-    override suspend fun shutdown(): OperationResultCode = OperationResultCode.Success
     override suspend fun forceFlush(): OperationResultCode = OperationResultCode.Success
+
+    override suspend fun shutdown(): OperationResultCode =
+        shutdownState.ifActive(OperationResultCode.Success) {
+            shutdownState.shutdown()
+            OperationResultCode.Success
+        }
 }

--- a/exporters-in-memory/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/InMemorySpanExporterImpl.kt
+++ b/exporters-in-memory/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/InMemorySpanExporterImpl.kt
@@ -1,6 +1,7 @@
 package io.opentelemetry.kotlin.tracing.export
 
 import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.export.MutableShutdownState
 import io.opentelemetry.kotlin.export.OperationResultCode
 import io.opentelemetry.kotlin.tracing.data.SpanData
 
@@ -8,15 +9,22 @@ import io.opentelemetry.kotlin.tracing.data.SpanData
 internal class InMemorySpanExporterImpl : InMemorySpanExporter {
 
     private val impl = mutableListOf<SpanData>()
+    private val shutdownState = MutableShutdownState()
 
     override val exportedSpans: List<SpanData>
         get() = impl
 
-    override suspend fun export(telemetry: List<SpanData>): OperationResultCode {
-        impl += telemetry
-        return OperationResultCode.Success
-    }
+    override suspend fun export(telemetry: List<SpanData>): OperationResultCode =
+        shutdownState.ifActive {
+            impl += telemetry
+            OperationResultCode.Success
+        }
 
     override suspend fun forceFlush(): OperationResultCode = OperationResultCode.Success
-    override suspend fun shutdown(): OperationResultCode = OperationResultCode.Success
+
+    override suspend fun shutdown(): OperationResultCode =
+        shutdownState.ifActive(OperationResultCode.Success) {
+            shutdownState.shutdown()
+            OperationResultCode.Success
+        }
 }

--- a/exporters-in-memory/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/export/InMemoryLogRecordExporterTest.kt
+++ b/exporters-in-memory/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/export/InMemoryLogRecordExporterTest.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.test.runTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 @OptIn(ExperimentalApi::class)
 internal class InMemoryLogRecordExporterTest {
@@ -34,5 +35,25 @@ internal class InMemoryLogRecordExporterTest {
     fun testExport() = runTest {
         exporter.export(fakeTelemetry)
         assertEquals(fakeTelemetry, exporter.exportedLogRecords)
+    }
+
+    @Test
+    fun testExportReturnsFailureAfterShutdown() = runTest {
+        exporter.shutdown()
+        val result = exporter.export(fakeTelemetry)
+        assertEquals(OperationResultCode.Failure, result)
+        assertTrue(exporter.exportedLogRecords.isEmpty())
+    }
+
+    @Test
+    fun testShutdownReturnsSuccessOnSecondCall() = runTest {
+        assertEquals(OperationResultCode.Success, exporter.shutdown())
+        assertEquals(OperationResultCode.Success, exporter.shutdown())
+    }
+
+    @Test
+    fun testForceFlushWorksAfterShutdown() = runTest {
+        exporter.shutdown()
+        assertEquals(OperationResultCode.Success, exporter.forceFlush())
     }
 }

--- a/exporters-in-memory/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/export/InMemorySpanExporterTest.kt
+++ b/exporters-in-memory/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/export/InMemorySpanExporterTest.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.test.runTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 @OptIn(ExperimentalApi::class)
 internal class InMemorySpanExporterTest {
@@ -34,5 +35,25 @@ internal class InMemorySpanExporterTest {
     fun testExport() = runTest {
         exporter.export(fakeTelemetry)
         assertEquals(fakeTelemetry, exporter.exportedSpans)
+    }
+
+    @Test
+    fun testExportReturnsFailureAfterShutdown() = runTest {
+        exporter.shutdown()
+        val result = exporter.export(fakeTelemetry)
+        assertEquals(OperationResultCode.Failure, result)
+        assertTrue(exporter.exportedSpans.isEmpty())
+    }
+
+    @Test
+    fun testShutdownReturnsSuccessOnSecondCall() = runTest {
+        assertEquals(OperationResultCode.Success, exporter.shutdown())
+        assertEquals(OperationResultCode.Success, exporter.shutdown())
+    }
+
+    @Test
+    fun testForceFlushWorksAfterShutdown() = runTest {
+        exporter.shutdown()
+        assertEquals(OperationResultCode.Success, exporter.forceFlush())
     }
 }

--- a/exporters-persistence/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/PersistingLogRecordExporter.kt
+++ b/exporters-persistence/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/PersistingLogRecordExporter.kt
@@ -1,6 +1,7 @@
 package io.opentelemetry.kotlin.logging.export
 
 import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.export.MutableShutdownState
 import io.opentelemetry.kotlin.export.OperationResultCode
 import io.opentelemetry.kotlin.export.OperationResultCode.Success
 import io.opentelemetry.kotlin.export.TelemetryRepository
@@ -14,17 +15,23 @@ internal class PersistingLogRecordExporter(
 
     @Suppress("DEPRECATION")
     private val exporter = createCompositeLogRecordExporter(exporters)
+    private val shutdownState = MutableShutdownState()
 
-    override suspend fun export(telemetry: List<ReadableLogRecord>): OperationResultCode {
-        val record = repository.store(telemetry)
-
-        val result = exporter.export(telemetry)
-        if (result == Success && record != null) {
-            repository.delete(record)
+    override suspend fun export(telemetry: List<ReadableLogRecord>): OperationResultCode =
+        shutdownState.ifActive {
+            val record = repository.store(telemetry)
+            val result = exporter.export(telemetry)
+            if (result == Success && record != null) {
+                repository.delete(record)
+            }
+            result
         }
-        return result
-    }
 
     override suspend fun forceFlush(): OperationResultCode = exporter.forceFlush()
-    override suspend fun shutdown(): OperationResultCode = exporter.shutdown()
+
+    override suspend fun shutdown(): OperationResultCode =
+        shutdownState.ifActive(OperationResultCode.Success) {
+            shutdownState.shutdown()
+            exporter.shutdown()
+        }
 }

--- a/exporters-persistence/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/PersistingLogRecordProcessor.kt
+++ b/exporters-persistence/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/PersistingLogRecordProcessor.kt
@@ -2,9 +2,11 @@ package io.opentelemetry.kotlin.logging.export
 
 import io.opentelemetry.kotlin.Clock
 import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.InstrumentationScopeInfo
 import io.opentelemetry.kotlin.context.Context
 import io.opentelemetry.kotlin.error.SdkErrorHandler
 import io.opentelemetry.kotlin.error.SdkErrorSeverity
+import io.opentelemetry.kotlin.export.MutableShutdownState
 import io.opentelemetry.kotlin.export.OperationResultCode
 import io.opentelemetry.kotlin.export.PersistedTelemetryConfig
 import io.opentelemetry.kotlin.export.PersistedTelemetryType
@@ -14,6 +16,7 @@ import io.opentelemetry.kotlin.export.TelemetryRepositoryImpl
 import io.opentelemetry.kotlin.export.TimeoutTelemetryCloseable
 import io.opentelemetry.kotlin.logging.model.ReadWriteLogRecord
 import io.opentelemetry.kotlin.logging.model.ReadableLogRecord
+import io.opentelemetry.kotlin.logging.model.SeverityNumber
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 
@@ -69,19 +72,34 @@ internal class PersistingLogRecordProcessor(
     @Suppress("DEPRECATION")
     private val processor = createCompositeLogRecordProcessor(processors + batchingProcessor)
     private val telemetryCloseable: TelemetryCloseable = TimeoutTelemetryCloseable(processor)
+    private val shutdownState = MutableShutdownState()
 
     override fun onEmit(log: ReadWriteLogRecord, context: Context) {
-        try {
-            processor.onEmit(log, context)
-        } catch (e: Throwable) {
-            sdkErrorHandler.onUserCodeError(
-                e,
-                "LogRecordProcessor.onEmit failed",
-                SdkErrorSeverity.WARNING
-            )
+        shutdownState.execute {
+            try {
+                processor.onEmit(log, context)
+            } catch (e: Throwable) {
+                sdkErrorHandler.onUserCodeError(
+                    e,
+                    "LogRecordProcessor.onEmit failed",
+                    SdkErrorSeverity.WARNING
+                )
+            }
         }
     }
 
+    override fun enabled(
+        context: Context,
+        instrumentationScopeInfo: InstrumentationScopeInfo,
+        severityNumber: SeverityNumber?,
+        eventName: String?,
+    ): Boolean = !shutdownState.isShutdown
+
     override suspend fun forceFlush(): OperationResultCode = telemetryCloseable.forceFlush()
-    override suspend fun shutdown(): OperationResultCode = telemetryCloseable.shutdown()
+
+    override suspend fun shutdown(): OperationResultCode =
+        shutdownState.ifActive(OperationResultCode.Success) {
+            shutdownState.shutdown()
+            telemetryCloseable.shutdown()
+        }
 }

--- a/exporters-persistence/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/export/PersistingLogRecordExporterTest.kt
+++ b/exporters-persistence/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/export/PersistingLogRecordExporterTest.kt
@@ -2,6 +2,7 @@ package io.opentelemetry.kotlin.logging.export
 
 import io.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.kotlin.export.FakeTelemetryRepository
+import io.opentelemetry.kotlin.export.OperationResultCode
 import io.opentelemetry.kotlin.export.OperationResultCode.Failure
 import io.opentelemetry.kotlin.export.OperationResultCode.Success
 import io.opentelemetry.kotlin.logging.model.FakeReadableLogRecord
@@ -72,5 +73,31 @@ internal class PersistingLogRecordExporterTest {
 
         val result = exporter.export(telemetry)
         assertEquals(Failure, result)
+    }
+
+    @Test
+    fun testExportReturnsFailureAfterShutdown() = runTest {
+        val repository = FakeTelemetryRepository<ReadableLogRecord>()
+        val exporter = PersistingLogRecordExporter(listOf(FakeLogRecordExporter()), repository)
+        exporter.shutdown()
+
+        val result = exporter.export(telemetry)
+        assertEquals(Failure, result)
+    }
+
+    @Test
+    fun testShutdownReturnsSuccessOnSecondCall() = runTest {
+        val repository = FakeTelemetryRepository<ReadableLogRecord>()
+        val exporter = PersistingLogRecordExporter(listOf(FakeLogRecordExporter()), repository)
+        assertEquals(Success, exporter.shutdown())
+        assertEquals(Success, exporter.shutdown())
+    }
+
+    @Test
+    fun testForceFlushWorksAfterShutdown() = runTest {
+        val repository = FakeTelemetryRepository<ReadableLogRecord>()
+        val exporter = PersistingLogRecordExporter(listOf(FakeLogRecordExporter()), repository)
+        exporter.shutdown()
+        assertEquals(OperationResultCode.Success, exporter.forceFlush())
     }
 }

--- a/exporters-persistence/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/export/PersistingLogRecordProcessorTest.kt
+++ b/exporters-persistence/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/export/PersistingLogRecordProcessorTest.kt
@@ -2,6 +2,7 @@ package io.opentelemetry.kotlin.logging.export
 
 import io.opentelemetry.kotlin.Clock
 import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.FakeInstrumentationScopeInfo
 import io.opentelemetry.kotlin.clock.FakeClock
 import io.opentelemetry.kotlin.context.Context
 import io.opentelemetry.kotlin.context.FakeContext
@@ -21,6 +22,7 @@ import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 @OptIn(ExperimentalApi::class, ExperimentalCoroutinesApi::class)
@@ -302,6 +304,43 @@ internal class PersistingLogRecordProcessorTest {
         val result = resultDeferred.await()
 
         assertEquals(Failure, result)
+    }
+
+    @Test
+    fun testShutdownReturnsSuccessOnSecondCall() = runTest {
+        val processor = createProcessor(
+            exporters = listOf(FakeLogRecordExporter()),
+        )
+
+        assertEquals(Success, processor.shutdown())
+        assertEquals(Success, processor.shutdown())
+    }
+
+    @Test
+    fun testEnabledReturnsFalseAfterShutdown() = runTest {
+        val processor = createProcessor(
+            exporters = listOf(FakeLogRecordExporter()),
+        )
+
+        processor.shutdown()
+        assertFalse(
+            processor.enabled(
+                FakeContext(),
+                FakeInstrumentationScopeInfo(),
+                null,
+                null,
+            )
+        )
+    }
+
+    @Test
+    fun testForceFlushWorksAfterShutdown() = runTest {
+        val processor = createProcessor(
+            exporters = listOf(FakeLogRecordExporter()),
+        )
+
+        processor.shutdown()
+        assertEquals(Success, processor.forceFlush())
     }
 
     private fun TestScope.createProcessor(


### PR DESCRIPTION
## Summary
- Add `MutableShutdownState` to log processors (`BatchLogRecordProcessorImpl`, `SimpleLogRecordProcessor`), log exporters (`StdoutLogRecordExporter`), in-memory exporters (`InMemorySpanExporterImpl`, `InMemoryLogRecordExporterImpl`), and persistence layer (`PersistingLogRecordExporter`, `PersistingLogRecordProcessor`)
- Guard data processing methods (`onEmit`, `export`, `enabled`) behind shutdown checks
- `forceFlush()` remains independent of shutdown state

## Test plan
- [ ] Verify export returns `Failure` after shutdown
- [ ] Verify `forceFlush` works after shutdown
- [ ] Verify idempotent shutdown returns `Success`
- [ ] Verify in-flight exports complete when shutdown is called concurrently

🤖 Generated with [Claude Code](https://claude.com/claude-code)