### PR TITLE
feat: add shutdown compliance to BatchTelemetryProcessor and TelemetryExporter

### DIFF
--- a/exporters-core/build.gradle.kts
+++ b/exporters-core/build.gradle.kts
@@ -12,6 +12,7 @@ kotlin {
         val commonMain by getting {
             dependencies {
                 implementation(project(":sdk-api"))
+                implementation(project(":sdk-common"))
                 implementation(project(":platform-implementations"))
                 implementation(libs.kotlinx.coroutines)
             }

--- a/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/export/BatchTelemetryProcessor.kt
+++ b/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/export/BatchTelemetryProcessor.kt
@@ -11,7 +11,6 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withTimeout
-import kotlin.concurrent.Volatile
 
 @OptIn(ExperimentalApi::class)
 internal class BatchTelemetryProcessor<T>(
@@ -26,9 +25,7 @@ internal class BatchTelemetryProcessor<T>(
     private val scope = CoroutineScope(SupervisorJob() + dispatcher)
     private val mutex = Mutex()
     private val queue = mutableListOf<T>()
-
-    @Volatile
-    private var running = true
+    private val shutdownState = MutableShutdownState()
 
     init {
         require(scheduleDelayMs > 0)
@@ -38,7 +35,7 @@ internal class BatchTelemetryProcessor<T>(
         require(maxExportBatchSize <= maxQueueSize)
 
         scope.launch {
-            while (running) {
+            while (!shutdownState.isShutdown) {
                 delay(scheduleDelayMs)
                 flushInternal()
             }
@@ -46,8 +43,10 @@ internal class BatchTelemetryProcessor<T>(
     }
 
     fun processTelemetry(telemetry: T) {
-        if (queue.size <= maxQueueSize) {
-            queue.add(telemetry)
+        shutdownState.execute {
+            if (queue.size <= maxQueueSize) {
+                queue.add(telemetry)
+            }
         }
     }
 
@@ -58,11 +57,11 @@ internal class BatchTelemetryProcessor<T>(
         return OperationResultCode.Success
     }
 
-    fun shutdown(): OperationResultCode {
-        running = false
-        scope.cancel()
-        return OperationResultCode.Success
-    }
+    fun shutdown(): OperationResultCode =
+        shutdownState.shutdown {
+            scope.cancel()
+            OperationResultCode.Success
+        }
 
     private suspend fun flushInternal() {
         while (queue.isNotEmpty()) {

--- a/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/export/BatchTelemetryProcessorTest.kt
+++ b/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/export/BatchTelemetryProcessorTest.kt
@@ -127,7 +127,6 @@ internal class BatchTelemetryProcessorTest {
 
         processor.processTelemetry(1)
 
-        // TODO: dry
         advanceTimeBy(10)
         processor.forceFlush()
         processor.shutdown()
@@ -138,6 +137,38 @@ internal class BatchTelemetryProcessorTest {
         advanceUntilIdle()
 
         assertEquals(1, exports.size)
+    }
+
+    @Test
+    fun testShutdownReturnsSuccessOnSecondCall() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val processor = BatchTelemetryProcessor<Int>(
+            maxQueueSize = 100,
+            maxExportBatchSize = 1,
+            scheduleDelayMs = 1,
+            exportTimeoutMs = 1000,
+            dispatcher = dispatcher,
+            exportAction = { OperationResultCode.Success }
+        )
+        assertEquals(OperationResultCode.Success, processor.shutdown())
+        assertEquals(OperationResultCode.Success, processor.shutdown())
+    }
+
+    @Test
+    fun testForceFlushWorksAfterShutdown() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val processor = BatchTelemetryProcessor<Int>(
+            maxQueueSize = 100,
+            maxExportBatchSize = 1,
+            scheduleDelayMs = 1,
+            exportTimeoutMs = 1000,
+            dispatcher = dispatcher,
+            exportAction = { OperationResultCode.Success }
+        )
+        processor.shutdown()
+        advanceUntilIdle()
+        // forceFlush is independent of shutdown
+        assertEquals(OperationResultCode.Success, processor.forceFlush())
     }
 
     @Test

--- a/exporters-otlp/build.gradle.kts
+++ b/exporters-otlp/build.gradle.kts
@@ -21,6 +21,7 @@ kotlin {
         val commonMain by getting {
             dependencies {
                 implementation(project(":sdk-api"))
+                implementation(project(":sdk-common"))
                 implementation(project(":exporters-protobuf"))
                 implementation(project(":platform-implementations"))
                 implementation(libs.ktor.client.core)

--- a/exporters-otlp/src/commonMain/kotlin/io/opentelemetry/kotlin/export/TelemetryExporter.kt
+++ b/exporters-otlp/src/commonMain/kotlin/io/opentelemetry/kotlin/export/TelemetryExporter.kt
@@ -17,17 +17,19 @@ internal class TelemetryExporter<T>(
 ) : TelemetryCloseable {
 
     private val scope: CoroutineScope = CoroutineScope(SupervisorJob())
+    private val shutdownState = MutableShutdownState()
 
     /**
      * Exports telemetry via coroutines and uses exponential backoff when a failure
      * is encountered.
      */
-    fun export(telemetry: List<T>): OperationResultCode {
-        scope.launch {
-            exportTelemetry(telemetry)
+    fun export(telemetry: List<T>): OperationResultCode =
+        shutdownState.ifActive {
+            scope.launch {
+                exportTelemetry(telemetry)
+            }
+            Success
         }
-        return Success
-    }
 
     private suspend fun exportTelemetry(telemetry: List<T>) {
         var delayMs = initialDelayMs
@@ -51,8 +53,9 @@ internal class TelemetryExporter<T>(
 
     override suspend fun forceFlush(): OperationResultCode = Success
 
-    override suspend fun shutdown(): OperationResultCode {
-        scope.cancel()
-        return Success
-    }
+    override suspend fun shutdown(): OperationResultCode =
+        shutdownState.shutdown {
+            scope.cancel()
+            Success
+        }
 }

--- a/exporters-otlp/src/commonTest/kotlin/io/opentelemetry/kotlin/export/TelemetryExporterTest.kt
+++ b/exporters-otlp/src/commonTest/kotlin/io/opentelemetry/kotlin/export/TelemetryExporterTest.kt
@@ -1,0 +1,46 @@
+package io.opentelemetry.kotlin.export
+
+import io.opentelemetry.kotlin.ExperimentalApi
+import kotlinx.coroutines.test.runTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalApi::class)
+internal class TelemetryExporterTest {
+
+    private lateinit var exporter: TelemetryExporter<String>
+
+    @BeforeTest
+    fun setup() {
+        exporter = TelemetryExporter(
+            initialDelayMs = 100,
+            maxAttemptIntervalMs = 1000,
+            maxAttempts = 3,
+            exportAction = { OtlpResponse.Success }
+        )
+    }
+
+    @Test
+    fun testExportReturnsFailureAfterShutdown() = runTest {
+        assertEquals(OperationResultCode.Success, exporter.shutdown())
+        assertEquals(OperationResultCode.Failure, exporter.export(listOf("data")))
+    }
+
+    @Test
+    fun testShutdownReturnsSuccessOnSecondCall() = runTest {
+        assertEquals(OperationResultCode.Success, exporter.shutdown())
+        assertEquals(OperationResultCode.Success, exporter.shutdown())
+    }
+
+    @Test
+    fun testForceFlushWorksAfterShutdown() = runTest {
+        assertEquals(OperationResultCode.Success, exporter.shutdown())
+        assertEquals(OperationResultCode.Success, exporter.forceFlush())
+    }
+
+    @Test
+    fun testExportSucceedsBeforeShutdown() {
+        assertEquals(OperationResultCode.Success, exporter.export(listOf("data")))
+    }
+}


### PR DESCRIPTION
## Summary
- Add `sdk-common` dependency to `exporters-core` and `exporters-otlp`
- Replace `shutdownState.ifActive(Success) { shutdownState.shutdown(); ... }` with `shutdownState.shutdown { ... }` in `BatchTelemetryProcessor` and `TelemetryExporter`

## Test plan
- [x] Existing tests pass
- [x] JVM compilation succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)