### PR TITLE
Add shutdown compliance to persisting exporters and processors

### DIFF
--- a/exporters-persistence/build.gradle.kts
+++ b/exporters-persistence/build.gradle.kts
@@ -12,6 +12,7 @@ kotlin {
         val commonMain by getting {
             dependencies {
                 implementation(project(":sdk-api"))
+                implementation(project(":sdk-common"))
                 implementation(project(":exporters-core"))
                 implementation(project(":exporters-otlp"))
                 implementation(project(":exporters-protobuf"))

--- a/exporters-persistence/src/commonMain/kotlin/io/opentelemetry/kotlin/export/PersistingExporter.kt
+++ b/exporters-persistence/src/commonMain/kotlin/io/opentelemetry/kotlin/export/PersistingExporter.kt
@@ -14,16 +14,23 @@ internal class PersistingExporter<T>(
     private val repository: TelemetryRepository<T>,
 ) : TelemetryCloseable {
 
-    suspend fun export(telemetry: List<T>): OperationResultCode {
-        val record = repository.store(telemetry)
+    private val shutdownState: MutableShutdownState = MutableShutdownState()
 
-        val result = delegateExport(telemetry)
-        if (result == Success && record != null) {
-            repository.delete(record)
+    suspend fun export(telemetry: List<T>): OperationResultCode =
+        shutdownState.ifActive {
+            val record = repository.store(telemetry)
+
+            val result = delegateExport(telemetry)
+            if (result == Success && record != null) {
+                repository.delete(record)
+            }
+            result
         }
-        return result
-    }
 
-    override suspend fun shutdown(): OperationResultCode = closeable.shutdown()
+    override suspend fun shutdown(): OperationResultCode =
+        shutdownState.shutdown {
+            closeable.shutdown()
+        }
+
     override suspend fun forceFlush(): OperationResultCode = closeable.forceFlush()
 }

--- a/exporters-persistence/src/commonMain/kotlin/io/opentelemetry/kotlin/export/TimeoutTelemetryCloseable.kt
+++ b/exporters-persistence/src/commonMain/kotlin/io/opentelemetry/kotlin/export/TimeoutTelemetryCloseable.kt
@@ -12,6 +12,8 @@ internal class TimeoutTelemetryCloseable(
     private val shutdownTimeoutMs: Long = 5000,
 ) : TelemetryCloseable {
 
+    private val shutdownState: MutableShutdownState = MutableShutdownState()
+
     override suspend fun forceFlush(): OperationResultCode {
         return try {
             withTimeout(flushTimeoutMs) {
@@ -22,7 +24,7 @@ internal class TimeoutTelemetryCloseable(
         }
     }
 
-    override suspend fun shutdown(): OperationResultCode {
+    override suspend fun shutdown(): OperationResultCode = shutdownState.shutdown {
         return try {
             withTimeout(shutdownTimeoutMs) {
                 delegate.shutdown()

--- a/exporters-persistence/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/PersistingLogRecordProcessor.kt
+++ b/exporters-persistence/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/PersistingLogRecordProcessor.kt
@@ -1,8 +1,10 @@
 package io.opentelemetry.kotlin.logging.export
 
+import io.opentelemetry.kotlin.InstrumentationScopeInfo
 import io.opentelemetry.kotlin.context.Context
 import io.opentelemetry.kotlin.error.SdkErrorHandler
 import io.opentelemetry.kotlin.error.SdkErrorSeverity
+import io.opentelemetry.kotlin.export.MutableShutdownState
 import io.opentelemetry.kotlin.export.OperationResultCode
 import io.opentelemetry.kotlin.export.PersistedTelemetryConfig
 import io.opentelemetry.kotlin.export.PersistedTelemetryType
@@ -13,6 +15,7 @@ import io.opentelemetry.kotlin.export.TimeoutTelemetryCloseable
 import io.opentelemetry.kotlin.init.LogExportConfigDsl
 import io.opentelemetry.kotlin.logging.model.ReadWriteLogRecord
 import io.opentelemetry.kotlin.logging.model.ReadableLogRecord
+import io.opentelemetry.kotlin.logging.model.SeverityNumber
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 
@@ -43,6 +46,7 @@ internal class PersistingLogRecordProcessor(
     dispatcher: CoroutineDispatcher = Dispatchers.Default,
 ) : LogRecordProcessor {
 
+    private val shutdownState: MutableShutdownState = MutableShutdownState()
     private val repository = TelemetryRepositoryImpl(
         type = PersistedTelemetryType.LOGS,
         config = config,
@@ -67,17 +71,30 @@ internal class PersistingLogRecordProcessor(
     private val telemetryCloseable: TelemetryCloseable = TimeoutTelemetryCloseable(composite)
 
     override fun onEmit(log: ReadWriteLogRecord, context: Context) {
-        try {
-            composite.onEmit(log, context)
-        } catch (e: Throwable) {
-            sdkErrorHandler.onUserCodeError(
-                e,
-                "LogRecordProcessor.onEmit failed",
-                SdkErrorSeverity.WARNING
-            )
+        shutdownState.execute {
+            try {
+                composite.onEmit(log, context)
+            } catch (e: Throwable) {
+                sdkErrorHandler.onUserCodeError(
+                    e,
+                    "LogRecordProcessor.onEmit failed",
+                    SdkErrorSeverity.WARNING
+                )
+            }
         }
     }
 
+    override fun enabled(
+        context: Context,
+        instrumentationScopeInfo: InstrumentationScopeInfo,
+        severityNumber: SeverityNumber?,
+        eventName: String?,
+    ): Boolean = !shutdownState.isShutdown
+
     override suspend fun forceFlush(): OperationResultCode = telemetryCloseable.forceFlush()
-    override suspend fun shutdown(): OperationResultCode = telemetryCloseable.shutdown()
+
+    override suspend fun shutdown(): OperationResultCode =
+        shutdownState.shutdown {
+            telemetryCloseable.shutdown()
+        }
 }

--- a/exporters-persistence/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/PersistingSpanProcessor.kt
+++ b/exporters-persistence/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/PersistingSpanProcessor.kt
@@ -3,6 +3,7 @@ package io.opentelemetry.kotlin.tracing.export
 import io.opentelemetry.kotlin.context.Context
 import io.opentelemetry.kotlin.error.SdkErrorHandler
 import io.opentelemetry.kotlin.error.SdkErrorSeverity
+import io.opentelemetry.kotlin.export.MutableShutdownState
 import io.opentelemetry.kotlin.export.OperationResultCode
 import io.opentelemetry.kotlin.export.PersistedTelemetryConfig
 import io.opentelemetry.kotlin.export.PersistedTelemetryType
@@ -44,6 +45,7 @@ internal class PersistingSpanProcessor(
     dispatcher: CoroutineDispatcher = Dispatchers.Default,
 ) : SpanProcessor {
 
+    private val shutdownState: MutableShutdownState = MutableShutdownState()
     private val repository = TelemetryRepositoryImpl(
         type = PersistedTelemetryType.SPANS,
         config = config,
@@ -67,7 +69,7 @@ internal class PersistingSpanProcessor(
     private val composite = dsl.compositeSpanProcessor(processor, batchingProcessor)
     private val telemetryCloseable: TelemetryCloseable = TimeoutTelemetryCloseable(composite)
 
-    override fun onStart(span: ReadWriteSpan, parentContext: Context) {
+    override fun onStart(span: ReadWriteSpan, parentContext: Context) = shutdownState.execute {
         try {
             composite.onStart(span, parentContext)
         } catch (e: Throwable) {
@@ -79,7 +81,7 @@ internal class PersistingSpanProcessor(
         }
     }
 
-    override fun onEnding(span: ReadWriteSpan) {
+    override fun onEnding(span: ReadWriteSpan) = shutdownState.execute {
         try {
             composite.onEnding(span)
         } catch (e: Throwable) {
@@ -91,7 +93,7 @@ internal class PersistingSpanProcessor(
         }
     }
 
-    override fun onEnd(span: ReadableSpan) {
+    override fun onEnd(span: ReadableSpan) = shutdownState.execute {
         try {
             composite.onEnd(span)
         } catch (e: Throwable) {
@@ -107,5 +109,8 @@ internal class PersistingSpanProcessor(
     override fun isEndRequired(): Boolean = composite.isEndRequired()
 
     override suspend fun forceFlush(): OperationResultCode = telemetryCloseable.forceFlush()
-    override suspend fun shutdown(): OperationResultCode = telemetryCloseable.shutdown()
+    override suspend fun shutdown(): OperationResultCode =
+        shutdownState.shutdown {
+            telemetryCloseable.shutdown()
+        }
 }

--- a/exporters-persistence/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/export/PersistingLogRecordExporterTest.kt
+++ b/exporters-persistence/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/export/PersistingLogRecordExporterTest.kt
@@ -71,4 +71,31 @@ internal class PersistingLogRecordExporterTest {
         val result = exporter.export(telemetry)
         assertEquals(Failure, result)
     }
+
+    @Test
+    fun testShutdown() = runTest {
+        val repository = FakeTelemetryRepository<ReadableLogRecord>()
+        val exporter = PersistingLogRecordExporter(FakeLogRecordExporter(), repository)
+
+        assertEquals(Success, exporter.export(telemetry))
+        assertEquals(1, repository.storeCalls)
+        assertEquals(1, repository.deleteCalls)
+        assertEquals(1, repository.storedTelemetry.size)
+
+        assertEquals(Success, exporter.shutdown())
+        assertEquals(Success, exporter.shutdown())
+
+        assertEquals(Failure, exporter.export(telemetry))
+        assertEquals(1, repository.storeCalls)
+        assertEquals(1, repository.deleteCalls)
+        assertEquals(1, repository.storedTelemetry.size)
+    }
+
+    @Test
+    fun testForceFlushWorksAfterShutdown() = runTest {
+        val repository = FakeTelemetryRepository<ReadableLogRecord>()
+        val exporter = PersistingLogRecordExporter(FakeLogRecordExporter(), repository)
+        exporter.shutdown()
+        assertEquals(Success, exporter.forceFlush())
+    }
 }

--- a/exporters-persistence/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/export/PersistingLogRecordProcessorTest.kt
+++ b/exporters-persistence/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/export/PersistingLogRecordProcessorTest.kt
@@ -1,6 +1,7 @@
 package io.opentelemetry.kotlin.logging.export
 
 import io.opentelemetry.kotlin.Clock
+import io.opentelemetry.kotlin.FakeInstrumentationScopeInfo
 import io.opentelemetry.kotlin.clock.FakeClock
 import io.opentelemetry.kotlin.context.Context
 import io.opentelemetry.kotlin.context.FakeContext
@@ -412,6 +413,61 @@ internal class PersistingLogRecordProcessorTest {
 
         // TODO: future: alter the assertion when persisted records are exported.
         assertFalse("log" in exportedBodies)
+    }
+
+    @Test
+    fun testShutdown() = runTest {
+        val delayingProcessor = DelayingLogRecordProcessor(shutdownDelayMs = 3000)
+        val exporter = FakeLogRecordExporter()
+        val processor = createProcessor(
+            processors = listOf(delayingProcessor),
+            exporters = listOf(exporter),
+        )
+
+        processor.onEmit(FakeReadWriteLogRecord(), context)
+        advanceTimeBy(5000)
+        assertEquals(1, delayingProcessor.logs.size)
+        advanceTimeBy(5000)
+        assertEquals(1, exporter.logs.size)
+        val resultDeferred = async { processor.shutdown() }
+        advanceTimeBy(4000)
+        val result = resultDeferred.await()
+        assertEquals(Success, result)
+
+        processor.onEmit(FakeReadWriteLogRecord(), context)
+        advanceTimeBy(5000)
+        assertEquals(1, delayingProcessor.logs.size)
+        advanceTimeBy(5000)
+        assertEquals(1, exporter.logs.size)
+    }
+
+    @Test
+    fun testEnabledReturnsFalseAfterShutdown() = runTest {
+        val processor = createProcessor(
+            processors = listOf(FakeLogRecordProcessor()),
+            exporters = listOf(FakeLogRecordExporter()),
+        )
+
+        processor.shutdown()
+        assertFalse(
+            processor.enabled(
+                FakeContext(),
+                FakeInstrumentationScopeInfo(),
+                null,
+                null,
+            )
+        )
+    }
+
+    @Test
+    fun testForceFlushWorksAfterShutdown() = runTest {
+        val processor = createProcessor(
+            processors = listOf(FakeLogRecordProcessor()),
+            exporters = listOf(FakeLogRecordExporter()),
+        )
+
+        processor.shutdown()
+        assertEquals(Success, processor.forceFlush())
     }
 
     private fun TestScope.createProcessor(

--- a/exporters-persistence/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/export/PersistingSpanExporterTest.kt
+++ b/exporters-persistence/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/export/PersistingSpanExporterTest.kt
@@ -71,4 +71,24 @@ internal class PersistingSpanExporterTest {
         val result = exporter.export(telemetry)
         assertEquals(Failure, result)
     }
+
+    @Test
+    fun testShutdown() = runTest {
+        val repository = FakeTelemetryRepository<SpanData>()
+        val exporter = PersistingSpanExporter(
+            FakeSpanExporter(exportReturnValue = { Success }),
+            repository,
+        )
+
+        assertEquals(Success, exporter.export(telemetry))
+        assertEquals(1, repository.storeCalls)
+        assertEquals(1, repository.deleteCalls)
+        assertEquals(1, repository.storedTelemetry.size)
+        exporter.shutdown()
+
+        assertEquals(Failure, exporter.export(telemetry))
+        assertEquals(1, repository.storeCalls)
+        assertEquals(1, repository.deleteCalls)
+        assertEquals(1, repository.storedTelemetry.size)
+    }
 }

--- a/exporters-persistence/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/export/PersistingSpanProcessorTest.kt
+++ b/exporters-persistence/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/export/PersistingSpanProcessorTest.kt
@@ -3,6 +3,7 @@ package io.opentelemetry.kotlin.tracing.export
 import io.opentelemetry.kotlin.Clock
 import io.opentelemetry.kotlin.clock.FakeClock
 import io.opentelemetry.kotlin.context.Context
+import io.opentelemetry.kotlin.context.FakeContext
 import io.opentelemetry.kotlin.export.FakeTelemetryFileSystem
 import io.opentelemetry.kotlin.export.OperationResultCode
 import io.opentelemetry.kotlin.export.OperationResultCode.Failure
@@ -406,6 +407,36 @@ internal class PersistingSpanProcessorTest {
 
         // TODO: future: alter the assertion when persisted records are exported.
         assertFalse("span" in exportedNames)
+    }
+
+    @Test
+    fun testShutdownStopsSpanProcessing() = runTest {
+        val exporter = FakeSpanExporter()
+        val processor = FakeSpanProcessor()
+
+        val span = FakeReadWriteSpan()
+
+        val persistingProcessor = createProcessor(
+            exporters = listOf(exporter),
+            processors = listOf(processor),
+        )
+
+        persistingProcessor.onStart(span, FakeContext())
+        persistingProcessor.onEnding(span)
+        persistingProcessor.onEnd(span)
+        assertEquals(1, processor.startCalls.size)
+        assertEquals(1, processor.endingCalls.size)
+        assertEquals(1, processor.endCalls.size)
+
+        assertEquals(Success, persistingProcessor.shutdown())
+        assertEquals(Success, persistingProcessor.shutdown())
+
+        persistingProcessor.onStart(span, FakeContext())
+        persistingProcessor.onEnding(span)
+        persistingProcessor.onEnd(span)
+        assertEquals(1, processor.startCalls.size)
+        assertEquals(1, processor.endingCalls.size)
+        assertEquals(1, processor.endCalls.size)
     }
 
     private fun TestScope.createProcessor(


### PR DESCRIPTION
## Goal

Add shutdown compliance to persisting exporters and processors. 

## Testing

Tests were added for the telemetry-specific exporters even though they weren't changed because they defer to a common telemetry-agnostic exporter which was changed.


