### PR TITLE
Add initial interface for TextMapPropagator

### DIFF
--- a/api/api/jvm/api.api
+++ b/api/api/jvm/api.api
@@ -117,6 +117,21 @@ public final class io/opentelemetry/kotlin/logging/SeverityNumber : java/lang/En
 	public static fun values ()[Lio/opentelemetry/kotlin/logging/SeverityNumber;
 }
 
+public abstract interface class io/opentelemetry/kotlin/propagation/TextMapGetter {
+	public abstract fun get (Ljava/lang/Object;Ljava/lang/String;)Ljava/lang/String;
+	public abstract fun keys (Ljava/lang/Object;)Ljava/util/Collection;
+}
+
+public abstract interface class io/opentelemetry/kotlin/propagation/TextMapPropagator {
+	public abstract fun extract (Lio/opentelemetry/kotlin/context/Context;Ljava/lang/Object;Lio/opentelemetry/kotlin/propagation/TextMapGetter;)Lio/opentelemetry/kotlin/context/Context;
+	public abstract fun fields ()Ljava/util/Collection;
+	public abstract fun inject (Lio/opentelemetry/kotlin/context/Context;Ljava/lang/Object;Lio/opentelemetry/kotlin/propagation/TextMapSetter;)V
+}
+
+public abstract interface class io/opentelemetry/kotlin/propagation/TextMapSetter {
+	public abstract fun set (Ljava/lang/Object;Ljava/lang/String;Ljava/lang/String;)V
+}
+
 public abstract interface class io/opentelemetry/kotlin/tracing/Span : io/opentelemetry/kotlin/attributes/AttributesMutator, io/opentelemetry/kotlin/tracing/SpanEventCreator, io/opentelemetry/kotlin/tracing/SpanLinkCreator {
 	public abstract fun end ()V
 	public abstract fun end (J)V

--- a/api/src/commonMain/kotlin/io/opentelemetry/kotlin/propagation/TextMapGetter.kt
+++ b/api/src/commonMain/kotlin/io/opentelemetry/kotlin/propagation/TextMapGetter.kt
@@ -1,0 +1,25 @@
+package io.opentelemetry.kotlin.propagation
+
+import io.opentelemetry.kotlin.ExperimentalApi
+
+/**
+ * Reads propagated fields from a carrier.
+ *
+ * [C] is the type of the carrier, e.g. an HTTP request object.
+ *
+ * https://opentelemetry.io/docs/specs/otel/context/api-propagators/#textmap-propagator
+ */
+@ExperimentalApi
+public interface TextMapGetter<C> {
+
+    /**
+     * Returns all keys present in [carrier].
+     * */
+    public fun keys(carrier: C): Collection<String>
+
+    /**
+     * Returns the first value for [key] in [carrier], or null if absent.
+     * Key lookup must be case-insensitive for HTTP carriers.
+     */
+    public fun get(carrier: C, key: String): String?
+}

--- a/api/src/commonMain/kotlin/io/opentelemetry/kotlin/propagation/TextMapPropagator.kt
+++ b/api/src/commonMain/kotlin/io/opentelemetry/kotlin/propagation/TextMapPropagator.kt
@@ -23,11 +23,11 @@ public interface TextMapPropagator {
     /**
      * Injects propagated fields from [context] into [carrier] using [setter].
      */
-    public fun <C> inject(context: Context, carrier: C, setter: TextMapSetter<C>)
+    public fun <T> inject(context: Context, carrier: T, setter: TextMapSetter<T>)
 
     /**
      * Extracts propagated fields from [carrier] using [getter] and returns a new
      * [Context] with those values merged in.
      */
-    public fun <C> extract(context: Context, carrier: C, getter: TextMapGetter<C>): Context
+    public fun <T> extract(context: Context, carrier: T, getter: TextMapGetter<T>): Context
 }

--- a/api/src/commonMain/kotlin/io/opentelemetry/kotlin/propagation/TextMapPropagator.kt
+++ b/api/src/commonMain/kotlin/io/opentelemetry/kotlin/propagation/TextMapPropagator.kt
@@ -1,0 +1,33 @@
+package io.opentelemetry.kotlin.propagation
+
+import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.ThreadSafe
+import io.opentelemetry.kotlin.context.Context
+
+/**
+ * Injects and extracts cross-cutting concern values as string key/value pairs into
+ * carriers that travel across process boundaries.
+ *
+ * https://opentelemetry.io/docs/specs/otel/context/api-propagators/#textmap-propagator
+ */
+@ExperimentalApi
+@ThreadSafe
+public interface TextMapPropagator {
+
+    /**
+     * Returns the field names this propagator reads and writes.
+     * Used by callers to extract relevant fields from carriers.
+     */
+    public fun fields(): Collection<String>
+
+    /**
+     * Injects propagated fields from [context] into [carrier] using [setter].
+     */
+    public fun <C> inject(context: Context, carrier: C, setter: TextMapSetter<C>)
+
+    /**
+     * Extracts propagated fields from [carrier] using [getter] and returns a new
+     * [Context] with those values merged in.
+     */
+    public fun <C> extract(context: Context, carrier: C, getter: TextMapGetter<C>): Context
+}

--- a/api/src/commonMain/kotlin/io/opentelemetry/kotlin/propagation/TextMapSetter.kt
+++ b/api/src/commonMain/kotlin/io/opentelemetry/kotlin/propagation/TextMapSetter.kt
@@ -1,0 +1,20 @@
+package io.opentelemetry.kotlin.propagation
+
+import io.opentelemetry.kotlin.ExperimentalApi
+
+/**
+ * Writes propagated fields into a carrier.
+ *
+ * [C] is the type of the carrier, e.g. a mutable HTTP request builder.
+ *
+ * https://opentelemetry.io/docs/specs/otel/context/api-propagators/#textmap-propagator
+ */
+@ExperimentalApi
+public fun interface TextMapSetter<C> {
+
+    /**
+     * Sets [key] to [value] on [carrier], replacing any existing value.
+     * Values must consist only of US-ASCII characters valid for HTTP headers.
+     */
+    public fun set(carrier: C, key: String, value: String)
+}

--- a/noop/src/commonMain/kotlin/io/opentelemetry/kotlin/propagation/NoopTextMapPropagator.kt
+++ b/noop/src/commonMain/kotlin/io/opentelemetry/kotlin/propagation/NoopTextMapPropagator.kt
@@ -1,0 +1,11 @@
+package io.opentelemetry.kotlin.propagation
+
+import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.context.Context
+
+@ExperimentalApi
+internal object NoopTextMapPropagator : TextMapPropagator {
+    override fun fields(): Collection<String> = emptyList()
+    override fun <C> inject(context: Context, carrier: C, setter: TextMapSetter<C>) {}
+    override fun <C> extract(context: Context, carrier: C, getter: TextMapGetter<C>): Context = context
+}

--- a/noop/src/commonMain/kotlin/io/opentelemetry/kotlin/propagation/NoopTextMapPropagator.kt
+++ b/noop/src/commonMain/kotlin/io/opentelemetry/kotlin/propagation/NoopTextMapPropagator.kt
@@ -6,6 +6,6 @@ import io.opentelemetry.kotlin.context.Context
 @ExperimentalApi
 internal object NoopTextMapPropagator : TextMapPropagator {
     override fun fields(): Collection<String> = emptyList()
-    override fun <C> inject(context: Context, carrier: C, setter: TextMapSetter<C>) {}
-    override fun <C> extract(context: Context, carrier: C, getter: TextMapGetter<C>): Context = context
+    override fun <T> inject(context: Context, carrier: T, setter: TextMapSetter<T>) {}
+    override fun <T> extract(context: Context, carrier: T, getter: TextMapGetter<T>): Context = context
 }

--- a/noop/src/commonTest/kotlin/io/opentelemetry/kotlin/NoopTests.kt
+++ b/noop/src/commonTest/kotlin/io/opentelemetry/kotlin/NoopTests.kt
@@ -3,6 +3,9 @@ package io.opentelemetry.kotlin
 import io.opentelemetry.kotlin.context.NoopContext
 import io.opentelemetry.kotlin.context.NoopContextKey
 import io.opentelemetry.kotlin.logging.SeverityNumber
+import io.opentelemetry.kotlin.propagation.NoopTextMapPropagator
+import io.opentelemetry.kotlin.propagation.TextMapGetter
+import io.opentelemetry.kotlin.propagation.TextMapSetter
 import io.opentelemetry.kotlin.tracing.NoopSpan
 import io.opentelemetry.kotlin.tracing.NoopSpanContext
 import io.opentelemetry.kotlin.tracing.NoopTraceFlags
@@ -216,6 +219,25 @@ internal class NoopTests {
         // merge and asNewResource return the same noop instance
         assertSame(empty, empty.merge(created))
         assertSame(empty, empty.asNewResource { attributes["k"] = "v" })
+    }
+
+    @Test
+    fun testNoopTextMapPropagator() {
+        assertEquals(emptyList(), NoopTextMapPropagator.fields())
+
+        val ctx = NoopOpenTelemetry.context.root()
+        val carrier = mutableMapOf("key" to "value")
+
+        // inject is a no-op — setter must never be called
+        NoopTextMapPropagator.inject(ctx, carrier, TextMapSetter { _, _, _ -> error("setter should not be called") })
+        assertEquals(mapOf("key" to "value"), carrier)
+
+        // extract returns the original context unchanged
+        val getter = object : TextMapGetter<MutableMap<String, String>> {
+            override fun keys(carrier: MutableMap<String, String>) = carrier.keys
+            override fun get(carrier: MutableMap<String, String>, key: String) = carrier[key]
+        }
+        assertSame(ctx, NoopTextMapPropagator.extract(ctx, carrier, getter))
     }
 
     private fun verifySpanOperationsAreNoop(span: NoopSpan) {


### PR DESCRIPTION
## Goal

Adds an initial interface for `TextMapPropagator`. This partially resolves #372 but no immediate implementation is planned yet.
