### PR TITLE
Add ShutdownState abstract class and MutableShutdownState

### DIFF
--- a/sdk-api/api/jvm/sdk-api.api
+++ b/sdk-api/api/jvm/sdk-api.api
@@ -17,6 +17,14 @@ public final class io/opentelemetry/kotlin/export/OperationResultCode$Success : 
 	public static final field INSTANCE Lio/opentelemetry/kotlin/export/OperationResultCode$Success;
 }
 
+public abstract class io/opentelemetry/kotlin/export/ShutdownState {
+	public fun <init> ()V
+	public final fun execute (Lkotlin/jvm/functions/Function0;)V
+	public final fun ifActive (Lkotlin/jvm/functions/Function0;)Lio/opentelemetry/kotlin/export/OperationResultCode;
+	public final fun ifActiveOrElse (Ljava/lang/Object;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+	public abstract fun isShutdown ()Z
+}
+
 public abstract interface class io/opentelemetry/kotlin/export/TelemetryCloseable {
 	public abstract fun forceFlush (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun shutdown (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;

--- a/sdk-api/src/commonMain/kotlin/io/opentelemetry/kotlin/export/ShutdownState.kt
+++ b/sdk-api/src/commonMain/kotlin/io/opentelemetry/kotlin/export/ShutdownState.kt
@@ -1,0 +1,40 @@
+package io.opentelemetry.kotlin.export
+
+import io.opentelemetry.kotlin.ExperimentalApi
+
+/**
+ * Execute code or return defaults depending on whether this is shutdown or not, respectively.
+ */
+@OptIn(ExperimentalApi::class)
+public abstract class ShutdownState {
+    public abstract val isShutdown: Boolean
+
+    /**
+     * Run the given [action] if this isn't shutdown. Otherwise, return [default].
+     * This method will not handle exceptions thrown by [action].
+     */
+    public inline fun <T> ifActiveOrElse(default: T, action: () -> T): T =
+        if (isShutdown) {
+            default
+        } else {
+            action()
+        }
+
+    /**
+     * Run the given [action] and return the resulting [OperationResultCode] if this isn't shutdown.
+     * Otherwise, return [OperationResultCode.Failure].
+     * This method will not handle exceptions thrown by [action].
+     */
+    public inline fun ifActive(
+        action: () -> OperationResultCode,
+    ): OperationResultCode =
+        ifActiveOrElse(OperationResultCode.Failure, action)
+
+    /**
+     * Run the given [action] if this isn't shutdown. Do nothing otherwise.
+     * This method will not handle exceptions thrown by [action].
+     */
+    public inline fun execute(action: () -> Unit) {
+        ifActiveOrElse(Unit, action)
+    }
+}

--- a/sdk-common/api/jvm/sdk-common.api
+++ b/sdk-common/api/jvm/sdk-common.api
@@ -1,0 +1,7 @@
+public final class io/opentelemetry/kotlin/export/MutableShutdownState : io/opentelemetry/kotlin/export/ShutdownState {
+	public fun <init> ()V
+	public fun isShutdown ()Z
+	public final fun shutdown ()V
+	public final fun shutdown (Lkotlin/jvm/functions/Function0;)Lio/opentelemetry/kotlin/export/OperationResultCode;
+}
+

--- a/sdk-common/build.gradle.kts
+++ b/sdk-common/build.gradle.kts
@@ -1,0 +1,29 @@
+plugins {
+    kotlin("multiplatform")
+    id("com.android.kotlin.multiplatform.library")
+    id("io.opentelemetry.kotlin.build-logic")
+    id("signing")
+    id("com.vanniktech.maven.publish")
+    id("org.jetbrains.kotlinx.kover")
+}
+
+kotlin {
+    sourceSets {
+        val commonMain by getting {
+            dependencies {
+                implementation(project(":sdk-api"))
+            }
+        }
+        val commonTest by getting {
+            dependencies {
+                implementation(libs.kotlin.test)
+                implementation(libs.kotlinx.coroutines.test)
+            }
+        }
+        val jvmTest by getting {
+            dependencies {
+                implementation(libs.kotlin.test)
+            }
+        }
+    }
+}

--- a/sdk-common/src/commonMain/kotlin/io/opentelemetry/kotlin/export/MutableShutdownState.kt
+++ b/sdk-common/src/commonMain/kotlin/io/opentelemetry/kotlin/export/MutableShutdownState.kt
@@ -1,0 +1,36 @@
+package io.opentelemetry.kotlin.export
+
+import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.ThreadSafe
+import kotlin.concurrent.Volatile
+
+/**
+ * Non-locking but thread-safe implementation of [ShutdownState]. Objects that can read but not modify
+ * the shutdown state should use [ShutdownState] instead of this.
+ */
+@ThreadSafe
+@OptIn(ExperimentalApi::class)
+public class MutableShutdownState : ShutdownState() {
+    @Volatile
+    override var isShutdown: Boolean = false
+        private set
+
+    public fun shutdown() {
+        isShutdown = true
+    }
+
+    /**
+     * If not already shut down, set the shutdown flag and run [action] to perform cleanup.
+     * If already shut down, return [OperationResultCode.Success].
+     * This method will not handle exceptions thrown by [action].
+     */
+    public inline fun shutdown(
+        action: () -> OperationResultCode,
+    ): OperationResultCode =
+        if (isShutdown) {
+            OperationResultCode.Success
+        } else {
+            shutdown()
+            action()
+        }
+}

--- a/sdk-common/src/commonTest/kotlin/io/opentelemetry/kotlin/export/ShutdownStateTest.kt
+++ b/sdk-common/src/commonTest/kotlin/io/opentelemetry/kotlin/export/ShutdownStateTest.kt
@@ -1,0 +1,159 @@
+package io.opentelemetry.kotlin.export
+
+import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.export.OperationResultCode.Failure
+import io.opentelemetry.kotlin.export.OperationResultCode.Success
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalApi::class)
+internal class ShutdownStateTest {
+
+    private lateinit var state: MutableShutdownState
+
+    @BeforeTest
+    fun setup() {
+        state = MutableShutdownState()
+    }
+
+    @Test
+    fun testInitialStateIsNotShutdown() {
+        assertFalse(state.isShutdown)
+    }
+
+    @Test
+    fun testShutdownTransitionsState() {
+        state.shutdown()
+        assertTrue(state.isShutdown)
+    }
+
+    @Test
+    fun testIsShutdownRemainsTrue() {
+        state.shutdown()
+        assertTrue(state.isShutdown)
+        state.shutdown()
+        assertTrue(state.isShutdown)
+    }
+
+    @Test
+    fun testIfActiveOrElseRunsActionWhenActive() {
+        val result = state.ifActiveOrElse("default") { "active" }
+        assertEquals("active", result)
+    }
+
+    @Test
+    fun testIfActiveOrElseReturnsDefaultWhenShutdown() {
+        state.shutdown()
+        val result = state.ifActiveOrElse("default") { "active" }
+        assertEquals("default", result)
+    }
+
+    @Test
+    fun testExecuteRunsActionWhenActive() {
+        var called = false
+        state.execute { called = true }
+        assertTrue(called)
+    }
+
+    @Test
+    fun testExecuteSkipsActionWhenShutdown() {
+        state.shutdown()
+        var called = false
+        state.execute { called = true }
+        assertFalse(called)
+    }
+
+    @Test
+    fun testIfActiveResultReturnsSuccessWhenActive() {
+        val result = state.ifActive { Success }
+        assertEquals(Success, result)
+    }
+
+    @Test
+    fun testIfActiveResultReturnsFailureWhenShutdown() {
+        state.shutdown()
+        val result = state.ifActive { Success }
+        assertEquals(Failure, result)
+    }
+
+    @Test
+    fun testReadOnlyIfActiveOrElseRunsActionWhenActive() {
+        val readOnly: ShutdownState = state
+        val result = readOnly.ifActiveOrElse("default") { "active" }
+        assertEquals("active", result)
+    }
+
+    @Test
+    fun testReadOnlyIfActiveOrElseReturnsDefaultWhenShutdown() {
+        val readOnly: ShutdownState = state
+        state.shutdown()
+        val result = readOnly.ifActiveOrElse("default") { "active" }
+        assertEquals("default", result)
+    }
+
+    @Test
+    fun testReadOnlyExecuteRunsActionWhenActive() {
+        val readOnly: ShutdownState = state
+        var called = false
+        readOnly.execute { called = true }
+        assertTrue(called)
+    }
+
+    @Test
+    fun testReadOnlyExecuteSkipsActionWhenShutdown() {
+        val readOnly: ShutdownState = state
+        state.shutdown()
+        var called = false
+        readOnly.execute { called = true }
+        assertFalse(called)
+    }
+
+    @Test
+    fun testReadOnlyIfActiveReturnsSuccessWhenActive() {
+        val readOnly: ShutdownState = state
+        val result = readOnly.ifActive { Success }
+        assertEquals(Success, result)
+    }
+
+    @Test
+    fun testReadOnlyIfActiveReturnsFailureWhenShutdown() {
+        val readOnly: ShutdownState = state
+        state.shutdown()
+        val result = readOnly.ifActive { Success }
+        assertEquals(Failure, result)
+    }
+
+    @Test
+    fun testShutdownWithActionRunsActionAndSetsFlag() {
+        var actionCalled = false
+        val result = state.shutdown {
+            actionCalled = true
+            Success
+        }
+        assertTrue(actionCalled)
+        assertTrue(state.isShutdown)
+        assertEquals(Success, result)
+    }
+
+    @Test
+    fun testShutdownWithActionReturnsSuccessWhenAlreadyShutdown() {
+        state.shutdown()
+        var actionCalled = false
+        val result = state.shutdown {
+            actionCalled = true
+            Failure
+        }
+        assertFalse(actionCalled)
+        assertEquals(Success, result)
+    }
+
+    @Test
+    fun testShutdownWithActionPropagatesFailure() {
+        val result = state.shutdown { Failure }
+        assertTrue(state.isShutdown)
+        assertEquals(Failure, result)
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -19,6 +19,7 @@ include(
     ":api",
     ":api-ext",
     ":sdk-api",
+    ":sdk-common",
     ":noop",
     ":implementation",
     ":model",


### PR DESCRIPTION
## Summary
- Introduces `ShutdownState` abstract class in `sdk-api` with `ifActiveOrElse`, `ifActive`, and `execute` helpers
- Introduces `MutableShutdownState` in new `sdk-common` module with `shutdown()` and `shutdown(action)` overloads
- Moves shutdown state tests to `sdk-common`

## Stack
1. **This PR** — Phase 1: ShutdownState + MutableShutdownState
2. Phase 2: BatchTelemetryProcessor + TelemetryExporter
3. Phase 3: Span processors + exporters
4. Phase 4-6: Log pipeline, in-memory exporters, persistence layer
5. Phase 7: Java interop adapters
6. Phase 8: TracerProviderImpl + TracerImpl
7. Phase 9: LoggerProviderImpl + LoggerImpl
8. Phase 10: CloseableOpenTelemetryImpl wiring