### PR TITLE
add shutdown compliance to Java interop adapters

### DIFF
--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/logging/export/LogRecordExporterAdapter.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/logging/export/LogRecordExporterAdapter.kt
@@ -2,6 +2,7 @@ package io.opentelemetry.kotlin.logging.export
 
 import io.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.kotlin.aliases.OtelJavaLogRecordExporter
+import io.opentelemetry.kotlin.export.MutableShutdownState
 import io.opentelemetry.kotlin.export.OperationResultCode
 import io.opentelemetry.kotlin.logging.model.ReadableLogRecord
 import io.opentelemetry.kotlin.toOperationResultCode
@@ -11,11 +12,18 @@ internal class LogRecordExporterAdapter(
     private val impl: OtelJavaLogRecordExporter
 ) : LogRecordExporter {
 
-    override suspend fun export(telemetry: List<ReadableLogRecord>): OperationResultCode {
-        val code = impl.export(telemetry.map(ReadableLogRecord::toLogRecordData))
-        return code.toOperationResultCode()
-    }
+    private val shutdownState = MutableShutdownState()
 
-    override suspend fun shutdown(): OperationResultCode = impl.shutdown().toOperationResultCode()
+    override suspend fun export(telemetry: List<ReadableLogRecord>): OperationResultCode =
+        shutdownState.ifActive {
+            impl.export(telemetry.map(ReadableLogRecord::toLogRecordData)).toOperationResultCode()
+        }
+
     override suspend fun forceFlush(): OperationResultCode = impl.flush().toOperationResultCode()
+
+    override suspend fun shutdown(): OperationResultCode =
+        shutdownState.ifActive(OperationResultCode.Success) {
+            shutdownState.shutdown()
+            impl.shutdown().toOperationResultCode()
+        }
 }

--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/logging/export/LogRecordProcessorAdapter.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/logging/export/LogRecordProcessorAdapter.kt
@@ -1,11 +1,14 @@
 package io.opentelemetry.kotlin.logging.export
 
 import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.InstrumentationScopeInfo
 import io.opentelemetry.kotlin.aliases.OtelJavaLogRecordProcessor
 import io.opentelemetry.kotlin.context.Context
 import io.opentelemetry.kotlin.context.toOtelJavaContext
+import io.opentelemetry.kotlin.export.MutableShutdownState
 import io.opentelemetry.kotlin.export.OperationResultCode
 import io.opentelemetry.kotlin.logging.model.ReadWriteLogRecord
+import io.opentelemetry.kotlin.logging.model.SeverityNumber
 import io.opentelemetry.kotlin.toOperationResultCode
 
 @OptIn(ExperimentalApi::class)
