### PR TITLE
Add shutdown compliance to core exporters and processors

### DIFF
--- a/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/SimpleLogRecordProcessor.kt
+++ b/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/SimpleLogRecordProcessor.kt
@@ -1,9 +1,12 @@
 package io.opentelemetry.kotlin.logging.export
 
+import io.opentelemetry.kotlin.InstrumentationScopeInfo
 import io.opentelemetry.kotlin.ReentrantReadWriteLock
 import io.opentelemetry.kotlin.context.Context
+import io.opentelemetry.kotlin.export.MutableShutdownState
 import io.opentelemetry.kotlin.export.OperationResultCode
 import io.opentelemetry.kotlin.logging.model.ReadWriteLogRecord
+import io.opentelemetry.kotlin.logging.model.SeverityNumber
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
@@ -18,18 +21,32 @@ internal class SimpleLogRecordProcessor(
 ) : LogRecordProcessor {
 
     private val lock = ReentrantReadWriteLock()
+    private val shutdownState = MutableShutdownState()
 
     override fun onEmit(
         log: ReadWriteLogRecord,
         context: Context
     ) {
-        scope.launch {
-            lock.write {
-                exporter.export(listOf(log))
+        shutdownState.execute {
+            scope.launch {
+                lock.write {
+                    exporter.export(listOf(log))
+                }
             }
         }
     }
 
-    override suspend fun forceFlush(): OperationResultCode = OperationResultCode.Success
-    override suspend fun shutdown(): OperationResultCode = OperationResultCode.Success
+    override fun enabled(
+        context: Context,
+        instrumentationScopeInfo: InstrumentationScopeInfo,
+        severityNumber: SeverityNumber?,
+        eventName: String?,
+    ): Boolean = !shutdownState.isShutdown
+
+    override suspend fun forceFlush(): OperationResultCode = exporter.forceFlush()
+
+    override suspend fun shutdown(): OperationResultCode =
+        shutdownState.shutdown {
+            exporter.shutdown()
+        }
 }

--- a/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/StdoutLogRecordExporter.kt
+++ b/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/StdoutLogRecordExporter.kt
@@ -1,5 +1,6 @@
 package io.opentelemetry.kotlin.logging.export
 
+import io.opentelemetry.kotlin.export.MutableShutdownState
 import io.opentelemetry.kotlin.export.OperationResultCode
 import io.opentelemetry.kotlin.logging.model.ReadableLogRecord
 import io.opentelemetry.kotlin.platformLog
@@ -11,15 +12,22 @@ internal class StdoutLogRecordExporter(
     private val logger: (String) -> Unit = ::platformLog
 ) : LogRecordExporter {
 
-    override suspend fun export(telemetry: List<ReadableLogRecord>): OperationResultCode {
-        telemetry.forEach { logRecord ->
-            logger(formatLogRecord(logRecord))
+    private val shutdownState = MutableShutdownState()
+
+    override suspend fun export(telemetry: List<ReadableLogRecord>): OperationResultCode =
+        shutdownState.ifActive {
+            telemetry.forEach { logRecord ->
+                logger(formatLogRecord(logRecord))
+            }
+            OperationResultCode.Success
         }
-        return OperationResultCode.Success
-    }
 
     override suspend fun forceFlush(): OperationResultCode = OperationResultCode.Success
-    override suspend fun shutdown(): OperationResultCode = OperationResultCode.Success
+
+    override suspend fun shutdown(): OperationResultCode =
+        shutdownState.shutdown {
+            OperationResultCode.Success
+        }
 
     private fun formatLogRecord(logRecord: ReadableLogRecord): String = buildString {
         append("LogRecord")

--- a/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/SimpleSpanProcessor.kt
+++ b/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/SimpleSpanProcessor.kt
@@ -2,6 +2,7 @@ package io.opentelemetry.kotlin.tracing.export
 
 import io.opentelemetry.kotlin.ReentrantReadWriteLock
 import io.opentelemetry.kotlin.context.Context
+import io.opentelemetry.kotlin.export.MutableShutdownState
 import io.opentelemetry.kotlin.export.OperationResultCode
 import io.opentelemetry.kotlin.tracing.model.ReadWriteSpan
 import io.opentelemetry.kotlin.tracing.model.ReadableSpan
@@ -19,6 +20,7 @@ internal class SimpleSpanProcessor(
 ) : SpanProcessor {
 
     private val lock = ReentrantReadWriteLock()
+    private val shutdownState = MutableShutdownState()
 
     override fun onStart(
         span: ReadWriteSpan,
@@ -30,15 +32,21 @@ internal class SimpleSpanProcessor(
     }
 
     override fun onEnd(span: ReadableSpan) {
-        scope.launch {
-            lock.write {
-                exporter.export(listOf(span))
+        shutdownState.execute {
+            scope.launch {
+                lock.write {
+                    exporter.export(listOf(span))
+                }
             }
         }
     }
 
     override fun isStartRequired(): Boolean = true
     override fun isEndRequired(): Boolean = true
-    override suspend fun forceFlush(): OperationResultCode = OperationResultCode.Success
-    override suspend fun shutdown(): OperationResultCode = OperationResultCode.Success
+    override suspend fun forceFlush(): OperationResultCode = exporter.forceFlush()
+
+    override suspend fun shutdown(): OperationResultCode =
+        shutdownState.shutdown {
+            exporter.shutdown()
+        }
 }

--- a/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/StdoutSpanExporter.kt
+++ b/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/StdoutSpanExporter.kt
@@ -1,5 +1,6 @@
 package io.opentelemetry.kotlin.tracing.export
 
+import io.opentelemetry.kotlin.export.MutableShutdownState
 import io.opentelemetry.kotlin.export.OperationResultCode
 import io.opentelemetry.kotlin.platformLog
 import io.opentelemetry.kotlin.tracing.data.SpanData
@@ -12,15 +13,22 @@ internal class StdoutSpanExporter(
     private val logger: (String) -> Unit = ::platformLog
 ) : SpanExporter {
 
-    override suspend fun export(telemetry: List<SpanData>): OperationResultCode {
-        telemetry.forEach { span ->
-            logger(formatSpan(span))
+    private val shutdownState = MutableShutdownState()
+
+    override suspend fun export(telemetry: List<SpanData>): OperationResultCode =
+        shutdownState.ifActive {
+            telemetry.forEach { span ->
+                logger(formatSpan(span))
+            }
+            OperationResultCode.Success
         }
-        return OperationResultCode.Success
-    }
 
     override suspend fun forceFlush(): OperationResultCode = OperationResultCode.Success
-    override suspend fun shutdown(): OperationResultCode = OperationResultCode.Success
+
+    override suspend fun shutdown(): OperationResultCode =
+        shutdownState.shutdown {
+            OperationResultCode.Success
+        }
 
     /**
      * Formats a [SpanData] into a human-readable string representation.

--- a/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/export/CompositeLogRecordExporterTest.kt
+++ b/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/export/CompositeLogRecordExporterTest.kt
@@ -157,6 +157,33 @@ internal class CompositeLogRecordExporterTest {
         assertTelemetryCapturedFailure(first, second)
     }
 
+    @Test
+    fun testShutdownPropagation() = runTest {
+        var firstShutdown = false
+        var secondShutdown = false
+        val first = FakeLogRecordExporter(
+            shutdownCode = {
+                firstShutdown = true
+                Success
+            }
+        )
+        val second = FakeLogRecordExporter(
+            shutdownCode = {
+                secondShutdown = true
+                Success
+            }
+        )
+        val exporter =
+            CompositeLogRecordExporter(
+                listOf(first, second),
+                errorHandler
+            )
+        assertEquals(Success, exporter.shutdown())
+        assertEquals(Success, exporter.export(fakeTelemetry))
+        assertTrue(firstShutdown)
+        assertTrue(secondShutdown)
+    }
+
     private suspend fun CompositeLogRecordExporter.assertReturnValuesMatch(
         export: OperationResultCode,
         flush: OperationResultCode,

--- a/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/export/CompositeLogRecordProcessorTest.kt
+++ b/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/export/CompositeLogRecordProcessorTest.kt
@@ -137,6 +137,32 @@ internal class CompositeLogRecordProcessorTest {
         assertTelemetryCapturedFailure(first, second)
     }
 
+    @Test
+    fun testShutdownPropagation() = runTest {
+        var firstShutdown = false
+        var secondShutdown = false
+        val first = FakeLogRecordProcessor(
+            shutdownCode = {
+                firstShutdown = true
+                Success
+            }
+        )
+        val second = FakeLogRecordProcessor(
+            shutdownCode = {
+                secondShutdown = true
+                Success
+            }
+        )
+        val processor =
+            CompositeLogRecordProcessor(
+                listOf(first, second),
+                errorHandler
+            )
+        assertEquals(Success, processor.shutdown())
+        assertTrue(firstShutdown)
+        assertTrue(secondShutdown)
+    }
+
     private suspend fun CompositeLogRecordProcessor.assertReturnValuesMatch(
         flush: OperationResultCode,
         shutdown: OperationResultCode

--- a/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/export/SimpleLogRecordProcessorTest.kt
+++ b/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/export/SimpleLogRecordProcessorTest.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 @OptIn(ExperimentalApi::class, ExperimentalCoroutinesApi::class)
@@ -20,9 +21,9 @@ internal class SimpleLogRecordProcessorTest {
     @Test
     fun testSpanProcessorDefaults() = runTest {
         val processor = FakeLogExportConfig().simpleLogRecordProcessor(FakeLogRecordExporter())
+        assertTrue(processor.enabled(FakeContext(), FakeInstrumentationScopeInfo(), null, null))
         assertEquals(OperationResultCode.Success, processor.shutdown())
         assertEquals(OperationResultCode.Success, processor.forceFlush())
-        assertTrue(processor.enabled(FakeContext(), FakeInstrumentationScopeInfo(), null, null))
     }
 
     @Test
@@ -38,5 +39,52 @@ internal class SimpleLogRecordProcessorTest {
 
         val export = exporter.logs.single()
         assertEquals(log.body, export.body)
+    }
+
+    @Test
+    fun testOnEmitNoOpAfterShutdown() = runTest {
+        val exporter = FakeLogRecordExporter()
+        val processor = SimpleLogRecordProcessor(
+            exporter,
+            CoroutineScope(UnconfinedTestDispatcher(testScheduler)),
+        )
+        processor.shutdown()
+
+        val log = FakeReadWriteLogRecord()
+        processor.onEmit(log, FakeContext())
+        assertTrue(exporter.logs.isEmpty())
+    }
+
+    @Test
+    fun testShutdownReturnsSuccessOnSecondCall() = runTest {
+        val processor = SimpleLogRecordProcessor(
+            FakeLogRecordExporter(),
+            CoroutineScope(UnconfinedTestDispatcher(testScheduler)),
+        )
+
+        assertEquals(OperationResultCode.Success, processor.shutdown())
+        assertEquals(OperationResultCode.Success, processor.shutdown())
+    }
+
+    @Test
+    fun testEnabledReturnsFalseAfterShutdown() = runTest {
+        val processor = SimpleLogRecordProcessor(
+            FakeLogRecordExporter(),
+            CoroutineScope(UnconfinedTestDispatcher(testScheduler)),
+        )
+        processor.shutdown()
+
+        assertFalse(processor.enabled(FakeContext(), FakeInstrumentationScopeInfo(), null, null))
+    }
+
+    @Test
+    fun testForceFlushWorksAfterShutdown() = runTest {
+        val processor = SimpleLogRecordProcessor(
+            FakeLogRecordExporter(),
+            CoroutineScope(UnconfinedTestDispatcher(testScheduler)),
+        )
+        processor.shutdown()
+
+        assertEquals(OperationResultCode.Success, processor.forceFlush())
     }
 }

--- a/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/export/StdoutLogRecordExporterTest.kt
+++ b/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/export/StdoutLogRecordExporterTest.kt
@@ -82,4 +82,30 @@ internal class StdoutLogRecordExporterTest {
         val exporter = StdoutLogRecordExporter()
         assertEquals(OperationResultCode.Success, exporter.shutdown())
     }
+
+    @Test
+    fun testExportReturnsFailureAfterShutdown() = runTest {
+        val output = mutableListOf<String>()
+        val exporter = StdoutLogRecordExporter(output::add)
+        exporter.shutdown()
+
+        val logRecord = FakeReadableLogRecord()
+        val result = exporter.export(listOf(logRecord))
+        assertEquals(OperationResultCode.Failure, result)
+        assertEquals(0, output.size)
+    }
+
+    @Test
+    fun testShutdownReturnsSuccessOnSecondCall() = runTest {
+        val exporter = StdoutLogRecordExporter()
+        assertEquals(OperationResultCode.Success, exporter.shutdown())
+        assertEquals(OperationResultCode.Success, exporter.shutdown())
+    }
+
+    @Test
+    fun testForceFlushWorksAfterShutdown() = runTest {
+        val exporter = StdoutLogRecordExporter()
+        exporter.shutdown()
+        assertEquals(OperationResultCode.Success, exporter.forceFlush())
+    }
 }

--- a/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/export/CompositeSpanExporterTest.kt
+++ b/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/export/CompositeSpanExporterTest.kt
@@ -178,6 +178,33 @@ internal class CompositeSpanExporterTest {
         assertTelemetryCapturedFailure(first, second)
     }
 
+    @Test
+    fun testShutdownPropagation() = runTest {
+        var firstShutdown = false
+        var secondShutdown = false
+        val first = FakeSpanExporter(
+            shutdownReturnValue = {
+                firstShutdown = true
+                Success
+            }
+        )
+        val second = FakeSpanExporter(
+            shutdownReturnValue = {
+                secondShutdown = true
+                Success
+            }
+        )
+        val exporter =
+            CompositeSpanExporter(
+                listOf(first, second),
+                errorHandler
+            )
+        assertEquals(Success, exporter.shutdown())
+        assertEquals(Success, exporter.export(fakeTelemetry))
+        assertTrue(firstShutdown)
+        assertTrue(secondShutdown)
+    }
+
     private suspend fun CompositeSpanExporter.assertReturnValuesMatch(
         export: OperationResultCode,
         flush: OperationResultCode,

--- a/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/export/CompositeSpanProcessorTest.kt
+++ b/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/export/CompositeSpanProcessorTest.kt
@@ -217,6 +217,32 @@ internal class CompositeSpanProcessorTest {
         assertTelemetryCapturedFailure(first, second)
     }
 
+    @Test
+    fun testShutdownPropagation() = runTest {
+        var firstShutdown = false
+        var secondShutdown = false
+        val first = FakeSpanProcessor(
+            shutdownCode = {
+                firstShutdown = true
+                Success
+            }
+        )
+        val second = FakeSpanProcessor(
+            shutdownCode = {
+                secondShutdown = true
+                Success
+            }
+        )
+        val processor =
+            CompositeSpanProcessor(
+                listOf(first, second),
+                errorHandler
+            )
+        assertEquals(Success, processor.shutdown())
+        assertTrue(firstShutdown)
+        assertTrue(secondShutdown)
+    }
+
     private suspend fun CompositeSpanProcessor.assertReturnValuesMatch(
         flush: OperationResultCode,
         shutdown: OperationResultCode

--- a/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/export/SimpleSpanProcessorTest.kt
+++ b/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/export/SimpleSpanProcessorTest.kt
@@ -36,4 +36,39 @@ internal class SimpleSpanProcessorTest {
         val export = exporter.exports.single()
         assertEquals(span.name, export.name)
     }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun testOnEndNoOpAfterShutdown() = runTest {
+        val exporter = FakeSpanExporter()
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val processor = SimpleSpanProcessor(exporter, scope)
+        processor.shutdown()
+
+        val span = FakeReadWriteSpan()
+        processor.onEnd(span)
+        assertTrue(exporter.exports.isEmpty())
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun testShutdownReturnsSuccessOnSecondCall() = runTest {
+        val exporter = FakeSpanExporter()
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val processor = SimpleSpanProcessor(exporter, scope)
+
+        assertEquals(OperationResultCode.Success, processor.shutdown())
+        assertEquals(OperationResultCode.Success, processor.shutdown())
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun testForceFlushWorksAfterShutdown() = runTest {
+        val exporter = FakeSpanExporter()
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val processor = SimpleSpanProcessor(exporter, scope)
+        processor.shutdown()
+
+        assertEquals(OperationResultCode.Success, processor.forceFlush())
+    }
 }

--- a/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/export/StdoutSpanExporterTest.kt
+++ b/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/export/StdoutSpanExporterTest.kt
@@ -87,4 +87,30 @@ internal class StdoutSpanExporterTest {
         val exporter = StdoutSpanExporter()
         assertEquals(OperationResultCode.Success, exporter.shutdown())
     }
+
+    @Test
+    fun testExportReturnsFailureAfterShutdown() = runTest {
+        val output = mutableListOf<String>()
+        val exporter = StdoutSpanExporter(output::add)
+        exporter.shutdown()
+
+        val span = FakeReadWriteSpan(name = "test-span")
+        val result = exporter.export(listOf(span))
+        assertEquals(OperationResultCode.Failure, result)
+        assertEquals(0, output.size)
+    }
+
+    @Test
+    fun testShutdownReturnsSuccessOnSecondCall() = runTest {
+        val exporter = StdoutSpanExporter()
+        assertEquals(OperationResultCode.Success, exporter.shutdown())
+        assertEquals(OperationResultCode.Success, exporter.shutdown())
+    }
+
+    @Test
+    fun testForceFlushWorksAfterShutdown() = runTest {
+        val exporter = StdoutSpanExporter()
+        exporter.shutdown()
+        assertEquals(OperationResultCode.Success, exporter.forceFlush())
+    }
 }

--- a/exporters-in-memory/build.gradle.kts
+++ b/exporters-in-memory/build.gradle.kts
@@ -12,6 +12,7 @@ kotlin {
         val commonMain by getting {
             dependencies {
                 implementation(project(":sdk-api"))
+                implementation(project(":sdk-common"))
             }
         }
         val commonTest by getting {

--- a/exporters-in-memory/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/InMemoryLogRecordExporterImpl.kt
+++ b/exporters-in-memory/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/InMemoryLogRecordExporterImpl.kt
@@ -1,20 +1,27 @@
 package io.opentelemetry.kotlin.logging.export
 
+import io.opentelemetry.kotlin.export.MutableShutdownState
 import io.opentelemetry.kotlin.export.OperationResultCode
 import io.opentelemetry.kotlin.logging.model.ReadableLogRecord
 
 internal class InMemoryLogRecordExporterImpl : InMemoryLogRecordExporter {
 
     private val impl = mutableListOf<ReadableLogRecord>()
+    private val shutdownState = MutableShutdownState()
 
     override val exportedLogRecords: List<ReadableLogRecord>
         get() = impl
 
-    override suspend fun export(telemetry: List<ReadableLogRecord>): OperationResultCode {
-        impl += telemetry
-        return OperationResultCode.Success
-    }
+    override suspend fun export(telemetry: List<ReadableLogRecord>): OperationResultCode =
+        shutdownState.ifActive {
+            impl += telemetry
+            OperationResultCode.Success
+        }
 
-    override suspend fun shutdown(): OperationResultCode = OperationResultCode.Success
     override suspend fun forceFlush(): OperationResultCode = OperationResultCode.Success
+
+    override suspend fun shutdown(): OperationResultCode =
+        shutdownState.shutdown {
+            OperationResultCode.Success
+        }
 }

--- a/exporters-in-memory/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/InMemorySpanExporterImpl.kt
+++ b/exporters-in-memory/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/InMemorySpanExporterImpl.kt
@@ -1,20 +1,27 @@
 package io.opentelemetry.kotlin.tracing.export
 
+import io.opentelemetry.kotlin.export.MutableShutdownState
 import io.opentelemetry.kotlin.export.OperationResultCode
 import io.opentelemetry.kotlin.tracing.data.SpanData
 
 internal class InMemorySpanExporterImpl : InMemorySpanExporter {
 
     private val impl = mutableListOf<SpanData>()
+    private val shutdownState = MutableShutdownState()
 
     override val exportedSpans: List<SpanData>
         get() = impl
 
-    override suspend fun export(telemetry: List<SpanData>): OperationResultCode {
-        impl += telemetry
-        return OperationResultCode.Success
-    }
+    override suspend fun export(telemetry: List<SpanData>): OperationResultCode =
+        shutdownState.ifActive {
+            impl += telemetry
+            OperationResultCode.Success
+        }
 
     override suspend fun forceFlush(): OperationResultCode = OperationResultCode.Success
-    override suspend fun shutdown(): OperationResultCode = OperationResultCode.Success
+
+    override suspend fun shutdown(): OperationResultCode =
+        shutdownState.shutdown {
+            OperationResultCode.Success
+        }
 }

--- a/exporters-in-memory/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/export/InMemoryLogRecordExporterTest.kt
+++ b/exporters-in-memory/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/export/InMemoryLogRecordExporterTest.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.test.runTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 internal class InMemoryLogRecordExporterTest {
 
@@ -32,5 +33,25 @@ internal class InMemoryLogRecordExporterTest {
     fun testExport() = runTest {
         exporter.export(fakeTelemetry)
         assertEquals(fakeTelemetry, exporter.exportedLogRecords)
+    }
+
+    @Test
+    fun testExportReturnsFailureAfterShutdown() = runTest {
+        exporter.shutdown()
+        val result = exporter.export(fakeTelemetry)
+        assertEquals(OperationResultCode.Failure, result)
+        assertTrue(exporter.exportedLogRecords.isEmpty())
+    }
+
+    @Test
+    fun testShutdownReturnsSuccessOnSecondCall() = runTest {
+        assertEquals(OperationResultCode.Success, exporter.shutdown())
+        assertEquals(OperationResultCode.Success, exporter.shutdown())
+    }
+
+    @Test
+    fun testForceFlushWorksAfterShutdown() = runTest {
+        exporter.shutdown()
+        assertEquals(OperationResultCode.Success, exporter.forceFlush())
     }
 }

--- a/exporters-in-memory/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/export/InMemorySpanExporterTest.kt
+++ b/exporters-in-memory/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/export/InMemorySpanExporterTest.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.test.runTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 internal class InMemorySpanExporterTest {
 
@@ -32,5 +33,25 @@ internal class InMemorySpanExporterTest {
     fun testExport() = runTest {
         exporter.export(fakeTelemetry)
         assertEquals(fakeTelemetry, exporter.exportedSpans)
+    }
+
+    @Test
+    fun testExportReturnsFailureAfterShutdown() = runTest {
+        exporter.shutdown()
+        val result = exporter.export(fakeTelemetry)
+        assertEquals(OperationResultCode.Failure, result)
+        assertTrue(exporter.exportedSpans.isEmpty())
+    }
+
+    @Test
+    fun testShutdownReturnsSuccessOnSecondCall() = runTest {
+        assertEquals(OperationResultCode.Success, exporter.shutdown())
+        assertEquals(OperationResultCode.Success, exporter.shutdown())
+    }
+
+    @Test
+    fun testForceFlushWorksAfterShutdown() = runTest {
+        exporter.shutdown()
+        assertEquals(OperationResultCode.Success, exporter.forceFlush())
     }
 }

--- a/exporters-otlp/build.gradle.kts
+++ b/exporters-otlp/build.gradle.kts
@@ -21,6 +21,7 @@ kotlin {
         val commonMain by getting {
             dependencies {
                 implementation(project(":sdk-api"))
+                implementation(project(":sdk-common"))
                 implementation(project(":exporters-protobuf"))
                 implementation(project(":platform-implementations"))
                 implementation(libs.ktor.client.core)

--- a/exporters-otlp/src/commonMain/kotlin/io/opentelemetry/kotlin/export/TelemetryExporter.kt
+++ b/exporters-otlp/src/commonMain/kotlin/io/opentelemetry/kotlin/export/TelemetryExporter.kt
@@ -14,18 +14,20 @@ internal class TelemetryExporter<T>(
     private val exportAction: suspend (telemetry: List<T>) -> OtlpResponse,
 ) : TelemetryCloseable {
 
+    private val shutdownState: MutableShutdownState = MutableShutdownState()
     private val scope: CoroutineScope = CoroutineScope(SupervisorJob())
 
     /**
      * Exports telemetry via coroutines and uses exponential backoff when a failure
      * is encountered.
      */
-    fun export(telemetry: List<T>): OperationResultCode {
-        scope.launch {
-            exportTelemetry(telemetry)
+    fun export(telemetry: List<T>): OperationResultCode =
+        shutdownState.ifActive {
+            scope.launch {
+                exportTelemetry(telemetry)
+            }
+            Success
         }
-        return Success
-    }
 
     private suspend fun exportTelemetry(telemetry: List<T>) {
         var delayMs = initialDelayMs
@@ -49,8 +51,9 @@ internal class TelemetryExporter<T>(
 
     override suspend fun forceFlush(): OperationResultCode = Success
 
-    override suspend fun shutdown(): OperationResultCode {
-        scope.cancel()
-        return Success
-    }
+    override suspend fun shutdown(): OperationResultCode =
+        shutdownState.shutdown {
+            scope.cancel()
+            Success
+        }
 }

--- a/exporters-otlp/src/commonTest/kotlin/io/opentelemetry/kotlin/export/TelemetryExporterTest.kt
+++ b/exporters-otlp/src/commonTest/kotlin/io/opentelemetry/kotlin/export/TelemetryExporterTest.kt
@@ -1,0 +1,46 @@
+package io.opentelemetry.kotlin.export
+
+import io.opentelemetry.kotlin.ExperimentalApi
+import kotlinx.coroutines.test.runTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalApi::class)
+internal class TelemetryExporterTest {
+
+    private lateinit var exporter: TelemetryExporter<String>
+
+    @BeforeTest
+    fun setup() {
+        exporter = TelemetryExporter(
+            initialDelayMs = 100,
+            maxAttemptIntervalMs = 1000,
+            maxAttempts = 3,
+            exportAction = { OtlpResponse.Success }
+        )
+    }
+
+    @Test
+    fun testExportReturnsFailureAfterShutdown() = runTest {
+        assertEquals(OperationResultCode.Success, exporter.shutdown())
+        assertEquals(OperationResultCode.Failure, exporter.export(listOf("data")))
+    }
+
+    @Test
+    fun testShutdownReturnsSuccessOnSecondCall() = runTest {
+        assertEquals(OperationResultCode.Success, exporter.shutdown())
+        assertEquals(OperationResultCode.Success, exporter.shutdown())
+    }
+
+    @Test
+    fun testForceFlushWorksAfterShutdown() = runTest {
+        assertEquals(OperationResultCode.Success, exporter.shutdown())
+        assertEquals(OperationResultCode.Success, exporter.forceFlush())
+    }
+
+    @Test
+    fun testExportSucceedsBeforeShutdown() {
+        assertEquals(OperationResultCode.Success, exporter.export(listOf("data")))
+    }
+}


### PR DESCRIPTION
## Goal

Make core processors and exporters compliant with shutdown. If a processor is shut down, any exporters it has access to will be shutdown as well.

## Testing

Tests added for components that are changed, but also components that don't need changing but behaviourally should obey the shutdown, e.g. `CompositLogRecordExporter`
