### PR TITLE
Add API for retrieving current span

### DIFF
--- a/api/api/jvm/api.api
+++ b/api/api/jvm/api.api
@@ -40,6 +40,7 @@ public abstract interface class io/opentelemetry/kotlin/context/Scope {
 
 public abstract interface class io/opentelemetry/kotlin/factory/ContextFactory {
 	public abstract fun createKey (Ljava/lang/String;)Lio/opentelemetry/kotlin/context/ContextKey;
+	public abstract fun currentSpan ()Lio/opentelemetry/kotlin/tracing/Span;
 	public abstract fun implicit ()Lio/opentelemetry/kotlin/context/Context;
 	public abstract fun root ()Lio/opentelemetry/kotlin/context/Context;
 	public abstract fun storeSpan (Lio/opentelemetry/kotlin/context/Context;Lio/opentelemetry/kotlin/tracing/Span;)Lio/opentelemetry/kotlin/context/Context;

--- a/api/src/commonMain/kotlin/io/opentelemetry/kotlin/factory/ContextFactory.kt
+++ b/api/src/commonMain/kotlin/io/opentelemetry/kotlin/factory/ContextFactory.kt
@@ -33,4 +33,10 @@ public interface ContextFactory {
      * [T] represents the type of the value that is stored in the context.
      */
     public fun <T> createKey(name: String): ContextKey<T>
+
+    /**
+     * Returns the [Span] from the implicit [Context], or an invalid non-recording [Span] if none
+     * exists.
+     */
+    public fun currentSpan(): Span
 }

--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/OpenTelemetryCompatEntrypoint.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/OpenTelemetryCompatEntrypoint.kt
@@ -42,8 +42,8 @@ internal fun createCompatOpenTelemetryImpl(
     val traceFlags = CompatTraceFlagsFactory()
     val traceState = CompatTraceStateFactory()
     val spanContext = CompatSpanContextFactory()
-    val contextFactory = CompatContextFactory()
     val span = CompatSpanFactory(spanContext)
+    val contextFactory = CompatContextFactory(span)
 
     val cfg = CompatOpenTelemetryConfig(clock, idGenerator).apply(config)
     val base = cfg.buildGlobalResource()

--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/OtelJavaOpenTelemetryExt.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/OtelJavaOpenTelemetryExt.kt
@@ -30,8 +30,8 @@ public fun OtelJavaOpenTelemetry.toOtelKotlinApi(): OpenTelemetry {
     val traceFlags = CompatTraceFlagsFactory()
     val traceState = CompatTraceStateFactory()
     val spanContext = CompatSpanContextFactory()
-    val contextFactory = CompatContextFactory()
     val span = CompatSpanFactory(spanContext)
+    val contextFactory = CompatContextFactory(span)
     val clock = ClockAdapter(OtelJavaClock.getDefault())
     return CompatOpenTelemetryImpl(
         tracerProvider = TracerProviderAdapter(tracerProvider, clock, CompatSpanLimitsConfig()),

--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/factory/CompatContextFactory.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/factory/CompatContextFactory.kt
@@ -9,7 +9,7 @@ import io.opentelemetry.kotlin.context.toOtelKotlinContext
 import io.opentelemetry.kotlin.tracing.Span
 import io.opentelemetry.kotlin.tracing.ext.storeInContext
 
-internal class CompatContextFactory : ContextFactory {
+internal class CompatContextFactory(private val spanFactory: SpanFactory) : ContextFactory {
 
     override fun root(): Context = OtelJavaContext.root().toOtelKotlinContext()
 
@@ -21,4 +21,6 @@ internal class CompatContextFactory : ContextFactory {
     override fun implicit(): Context = OtelJavaContext.current().toOtelKotlinContext()
 
     override fun <T> createKey(name: String): ContextKey<T> = ContextKeyAdapter(OtelJavaContextKey.named(name))
+
+    override fun currentSpan(): Span = spanFactory.fromContext(implicit())
 }

--- a/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/context/ContextRetrievalTest.kt
+++ b/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/context/ContextRetrievalTest.kt
@@ -10,6 +10,8 @@ import io.opentelemetry.kotlin.aliases.OtelJavaSpanContext
 import io.opentelemetry.kotlin.aliases.OtelJavaStatusCode
 import io.opentelemetry.kotlin.clock.FakeClock
 import io.opentelemetry.kotlin.factory.CompatContextFactory
+import io.opentelemetry.kotlin.factory.CompatSpanContextFactory
+import io.opentelemetry.kotlin.factory.CompatSpanFactory
 import io.opentelemetry.kotlin.init.CompatSpanLimitsConfig
 import io.opentelemetry.kotlin.tracing.SpanKind
 import io.opentelemetry.kotlin.tracing.model.OtelJavaSpanAdapter
@@ -26,7 +28,8 @@ internal class ContextRetrievalTest {
     private lateinit var kotlinDecorator: Context
     private lateinit var javaDecorator: OtelJavaContext
 
-    private val contextFactory = CompatContextFactory()
+    private val spanFactory = CompatSpanFactory(CompatSpanContextFactory())
+    private val contextFactory = CompatContextFactory(spanFactory)
 
     @Before
     fun setUp() {

--- a/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/context/OtelJavaContextAdapterTest.kt
+++ b/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/context/OtelJavaContextAdapterTest.kt
@@ -2,6 +2,8 @@ package io.opentelemetry.kotlin.context
 
 import io.opentelemetry.kotlin.aliases.OtelJavaContextKey
 import io.opentelemetry.kotlin.factory.CompatContextFactory
+import io.opentelemetry.kotlin.factory.CompatSpanContextFactory
+import io.opentelemetry.kotlin.factory.CompatSpanFactory
 import org.junit.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotSame
@@ -9,7 +11,7 @@ import kotlin.test.assertNull
 
 internal class OtelJavaContextAdapterTest {
 
-    private val contextFactory = CompatContextFactory()
+    private val contextFactory = CompatContextFactory(CompatSpanFactory(CompatSpanContextFactory()))
 
     @Test
     fun `test context`() {

--- a/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/factory/ContextFactoryImplTest.kt
+++ b/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/factory/ContextFactoryImplTest.kt
@@ -2,15 +2,17 @@ package io.opentelemetry.kotlin.factory
 
 import io.opentelemetry.kotlin.aliases.OtelJavaContext
 import io.opentelemetry.kotlin.assertions.assertSpanContextsMatch
+import io.opentelemetry.kotlin.context.asImplicitContext
 import io.opentelemetry.kotlin.context.toOtelJavaContext
 import io.opentelemetry.kotlin.createCompatOpenTelemetry
 import org.junit.Test
+import kotlin.test.assertFalse
 import kotlin.test.assertSame
 
 internal class ContextFactoryImplTest {
 
-    private val contextFactory = CompatContextFactory()
     private val spanFactory = CompatSpanFactory(CompatSpanContextFactory())
+    private val contextFactory = CompatContextFactory(spanFactory)
 
     @Test
     fun `test root`() {
@@ -29,5 +31,21 @@ internal class ContextFactoryImplTest {
     @Test
     fun `test current`() {
         assertSame(OtelJavaContext.current(), contextFactory.implicit().toOtelJavaContext())
+    }
+
+    @Test
+    fun `currentSpan returns invalid span when no span active`() {
+        assertFalse(contextFactory.currentSpan().spanContext.isValid)
+        assertFalse(contextFactory.currentSpan().isRecording())
+    }
+
+    @Test
+    fun `currentSpan returns span stored in implicit context`() {
+        val tracer = createCompatOpenTelemetry().tracerProvider.getTracer("tracer")
+        val span = tracer.startSpan("span")
+        val ctx = contextFactory.storeSpan(contextFactory.implicit(), span)
+        ctx.asImplicitContext {
+            assertSpanContextsMatch(span.spanContext, contextFactory.currentSpan().spanContext)
+        }
     }
 }

--- a/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/factory/SpanFactoryImplTest.kt
+++ b/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/factory/SpanFactoryImplTest.kt
@@ -10,8 +10,8 @@ internal class SpanFactoryImplTest {
     private val spanContextFactory = CompatSpanContextFactory()
     private val traceStateFactory = CompatTraceStateFactory()
     private val traceFlagsFactory = CompatTraceFlagsFactory()
-    private val contextFactory = CompatContextFactory()
     private val spanFactory = CompatSpanFactory(spanContextFactory)
+    private val contextFactory = CompatContextFactory(spanFactory)
 
     @Test
     fun `test invalid is the same instance`() {

--- a/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/tracing/SpanExtTest.kt
+++ b/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/tracing/SpanExtTest.kt
@@ -26,7 +26,7 @@ internal class SpanExtTest {
     private val traceStateFactory = CompatTraceStateFactory()
     private val traceFlagsFactory = CompatTraceFlagsFactory()
     private val spanFactory = CompatSpanFactory(spanContextFactory)
-    private val contextFactory = CompatContextFactory()
+    private val contextFactory = CompatContextFactory(spanFactory)
     private val generator = OtelJavaIdGenerator.random()
 
     private val validSpanContext = spanContextFactory.create(

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/OpenTelemetryImplEntrypoint.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/OpenTelemetryImplEntrypoint.kt
@@ -46,7 +46,7 @@ internal fun createOpenTelemetryImpl(
     val traceFlags = TraceFlagsFactoryImpl()
     val traceState = TraceStateFactoryImpl()
     val spanContext = SpanContextFactoryImpl(idGenerator, traceFlags, traceState)
-    val contextFactory = ContextFactoryImpl()
+    val contextFactory = ContextFactoryImpl(spanContext)
     val span = SpanFactoryImpl(spanContext, contextFactory.spanKey)
 
     val cfg = OpenTelemetryConfigImpl(clock).apply(config)

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/factory/ContextFactoryImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/factory/ContextFactoryImpl.kt
@@ -6,13 +6,18 @@ import io.opentelemetry.kotlin.context.ContextKey
 import io.opentelemetry.kotlin.context.ContextKeyImpl
 import io.opentelemetry.kotlin.context.DefaultImplicitContextStorage
 import io.opentelemetry.kotlin.context.ImplicitContextStorage
+import io.opentelemetry.kotlin.tracing.NonRecordingSpan
 import io.opentelemetry.kotlin.tracing.Span
 
-internal class ContextFactoryImpl : ContextFactory {
+internal class ContextFactoryImpl(spanContextFactory: SpanContextFactory) : ContextFactory {
 
     private val storage: ImplicitContextStorage = DefaultImplicitContextStorage { root }
     private val root by lazy { ContextImpl(storage) }
     internal val spanKey by lazy { createKey<Span>("otel-kotlin-span") }
+    private val invalidSpan by lazy {
+        val invalidCtx = spanContextFactory.invalid
+        NonRecordingSpan(invalidCtx, invalidCtx)
+    }
 
     override fun root(): Context = root
 
@@ -23,4 +28,6 @@ internal class ContextFactoryImpl : ContextFactory {
     override fun implicit(): Context = storage.implicitContext()
 
     override fun <T> createKey(name: String): ContextKey<T> = ContextKeyImpl(name)
+
+    override fun currentSpan(): Span = implicit().get(spanKey) ?: invalidSpan
 }

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/context/ContextImplTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/context/ContextImplTest.kt
@@ -1,6 +1,8 @@
 package io.opentelemetry.kotlin.context
 
 import io.opentelemetry.kotlin.factory.ContextFactoryImpl
+import io.opentelemetry.kotlin.factory.IdGeneratorImpl
+import io.opentelemetry.kotlin.factory.SpanContextFactoryImpl
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -14,7 +16,7 @@ internal class ContextImplTest {
 
     @BeforeTest
     fun setUp() {
-        factory = ContextFactoryImpl()
+        factory = ContextFactoryImpl(SpanContextFactoryImpl(IdGeneratorImpl()))
     }
 
     @Test

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/context/DefaultImplicitContextStorageImplTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/context/DefaultImplicitContextStorageImplTest.kt
@@ -1,6 +1,8 @@
 package io.opentelemetry.kotlin.context
 
 import io.opentelemetry.kotlin.factory.ContextFactoryImpl
+import io.opentelemetry.kotlin.factory.IdGeneratorImpl
+import io.opentelemetry.kotlin.factory.SpanContextFactoryImpl
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertSame
@@ -12,7 +14,7 @@ internal class DefaultImplicitContextStorageImplTest {
 
     @BeforeTest
     fun setUp() {
-        factory = ContextFactoryImpl()
+        factory = ContextFactoryImpl(SpanContextFactoryImpl(IdGeneratorImpl()))
         storage = DefaultImplicitContextStorage(factory::root)
     }
 

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/context/ImplicitContextTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/context/ImplicitContextTest.kt
@@ -2,6 +2,8 @@ package io.opentelemetry.kotlin.context
 
 import io.opentelemetry.kotlin.factory.ContextFactory
 import io.opentelemetry.kotlin.factory.ContextFactoryImpl
+import io.opentelemetry.kotlin.factory.IdGeneratorImpl
+import io.opentelemetry.kotlin.factory.SpanContextFactoryImpl
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertFailsWith
@@ -15,7 +17,7 @@ internal class ImplicitContextTest {
 
     @BeforeTest
     fun setUp() {
-        factory = ContextFactoryImpl()
+        factory = ContextFactoryImpl(SpanContextFactoryImpl(IdGeneratorImpl()))
     }
 
     @Test

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/context/SpanStorageTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/context/SpanStorageTest.kt
@@ -6,12 +6,14 @@ import io.opentelemetry.kotlin.factory.SpanContextFactoryImpl
 import io.opentelemetry.kotlin.factory.SpanFactoryImpl
 import io.opentelemetry.kotlin.tracing.FakeSpan
 import kotlin.test.Test
+import kotlin.test.assertFalse
 import kotlin.test.assertSame
 
 internal class SpanStorageTest {
 
-    private val contextFactory = ContextFactoryImpl()
-    private val spanFactory = SpanFactoryImpl(SpanContextFactoryImpl(IdGeneratorImpl()), contextFactory.spanKey)
+    private val spanContextFactory = SpanContextFactoryImpl(IdGeneratorImpl())
+    private val contextFactory = ContextFactoryImpl(spanContextFactory)
+    private val spanFactory = SpanFactoryImpl(spanContextFactory, contextFactory.spanKey)
 
     @Test
     fun testSpanStorage() {
@@ -32,5 +34,23 @@ internal class SpanStorageTest {
         val finalCtx = contextFactory.storeSpan(newCtx, otherSpan)
         val retrievedSpan = spanFactory.fromContext(finalCtx)
         assertSame(otherSpan, retrievedSpan)
+    }
+
+    @Test
+    fun testCurrentSpanReturnsInvalid() {
+        assertFalse(contextFactory.currentSpan().spanContext.isValid)
+        assertFalse(contextFactory.currentSpan().isRecording())
+    }
+
+    @Test
+    fun testCurrentSpanReturnsActive() {
+        val span = FakeSpan()
+        val ctx = contextFactory.storeSpan(contextFactory.implicit(), span)
+        val scope = ctx.attach()
+        try {
+            assertSame(span, contextFactory.currentSpan())
+        } finally {
+            scope.detach()
+        }
     }
 }

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/factory/SpanFactoryImplTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/factory/SpanFactoryImplTest.kt
@@ -7,8 +7,9 @@ import kotlin.test.assertFalse
 
 internal class SpanFactoryImplTest {
 
-    private val contextFactory = ContextFactoryImpl()
-    private val factory = SpanFactoryImpl(SpanContextFactoryImpl(IdGeneratorImpl()), contextFactory.spanKey)
+    private val spanContextFactory = SpanContextFactoryImpl(IdGeneratorImpl())
+    private val contextFactory = ContextFactoryImpl(spanContextFactory)
+    private val factory = SpanFactoryImpl(spanContextFactory, contextFactory.spanKey)
 
     @Test
     fun testInvalidSpan() {

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/LogContextTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/LogContextTest.kt
@@ -43,7 +43,7 @@ internal class LogContextTest {
         val traceFlags = TraceFlagsFactoryImpl()
         val traceState = TraceStateFactoryImpl()
         spanContextFactory = SpanContextFactoryImpl(idGenerator, traceFlags, traceState)
-        contextFactory = ContextFactoryImpl()
+        contextFactory = ContextFactoryImpl(spanContextFactory)
         spanFactory =
             SpanFactoryImpl(spanContextFactory, (contextFactory as ContextFactoryImpl).spanKey)
         logger = LoggerImpl(

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/TracerSamplerTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/TracerSamplerTest.kt
@@ -45,7 +45,7 @@ internal class TracerSamplerTest {
         val traceFlags = TraceFlagsFactoryImpl()
         val traceState = TraceStateFactoryImpl()
         spanContextFactory = SpanContextFactoryImpl(idGenerator, traceFlags, traceState)
-        contextFactory = ContextFactoryImpl()
+        contextFactory = ContextFactoryImpl(spanContextFactory)
         spanFactory = SpanFactoryImpl(spanContextFactory, (contextFactory as ContextFactoryImpl).spanKey)
     }
 

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/TracerSpanContextTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/TracerSpanContextTest.kt
@@ -44,7 +44,7 @@ internal class TracerSpanContextTest {
         val traceFlags = TraceFlagsFactoryImpl()
         val traceState = TraceStateFactoryImpl()
         spanContextFactory = SpanContextFactoryImpl(idGenerator, traceFlags, traceState)
-        contextFactory = ContextFactoryImpl()
+        contextFactory = ContextFactoryImpl(spanContextFactory)
         spanFactory = SpanFactoryImpl(spanContextFactory, (contextFactory as ContextFactoryImpl).spanKey)
         tracer = TracerImpl(
             clock = clock,

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/sampling/BuiltInSamplersTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/sampling/BuiltInSamplersTest.kt
@@ -26,7 +26,7 @@ internal class BuiltInSamplersTest {
     private val traceFlagsFactory = TraceFlagsFactoryImpl()
     private val traceStateFactory = TraceStateFactoryImpl()
     private val spanContextFactory = SpanContextFactoryImpl(idGenerator, traceFlagsFactory, traceStateFactory)
-    private val contextFactory = ContextFactoryImpl()
+    private val contextFactory = ContextFactoryImpl(spanContextFactory)
     private val spanFactory = SpanFactoryImpl(spanContextFactory, contextFactory.spanKey)
     private val scope = InstrumentationScopeInfoImpl("test", null, null, emptyMap())
 

--- a/noop/src/commonMain/kotlin/io/opentelemetry/kotlin/factory/NoopContextFactory.kt
+++ b/noop/src/commonMain/kotlin/io/opentelemetry/kotlin/factory/NoopContextFactory.kt
@@ -4,6 +4,7 @@ import io.opentelemetry.kotlin.context.Context
 import io.opentelemetry.kotlin.context.ContextKey
 import io.opentelemetry.kotlin.context.NoopContext
 import io.opentelemetry.kotlin.context.NoopContextKey
+import io.opentelemetry.kotlin.tracing.NoopSpan
 import io.opentelemetry.kotlin.tracing.Span
 
 internal object NoopContextFactory : ContextFactory {
@@ -18,4 +19,6 @@ internal object NoopContextFactory : ContextFactory {
     override fun implicit(): Context = NoopContext
 
     override fun <T> createKey(name: String): ContextKey<T> = NoopContextKey(name)
+
+    override fun currentSpan(): Span = NoopSpan
 }

--- a/test-fakes/src/commonMain/kotlin/io/opentelemetry/kotlin/factory/FakeContextFactory.kt
+++ b/test-fakes/src/commonMain/kotlin/io/opentelemetry/kotlin/factory/FakeContextFactory.kt
@@ -4,6 +4,7 @@ import io.opentelemetry.kotlin.context.Context
 import io.opentelemetry.kotlin.context.ContextKey
 import io.opentelemetry.kotlin.context.FakeContext
 import io.opentelemetry.kotlin.context.FakeContextKey
+import io.opentelemetry.kotlin.tracing.FakeSpan
 import io.opentelemetry.kotlin.tracing.Span
 
 class FakeContextFactory : ContextFactory {
@@ -18,4 +19,6 @@ class FakeContextFactory : ContextFactory {
     override fun implicit(): Context = FakeContext()
 
     override fun <T> createKey(name: String): ContextKey<T> = FakeContextKey(name)
+
+    override fun currentSpan(): Span = FakeSpan()
 }


### PR DESCRIPTION
## Goal

Adds an API for retrieving the current span to `ContextFactory`. This improves on the current situation where it's necessary to retrieve the `Context` via `implicit()` and then obtain a span from there. This closes #332

## Testing

Added unit tests.