@@ -13,15 +16,31 @@ internal class LogRecordProcessorAdapter(
     private val impl: OtelJavaLogRecordProcessor
 ) : LogRecordProcessor {
 
+    private val shutdownState = MutableShutdownState()
+
     override fun onEmit(
         log: ReadWriteLogRecord,
         context: Context
     ) {
-        if (log is ReadWriteLogRecordAdapter) {
-            impl.onEmit(context.toOtelJavaContext(), log.impl)
+        shutdownState.execute {
+            if (log is ReadWriteLogRecordAdapter) {
+                impl.onEmit(context.toOtelJavaContext(), log.impl)
+            }
         }
     }
 
-    override suspend fun shutdown(): OperationResultCode = impl.shutdown().toOperationResultCode()
+    override fun enabled(
+        context: Context,
+        instrumentationScopeInfo: InstrumentationScopeInfo,
+        severityNumber: SeverityNumber?,
+        eventName: String?,
+    ): Boolean = !shutdownState.isShutdown
+
     override suspend fun forceFlush(): OperationResultCode = impl.forceFlush().toOperationResultCode()
+
+    override suspend fun shutdown(): OperationResultCode =
+        shutdownState.ifActive(OperationResultCode.Success) {
+            shutdownState.shutdown()
+            impl.shutdown().toOperationResultCode()
+        }
 }

--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/tracing/export/SpanExporterAdapter.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/tracing/export/SpanExporterAdapter.kt
@@ -2,6 +2,7 @@ package io.opentelemetry.kotlin.tracing.export
 
 import io.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.kotlin.aliases.OtelJavaSpanExporter
+import io.opentelemetry.kotlin.export.MutableShutdownState
 import io.opentelemetry.kotlin.export.OperationResultCode
 import io.opentelemetry.kotlin.toOperationResultCode
 import io.opentelemetry.kotlin.tracing.data.SpanData
@@ -12,11 +13,18 @@ internal class SpanExporterAdapter(
     private val impl: OtelJavaSpanExporter
 ) : SpanExporter {
 
-    override suspend fun export(telemetry: List<SpanData>): OperationResultCode {
-        val code = impl.export(telemetry.map(SpanData::toOtelJavaSpanData))
-        return code.toOperationResultCode()
-    }
+    private val shutdownState = MutableShutdownState()
 
-    override suspend fun shutdown(): OperationResultCode = impl.shutdown().toOperationResultCode()
+    override suspend fun export(telemetry: List<SpanData>): OperationResultCode =
+        shutdownState.ifActive {
+            impl.export(telemetry.map(SpanData::toOtelJavaSpanData)).toOperationResultCode()
+        }
+
     override suspend fun forceFlush(): OperationResultCode = impl.flush().toOperationResultCode()
+
+    override suspend fun shutdown(): OperationResultCode =
+        shutdownState.ifActive(OperationResultCode.Success) {
+            shutdownState.shutdown()
+            impl.shutdown().toOperationResultCode()
+        }
 }

--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/tracing/export/SpanProcessorAdapter.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/tracing/export/SpanProcessorAdapter.kt
@@ -4,6 +4,7 @@ import io.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.kotlin.aliases.OtelJavaSpanProcessor
 import io.opentelemetry.kotlin.context.Context
 import io.opentelemetry.kotlin.context.toOtelJavaContext
+import io.opentelemetry.kotlin.export.MutableShutdownState
 import io.opentelemetry.kotlin.export.OperationResultCode
 import io.opentelemetry.kotlin.toOperationResultCode
 import io.opentelemetry.kotlin.tracing.model.ReadWriteSpan
@@ -16,12 +17,16 @@ internal class SpanProcessorAdapter(
     private val impl: OtelJavaSpanProcessor
 ) : SpanProcessor {
 
+    private val shutdownState = MutableShutdownState()
+
     override fun onStart(
         span: ReadWriteSpan,
         parentContext: Context
     ) {
-        if (span is ReadWriteSpanAdapter) {
-            impl.onStart(parentContext.toOtelJavaContext(), span.impl)
+        shutdownState.execute {
+            if (span is ReadWriteSpanAdapter) {
+                impl.onStart(parentContext.toOtelJavaContext(), span.impl)
+            }
         }
     }
 
@@ -30,13 +35,20 @@ internal class SpanProcessorAdapter(
     }
 
     override fun onEnd(span: ReadableSpan) {
-        if (span is ReadableSpanAdapter) {
-            impl.onEnd(span.impl)
+        shutdownState.execute {
+            if (span is ReadableSpanAdapter) {
+                impl.onEnd(span.impl)
+            }
         }
     }
 
     override fun isStartRequired(): Boolean = impl.isStartRequired
     override fun isEndRequired(): Boolean = impl.isEndRequired
-    override suspend fun shutdown(): OperationResultCode = impl.shutdown().toOperationResultCode()
     override suspend fun forceFlush(): OperationResultCode = impl.forceFlush().toOperationResultCode()
+
+    override suspend fun shutdown(): OperationResultCode =
+        shutdownState.ifActive(OperationResultCode.Success) {
+            shutdownState.shutdown()
+            impl.shutdown().toOperationResultCode()
+        }
 }

--- a/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/logging/export/LogRecordExporterAdapterTest.kt
+++ b/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/logging/export/LogRecordExporterAdapterTest.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 @OptIn(ExperimentalApi::class)
 internal class LogRecordExporterAdapterTest {
@@ -55,5 +56,25 @@ internal class LogRecordExporterAdapterTest {
         assertEquals(originalScope.version, observedScope.version)
         assertEquals(originalScope.schemaUrl, observedScope.schemaUrl)
         assertEquals(originalScope.attributes, observedScope.attributes.convertToMap())
+    }
+
+    @Test
+    fun `test export returns failure after shutdown`() = runTest {
+        wrapper.shutdown()
+        val result = wrapper.export(listOf(FakeReadableLogRecord()))
+        assertEquals(OperationResultCode.Failure, result)
+        assertTrue(impl.exports.isEmpty())
+    }
+
+    @Test
+    fun `test shutdown returns success on second call`() = runTest {
+        assertEquals(OperationResultCode.Success, wrapper.shutdown())
+        assertEquals(OperationResultCode.Success, wrapper.shutdown())
+    }
+
+    @Test
+    fun `test force flush works after shutdown`() = runTest {
+        wrapper.shutdown()
+        assertEquals(OperationResultCode.Success, wrapper.forceFlush())
     }
 }

--- a/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/logging/export/LogRecordProcessorAdapterTest.kt
+++ b/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/logging/export/LogRecordProcessorAdapterTest.kt
@@ -1,0 +1,43 @@
+package io.opentelemetry.kotlin.logging.export
+
+import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.FakeInstrumentationScopeInfo
+import io.opentelemetry.kotlin.context.FakeContext
+import io.opentelemetry.kotlin.export.OperationResultCode
+import io.opentelemetry.kotlin.fakes.otel.java.FakeOtelJavaLogRecordProcessor
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+
+@OptIn(ExperimentalApi::class)
+internal class LogRecordProcessorAdapterTest {
+
+    private lateinit var impl: FakeOtelJavaLogRecordProcessor
+    private lateinit var wrapper: LogRecordProcessorAdapter
+
+    @Before
+    fun setUp() {
+        impl = FakeOtelJavaLogRecordProcessor()
+        wrapper = LogRecordProcessorAdapter(impl)
+    }
+
+    @Test
+    fun `test shutdown returns success on second call`() = runTest {
+        assertEquals(OperationResultCode.Success, wrapper.shutdown())
+        assertEquals(OperationResultCode.Success, wrapper.shutdown())
+    }
+
+    @Test
+    fun `test enabled returns false after shutdown`() = runTest {
+        wrapper.shutdown()
+        assertFalse(wrapper.enabled(FakeContext(), FakeInstrumentationScopeInfo(), null, null))
+    }
+
+    @Test
+    fun `test force flush works after shutdown`() = runTest {
+        wrapper.shutdown()
+        assertEquals(OperationResultCode.Success, wrapper.forceFlush())
+    }
+}

--- a/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/tracing/export/SpanExporterAdapterTest.kt
+++ b/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/tracing/export/SpanExporterAdapterTest.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 @OptIn(ExperimentalApi::class)
 internal class SpanExporterAdapterTest {
@@ -70,5 +71,25 @@ internal class SpanExporterAdapterTest {
         val observedLink = observed.links.single()
         assertEquals(originalLink.spanContext.spanId, observedLink.spanContext.spanId)
         assertEquals(originalLink.attributes, observedLink.attributes.convertToMap())
+    }
+
+    @Test
+    fun `test export returns failure after shutdown`() = runTest {
+        wrapper.shutdown()
+        val result = wrapper.export(listOf(FakeSpanData()))
+        assertEquals(OperationResultCode.Failure, result)
+        assertTrue(impl.exports.isEmpty())
+    }
+
+    @Test
+    fun `test shutdown returns success on second call`() = runTest {
+        assertEquals(OperationResultCode.Success, wrapper.shutdown())
+        assertEquals(OperationResultCode.Success, wrapper.shutdown())
+    }
+
+    @Test
+    fun `test force flush works after shutdown`() = runTest {
+        wrapper.shutdown()
+        assertEquals(OperationResultCode.Success, wrapper.forceFlush())
     }
 }

--- a/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/tracing/export/SpanProcessorAdapterTest.kt
+++ b/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/tracing/export/SpanProcessorAdapterTest.kt
@@ -1,0 +1,34 @@
+package io.opentelemetry.kotlin.tracing.export
+
+import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.export.OperationResultCode
+import io.opentelemetry.kotlin.fakes.otel.java.FakeOtelJavaSpanProcessor
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalApi::class)
+internal class SpanProcessorAdapterTest {
+
+    private lateinit var impl: FakeOtelJavaSpanProcessor
+    private lateinit var wrapper: SpanProcessorAdapter
+
+    @Before
+    fun setUp() {
+        impl = FakeOtelJavaSpanProcessor()
+        wrapper = SpanProcessorAdapter(impl)
+    }
+
+    @Test
+    fun `test shutdown returns success on second call`() = runTest {
+        assertEquals(OperationResultCode.Success, wrapper.shutdown())
+        assertEquals(OperationResultCode.Success, wrapper.shutdown())
+    }
+
+    @Test
+    fun `test force flush works after shutdown`() = runTest {
+        wrapper.shutdown()
+        assertEquals(OperationResultCode.Success, wrapper.forceFlush())
+    }
+}


### PR DESCRIPTION
## Summary
- Add `MutableShutdownState` to all four compat adapters (`SpanProcessorAdapter`, `LogRecordProcessorAdapter`, `SpanExporterAdapter`, `LogRecordExporterAdapter`)
- Guard data methods (`onStart`, `onEnd`, `onEmit`, `export`) to prevent data from reaching OtelJava impls after shutdown

## Test plan
- [ ] Verify data methods no-op after shutdown
- [ ] Verify idempotent shutdown returns `Success`
- [ ] Verify `forceFlush` works after shutdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)