### PR TITLE
Allow specifying timeout for OTLP export

### DIFF
--- a/exporters-otlp/api/jvm/exporters-otlp.api
+++ b/exporters-otlp/api/jvm/exporters-otlp.api
@@ -1,10 +1,10 @@
 public final class io/opentelemetry/kotlin/logging/export/OtlpLogRecordExporterApiKt {
-	public static final fun otlpHttpLogRecordExporter (Lio/opentelemetry/kotlin/init/LogExportConfigDsl;Ljava/lang/String;Lio/ktor/client/engine/HttpClientEngine;)Lio/opentelemetry/kotlin/logging/export/LogRecordExporter;
-	public static synthetic fun otlpHttpLogRecordExporter$default (Lio/opentelemetry/kotlin/init/LogExportConfigDsl;Ljava/lang/String;Lio/ktor/client/engine/HttpClientEngine;ILjava/lang/Object;)Lio/opentelemetry/kotlin/logging/export/LogRecordExporter;
+	public static final fun otlpHttpLogRecordExporter (Lio/opentelemetry/kotlin/init/LogExportConfigDsl;Ljava/lang/String;Lio/ktor/client/engine/HttpClientEngine;J)Lio/opentelemetry/kotlin/logging/export/LogRecordExporter;
+	public static synthetic fun otlpHttpLogRecordExporter$default (Lio/opentelemetry/kotlin/init/LogExportConfigDsl;Ljava/lang/String;Lio/ktor/client/engine/HttpClientEngine;JILjava/lang/Object;)Lio/opentelemetry/kotlin/logging/export/LogRecordExporter;
 }
 
 public final class io/opentelemetry/kotlin/tracing/export/OtlpSpanExporterApiKt {
-	public static final fun otlpHttpSpanExporter (Lio/opentelemetry/kotlin/init/TraceExportConfigDsl;Ljava/lang/String;Lio/ktor/client/engine/HttpClientEngine;)Lio/opentelemetry/kotlin/tracing/export/SpanExporter;
-	public static synthetic fun otlpHttpSpanExporter$default (Lio/opentelemetry/kotlin/init/TraceExportConfigDsl;Ljava/lang/String;Lio/ktor/client/engine/HttpClientEngine;ILjava/lang/Object;)Lio/opentelemetry/kotlin/tracing/export/SpanExporter;
+	public static final fun otlpHttpSpanExporter (Lio/opentelemetry/kotlin/init/TraceExportConfigDsl;Ljava/lang/String;Lio/ktor/client/engine/HttpClientEngine;J)Lio/opentelemetry/kotlin/tracing/export/SpanExporter;
+	public static synthetic fun otlpHttpSpanExporter$default (Lio/opentelemetry/kotlin/init/TraceExportConfigDsl;Ljava/lang/String;Lio/ktor/client/engine/HttpClientEngine;JILjava/lang/Object;)Lio/opentelemetry/kotlin/tracing/export/SpanExporter;
 }
 

--- a/exporters-otlp/src/commonMain/kotlin/io/opentelemetry/kotlin/export/ExportDefaults.kt
+++ b/exporters-otlp/src/commonMain/kotlin/io/opentelemetry/kotlin/export/ExportDefaults.kt
@@ -1,5 +1,6 @@
 package io.opentelemetry.kotlin.export
 
+internal const val EXPORT_REQUEST_TIMEOUT_MS: Long = 10_000L // 10s
 internal const val EXPORT_INITIAL_DELAY_MS: Long = 30_000L // 30s
 internal const val EXPORT_MAX_ATTEMPT_INTERVAL_MS: Long = 600000L // 10 mins
 internal const val EXPORT_MAX_ATTEMPTS: Int = 8 // maximum of 8 retries per export call

--- a/exporters-otlp/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/OtlpLogRecordExporterApi.kt
+++ b/exporters-otlp/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/OtlpLogRecordExporterApi.kt
@@ -6,6 +6,7 @@ import io.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.kotlin.export.EXPORT_INITIAL_DELAY_MS
 import io.opentelemetry.kotlin.export.EXPORT_MAX_ATTEMPTS
 import io.opentelemetry.kotlin.export.EXPORT_MAX_ATTEMPT_INTERVAL_MS
+import io.opentelemetry.kotlin.export.EXPORT_REQUEST_TIMEOUT_MS
 import io.opentelemetry.kotlin.export.OtlpClient
 import io.opentelemetry.kotlin.export.createDefaultHttpClient
 import io.opentelemetry.kotlin.export.createHttpEngine
@@ -18,9 +19,10 @@ import io.opentelemetry.kotlin.init.LogExportConfigDsl
 public fun LogExportConfigDsl.otlpHttpLogRecordExporter(
     baseUrl: String,
     httpClientEngine: HttpClientEngine = createHttpEngine(),
+    timeoutMs: Long = EXPORT_REQUEST_TIMEOUT_MS,
 ): LogRecordExporter =
     OtlpHttpLogRecordExporter(
-        OtlpClient(baseUrl, createDefaultHttpClient(engine = httpClientEngine)),
+        OtlpClient(baseUrl, createDefaultHttpClient(requestTimeoutMs = timeoutMs, engine = httpClientEngine)),
         EXPORT_INITIAL_DELAY_MS,
         EXPORT_MAX_ATTEMPT_INTERVAL_MS,
         EXPORT_MAX_ATTEMPTS

--- a/exporters-otlp/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/OtlpSpanExporterApi.kt
+++ b/exporters-otlp/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/OtlpSpanExporterApi.kt
@@ -5,6 +5,7 @@ import io.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.kotlin.export.EXPORT_INITIAL_DELAY_MS
 import io.opentelemetry.kotlin.export.EXPORT_MAX_ATTEMPTS
 import io.opentelemetry.kotlin.export.EXPORT_MAX_ATTEMPT_INTERVAL_MS
+import io.opentelemetry.kotlin.export.EXPORT_REQUEST_TIMEOUT_MS
 import io.opentelemetry.kotlin.export.OtlpClient
 import io.opentelemetry.kotlin.export.createDefaultHttpClient
 import io.opentelemetry.kotlin.export.createHttpEngine
@@ -17,8 +18,9 @@ import io.opentelemetry.kotlin.init.TraceExportConfigDsl
 public fun TraceExportConfigDsl.otlpHttpSpanExporter(
     baseUrl: String,
     httpClientEngine: HttpClientEngine = createHttpEngine(),
+    timeoutMs: Long = EXPORT_REQUEST_TIMEOUT_MS,
 ): SpanExporter = OtlpHttpSpanExporter(
-    OtlpClient(baseUrl, createDefaultHttpClient(engine = httpClientEngine)),
+    OtlpClient(baseUrl, createDefaultHttpClient(requestTimeoutMs = timeoutMs, engine = httpClientEngine)),
     EXPORT_INITIAL_DELAY_MS,
     EXPORT_MAX_ATTEMPT_INTERVAL_MS,
     EXPORT_MAX_ATTEMPTS


### PR DESCRIPTION
## Goal

Allows specifying a timeout for OTLP export and provides a default rather than relying on Ktor.

Closes #384.