### PR TITLE
Update release workflow to fetch git tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,8 @@ jobs:
             exit 1
           fi
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0 # needed so get-prior-version.sh can find prior version tags
       - name: Set environment variables
         run: |
           version=$(.github/scripts/get-version.sh)


### PR DESCRIPTION
## Goal

Updates the release workflow so that it fetches git tags. This was failing [the CI workflow](https://github.com/open-telemetry/opentelemetry-kotlin/actions/runs/22940255079/job/66580161577#step:4:20) as the tag wasn't fetched, despite existing.