### PR TITLE
Rename EventData to SpanEventData

### DIFF
--- a/api/api/jvm/api.api
+++ b/api/api/jvm/api.api
@@ -157,7 +157,7 @@ public final class io/opentelemetry/kotlin/tracing/TracerProvider$DefaultImpls {
 public abstract interface annotation class io/opentelemetry/kotlin/tracing/TracingDsl : java/lang/annotation/Annotation {
 }
 
-public abstract interface class io/opentelemetry/kotlin/tracing/data/EventData : io/opentelemetry/kotlin/attributes/AttributeContainer {
+public abstract interface class io/opentelemetry/kotlin/tracing/data/SpanEventData : io/opentelemetry/kotlin/attributes/AttributeContainer {
 	public abstract fun getName ()Ljava/lang/String;
 	public abstract fun getTimestamp ()J
 }
@@ -216,7 +216,7 @@ public abstract interface class io/opentelemetry/kotlin/tracing/model/SpanContex
 	public abstract fun isValid ()Z
 }
 
-public abstract interface class io/opentelemetry/kotlin/tracing/model/SpanEvent : io/opentelemetry/kotlin/attributes/MutableAttributeContainer, io/opentelemetry/kotlin/tracing/data/EventData {
+public abstract interface class io/opentelemetry/kotlin/tracing/model/SpanEvent : io/opentelemetry/kotlin/attributes/MutableAttributeContainer, io/opentelemetry/kotlin/tracing/data/SpanEventData {
 }
 
 public final class io/opentelemetry/kotlin/tracing/model/SpanKind : java/lang/Enum {

--- a/api/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/data/SpanEventData.kt
+++ b/api/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/data/SpanEventData.kt
@@ -8,7 +8,7 @@ import io.opentelemetry.kotlin.attributes.AttributeContainer
  * A read-only representation of a span event
  */
 @ExperimentalApi
-public interface EventData : AttributeContainer {
+public interface SpanEventData : AttributeContainer {
 
     /**
      * The name of the event

--- a/api/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/data/SpanSchema.kt
+++ b/api/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/data/SpanSchema.kt
@@ -53,7 +53,7 @@ public interface SpanSchema : AttributeContainer {
      * A list of events associated with the span.
      */
     @ThreadSafe
-    public val events: List<EventData>
+    public val events: List<SpanEventData>
 
     /**
      * A list of links associated with the span.

--- a/api/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/model/SpanEvent.kt
+++ b/api/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/model/SpanEvent.kt
@@ -4,7 +4,7 @@ import io.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.kotlin.ThreadSafe
 import io.opentelemetry.kotlin.attributes.MutableAttributeContainer
 import io.opentelemetry.kotlin.tracing.TracingDsl
-import io.opentelemetry.kotlin.tracing.data.EventData
+import io.opentelemetry.kotlin.tracing.data.SpanEventData
 
 /**
  * Represents an event that happened on a span
@@ -14,4 +14,4 @@ import io.opentelemetry.kotlin.tracing.data.EventData
 @TracingDsl
 @ExperimentalApi
 @ThreadSafe
-public interface SpanEvent : EventData, MutableAttributeContainer
+public interface SpanEvent : SpanEventData, MutableAttributeContainer

--- a/compat/api/jvm/compat.api
+++ b/compat/api/jvm/compat.api
@@ -52,7 +52,7 @@ public final class io/opentelemetry/kotlin/tracing/ext/SpanContextStorageExtKt {
 }
 
 public final class io/opentelemetry/kotlin/tracing/ext/SpanEventDataExtKt {
-	public static final fun toOtelJavaEventData (Lio/opentelemetry/kotlin/tracing/data/EventData;)Lio/opentelemetry/sdk/trace/data/EventData;
+	public static final fun toOtelJavaEventData (Lio/opentelemetry/kotlin/tracing/data/SpanEventData;)Lio/opentelemetry/sdk/trace/data/EventData;
 }
 
 public final class io/opentelemetry/kotlin/tracing/ext/SpanLinkDataExtKt {

--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/tracing/data/SpanDataAdapter.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/tracing/data/SpanDataAdapter.kt
@@ -23,7 +23,7 @@ internal class SpanDataAdapter(
     override val startTimestamp: Long = impl.startEpochNanos
     override val endTimestamp: Long? = impl.endEpochNanos
     override val attributes: Map<String, Any> = impl.attributes.convertToMap()
-    override val events: List<EventData> = impl.events.map { EventDataAdapter(it) }
+    override val events: List<SpanEventData> = impl.events.map { SpanEventDataAdapter(it) }
     override val links: List<SpanLinkData> = impl.links.map { SpanLinkDataAdapter(it) }
     override val resource: Resource = ResourceAdapter(impl.resource)
     override val instrumentationScopeInfo: InstrumentationScopeInfo = impl.instrumentationScopeInfo.toOtelKotlinInstrumentationScopeInfo()

--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/tracing/data/SpanEventDataAdapter.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/tracing/data/SpanEventDataAdapter.kt
@@ -3,9 +3,9 @@ package io.opentelemetry.kotlin.tracing.data
 import io.opentelemetry.kotlin.aliases.OtelJavaEventData
 import io.opentelemetry.kotlin.attributes.convertToMap
 
-internal class EventDataAdapter(
+internal class SpanEventDataAdapter(
     impl: OtelJavaEventData,
-) : EventData {
+) : SpanEventData {
     override val name: String = impl.name
     override val timestamp: Long = impl.epochNanos
     override val attributes: Map<String, Any> = impl.attributes.convertToMap()

--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/tracing/ext/SpanEventDataExt.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/tracing/ext/SpanEventDataExt.kt
@@ -2,9 +2,9 @@ package io.opentelemetry.kotlin.tracing.ext
 
 import io.opentelemetry.kotlin.aliases.OtelJavaEventData
 import io.opentelemetry.kotlin.attributes.attrsFromMap
-import io.opentelemetry.kotlin.tracing.data.EventData
+import io.opentelemetry.kotlin.tracing.data.SpanEventData
 
-public fun EventData.toOtelJavaEventData(): OtelJavaEventData = OtelJavaEventData.create(
+public fun SpanEventData.toOtelJavaEventData(): OtelJavaEventData = OtelJavaEventData.create(
     timestamp,
     name,
     attrsFromMap(attributes)

--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/tracing/model/ReadableSpanAdapter.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/tracing/model/ReadableSpanAdapter.kt
@@ -6,10 +6,10 @@ import io.opentelemetry.kotlin.attributes.convertToMap
 import io.opentelemetry.kotlin.resource.Resource
 import io.opentelemetry.kotlin.resource.ResourceAdapter
 import io.opentelemetry.kotlin.scope.toOtelKotlinInstrumentationScopeInfo
-import io.opentelemetry.kotlin.tracing.data.EventData
-import io.opentelemetry.kotlin.tracing.data.EventDataAdapter
 import io.opentelemetry.kotlin.tracing.data.SpanData
 import io.opentelemetry.kotlin.tracing.data.SpanDataAdapter
+import io.opentelemetry.kotlin.tracing.data.SpanEventData
+import io.opentelemetry.kotlin.tracing.data.SpanEventDataAdapter
 import io.opentelemetry.kotlin.tracing.data.SpanLinkData
 import io.opentelemetry.kotlin.tracing.data.SpanLinkDataAdapter
 import io.opentelemetry.kotlin.tracing.data.StatusData
@@ -34,8 +34,8 @@ internal class ReadableSpanAdapter(
         get() = impl.toSpanData().endEpochNanos
     override val attributes: Map<String, Any>
         get() = impl.attributes.convertToMap()
-    override val events: List<EventData>
-        get() = impl.toSpanData().events.map(::EventDataAdapter)
+    override val events: List<SpanEventData>
+        get() = impl.toSpanData().events.map(::SpanEventDataAdapter)
     override val links: List<SpanLinkData>
         get() = impl.toSpanData().links.map(::SpanLinkDataAdapter)
     override val hasEnded: Boolean

--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/tracing/model/SpanAdapter.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/tracing/model/SpanAdapter.kt
@@ -12,7 +12,7 @@ import io.opentelemetry.kotlin.attributes.MutableAttributeContainer
 import io.opentelemetry.kotlin.init.CompatSpanLimitsConfig
 import io.opentelemetry.kotlin.tracing.SpanEventCompatImpl
 import io.opentelemetry.kotlin.tracing.SpanLinkCompatImpl
-import io.opentelemetry.kotlin.tracing.data.EventData
+import io.opentelemetry.kotlin.tracing.data.SpanEventData
 import io.opentelemetry.kotlin.tracing.data.SpanLinkData
 import io.opentelemetry.kotlin.tracing.data.StatusData
 import io.opentelemetry.kotlin.tracing.ext.toOtelJavaSpanContext
@@ -31,7 +31,7 @@ internal class SpanAdapter(
 ) : Span, OtelJavaImplicitContextKeyed {
 
     private val attrs: MutableMap<String, Any> = ConcurrentHashMap()
-    private val eventsImpl: ConcurrentLinkedQueue<EventData> = ConcurrentLinkedQueue()
+    private val eventsImpl: ConcurrentLinkedQueue<SpanEventData> = ConcurrentLinkedQueue()
     private val linksImpl: ConcurrentLinkedQueue<SpanLink> = ConcurrentLinkedQueue()
 
     private var implName: String = ""
@@ -63,7 +63,7 @@ internal class SpanAdapter(
     override val attributes: Map<String, Any>
         get() = attrs.toMap()
 
-    override val events: List<EventData>
+    override val events: List<SpanEventData>
         get() = eventsImpl.toList()
 
     override val links: List<SpanLinkData>

--- a/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/tracing/model/ReadWriteSpanAdapterTest.kt
+++ b/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/tracing/model/ReadWriteSpanAdapterTest.kt
@@ -15,7 +15,7 @@ import io.opentelemetry.kotlin.fakes.otel.java.FakeOtelJavaReadableSpan
 import io.opentelemetry.kotlin.fakes.otel.java.FakeOtelJavaSpanData
 import io.opentelemetry.kotlin.framework.OtelKotlinHarness
 import io.opentelemetry.kotlin.scope.toOtelJavaInstrumentationScopeInfo
-import io.opentelemetry.kotlin.tracing.data.EventData
+import io.opentelemetry.kotlin.tracing.data.SpanEventData
 import io.opentelemetry.kotlin.tracing.data.SpanLinkData
 import io.opentelemetry.kotlin.tracing.data.StatusData
 import io.opentelemetry.kotlin.tracing.export.FakeSpanProcessor
@@ -138,7 +138,7 @@ internal class ReadWriteSpanAdapterTest {
         expectedName: String? = null,
         expectedStatus: StatusData? = null,
         expectedAttributes: Map<String, Any>? = null,
-        expectedEvents: List<EventData>? = null,
+        expectedEvents: List<SpanEventData>? = null,
         expectedLinks: List<SpanLinkData>? = null,
     ): (span: ReadWriteSpan, _: Context) -> Unit {
         return fun(span: ReadWriteSpan, context: Context) {
@@ -161,7 +161,7 @@ internal class ReadWriteSpanAdapterTest {
         expectedName: String? = null,
         expectedStatus: StatusData? = null,
         expectedAttributes: Map<String, Any>? = null,
-        expectedEvents: List<EventData>? = null,
+        expectedEvents: List<SpanEventData>? = null,
         expectedLinks: List<SpanLinkData>? = null,
     ): (span: ReadableSpan) -> Unit {
         return fun(readableSpan: ReadableSpan) {

--- a/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/export/StdoutSpanExporterTest.kt
+++ b/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/export/StdoutSpanExporterTest.kt
@@ -7,7 +7,7 @@ import io.opentelemetry.kotlin.framework.loadTestFixture
 import io.opentelemetry.kotlin.resource.FakeResource
 import io.opentelemetry.kotlin.tracing.FakeReadWriteSpan
 import io.opentelemetry.kotlin.tracing.FakeSpanContext
-import io.opentelemetry.kotlin.tracing.data.FakeEventData
+import io.opentelemetry.kotlin.tracing.data.FakeSpanEventData
 import io.opentelemetry.kotlin.tracing.data.FakeSpanLinkData
 import io.opentelemetry.kotlin.tracing.data.StatusData
 import io.opentelemetry.kotlin.tracing.model.SpanKind
@@ -54,8 +54,8 @@ internal class StdoutSpanExporterTest {
             endTimestamp = 2000000000L,
             attributes = mapOf("http.method" to "GET", "http.status_code" to 200),
             events = listOf(
-                FakeEventData(name = "request.started", timestamp = 1100000000L),
-                FakeEventData(name = "request.completed", timestamp = 1900000000L)
+                FakeSpanEventData(name = "request.started", timestamp = 1100000000L),
+                FakeSpanEventData(name = "request.completed", timestamp = 1900000000L)
             ),
             links = listOf(
                 FakeSpanLinkData()

--- a/exporters-protobuf/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/SpanDataProtobufConversion.kt
+++ b/exporters-protobuf/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/SpanDataProtobufConversion.kt
@@ -7,7 +7,7 @@ import io.opentelemetry.kotlin.export.conversion.toAttributeMap
 import io.opentelemetry.kotlin.export.conversion.toFlagsInt
 import io.opentelemetry.kotlin.export.conversion.toW3CString
 import io.opentelemetry.kotlin.resource.Resource
-import io.opentelemetry.kotlin.tracing.data.EventData
+import io.opentelemetry.kotlin.tracing.data.SpanEventData
 import io.opentelemetry.kotlin.tracing.data.SpanLinkData
 import io.opentelemetry.kotlin.tracing.data.SpanData
 import io.opentelemetry.kotlin.tracing.data.StatusData
@@ -63,9 +63,9 @@ internal fun Span.toSpanData(
     hasEnded = true
 )
 
-private fun List<EventData>.toSpanEvent(): List<Span.Event> = map { it.toSpanEvent() }
+private fun List<SpanEventData>.toSpanEvent(): List<Span.Event> = map { it.toSpanEvent() }
 
-private fun EventData.toSpanEvent(): Span.Event = Span.Event(
+private fun SpanEventData.toSpanEvent(): Span.Event = Span.Event(
     name = name,
     time_unix_nano = timestamp,
     attributes = attributes.createKeyValues()
@@ -85,7 +85,7 @@ private fun Status.toStatusData(): StatusData = when (code) {
     else -> StatusData.Unset
 }
 
-private fun Span.Event.toEventData(): EventData = DeserializedEventData(
+private fun Span.Event.toEventData(): SpanEventData = DeserializedSpanEventData(
     name = name,
     timestamp = time_unix_nano,
     attributes = attributes.toAttributeMap()
@@ -110,16 +110,16 @@ private class DeserializedSpanData(
     override val resource: Resource,
     override val instrumentationScopeInfo: InstrumentationScopeInfo,
     override val attributes: Map<String, Any>,
-    override val events: List<EventData>,
+    override val events: List<SpanEventData>,
     override val links: List<SpanLinkData>,
     override val hasEnded: Boolean
 ) : SpanData
 
-private class DeserializedEventData(
+private class DeserializedSpanEventData(
     override val name: String,
     override val timestamp: Long,
     override val attributes: Map<String, Any>
-) : EventData
+) : SpanEventData
 
 private class DeserializedSpanLinkData(
     override val spanContext: SpanContext,

--- a/exporters-protobuf/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/export/ExportTraceServiceRequestCreatorTest.kt
+++ b/exporters-protobuf/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/export/ExportTraceServiceRequestCreatorTest.kt
@@ -6,8 +6,8 @@ import io.opentelemetry.kotlin.factory.toHexString
 import io.opentelemetry.kotlin.tracing.FakeSpanContext
 import io.opentelemetry.kotlin.tracing.FakeTraceFlags
 import io.opentelemetry.kotlin.tracing.FakeTraceState
-import io.opentelemetry.kotlin.tracing.data.EventData
-import io.opentelemetry.kotlin.tracing.data.FakeEventData
+import io.opentelemetry.kotlin.tracing.data.SpanEventData
+import io.opentelemetry.kotlin.tracing.data.FakeSpanEventData
 import io.opentelemetry.kotlin.tracing.data.FakeSpanLinkData
 import io.opentelemetry.kotlin.tracing.data.FakeSpanData
 import io.opentelemetry.kotlin.tracing.data.SpanLinkData
@@ -97,9 +97,9 @@ class ExportTraceServiceRequestCreatorTest {
     @Test
     fun testMultipleEventsRoundTrip() {
         val events = listOf(
-            FakeEventData(name = "event1", timestamp = 1000L, attributes = mapOf("key1" to "val1")),
-            FakeEventData(name = "event2", timestamp = 2000L, attributes = mapOf("key2" to "val2")),
-            FakeEventData(name = "event3", timestamp = 3000L, attributes = emptyMap())
+            FakeSpanEventData(name = "event1", timestamp = 1000L, attributes = mapOf("key1" to "val1")),
+            FakeSpanEventData(name = "event2", timestamp = 2000L, attributes = mapOf("key2" to "val2")),
+            FakeSpanEventData(name = "event3", timestamp = 3000L, attributes = emptyMap())
         )
         val spanData = FakeSpanData(events = events)
         val byteArray = listOf(spanData).toProtobufByteArray()
@@ -179,8 +179,8 @@ class ExportTraceServiceRequestCreatorTest {
     }
 
     private fun assertEventMatches(
-        expectedEvent: EventData,
-        observedEvent: EventData
+        expectedEvent: SpanEventData,
+        observedEvent: SpanEventData
     ) {
         assertEquals(expectedEvent.name, observedEvent.name)
         assertEquals(expectedEvent.timestamp, observedEvent.timestamp)

--- a/exporters-protobuf/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/export/SpanDataProtobufConversionTest.kt
+++ b/exporters-protobuf/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/export/SpanDataProtobufConversionTest.kt
@@ -2,7 +2,7 @@ package io.opentelemetry.kotlin.tracing.export
 
 import io.opentelemetry.kotlin.export.assertAttributesMatch
 import io.opentelemetry.kotlin.factory.toHexString
-import io.opentelemetry.kotlin.tracing.data.EventData
+import io.opentelemetry.kotlin.tracing.data.SpanEventData
 import io.opentelemetry.kotlin.tracing.data.FakeSpanData
 import io.opentelemetry.kotlin.tracing.data.SpanLinkData
 import io.opentelemetry.kotlin.tracing.data.StatusData
@@ -42,7 +42,7 @@ class SpanDataProtobufConversionTest {
     }
 
     private fun assertEventsMatch(
-        events: List<EventData>, eventsList: List<Span.Event>
+        events: List<SpanEventData>, eventsList: List<Span.Event>
     ) {
         assertEquals(events.size, eventsList.size)
         events.forEachIndexed { index, event ->

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/SpanRelationshipsImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/SpanRelationshipsImpl.kt
@@ -5,7 +5,7 @@ import io.opentelemetry.kotlin.attributes.AttributesModel
 import io.opentelemetry.kotlin.attributes.MutableAttributeContainer
 import io.opentelemetry.kotlin.init.config.SpanLimitConfig
 import io.opentelemetry.kotlin.threadSafeList
-import io.opentelemetry.kotlin.tracing.data.EventData
+import io.opentelemetry.kotlin.tracing.data.SpanEventData
 import io.opentelemetry.kotlin.tracing.data.SpanLinkData
 import io.opentelemetry.kotlin.tracing.model.SpanContext
 import io.opentelemetry.kotlin.tracing.model.SpanRelationships
@@ -17,7 +17,7 @@ internal class SpanRelationshipsImpl(
 ) : SpanRelationships, MutableAttributeContainer by attrs {
 
     val links = threadSafeList<SpanLinkData>()
-    val events = threadSafeList<EventData>()
+    val events = threadSafeList<SpanEventData>()
 
     override fun addLink(
         spanContext: SpanContext,

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/model/SpanModel.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/model/SpanModel.kt
@@ -10,8 +10,8 @@ import io.opentelemetry.kotlin.resource.Resource
 import io.opentelemetry.kotlin.tracing.SpanDataImpl
 import io.opentelemetry.kotlin.tracing.SpanEventImpl
 import io.opentelemetry.kotlin.tracing.SpanLinkImpl
-import io.opentelemetry.kotlin.tracing.data.EventData
 import io.opentelemetry.kotlin.tracing.data.SpanData
+import io.opentelemetry.kotlin.tracing.data.SpanEventData
 import io.opentelemetry.kotlin.tracing.data.SpanLinkData
 import io.opentelemetry.kotlin.tracing.data.StatusData
 import io.opentelemetry.kotlin.tracing.export.SpanProcessor
@@ -92,9 +92,9 @@ internal class SpanModel(
 
     override fun isRecording(): Boolean = state != State.ENDED
 
-    private val eventsList = mutableListOf<EventData>()
+    private val eventsList = mutableListOf<SpanEventData>()
 
-    override val events: List<EventData>
+    override val events: List<SpanEventData>
         get() = lock.read {
             eventsList.toList()
         }

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/integration/test/model/ReadableSpanConversionTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/integration/test/model/ReadableSpanConversionTest.kt
@@ -5,7 +5,7 @@ import io.opentelemetry.kotlin.framework.serialization.SerializableSpanData
 import io.opentelemetry.kotlin.resource.FakeResource
 import io.opentelemetry.kotlin.tracing.FakeReadWriteSpan
 import io.opentelemetry.kotlin.tracing.FakeSpanContext
-import io.opentelemetry.kotlin.tracing.data.FakeEventData
+import io.opentelemetry.kotlin.tracing.data.FakeSpanEventData
 import io.opentelemetry.kotlin.tracing.data.FakeSpanLinkData
 import io.opentelemetry.kotlin.tracing.data.StatusData
 import io.opentelemetry.kotlin.tracing.model.SpanContext
@@ -31,7 +31,7 @@ internal class ReadableSpanConversionTest {
                 )
             ),
             events = listOf(
-                FakeEventData(
+                FakeSpanEventData(
                     "fake_event",
                     500,
                     mapOf("foo" to "bar")

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/integration/test/model/ReadableSpanExt.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/integration/test/model/ReadableSpanExt.kt
@@ -9,7 +9,7 @@ import io.opentelemetry.kotlin.framework.serialization.SerializableSpanContext
 import io.opentelemetry.kotlin.framework.serialization.SerializableSpanData
 import io.opentelemetry.kotlin.framework.serialization.SerializableSpanStatusData
 import io.opentelemetry.kotlin.resource.Resource
-import io.opentelemetry.kotlin.tracing.data.EventData
+import io.opentelemetry.kotlin.tracing.data.SpanEventData
 import io.opentelemetry.kotlin.tracing.data.SpanLinkData
 import io.opentelemetry.kotlin.tracing.data.StatusData
 import io.opentelemetry.kotlin.tracing.model.ReadableSpan
@@ -25,7 +25,7 @@ internal fun ReadableSpan.toSerializable(): SerializableSpanData =
         parentSpanContext = spanContext.toSerializable(),
         startTimestamp = startTimestamp,
         attributes = attributes.toSerializable(),
-        events = events.map(EventData::toSerializable),
+        events = events.map(SpanEventData::toSerializable),
         links = links.map(SpanLinkData::toSerializable),
         endTimestamp = endTimestamp ?: -1,
         ended = hasEnded,
@@ -59,7 +59,7 @@ private fun InstrumentationScopeInfo.toSerializable(): SerializableInstrumentati
         attributes.toSerializable()
     )
 
-private fun EventData.toSerializable(): SerializableEventData =
+private fun SpanEventData.toSerializable(): SerializableEventData =
     SerializableEventData(
         name,
         attributes.toSerializable(),

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/SpanEventTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/SpanEventTest.kt
@@ -6,7 +6,7 @@ import io.opentelemetry.kotlin.factory.FakeIdGenerator
 import io.opentelemetry.kotlin.factory.FakeSdkFactory
 import io.opentelemetry.kotlin.init.config.SpanLimitConfig
 import io.opentelemetry.kotlin.resource.FakeResource
-import io.opentelemetry.kotlin.tracing.data.EventData
+import io.opentelemetry.kotlin.tracing.data.SpanEventData
 import io.opentelemetry.kotlin.tracing.export.FakeSpanProcessor
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -152,14 +152,14 @@ internal class SpanEventTest {
         assertEquals(fakeSpanLimitsConfig.attributeCountLimit, event.attributes.size)
     }
 
-    private fun retrieveEvents(expected: Int): List<EventData> {
+    private fun retrieveEvents(expected: Int): List<SpanEventData> {
         val events = processor.endCalls.single().events
         assertEquals(expected, events.size)
         return events
     }
 
     private fun assertEventData(
-        event: EventData,
+        event: SpanEventData,
         name: String,
         time: Long,
         attrs: Map<String, Any>

--- a/integration-test/src/commonMain/kotlin/io/opentelemetry/kotlin/framework/serialization/conversion/SerializableEventData.kt
+++ b/integration-test/src/commonMain/kotlin/io/opentelemetry/kotlin/framework/serialization/conversion/SerializableEventData.kt
@@ -1,9 +1,9 @@
 package io.opentelemetry.kotlin.framework.serialization.conversion
 
 import io.opentelemetry.kotlin.framework.serialization.SerializableEventData
-import io.opentelemetry.kotlin.tracing.data.EventData
+import io.opentelemetry.kotlin.tracing.data.SpanEventData
 
-fun EventData.toSerializable() =
+fun SpanEventData.toSerializable() =
     SerializableEventData(
         name = name,
         attributes = attributes.toSerializable(),

--- a/integration-test/src/commonTest/kotlin/io/opentelemetry/kotlin/framework/serialization/SerializableSpanDataTest.kt
+++ b/integration-test/src/commonTest/kotlin/io/opentelemetry/kotlin/framework/serialization/SerializableSpanDataTest.kt
@@ -2,8 +2,8 @@ package io.opentelemetry.kotlin.framework.serialization
 
 import io.opentelemetry.kotlin.framework.serialization.conversion.toSerializable
 import io.opentelemetry.kotlin.resource.Resource
-import io.opentelemetry.kotlin.tracing.data.EventData
 import io.opentelemetry.kotlin.tracing.data.FakeSpanData
+import io.opentelemetry.kotlin.tracing.data.SpanEventData
 import io.opentelemetry.kotlin.tracing.data.SpanLinkData
 import io.opentelemetry.kotlin.tracing.data.StatusData
 import io.opentelemetry.kotlin.tracing.model.SpanContext
@@ -52,7 +52,7 @@ internal class SerializableSpanDataTest {
         assertEquals(expected.mapValues { it.value.toString() }, observed)
     }
 
-    private fun compareEvents(expected: List<EventData>, observed: List<SerializableEventData>) {
+    private fun compareEvents(expected: List<SpanEventData>, observed: List<SerializableEventData>) {
         assertEquals(expected.size, observed.size)
 
         expected.forEachIndexed { index, data ->

--- a/model/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/NonRecordingSpan.kt
+++ b/model/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/NonRecordingSpan.kt
@@ -1,7 +1,7 @@
 package io.opentelemetry.kotlin.tracing
 
 import io.opentelemetry.kotlin.attributes.MutableAttributeContainer
-import io.opentelemetry.kotlin.tracing.data.EventData
+import io.opentelemetry.kotlin.tracing.data.SpanEventData
 import io.opentelemetry.kotlin.tracing.data.SpanLinkData
 import io.opentelemetry.kotlin.tracing.data.StatusData
 import io.opentelemetry.kotlin.tracing.model.Span
@@ -30,7 +30,7 @@ class NonRecordingSpan(
     override val attributes: Map<String, Any>
         get() = emptyMap()
 
-    override val events: List<EventData>
+    override val events: List<SpanEventData>
         get() = emptyList()
 
     override val links: List<SpanLinkData>

--- a/model/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/SpanDataImpl.kt
+++ b/model/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/SpanDataImpl.kt
@@ -3,8 +3,8 @@ package io.opentelemetry.kotlin.tracing
 
 import io.opentelemetry.kotlin.InstrumentationScopeInfo
 import io.opentelemetry.kotlin.resource.Resource
-import io.opentelemetry.kotlin.tracing.data.EventData
 import io.opentelemetry.kotlin.tracing.data.SpanData
+import io.opentelemetry.kotlin.tracing.data.SpanEventData
 import io.opentelemetry.kotlin.tracing.data.SpanLinkData
 import io.opentelemetry.kotlin.tracing.data.StatusData
 import io.opentelemetry.kotlin.tracing.model.SpanContext
@@ -19,7 +19,7 @@ class SpanDataImpl(
     override val startTimestamp: Long,
     override val endTimestamp: Long?,
     override val attributes: Map<String, Any>,
-    override val events: List<EventData>,
+    override val events: List<SpanEventData>,
     override val links: List<SpanLinkData>,
     override val resource: Resource,
     override val instrumentationScopeInfo: InstrumentationScopeInfo,

--- a/noop/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/NoopSpan.kt
+++ b/noop/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/NoopSpan.kt
@@ -2,7 +2,7 @@ package io.opentelemetry.kotlin.tracing
 
 import io.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.kotlin.attributes.MutableAttributeContainer
-import io.opentelemetry.kotlin.tracing.data.EventData
+import io.opentelemetry.kotlin.tracing.data.SpanEventData
 import io.opentelemetry.kotlin.tracing.data.SpanLinkData
 import io.opentelemetry.kotlin.tracing.data.StatusData
 import io.opentelemetry.kotlin.tracing.model.Span
@@ -19,7 +19,7 @@ internal object NoopSpan : Span {
     override val spanKind: SpanKind = SpanKind.INTERNAL
     override val startTimestamp: Long = -1L
     override val attributes: Map<String, Any> = emptyMap()
-    override val events: List<EventData> = emptyList()
+    override val events: List<SpanEventData> = emptyList()
     override val links: List<SpanLinkData> = emptyList()
 
     override fun end() {

--- a/test-fakes/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/FakeReadWriteSpan.kt
+++ b/test-fakes/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/FakeReadWriteSpan.kt
@@ -5,8 +5,8 @@ import io.opentelemetry.kotlin.InstrumentationScopeInfo
 import io.opentelemetry.kotlin.attributes.MutableAttributeContainer
 import io.opentelemetry.kotlin.resource.FakeResource
 import io.opentelemetry.kotlin.resource.Resource
-import io.opentelemetry.kotlin.tracing.data.EventData
 import io.opentelemetry.kotlin.tracing.data.SpanData
+import io.opentelemetry.kotlin.tracing.data.SpanEventData
 import io.opentelemetry.kotlin.tracing.data.SpanLinkData
 import io.opentelemetry.kotlin.tracing.data.StatusData
 import io.opentelemetry.kotlin.tracing.model.ReadWriteSpan
@@ -20,7 +20,7 @@ class FakeReadWriteSpan(
     override val spanContext: SpanContext = FakeSpanContext.INVALID,
     override val spanKind: SpanKind = SpanKind.INTERNAL,
     override val startTimestamp: Long = 0,
-    override val events: List<EventData> = emptyList(),
+    override val events: List<SpanEventData> = emptyList(),
     override val links: List<SpanLinkData> = emptyList(),
     override val attributes: Map<String, Any> = emptyMap(),
     override val endTimestamp: Long? = 0,

--- a/test-fakes/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/FakeSpan.kt
+++ b/test-fakes/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/FakeSpan.kt
@@ -2,8 +2,8 @@ package io.opentelemetry.kotlin.tracing
 
 import io.opentelemetry.kotlin.attributes.FakeMutableAttributeContainer
 import io.opentelemetry.kotlin.attributes.MutableAttributeContainer
-import io.opentelemetry.kotlin.tracing.data.EventData
 import io.opentelemetry.kotlin.tracing.data.FakeSpanLinkData
+import io.opentelemetry.kotlin.tracing.data.SpanEventData
 import io.opentelemetry.kotlin.tracing.data.SpanLinkData
 import io.opentelemetry.kotlin.tracing.data.StatusData
 import io.opentelemetry.kotlin.tracing.model.Span
@@ -16,7 +16,7 @@ class FakeSpan(
     override val spanContext: SpanContext = FakeSpanContext.INVALID,
 ) : Span {
 
-    override val events: MutableList<EventData> = mutableListOf()
+    override val events: MutableList<SpanEventData> = mutableListOf()
     override val links: MutableList<SpanLinkData> = mutableListOf()
 
     private var recording: Boolean = true

--- a/test-fakes/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/data/FakeSpanData.kt
+++ b/test-fakes/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/data/FakeSpanData.kt
@@ -19,7 +19,7 @@ class FakeSpanData(
     override val resource: Resource = FakeResource(),
     override val instrumentationScopeInfo: InstrumentationScopeInfo = FakeInstrumentationScopeInfo(),
     override val attributes: Map<String, Any> = mapOf("key" to "value"),
-    override val events: List<EventData> = listOf(FakeEventData()),
+    override val events: List<SpanEventData> = listOf(FakeSpanEventData()),
     override val links: List<SpanLinkData> = listOf(FakeSpanLinkData()),
     override val hasEnded: Boolean = true,
 ) : SpanData

--- a/test-fakes/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/data/FakeSpanEventData.kt
+++ b/test-fakes/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/data/FakeSpanEventData.kt
@@ -1,6 +1,6 @@
 package io.opentelemetry.kotlin.tracing.data
-class FakeEventData(
+class FakeSpanEventData(
     override val name: String = "event",
     override val timestamp: Long = 1000,
     override val attributes: Map<String, Any> = mapOf("key" to "value")
-) : EventData
+) : SpanEventData


### PR DESCRIPTION
## Goal

Renames `EventData` to `SpanEventData`. This feels better as it disambiguates the concept from an 'event' which is sent as a log.

## Testing

Relied on existing test coverage.
