### PR TITLE
Add Meter API

### DIFF
--- a/api/api/jvm/api.api
+++ b/api/api/jvm/api.api
@@ -134,6 +134,9 @@ public final class io/opentelemetry/kotlin/logging/SeverityNumber : java/lang/En
 	public static fun values ()[Lio/opentelemetry/kotlin/logging/SeverityNumber;
 }
 
+public abstract interface class io/opentelemetry/kotlin/metrics/Meter {
+}
+
 public abstract interface class io/opentelemetry/kotlin/propagation/PropagatorFactory {
 	public abstract fun composite (Ljava/util/List;)Lio/opentelemetry/kotlin/propagation/TextMapPropagator;
 	public abstract fun composite ([Lio/opentelemetry/kotlin/propagation/TextMapPropagator;)Lio/opentelemetry/kotlin/propagation/TextMapPropagator;

--- a/api/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/Meter.kt
+++ b/api/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/Meter.kt
@@ -1,0 +1,18 @@
+package io.opentelemetry.kotlin.metrics
+
+import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.ThreadSafe
+
+/**
+ * Provides instruments used to record measurements which are aggregated to metrics.
+ *
+ * Instruments are obtained through methods provided by this interface.
+ *
+ * See the [instrument selection guidelines](https://opentelemetry.io/docs/specs/otel/metrics/supplementary-guidelines/#instrument-selection)
+ * for help choosing the right instrument.
+ *
+ * https://opentelemetry.io/docs/specs/otel/metrics/api/#meter
+ */
+@ExperimentalApi
+@ThreadSafe
+public interface Meter

--- a/noop/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/NoopMeter.kt
+++ b/noop/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/NoopMeter.kt
@@ -1,0 +1,11 @@
+package io.opentelemetry.kotlin.metrics
+
+import io.opentelemetry.kotlin.ExperimentalApi
+
+/**
+ * No-op implementation of [Meter].
+ *
+ * This implementation should induce as close to zero overhead as possible.
+ */
+@ExperimentalApi
+internal object NoopMeter : Meter


### PR DESCRIPTION
## Goal

Adds a metrics API (intentionally empty for now). Instrument factory methods and MeterProvider will be added in follow-up PRs under the [Metrics API milestone](https://github.com/open-telemetry/opentelemetry-kotlin/milestone/5). Closes #377.

## Testing

Since this just adds an empty entry point, no behavioral impact is expected. Both `build` and `detekt` are passing.