### PR TITLE
Wire shared MutableShutdownState through CloseableOpenTelemetryImpl

### DIFF
--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/CloseableOpenTelemetryImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/CloseableOpenTelemetryImpl.kt
@@ -1,5 +1,6 @@
 package io.opentelemetry.kotlin
 
+import io.opentelemetry.kotlin.export.MutableShutdownState
 import io.opentelemetry.kotlin.export.OperationResultCode
 import io.opentelemetry.kotlin.export.OperationResultCode.Failure
 import io.opentelemetry.kotlin.export.OperationResultCode.Success
@@ -15,6 +16,7 @@ internal class CloseableOpenTelemetryImpl(
     override val loggerProvider: LoggerProvider,
     override val clock: Clock,
     private val sdkFactory: SdkFactory,
+    private val shutdownState: MutableShutdownState = MutableShutdownState(),
     private val timeoutMs: Long = 3000,
 ) : OpenTelemetrySdk, SdkFactory by sdkFactory, TelemetryCloseable {
 
@@ -30,17 +32,20 @@ internal class CloseableOpenTelemetryImpl(
         combineResults(tracerResult, loggerResult)
     }
 
-    override suspend fun shutdown(): OperationResultCode = withOverallTimeout {
-        val tracerResult = when (tracerProvider) {
-            is TelemetryCloseable -> tracerProvider.shutdown()
-            else -> Success
+    override suspend fun shutdown(): OperationResultCode =
+        shutdownState.shutdown {
+            withOverallTimeout {
+                val tracerResult = when (tracerProvider) {
+                    is TelemetryCloseable -> tracerProvider.shutdown()
+                    else -> Success
+                }
+                val loggerResult = when (loggerProvider) {
+                    is TelemetryCloseable -> loggerProvider.shutdown()
+                    else -> Success
+                }
+                combineResults(tracerResult, loggerResult)
+            }
         }
-        val loggerResult = when (loggerProvider) {
-            is TelemetryCloseable -> loggerProvider.shutdown()
-            else -> Success
-        }
-        combineResults(tracerResult, loggerResult)
-    }
 
     private suspend fun withOverallTimeout(action: suspend () -> OperationResultCode): OperationResultCode =
         try {

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/OpenTelemetryImplEntrypoint.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/OpenTelemetryImplEntrypoint.kt
@@ -46,9 +46,20 @@ internal fun createOpenTelemetryImpl(
     val loggingConfig = cfg.loggingConfig.generateLoggingConfig()
     val shutdownState = MutableShutdownState()
     return CloseableOpenTelemetryImpl(
-        tracerProvider = TracerProviderImpl(clock, tracingConfig, sdkFactory, shutdownState),
-        loggerProvider = LoggerProviderImpl(clock, loggingConfig, sdkFactory, shutdownState),
+        tracerProvider = TracerProviderImpl(
+            clock = clock,
+            tracingConfig = tracingConfig,
+            sdkFactory = sdkFactory,
+            shutdownState = shutdownState,
+        ),
+        loggerProvider = LoggerProviderImpl(
+            clock = clock,
+            loggingConfig = loggingConfig,
+            sdkFactory = sdkFactory,
+            shutdownState = shutdownState,
+        ),
         clock = clock,
-        sdkFactory = sdkFactory
+        sdkFactory = sdkFactory,
+        shutdownState = shutdownState,
     )
 }

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/CloseableOpenTelemetryImplTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/CloseableOpenTelemetryImplTest.kt
@@ -144,7 +144,29 @@ internal class CloseableOpenTelemetryImplTest {
         assertEquals(Failure, result)
     }
 
-    // TODO: test cases where telemetry submitted after shutdown. For tracer/logger impl in separate PR?
+    @Test
+    fun testShutdownReturnsSuccessOnSecondCall() = runTest {
+        val tracerProvider = FakeCloseableTracerProvider(shutdownResult = Success)
+        val loggerProvider = FakeCloseableLoggerProvider(shutdownResult = Success)
+        val api = createOpenTelemetry(tracerProvider, loggerProvider)
+
+        assertEquals(Success, api.shutdown())
+        assertEquals(Success, api.shutdown())
+        assertEquals(1, tracerProvider.shutdownCount)
+        assertEquals(1, loggerProvider.shutdownCount)
+    }
+
+    @Test
+    fun testForceFlushWorksAfterShutdown() = runTest {
+        val tracerProvider = FakeCloseableTracerProvider(flushResult = Success)
+        val loggerProvider = FakeCloseableLoggerProvider(flushResult = Success)
+        val api = createOpenTelemetry(tracerProvider, loggerProvider)
+
+        assertEquals(Success, api.shutdown())
+        assertEquals(Success, api.forceFlush())
+        assertEquals(1, tracerProvider.flushCount)
+        assertEquals(1, loggerProvider.flushCount)
+    }
 
     private fun createOpenTelemetry(
         tracerProvider: TracerProvider,


### PR DESCRIPTION
## Summary
- Replaces manual shutdown pattern in `CloseableOpenTelemetryImpl` with `shutdownState.shutdown { ... }`
- This is the final PR in the stack, wiring the shared `MutableShutdownState` through the top-level SDK entry point

## Stack
1. Phase 1: ShutdownState + MutableShutdownState
2. Phase 2: BatchTelemetryProcessor + TelemetryExporter
3. Phase 3: Span processors + exporters
4. Phase 4-6: Log pipeline, in-memory exporters, persistence layer
5. Phase 7: Java interop adapters
6. Phase 8: TracerProviderImpl + TracerImpl
7. Phase 9: LoggerProviderImpl + LoggerImpl
8. **This PR** — Phase 10: CloseableOpenTelemetryImpl wiring