### PR TITLE
Rename MutableAttributeContainer

### DIFF
--- a/api-ext/api/jvm/api-ext.api
+++ b/api-ext/api/jvm/api-ext.api
@@ -3,8 +3,8 @@ public final class io/opentelemetry/kotlin/OpenTelemetryExtKt {
 	public static final fun getTracer (Lio/opentelemetry/kotlin/OpenTelemetry;Ljava/lang/String;)Lio/opentelemetry/kotlin/tracing/Tracer;
 }
 
-public final class io/opentelemetry/kotlin/attributes/MutableAttributeContainerExtKt {
-	public static final fun setAttributes (Lio/opentelemetry/kotlin/attributes/MutableAttributeContainer;Ljava/util/Map;)V
+public final class io/opentelemetry/kotlin/attributes/AttributesMutatorExtKt {
+	public static final fun setAttributes (Lio/opentelemetry/kotlin/attributes/AttributesMutator;Ljava/util/Map;)V
 }
 
 public final class io/opentelemetry/kotlin/context/ContextApiExtKt {

--- a/api-ext/src/commonMain/kotlin/io/opentelemetry/kotlin/attributes/AttributesMutatorExt.kt
+++ b/api-ext/src/commonMain/kotlin/io/opentelemetry/kotlin/attributes/AttributesMutatorExt.kt
@@ -4,7 +4,7 @@ import io.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.kotlin.ThreadSafe
 
 /**
- * Sets attributes on an [io.opentelemetry.kotlin.attributes.MutableAttributeContainer] from a [Map].
+ * Sets attributes on an [io.opentelemetry.kotlin.attributes.AttributesMutator] from a [Map].
  * Only values in the map of a type supported by the
  * OpenTelemetry API will be set. Other values will be ignored.
  *
@@ -12,7 +12,7 @@ import io.opentelemetry.kotlin.ThreadSafe
  */
 @ExperimentalApi
 @ThreadSafe
-public fun MutableAttributeContainer.setAttributes(attributes: Map<String, Any>) {
+public fun AttributesMutator.setAttributes(attributes: Map<String, Any>) {
     attributes.forEach {
         when (val input = it.value) {
             is String -> setStringAttribute(it.key, input)
@@ -27,7 +27,7 @@ public fun MutableAttributeContainer.setAttributes(attributes: Map<String, Any>)
 }
 
 @Suppress("UNCHECKED_CAST")
-private fun MutableAttributeContainer.handleCollection(key: String, input: List<*>) {
+private fun AttributesMutator.handleCollection(key: String, input: List<*>) {
     when {
         input.all { it is String } -> setStringListAttribute(key, input as List<String>)
         input.all { it is Boolean } -> setBooleanListAttribute(key, input as List<Boolean>)

--- a/api-ext/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/SpanExt.kt
+++ b/api-ext/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/SpanExt.kt
@@ -2,7 +2,7 @@ package io.opentelemetry.kotlin.tracing
 
 import io.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.kotlin.ThreadSafe
-import io.opentelemetry.kotlin.attributes.MutableAttributeContainer
+import io.opentelemetry.kotlin.attributes.AttributesMutator
 import io.opentelemetry.kotlin.exceptionType
 import io.opentelemetry.kotlin.tracing.data.StatusData
 import io.opentelemetry.kotlin.tracing.model.Span
@@ -14,7 +14,7 @@ import io.opentelemetry.kotlin.tracing.model.Span
 @ThreadSafe
 public fun Span.recordException(
     exception: Throwable,
-    attributes: MutableAttributeContainer.() -> Unit = {}
+    attributes: AttributesMutator.() -> Unit = {}
 ) {
     addEvent("exception") {
         setStringAttribute("exception.stacktrace", exception.stackTraceToString())
@@ -33,7 +33,7 @@ public fun Span.recordException(
  */
 @ExperimentalApi
 @ThreadSafe
-public fun Span.addLink(span: Span, attributes: MutableAttributeContainer.() -> Unit = {}) {
+public fun Span.addLink(span: Span, attributes: AttributesMutator.() -> Unit = {}) {
     addLink(span.spanContext, attributes)
 }
 

--- a/api-ext/src/commonTest/kotlin/io/opentelemetry/kotlin/attributes/AttributeContainerExtTest.kt
+++ b/api-ext/src/commonTest/kotlin/io/opentelemetry/kotlin/attributes/AttributeContainerExtTest.kt
@@ -7,7 +7,7 @@ internal class AttributeContainerExtTest {
 
     @Test
     fun testSetAttributes() {
-        val attrs = FakeMutableAttributeContainer()
+        val attrs = FakeAttributesMutator()
         val input = mapOf(
             "string" to "value",
             "long" to 5L,
@@ -39,9 +39,9 @@ internal class AttributeContainerExtTest {
         override fun toString(): String = "ComplexObject"
     }
 
-    private class FakeMutableAttributeContainer(
+    private class FakeAttributesMutator(
         val attributes: MutableMap<String, Any> = mutableMapOf()
-    ) : MutableAttributeContainer {
+    ) : AttributesMutator {
         override fun setBooleanAttribute(key: String, value: Boolean) {
             attributes[key] = value
         }

--- a/api/api/jvm/api.api
+++ b/api/api/jvm/api.api
@@ -18,7 +18,7 @@ public abstract interface class io/opentelemetry/kotlin/attributes/AttributeCont
 	public abstract fun getAttributes ()Ljava/util/Map;
 }
 
-public abstract interface class io/opentelemetry/kotlin/attributes/MutableAttributeContainer {
+public abstract interface class io/opentelemetry/kotlin/attributes/AttributesMutator {
 	public abstract fun setBooleanAttribute (Ljava/lang/String;Z)V
 	public abstract fun setBooleanListAttribute (Ljava/lang/String;Ljava/util/List;)V
 	public abstract fun setDoubleAttribute (Ljava/lang/String;D)V
@@ -207,7 +207,7 @@ public abstract interface class io/opentelemetry/kotlin/tracing/model/SpanContex
 	public abstract fun isValid ()Z
 }
 
-public abstract interface class io/opentelemetry/kotlin/tracing/model/SpanEvent : io/opentelemetry/kotlin/attributes/MutableAttributeContainer, io/opentelemetry/kotlin/tracing/data/SpanEventData {
+public abstract interface class io/opentelemetry/kotlin/tracing/model/SpanEvent : io/opentelemetry/kotlin/attributes/AttributesMutator, io/opentelemetry/kotlin/tracing/data/SpanEventData {
 }
 
 public final class io/opentelemetry/kotlin/tracing/model/SpanKind : java/lang/Enum {
@@ -221,10 +221,10 @@ public final class io/opentelemetry/kotlin/tracing/model/SpanKind : java/lang/En
 	public static fun values ()[Lio/opentelemetry/kotlin/tracing/model/SpanKind;
 }
 
-public abstract interface class io/opentelemetry/kotlin/tracing/model/SpanLink : io/opentelemetry/kotlin/attributes/MutableAttributeContainer, io/opentelemetry/kotlin/tracing/data/SpanLinkData {
+public abstract interface class io/opentelemetry/kotlin/tracing/model/SpanLink : io/opentelemetry/kotlin/attributes/AttributesMutator, io/opentelemetry/kotlin/tracing/data/SpanLinkData {
 }
 
-public abstract interface class io/opentelemetry/kotlin/tracing/model/SpanRelationships : io/opentelemetry/kotlin/attributes/MutableAttributeContainer {
+public abstract interface class io/opentelemetry/kotlin/tracing/model/SpanRelationships : io/opentelemetry/kotlin/attributes/AttributesMutator {
 	public abstract fun addEvent (Ljava/lang/String;Ljava/lang/Long;Lkotlin/jvm/functions/Function1;)V
 	public abstract fun addLink (Lio/opentelemetry/kotlin/tracing/model/SpanContext;Lkotlin/jvm/functions/Function1;)V
 }

--- a/api/src/commonMain/kotlin/io/opentelemetry/kotlin/attributes/AttributesMutator.kt
+++ b/api/src/commonMain/kotlin/io/opentelemetry/kotlin/attributes/AttributesMutator.kt
@@ -10,7 +10,7 @@ import io.opentelemetry.kotlin.ThreadSafe
  */
 @ExperimentalApi
 @ThreadSafe
-public interface MutableAttributeContainer {
+public interface AttributesMutator {
 
     /**
      * Sets an attribute with a boolean value.

--- a/api/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/Logger.kt
+++ b/api/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/Logger.kt
@@ -2,7 +2,7 @@ package io.opentelemetry.kotlin.logging
 
 import io.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.kotlin.ThreadSafe
-import io.opentelemetry.kotlin.attributes.MutableAttributeContainer
+import io.opentelemetry.kotlin.attributes.AttributesMutator
 import io.opentelemetry.kotlin.context.Context
 import io.opentelemetry.kotlin.logging.model.SeverityNumber
 
@@ -52,6 +52,6 @@ public interface Logger {
         context: Context? = null,
         severityNumber: SeverityNumber? = null,
         severityText: String? = null,
-        attributes: (MutableAttributeContainer.() -> Unit)? = null,
+        attributes: (AttributesMutator.() -> Unit)? = null,
     )
 }

--- a/api/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/LoggerProvider.kt
+++ b/api/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/LoggerProvider.kt
@@ -2,7 +2,7 @@ package io.opentelemetry.kotlin.logging
 
 import io.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.kotlin.ThreadSafe
-import io.opentelemetry.kotlin.attributes.MutableAttributeContainer
+import io.opentelemetry.kotlin.attributes.AttributesMutator
 
 /**
  * Provider for retrieving [Logger] instances.
@@ -24,6 +24,6 @@ public interface LoggerProvider {
         name: String,
         version: String? = null,
         schemaUrl: String? = null,
-        attributes: (MutableAttributeContainer.() -> Unit)? = null,
+        attributes: (AttributesMutator.() -> Unit)? = null,
     ): Logger
 }

--- a/api/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/TracerProvider.kt
+++ b/api/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/TracerProvider.kt
@@ -2,7 +2,7 @@ package io.opentelemetry.kotlin.tracing
 
 import io.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.kotlin.ThreadSafe
-import io.opentelemetry.kotlin.attributes.MutableAttributeContainer
+import io.opentelemetry.kotlin.attributes.AttributesMutator
 
 /**
  * TracerProvider is a factory for retrieving instances of [Tracer].
@@ -24,6 +24,6 @@ public interface TracerProvider {
         name: String,
         version: String? = null,
         schemaUrl: String? = null,
-        attributes: (MutableAttributeContainer.() -> Unit)? = null,
+        attributes: (AttributesMutator.() -> Unit)? = null,
     ): Tracer
 }

--- a/api/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/model/SpanEvent.kt
+++ b/api/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/model/SpanEvent.kt
@@ -2,7 +2,7 @@ package io.opentelemetry.kotlin.tracing.model
 
 import io.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.kotlin.ThreadSafe
-import io.opentelemetry.kotlin.attributes.MutableAttributeContainer
+import io.opentelemetry.kotlin.attributes.AttributesMutator
 import io.opentelemetry.kotlin.tracing.TracingDsl
 import io.opentelemetry.kotlin.tracing.data.SpanEventData
 
@@ -14,4 +14,4 @@ import io.opentelemetry.kotlin.tracing.data.SpanEventData
 @TracingDsl
 @ExperimentalApi
 @ThreadSafe
-public interface SpanEvent : SpanEventData, MutableAttributeContainer
+public interface SpanEvent : SpanEventData, AttributesMutator

--- a/api/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/model/SpanLink.kt
+++ b/api/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/model/SpanLink.kt
@@ -2,7 +2,7 @@ package io.opentelemetry.kotlin.tracing.model
 
 import io.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.kotlin.ThreadSafe
-import io.opentelemetry.kotlin.attributes.MutableAttributeContainer
+import io.opentelemetry.kotlin.attributes.AttributesMutator
 import io.opentelemetry.kotlin.tracing.data.SpanLinkData
 
 /**
@@ -12,4 +12,4 @@ import io.opentelemetry.kotlin.tracing.data.SpanLinkData
  */
 @ExperimentalApi
 @ThreadSafe
-public interface SpanLink : SpanLinkData, MutableAttributeContainer
+public interface SpanLink : SpanLinkData, AttributesMutator

--- a/api/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/model/SpanRelationships.kt
+++ b/api/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/model/SpanRelationships.kt
@@ -2,7 +2,7 @@ package io.opentelemetry.kotlin.tracing.model
 
 import io.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.kotlin.ThreadSafe
-import io.opentelemetry.kotlin.attributes.MutableAttributeContainer
+import io.opentelemetry.kotlin.attributes.AttributesMutator
 
 /**
  * Provides operations that add relationships (events + links) to a span
@@ -10,13 +10,13 @@ import io.opentelemetry.kotlin.attributes.MutableAttributeContainer
  * https://opentelemetry.io/docs/specs/otel/trace/api/
  */
 @ExperimentalApi
-public interface SpanRelationships : MutableAttributeContainer {
+public interface SpanRelationships : AttributesMutator {
 
     /**
      * Adds a link to the span that associates it with another [SpanContext].
      */
     @ThreadSafe
-    public fun addLink(spanContext: SpanContext, attributes: (MutableAttributeContainer.() -> Unit)? = null)
+    public fun addLink(spanContext: SpanContext, attributes: (AttributesMutator.() -> Unit)? = null)
 
     /**
      * Adds an event to the span.
@@ -25,6 +25,6 @@ public interface SpanRelationships : MutableAttributeContainer {
     public fun addEvent(
         name: String,
         timestamp: Long? = null,
-        attributes: (MutableAttributeContainer.() -> Unit)? = null,
+        attributes: (AttributesMutator.() -> Unit)? = null,
     )
 }

--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/attributes/CompatAttributesModel.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/attributes/CompatAttributesModel.kt
@@ -6,7 +6,7 @@ import io.opentelemetry.kotlin.aliases.OtelJavaAttributesBuilder
 
 internal class CompatAttributesModel(
     private val attrs: OtelJavaAttributesBuilder = OtelJavaAttributes.builder()
-) : MutableAttributeContainer, AttributeContainer {
+) : AttributesMutator, AttributeContainer {
 
     override fun setBooleanAttribute(key: String, value: Boolean) {
         attrs.put(key, value)

--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/init/CompatLoggerProviderConfig.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/init/CompatLoggerProviderConfig.kt
@@ -5,8 +5,8 @@ import io.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.kotlin.aliases.OtelJavaResource
 import io.opentelemetry.kotlin.aliases.OtelJavaSdkLoggerProvider
 import io.opentelemetry.kotlin.aliases.OtelJavaSdkLoggerProviderBuilder
+import io.opentelemetry.kotlin.attributes.AttributesMutator
 import io.opentelemetry.kotlin.attributes.CompatAttributesModel
-import io.opentelemetry.kotlin.attributes.MutableAttributeContainer
 import io.opentelemetry.kotlin.attributes.setAttributes
 import io.opentelemetry.kotlin.logging.LoggerProvider
 import io.opentelemetry.kotlin.logging.LoggerProviderAdapter
@@ -20,7 +20,7 @@ internal class CompatLoggerProviderConfig(
 
     private val builder: OtelJavaSdkLoggerProviderBuilder = OtelJavaSdkLoggerProvider.builder()
 
-    override fun resource(schemaUrl: String?, attributes: MutableAttributeContainer.() -> Unit) {
+    override fun resource(schemaUrl: String?, attributes: AttributesMutator.() -> Unit) {
         val attrs = CompatAttributesModel().apply(attributes).otelJavaAttributes()
         builder.setResource(OtelJavaResource.create(attrs, schemaUrl))
     }

--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/init/CompatTracerProviderConfig.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/init/CompatTracerProviderConfig.kt
@@ -6,8 +6,8 @@ import io.opentelemetry.kotlin.aliases.OtelJavaIdGenerator
 import io.opentelemetry.kotlin.aliases.OtelJavaResource
 import io.opentelemetry.kotlin.aliases.OtelJavaSdkTracerProvider
 import io.opentelemetry.kotlin.aliases.OtelJavaSdkTracerProviderBuilder
+import io.opentelemetry.kotlin.attributes.AttributesMutator
 import io.opentelemetry.kotlin.attributes.CompatAttributesModel
-import io.opentelemetry.kotlin.attributes.MutableAttributeContainer
 import io.opentelemetry.kotlin.attributes.setAttributes
 import io.opentelemetry.kotlin.factory.IdGenerator
 import io.opentelemetry.kotlin.tracing.TracerProvider
@@ -30,7 +30,7 @@ internal class CompatTracerProviderConfig(
         }
     }
 
-    override fun resource(schemaUrl: String?, attributes: MutableAttributeContainer.() -> Unit) {
+    override fun resource(schemaUrl: String?, attributes: AttributesMutator.() -> Unit) {
         val attrs = CompatAttributesModel().apply(attributes).otelJavaAttributes()
         builder.setResource(OtelJavaResource.create(attrs, schemaUrl))
     }

--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/logging/LoggerAdapter.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/logging/LoggerAdapter.kt
@@ -2,8 +2,8 @@ package io.opentelemetry.kotlin.logging
 
 import io.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.kotlin.aliases.OtelJavaLogger
+import io.opentelemetry.kotlin.attributes.AttributesMutator
 import io.opentelemetry.kotlin.attributes.CompatAttributesModel
-import io.opentelemetry.kotlin.attributes.MutableAttributeContainer
 import io.opentelemetry.kotlin.context.Context
 import io.opentelemetry.kotlin.context.OtelJavaContextAdapter
 import io.opentelemetry.kotlin.context.OtelJavaContextKeyRepository
@@ -33,7 +33,7 @@ internal class LoggerAdapter(
         context: Context?,
         severityNumber: SeverityNumber?,
         severityText: String?,
-        attributes: (MutableAttributeContainer.() -> Unit)?
+        attributes: (AttributesMutator.() -> Unit)?
     ) {
         processTelemetry(
             eventName = eventName,
@@ -55,7 +55,7 @@ internal class LoggerAdapter(
         context: Context?,
         severityNumber: SeverityNumber?,
         severityText: String?,
-        attributes: (MutableAttributeContainer.() -> Unit)?
+        attributes: (AttributesMutator.() -> Unit)?
     ) {
         val builder = impl.logRecordBuilder()
 

--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/logging/LoggerProviderAdapter.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/logging/LoggerProviderAdapter.kt
@@ -2,7 +2,7 @@ package io.opentelemetry.kotlin.logging
 
 import io.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.kotlin.aliases.OtelJavaLoggerProvider
-import io.opentelemetry.kotlin.attributes.MutableAttributeContainer
+import io.opentelemetry.kotlin.attributes.AttributesMutator
 import java.util.concurrent.ConcurrentHashMap
 
 @ExperimentalApi
@@ -14,7 +14,7 @@ internal class LoggerProviderAdapter(private val impl: OtelJavaLoggerProvider) :
         name: String,
         version: String?,
         schemaUrl: String?,
-        attributes: (MutableAttributeContainer.() -> Unit)?
+        attributes: (AttributesMutator.() -> Unit)?
     ): Logger {
         val key = name.plus(version).plus(schemaUrl)
         return map.getOrPut(key) {

--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/tracing/SpanEventCompatImpl.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/tracing/SpanEventCompatImpl.kt
@@ -2,8 +2,8 @@ package io.opentelemetry.kotlin.tracing
 
 import io.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.kotlin.attributes.AttributeContainer
+import io.opentelemetry.kotlin.attributes.AttributesMutator
 import io.opentelemetry.kotlin.attributes.CompatAttributesModel
-import io.opentelemetry.kotlin.attributes.MutableAttributeContainer
 import io.opentelemetry.kotlin.tracing.model.SpanEvent
 
 @OptIn(ExperimentalApi::class)
@@ -11,4 +11,4 @@ internal class SpanEventCompatImpl(
     override val name: String,
     override val timestamp: Long,
     private val attrs: CompatAttributesModel
-) : SpanEvent, MutableAttributeContainer by attrs, AttributeContainer by attrs
+) : SpanEvent, AttributesMutator by attrs, AttributeContainer by attrs

--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/tracing/SpanLinkCompatImpl.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/tracing/SpanLinkCompatImpl.kt
@@ -2,8 +2,8 @@ package io.opentelemetry.kotlin.tracing
 
 import io.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.kotlin.attributes.AttributeContainer
+import io.opentelemetry.kotlin.attributes.AttributesMutator
 import io.opentelemetry.kotlin.attributes.CompatAttributesModel
-import io.opentelemetry.kotlin.attributes.MutableAttributeContainer
 import io.opentelemetry.kotlin.tracing.model.SpanContext
 import io.opentelemetry.kotlin.tracing.model.SpanLink
 
@@ -11,4 +11,4 @@ import io.opentelemetry.kotlin.tracing.model.SpanLink
 internal class SpanLinkCompatImpl(
     override val spanContext: SpanContext,
     private val attrs: CompatAttributesModel
-) : SpanLink, MutableAttributeContainer by attrs, AttributeContainer by attrs
+) : SpanLink, AttributesMutator by attrs, AttributeContainer by attrs

--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/tracing/TracerProviderAdapter.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/tracing/TracerProviderAdapter.kt
@@ -3,7 +3,7 @@ package io.opentelemetry.kotlin.tracing
 import io.opentelemetry.kotlin.Clock
 import io.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.kotlin.aliases.OtelJavaTracerProvider
-import io.opentelemetry.kotlin.attributes.MutableAttributeContainer
+import io.opentelemetry.kotlin.attributes.AttributesMutator
 import io.opentelemetry.kotlin.init.CompatSpanLimitsConfig
 import java.util.concurrent.ConcurrentHashMap
 
@@ -20,7 +20,7 @@ internal class TracerProviderAdapter(
         name: String,
         version: String?,
         schemaUrl: String?,
-        attributes: (MutableAttributeContainer.() -> Unit)?
+        attributes: (AttributesMutator.() -> Unit)?
     ): Tracer {
         val key = name.plus(version).plus(schemaUrl)
 

--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/tracing/model/ReadWriteSpanAdapter.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/tracing/model/ReadWriteSpanAdapter.kt
@@ -2,8 +2,8 @@ package io.opentelemetry.kotlin.tracing.model
 
 import io.opentelemetry.kotlin.aliases.OtelJavaAttributeKey
 import io.opentelemetry.kotlin.aliases.OtelJavaReadWriteSpan
+import io.opentelemetry.kotlin.attributes.AttributesMutator
 import io.opentelemetry.kotlin.attributes.CompatAttributesModel
-import io.opentelemetry.kotlin.attributes.MutableAttributeContainer
 import io.opentelemetry.kotlin.tracing.data.StatusData
 import io.opentelemetry.kotlin.tracing.ext.toOtelJavaStatusData
 import java.util.concurrent.TimeUnit
@@ -42,7 +42,7 @@ internal class ReadWriteSpanAdapter(
 
     override fun addLink(
         spanContext: SpanContext,
-        attributes: (MutableAttributeContainer.() -> Unit)?
+        attributes: (AttributesMutator.() -> Unit)?
     ) {
         val container = CompatAttributesModel()
         if (attributes != null) {
@@ -55,7 +55,7 @@ internal class ReadWriteSpanAdapter(
     override fun addEvent(
         name: String,
         timestamp: Long?,
-        attributes: (MutableAttributeContainer.() -> Unit)?
+        attributes: (AttributesMutator.() -> Unit)?
     ) {
         val container = CompatAttributesModel()
         if (attributes != null) {

--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/tracing/model/SpanAdapter.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/tracing/model/SpanAdapter.kt
@@ -7,8 +7,8 @@ import io.opentelemetry.kotlin.aliases.OtelJavaImplicitContextKeyed
 import io.opentelemetry.kotlin.aliases.OtelJavaScope
 import io.opentelemetry.kotlin.aliases.OtelJavaSpan
 import io.opentelemetry.kotlin.aliases.OtelJavaSpanContext
+import io.opentelemetry.kotlin.attributes.AttributesMutator
 import io.opentelemetry.kotlin.attributes.CompatAttributesModel
-import io.opentelemetry.kotlin.attributes.MutableAttributeContainer
 import io.opentelemetry.kotlin.init.CompatSpanLimitsConfig
 import io.opentelemetry.kotlin.tracing.SpanEventCompatImpl
 import io.opentelemetry.kotlin.tracing.SpanLinkCompatImpl
@@ -81,7 +81,7 @@ internal class SpanAdapter(
 
     override fun addLink(
         spanContext: SpanContext,
-        attributes: (MutableAttributeContainer.() -> Unit)?
+        attributes: (AttributesMutator.() -> Unit)?
     ) {
         val container = CompatAttributesModel()
         if (attributes != null) {
@@ -96,7 +96,7 @@ internal class SpanAdapter(
     override fun addEvent(
         name: String,
         timestamp: Long?,
-        attributes: (MutableAttributeContainer.() -> Unit)?
+        attributes: (AttributesMutator.() -> Unit)?
     ) {
         val container = CompatAttributesModel()
         if (attributes != null) {

--- a/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/tracing/SpanExportTest.kt
+++ b/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/tracing/SpanExportTest.kt
@@ -2,7 +2,7 @@ package io.opentelemetry.kotlin.tracing
 
 import io.opentelemetry.kotlin.assertions.assertSpanContextsMatch
 import io.opentelemetry.kotlin.attributes.AttributeContainer
-import io.opentelemetry.kotlin.attributes.MutableAttributeContainer
+import io.opentelemetry.kotlin.attributes.AttributesMutator
 import io.opentelemetry.kotlin.context.Context
 import io.opentelemetry.kotlin.export.OperationResultCode
 import io.opentelemetry.kotlin.framework.OtelKotlinHarness
@@ -338,7 +338,7 @@ internal class SpanExportTest {
         assertTrue(spanId.matches(hexPattern))
     }
 
-    private fun MutableAttributeContainer.assertAttributes() {
+    private fun AttributesMutator.assertAttributes() {
         val reader = this as AttributeContainer
         assertTrue(reader.attributes.isEmpty())
 

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/attributes/AttributesModel.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/attributes/AttributesModel.kt
@@ -7,7 +7,7 @@ import io.opentelemetry.kotlin.threadSafeMap
 internal class AttributesModel(
     private val attributeLimit: Int = DEFAULT_ATTRIBUTE_LIMIT,
     private val attrs: MutableMap<String, Any> = threadSafeMap()
-) : MutableAttributeContainer, AttributeContainer {
+) : AttributesMutator, AttributeContainer {
 
     override fun setBooleanAttribute(key: String, value: Boolean) {
         if (canAddAttribute(key)) {

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/ResourceConfigImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/ResourceConfigImpl.kt
@@ -1,8 +1,8 @@
 package io.opentelemetry.kotlin.init
 
 import io.opentelemetry.kotlin.attributes.AttributesModel
+import io.opentelemetry.kotlin.attributes.AttributesMutator
 import io.opentelemetry.kotlin.attributes.DEFAULT_ATTRIBUTE_LIMIT
-import io.opentelemetry.kotlin.attributes.MutableAttributeContainer
 import io.opentelemetry.kotlin.attributes.setAttributes
 import io.opentelemetry.kotlin.resource.Resource
 import io.opentelemetry.kotlin.resource.ResourceImpl
@@ -14,7 +14,7 @@ internal class ResourceConfigImpl : ResourceConfigDsl {
 
     override fun resource(
         schemaUrl: String?,
-        attributes: MutableAttributeContainer.() -> Unit
+        attributes: AttributesMutator.() -> Unit
     ) {
         this.schemaUrl = schemaUrl
         resourceAttrs.attributes()

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/LoggerImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/LoggerImpl.kt
@@ -2,7 +2,7 @@ package io.opentelemetry.kotlin.logging
 
 import io.opentelemetry.kotlin.Clock
 import io.opentelemetry.kotlin.InstrumentationScopeInfo
-import io.opentelemetry.kotlin.attributes.MutableAttributeContainer
+import io.opentelemetry.kotlin.attributes.AttributesMutator
 import io.opentelemetry.kotlin.context.Context
 import io.opentelemetry.kotlin.export.ShutdownState
 import io.opentelemetry.kotlin.factory.ContextFactory
@@ -52,7 +52,7 @@ internal class LoggerImpl(
         context: Context?,
         severityNumber: SeverityNumber?,
         severityText: String?,
-        attributes: (MutableAttributeContainer.() -> Unit)?
+        attributes: (AttributesMutator.() -> Unit)?
     ) {
         processTelemetry(
             context = context,
@@ -74,7 +74,7 @@ internal class LoggerImpl(
         eventName: String?,
         severityText: String?,
         severityNumber: SeverityNumber?,
-        attributes: (MutableAttributeContainer.() -> Unit)?
+        attributes: (AttributesMutator.() -> Unit)?
     ) {
         shutdownState.execute {
             val ctx = context ?: contextFactory.implicit()

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/LoggerProviderImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/LoggerProviderImpl.kt
@@ -2,7 +2,7 @@ package io.opentelemetry.kotlin.logging
 
 import io.opentelemetry.kotlin.Clock
 import io.opentelemetry.kotlin.NoopOpenTelemetry
-import io.opentelemetry.kotlin.attributes.MutableAttributeContainer
+import io.opentelemetry.kotlin.attributes.AttributesMutator
 import io.opentelemetry.kotlin.export.DelegatingTelemetryCloseable
 import io.opentelemetry.kotlin.export.MutableShutdownState
 import io.opentelemetry.kotlin.export.OperationResultCode
@@ -47,7 +47,7 @@ internal class LoggerProviderImpl(
         name: String,
         version: String?,
         schemaUrl: String?,
-        attributes: (MutableAttributeContainer.() -> Unit)?
+        attributes: (AttributesMutator.() -> Unit)?
     ): Logger =
         shutdownState.ifActiveOrElse(noopLogger) {
             val key = apiProvider.createInstrumentationScopeInfo(name, version, schemaUrl, attributes)

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/provider/ApiProviderImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/provider/ApiProviderImpl.kt
@@ -4,8 +4,8 @@ import io.opentelemetry.kotlin.InstrumentationScopeInfo
 import io.opentelemetry.kotlin.InstrumentationScopeInfoImpl
 import io.opentelemetry.kotlin.ThreadSafe
 import io.opentelemetry.kotlin.attributes.AttributesModel
+import io.opentelemetry.kotlin.attributes.AttributesMutator
 import io.opentelemetry.kotlin.attributes.DEFAULT_ATTRIBUTE_LIMIT
-import io.opentelemetry.kotlin.attributes.MutableAttributeContainer
 import io.opentelemetry.kotlin.threadSafeMap
 
 /**
@@ -33,7 +33,7 @@ internal class ApiProviderImpl<T>(
         name: String,
         version: String?,
         schemaUrl: String?,
-        attributes: (MutableAttributeContainer.() -> Unit)?
+        attributes: (AttributesMutator.() -> Unit)?
     ): InstrumentationScopeInfo {
         val container = AttributesModel(DEFAULT_ATTRIBUTE_LIMIT, mutableMapOf())
         if (attributes != null) {

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/SpanEventImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/SpanEventImpl.kt
@@ -2,11 +2,11 @@ package io.opentelemetry.kotlin.tracing
 
 import io.opentelemetry.kotlin.attributes.AttributeContainer
 import io.opentelemetry.kotlin.attributes.AttributesModel
-import io.opentelemetry.kotlin.attributes.MutableAttributeContainer
+import io.opentelemetry.kotlin.attributes.AttributesMutator
 import io.opentelemetry.kotlin.tracing.model.SpanEvent
 
 internal class SpanEventImpl(
     override val name: String,
     override val timestamp: Long,
     private val attrs: AttributesModel
-) : SpanEvent, MutableAttributeContainer by attrs, AttributeContainer by attrs
+) : SpanEvent, AttributesMutator by attrs, AttributeContainer by attrs

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/SpanLinkImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/SpanLinkImpl.kt
@@ -2,11 +2,11 @@ package io.opentelemetry.kotlin.tracing
 
 import io.opentelemetry.kotlin.attributes.AttributeContainer
 import io.opentelemetry.kotlin.attributes.AttributesModel
-import io.opentelemetry.kotlin.attributes.MutableAttributeContainer
+import io.opentelemetry.kotlin.attributes.AttributesMutator
 import io.opentelemetry.kotlin.tracing.model.SpanContext
 import io.opentelemetry.kotlin.tracing.model.SpanLink
 
 internal class SpanLinkImpl(
     override val spanContext: SpanContext,
     private val attrs: AttributesModel
-) : SpanLink, MutableAttributeContainer by attrs, AttributeContainer by attrs
+) : SpanLink, AttributesMutator by attrs, AttributeContainer by attrs

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/SpanRelationshipsImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/SpanRelationshipsImpl.kt
@@ -2,7 +2,7 @@ package io.opentelemetry.kotlin.tracing
 
 import io.opentelemetry.kotlin.Clock
 import io.opentelemetry.kotlin.attributes.AttributesModel
-import io.opentelemetry.kotlin.attributes.MutableAttributeContainer
+import io.opentelemetry.kotlin.attributes.AttributesMutator
 import io.opentelemetry.kotlin.init.config.SpanLimitConfig
 import io.opentelemetry.kotlin.threadSafeList
 import io.opentelemetry.kotlin.tracing.data.SpanEventData
@@ -13,15 +13,15 @@ import io.opentelemetry.kotlin.tracing.model.SpanRelationships
 internal class SpanRelationshipsImpl(
     val clock: Clock,
     val spanLimitConfig: SpanLimitConfig,
-    val attrs: MutableAttributeContainer = AttributesModel(spanLimitConfig.attributeCountLimit),
-) : SpanRelationships, MutableAttributeContainer by attrs {
+    val attrs: AttributesMutator = AttributesModel(spanLimitConfig.attributeCountLimit),
+) : SpanRelationships, AttributesMutator by attrs {
 
     val links = threadSafeList<SpanLinkData>()
     val events = threadSafeList<SpanEventData>()
 
     override fun addLink(
         spanContext: SpanContext,
-        attributes: (MutableAttributeContainer.() -> Unit)?
+        attributes: (AttributesMutator.() -> Unit)?
     ) {
         if (links.size < spanLimitConfig.linkCountLimit) {
             val container = AttributesModel(spanLimitConfig.attributeCountPerLinkLimit)
@@ -35,7 +35,7 @@ internal class SpanRelationshipsImpl(
     override fun addEvent(
         name: String,
         timestamp: Long?,
-        attributes: (MutableAttributeContainer.() -> Unit)?
+        attributes: (AttributesMutator.() -> Unit)?
     ) {
         if (events.size < spanLimitConfig.eventCountLimit) {
             val container = AttributesModel(spanLimitConfig.attributeCountPerEventLimit)

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/TracerProviderImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/TracerProviderImpl.kt
@@ -2,7 +2,7 @@ package io.opentelemetry.kotlin.tracing
 
 import io.opentelemetry.kotlin.Clock
 import io.opentelemetry.kotlin.NoopOpenTelemetry
-import io.opentelemetry.kotlin.attributes.MutableAttributeContainer
+import io.opentelemetry.kotlin.attributes.AttributesMutator
 import io.opentelemetry.kotlin.export.DelegatingTelemetryCloseable
 import io.opentelemetry.kotlin.export.MutableShutdownState
 import io.opentelemetry.kotlin.export.OperationResultCode
@@ -54,7 +54,7 @@ internal class TracerProviderImpl(
         name: String,
         version: String?,
         schemaUrl: String?,
-        attributes: (MutableAttributeContainer.() -> Unit)?
+        attributes: (AttributesMutator.() -> Unit)?
     ): Tracer =
         shutdownState.ifActiveOrElse(noopTracer) {
             val key = apiProvider.createInstrumentationScopeInfo(

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/model/SpanModel.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/model/SpanModel.kt
@@ -4,7 +4,7 @@ import io.opentelemetry.kotlin.Clock
 import io.opentelemetry.kotlin.InstrumentationScopeInfo
 import io.opentelemetry.kotlin.ReentrantReadWriteLock
 import io.opentelemetry.kotlin.attributes.AttributesModel
-import io.opentelemetry.kotlin.attributes.MutableAttributeContainer
+import io.opentelemetry.kotlin.attributes.AttributesMutator
 import io.opentelemetry.kotlin.init.config.SpanLimitConfig
 import io.opentelemetry.kotlin.resource.Resource
 import io.opentelemetry.kotlin.tracing.SpanDataImpl
@@ -108,7 +108,7 @@ internal class SpanModel(
 
     override fun addLink(
         spanContext: SpanContext,
-        attributes: (MutableAttributeContainer.() -> Unit)?
+        attributes: (AttributesMutator.() -> Unit)?
     ) {
         lock.write {
             if (isRecording() && linksList.size < spanLimitConfig.linkCountLimit && !hasSpanContext(spanContext)) {
@@ -131,7 +131,7 @@ internal class SpanModel(
     override fun addEvent(
         name: String,
         timestamp: Long?,
-        attributes: (MutableAttributeContainer.() -> Unit)?
+        attributes: (AttributesMutator.() -> Unit)?
     ) {
         lock.write {
             if (isRecording() && eventsList.size < spanLimitConfig.eventCountLimit) {

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/attributes/AttributesMutatorImplTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/attributes/AttributesMutatorImplTest.kt
@@ -3,7 +3,7 @@ package io.opentelemetry.kotlin.attributes
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
-internal class MutableAttributeContainerImplTest {
+internal class AttributesMutatorImplTest {
 
     private val attributeLimit = 8
     private val expected = mapOf(
@@ -35,7 +35,7 @@ internal class MutableAttributeContainerImplTest {
         assertEquals(expected, attrs)
     }
 
-    private fun MutableAttributeContainer.addTestAttributes(keyToken: String = "") {
+    private fun AttributesMutator.addTestAttributes(keyToken: String = "") {
         setStringAttribute("string$keyToken", "value")
         setDoubleAttribute("double$keyToken", 3.14)
         setBooleanAttribute("boolean$keyToken", true)
@@ -46,7 +46,7 @@ internal class MutableAttributeContainerImplTest {
         setLongListAttribute("long_list$keyToken", listOf(90000000000000))
     }
 
-    private fun MutableAttributeContainer.addTestAttributesAlternateValues() {
+    private fun AttributesMutator.addTestAttributesAlternateValues() {
         setStringAttribute("string", "override")
         setDoubleAttribute("double", 5.4)
         setBooleanAttribute("boolean", false)

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/LogAttributesTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/LogAttributesTest.kt
@@ -1,7 +1,7 @@
 package io.opentelemetry.kotlin.logging
 
 import io.opentelemetry.kotlin.InstrumentationScopeInfoImpl
-import io.opentelemetry.kotlin.attributes.MutableAttributeContainer
+import io.opentelemetry.kotlin.attributes.AttributesMutator
 import io.opentelemetry.kotlin.clock.FakeClock
 import io.opentelemetry.kotlin.export.MutableShutdownState
 import io.opentelemetry.kotlin.factory.FakeContextFactory
@@ -97,7 +97,7 @@ internal class LogAttributesTest {
         assertEquals(expected, log.attributes)
     }
 
-    private fun MutableAttributeContainer.addTestAttributes(keyToken: String = "") {
+    private fun AttributesMutator.addTestAttributes(keyToken: String = "") {
         setStringAttribute("string$keyToken", "value")
         setDoubleAttribute("double$keyToken", 3.14)
         setBooleanAttribute("boolean$keyToken", true)
@@ -108,7 +108,7 @@ internal class LogAttributesTest {
         setLongListAttribute("long_list$keyToken", listOf(90000000000000))
     }
 
-    private fun MutableAttributeContainer.addTestAttributesAlternateValues() {
+    private fun AttributesMutator.addTestAttributesAlternateValues() {
         setStringAttribute("string", "old-value")
         setDoubleAttribute("double", 6.14)
         setBooleanAttribute("boolean", false)

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/SpanAttributesTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/SpanAttributesTest.kt
@@ -1,7 +1,7 @@
 package io.opentelemetry.kotlin.tracing
 
 import io.opentelemetry.kotlin.InstrumentationScopeInfoImpl
-import io.opentelemetry.kotlin.attributes.MutableAttributeContainer
+import io.opentelemetry.kotlin.attributes.AttributesMutator
 import io.opentelemetry.kotlin.clock.FakeClock
 import io.opentelemetry.kotlin.export.MutableShutdownState
 import io.opentelemetry.kotlin.factory.FakeContextFactory
@@ -118,7 +118,7 @@ internal class SpanAttributesTest {
         assertEquals(expected, span.attributes)
     }
 
-    private fun MutableAttributeContainer.addTestAttributes(keyToken: String = "") {
+    private fun AttributesMutator.addTestAttributes(keyToken: String = "") {
         setStringAttribute("string$keyToken", "value")
         setDoubleAttribute("double$keyToken", 3.14)
         setBooleanAttribute("boolean$keyToken", true)
@@ -129,7 +129,7 @@ internal class SpanAttributesTest {
         setLongListAttribute("long_list$keyToken", listOf(90000000000000))
     }
 
-    private fun MutableAttributeContainer.addTestAttributesAlternateValues() {
+    private fun AttributesMutator.addTestAttributesAlternateValues() {
         setStringAttribute("string", "override")
         setDoubleAttribute("double", 5.4)
         setBooleanAttribute("boolean", false)

--- a/integration-test/src/commonMain/kotlin/io/opentelemetry/kotlin/framework/TestHarnessConfig.kt
+++ b/integration-test/src/commonMain/kotlin/io/opentelemetry/kotlin/framework/TestHarnessConfig.kt
@@ -1,6 +1,6 @@
 package io.opentelemetry.kotlin.framework
 
-import io.opentelemetry.kotlin.attributes.MutableAttributeContainer
+import io.opentelemetry.kotlin.attributes.AttributesMutator
 import io.opentelemetry.kotlin.init.LogLimitsConfigDsl
 import io.opentelemetry.kotlin.init.SpanLimitsConfigDsl
 import io.opentelemetry.kotlin.logging.export.LogRecordProcessor
@@ -8,7 +8,7 @@ import io.opentelemetry.kotlin.tracing.export.SpanProcessor
 
 data class TestHarnessConfig(
     var schemaUrl: String? = null,
-    var attributes: (MutableAttributeContainer.() -> Unit)? = null,
+    var attributes: (AttributesMutator.() -> Unit)? = null,
     val spanProcessors: MutableList<SpanProcessor> = mutableListOf(),
     val logRecordProcessors: MutableList<LogRecordProcessor> = mutableListOf(),
     var spanLimits: SpanLimitsConfigDsl.() -> Unit = {},

--- a/model/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/NonRecordingSpan.kt
+++ b/model/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/NonRecordingSpan.kt
@@ -1,6 +1,6 @@
 package io.opentelemetry.kotlin.tracing
 
-import io.opentelemetry.kotlin.attributes.MutableAttributeContainer
+import io.opentelemetry.kotlin.attributes.AttributesMutator
 import io.opentelemetry.kotlin.tracing.data.SpanEventData
 import io.opentelemetry.kotlin.tracing.data.SpanLinkData
 import io.opentelemetry.kotlin.tracing.data.StatusData
@@ -49,14 +49,14 @@ class NonRecordingSpan(
 
     override fun addLink(
         spanContext: SpanContext,
-        attributes: (MutableAttributeContainer.() -> Unit)?
+        attributes: (AttributesMutator.() -> Unit)?
     ) {
     }
 
     override fun addEvent(
         name: String,
         timestamp: Long?,
-        attributes: (MutableAttributeContainer.() -> Unit)?
+        attributes: (AttributesMutator.() -> Unit)?
     ) {
     }
 

--- a/noop/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/NoopLogger.kt
+++ b/noop/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/NoopLogger.kt
@@ -1,7 +1,7 @@
 package io.opentelemetry.kotlin.logging
 
 import io.opentelemetry.kotlin.ExperimentalApi
-import io.opentelemetry.kotlin.attributes.MutableAttributeContainer
+import io.opentelemetry.kotlin.attributes.AttributesMutator
 import io.opentelemetry.kotlin.context.Context
 import io.opentelemetry.kotlin.logging.model.SeverityNumber
 
@@ -21,7 +21,7 @@ internal object NoopLogger : Logger {
         context: Context?,
         severityNumber: SeverityNumber?,
         severityText: String?,
-        attributes: (MutableAttributeContainer.() -> Unit)?
+        attributes: (AttributesMutator.() -> Unit)?
     ) {
     }
 }

--- a/noop/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/NoopLoggerProvider.kt
+++ b/noop/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/NoopLoggerProvider.kt
@@ -1,7 +1,7 @@
 package io.opentelemetry.kotlin.logging
 
 import io.opentelemetry.kotlin.ExperimentalApi
-import io.opentelemetry.kotlin.attributes.MutableAttributeContainer
+import io.opentelemetry.kotlin.attributes.AttributesMutator
 
 @ExperimentalApi
 internal object NoopLoggerProvider : LoggerProvider {
@@ -9,6 +9,6 @@ internal object NoopLoggerProvider : LoggerProvider {
         name: String,
         version: String?,
         schemaUrl: String?,
-        attributes: (MutableAttributeContainer.() -> Unit)?
+        attributes: (AttributesMutator.() -> Unit)?
     ): Logger = NoopLogger
 }

--- a/noop/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/NoopSpan.kt
+++ b/noop/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/NoopSpan.kt
@@ -1,7 +1,7 @@
 package io.opentelemetry.kotlin.tracing
 
 import io.opentelemetry.kotlin.ExperimentalApi
-import io.opentelemetry.kotlin.attributes.MutableAttributeContainer
+import io.opentelemetry.kotlin.attributes.AttributesMutator
 import io.opentelemetry.kotlin.tracing.data.SpanEventData
 import io.opentelemetry.kotlin.tracing.data.SpanLinkData
 import io.opentelemetry.kotlin.tracing.data.StatusData
@@ -28,10 +28,10 @@ internal object NoopSpan : Span {
     override fun end(timestamp: Long) {
     }
 
-    override fun addLink(spanContext: SpanContext, attributes: (MutableAttributeContainer.() -> Unit)?) {
+    override fun addLink(spanContext: SpanContext, attributes: (AttributesMutator.() -> Unit)?) {
     }
 
-    override fun addEvent(name: String, timestamp: Long?, attributes: (MutableAttributeContainer.() -> Unit)?) {
+    override fun addEvent(name: String, timestamp: Long?, attributes: (AttributesMutator.() -> Unit)?) {
     }
 
     override fun isRecording(): Boolean = false

--- a/noop/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/NoopTracerProvider.kt
+++ b/noop/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/NoopTracerProvider.kt
@@ -1,7 +1,7 @@
 package io.opentelemetry.kotlin.tracing
 
 import io.opentelemetry.kotlin.ExperimentalApi
-import io.opentelemetry.kotlin.attributes.MutableAttributeContainer
+import io.opentelemetry.kotlin.attributes.AttributesMutator
 
 @ExperimentalApi
 internal object NoopTracerProvider : TracerProvider {
@@ -9,6 +9,6 @@ internal object NoopTracerProvider : TracerProvider {
         name: String,
         version: String?,
         schemaUrl: String?,
-        attributes: (MutableAttributeContainer.() -> Unit)?
+        attributes: (AttributesMutator.() -> Unit)?
     ): Tracer = NoopTracer
 }

--- a/sdk-api/api/jvm/sdk-api.api
+++ b/sdk-api/api/jvm/sdk-api.api
@@ -128,7 +128,7 @@ public final class io/opentelemetry/kotlin/logging/export/LogRecordProcessor$Def
 	public static fun enabled (Lio/opentelemetry/kotlin/logging/export/LogRecordProcessor;Lio/opentelemetry/kotlin/context/Context;Lio/opentelemetry/kotlin/InstrumentationScopeInfo;Lio/opentelemetry/kotlin/logging/model/SeverityNumber;Ljava/lang/String;)Z
 }
 
-public abstract interface class io/opentelemetry/kotlin/logging/model/ReadWriteLogRecord : io/opentelemetry/kotlin/attributes/MutableAttributeContainer, io/opentelemetry/kotlin/logging/model/ReadableLogRecord {
+public abstract interface class io/opentelemetry/kotlin/logging/model/ReadWriteLogRecord : io/opentelemetry/kotlin/attributes/AttributeContainer, io/opentelemetry/kotlin/attributes/AttributesMutator, io/opentelemetry/kotlin/logging/model/ReadableLogRecord {
 	public abstract fun getBody ()Ljava/lang/String;
 	public abstract fun getEventName ()Ljava/lang/String;
 	public abstract fun getObservedTimestamp ()Ljava/lang/Long;

--- a/sdk-api/src/commonMain/kotlin/io/opentelemetry/kotlin/init/ResourceConfigDsl.kt
+++ b/sdk-api/src/commonMain/kotlin/io/opentelemetry/kotlin/init/ResourceConfigDsl.kt
@@ -1,7 +1,7 @@
 package io.opentelemetry.kotlin.init
 
 import io.opentelemetry.kotlin.ExperimentalApi
-import io.opentelemetry.kotlin.attributes.MutableAttributeContainer
+import io.opentelemetry.kotlin.attributes.AttributesMutator
 
 /**
  * Defines configuration for a resource.
@@ -12,7 +12,7 @@ public interface ResourceConfigDsl {
     /**
      * Declares a resource, including an optional schema and any attributes.
      */
-    public fun resource(schemaUrl: String? = null, attributes: MutableAttributeContainer.() -> Unit)
+    public fun resource(schemaUrl: String? = null, attributes: AttributesMutator.() -> Unit)
 
     /**
      * Declares a resource by taking a copy of the supplied Map values.

--- a/sdk-api/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/model/ReadWriteLogRecord.kt
+++ b/sdk-api/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/model/ReadWriteLogRecord.kt
@@ -1,7 +1,8 @@
 package io.opentelemetry.kotlin.logging.model
 
 import io.opentelemetry.kotlin.ExperimentalApi
-import io.opentelemetry.kotlin.attributes.MutableAttributeContainer
+import io.opentelemetry.kotlin.attributes.AttributeContainer
+import io.opentelemetry.kotlin.attributes.AttributesMutator
 
 /**
  * A read-write representation of a log record.
@@ -9,7 +10,7 @@ import io.opentelemetry.kotlin.attributes.MutableAttributeContainer
  * https://opentelemetry.io/docs/specs/otel/logs/sdk/#readablelogrecord
  */
 @ExperimentalApi
-public interface ReadWriteLogRecord : ReadableLogRecord, MutableAttributeContainer {
+public interface ReadWriteLogRecord : ReadableLogRecord, AttributesMutator, AttributeContainer {
 
     /**
      * The timestamp in nanoseconds at which the event occurred.

--- a/test-fakes/src/commonMain/kotlin/io/opentelemetry/kotlin/attributes/FakeAttributesMutator.kt
+++ b/test-fakes/src/commonMain/kotlin/io/opentelemetry/kotlin/attributes/FakeAttributesMutator.kt
@@ -1,7 +1,7 @@
 package io.opentelemetry.kotlin.attributes
-class FakeMutableAttributeContainer(
+class FakeAttributesMutator(
     private val map: MutableMap<String, Any> = mutableMapOf()
-) : MutableAttributeContainer {
+) : AttributesMutator {
 
     override fun setBooleanAttribute(key: String, value: Boolean) {
         map[key] = value

--- a/test-fakes/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/FakeLogger.kt
+++ b/test-fakes/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/FakeLogger.kt
@@ -1,6 +1,6 @@
 package io.opentelemetry.kotlin.logging
 
-import io.opentelemetry.kotlin.attributes.MutableAttributeContainer
+import io.opentelemetry.kotlin.attributes.AttributesMutator
 import io.opentelemetry.kotlin.context.Context
 import io.opentelemetry.kotlin.logging.model.FakeReadableLogRecord
 import io.opentelemetry.kotlin.logging.model.SeverityNumber
@@ -26,7 +26,7 @@ class FakeLogger(
         context: Context?,
         severityNumber: SeverityNumber?,
         severityText: String?,
-        attributes: (MutableAttributeContainer.() -> Unit)?
+        attributes: (AttributesMutator.() -> Unit)?
     ) {
         processTelemetry(eventName, timestamp, observedTimestamp, severityNumber, severityText, body)
     }

--- a/test-fakes/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/FakeLoggerProvider.kt
+++ b/test-fakes/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/FakeLoggerProvider.kt
@@ -1,6 +1,6 @@
 package io.opentelemetry.kotlin.logging
 
-import io.opentelemetry.kotlin.attributes.MutableAttributeContainer
+import io.opentelemetry.kotlin.attributes.AttributesMutator
 
 class FakeLoggerProvider : LoggerProvider {
 
@@ -10,7 +10,7 @@ class FakeLoggerProvider : LoggerProvider {
         name: String,
         version: String?,
         schemaUrl: String?,
-        attributes: (MutableAttributeContainer.() -> Unit)?
+        attributes: (AttributesMutator.() -> Unit)?
     ): Logger = map.getOrPut(name) {
         FakeLogger(name)
     }

--- a/test-fakes/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/FakeReadWriteSpan.kt
+++ b/test-fakes/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/FakeReadWriteSpan.kt
@@ -2,7 +2,7 @@ package io.opentelemetry.kotlin.tracing
 
 import io.opentelemetry.kotlin.FakeInstrumentationScopeInfo
 import io.opentelemetry.kotlin.InstrumentationScopeInfo
-import io.opentelemetry.kotlin.attributes.MutableAttributeContainer
+import io.opentelemetry.kotlin.attributes.AttributesMutator
 import io.opentelemetry.kotlin.resource.FakeResource
 import io.opentelemetry.kotlin.resource.Resource
 import io.opentelemetry.kotlin.tracing.data.SpanData
@@ -39,7 +39,7 @@ class FakeReadWriteSpan(
 
     override fun addLink(
         spanContext: SpanContext,
-        attributes: (MutableAttributeContainer.() -> Unit)?
+        attributes: (AttributesMutator.() -> Unit)?
     ) {
         throw UnsupportedOperationException()
     }
@@ -47,7 +47,7 @@ class FakeReadWriteSpan(
     override fun addEvent(
         name: String,
         timestamp: Long?,
-        attributes: (MutableAttributeContainer.() -> Unit)?
+        attributes: (AttributesMutator.() -> Unit)?
     ) {
         throw UnsupportedOperationException()
     }

--- a/test-fakes/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/FakeSpan.kt
+++ b/test-fakes/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/FakeSpan.kt
@@ -1,7 +1,7 @@
 package io.opentelemetry.kotlin.tracing
 
-import io.opentelemetry.kotlin.attributes.FakeMutableAttributeContainer
-import io.opentelemetry.kotlin.attributes.MutableAttributeContainer
+import io.opentelemetry.kotlin.attributes.AttributesMutator
+import io.opentelemetry.kotlin.attributes.FakeAttributesMutator
 import io.opentelemetry.kotlin.tracing.data.FakeSpanLinkData
 import io.opentelemetry.kotlin.tracing.data.SpanEventData
 import io.opentelemetry.kotlin.tracing.data.SpanLinkData
@@ -44,9 +44,9 @@ class FakeSpan(
 
     override fun addLink(
         spanContext: SpanContext,
-        attributes: (MutableAttributeContainer.() -> Unit)?
+        attributes: (AttributesMutator.() -> Unit)?
     ) {
-        val container = FakeMutableAttributeContainer()
+        val container = FakeAttributesMutator()
         if (attributes != null) {
             attributes(container)
         }
@@ -57,7 +57,7 @@ class FakeSpan(
     override fun addEvent(
         name: String,
         timestamp: Long?,
-        attributes: (MutableAttributeContainer.() -> Unit)?
+        attributes: (AttributesMutator.() -> Unit)?
     ) {
         val fakeSpanEvent = FakeSpanEvent(name, timestamp ?: 0)
         if (attributes != null) {

--- a/test-fakes/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/FakeTracerProvider.kt
+++ b/test-fakes/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/FakeTracerProvider.kt
@@ -1,6 +1,6 @@
 package io.opentelemetry.kotlin.tracing
 
-import io.opentelemetry.kotlin.attributes.MutableAttributeContainer
+import io.opentelemetry.kotlin.attributes.AttributesMutator
 
 class FakeTracerProvider : TracerProvider {
 
@@ -10,7 +10,7 @@ class FakeTracerProvider : TracerProvider {
         name: String,
         version: String?,
         schemaUrl: String?,
-        attributes: (MutableAttributeContainer.() -> Unit)?
+        attributes: (AttributesMutator.() -> Unit)?
     ): Tracer = map.getOrPut(name) {
         FakeTracer(name)
     }


### PR DESCRIPTION
## Goal

Renames `MutableAttributeContainer` as `AttributesMutator` to follow the `*Mutator` convention added in #246. 

## Testing

Relied on existing test coverage.
