### PR TITLE
Setup instrumentation module

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -43,3 +43,15 @@ include(
     "examples:example-app-android",
     ":smoke-test",
 )
+
+includeFromDir("instrumentation")
+
+fun includeFromDir(dirName: String, maxDepth: Int = 3) {
+    val dir = File(rootDir, dirName)
+    val separator = Regex("[/\\\\]")
+    dir.walk().maxDepth(maxDepth).forEach {
+        if (it.name == "build.gradle.kts") {
+            include(":$dirName:${it.parentFile.toRelativeString(dir).replace(separator, ":")}")
+        }
+    }
+}


### PR DESCRIPTION
## Goal

Sets up the buildscript to pick up instrumentation modules in the `instrumentation` directory as suggested in #268. This follows the same approach used by [opentelemetry-android's buildscript](https://github.com/open-telemetry/opentelemetry-android/blob/main/settings.gradle.kts#L26).