### PR TITLE
Hook up attributes in compat resource implementation

### DIFF
--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/attributes/CompatAttributesModel.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/attributes/CompatAttributesModel.kt
@@ -5,7 +5,7 @@ import io.opentelemetry.kotlin.aliases.OtelJavaAttributes
 import io.opentelemetry.kotlin.aliases.OtelJavaAttributesBuilder
 
 internal class CompatAttributesModel(
-    private val attrs: OtelJavaAttributesBuilder = OtelJavaAttributes.builder()
+    internal val attrs: OtelJavaAttributesBuilder = OtelJavaAttributes.builder()
 ) : AttributesMutator, AttributeContainer {
 
     override fun setBooleanAttribute(key: String, value: Boolean) {

--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/factory/CompatResourceFactory.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/factory/CompatResourceFactory.kt
@@ -2,16 +2,20 @@ package io.opentelemetry.kotlin.factory
 
 import io.opentelemetry.kotlin.aliases.OtelJavaResourceBuilder
 import io.opentelemetry.kotlin.attributes.AttributesMutator
+import io.opentelemetry.kotlin.attributes.CompatAttributesModel
 import io.opentelemetry.kotlin.resource.Resource
 import io.opentelemetry.kotlin.resource.ResourceAdapter
 
 internal object CompatResourceFactory : ResourceFactory {
     override val empty: Resource = ResourceAdapter(OtelJavaResourceBuilder().build())
 
-    override fun create(schemaUrl: String?, attributes: AttributesMutator.() -> Unit): Resource =
-        ResourceAdapter(
+    override fun create(schemaUrl: String?, attributes: AttributesMutator.() -> Unit): Resource {
+        val attrs: CompatAttributesModel = CompatAttributesModel().apply { attributes() }
+        return ResourceAdapter(
             OtelJavaResourceBuilder().apply {
                 schemaUrl?.let { setSchemaUrl(it) }
+                putAll(attrs.attrs.build())
             }.build()
         )
+    }
 }

--- a/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/factory/ResourceFactoryTest.kt
+++ b/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/factory/ResourceFactoryTest.kt
@@ -30,4 +30,21 @@ internal class ResourceFactoryTest {
         val resource = factory.create {}
         assertNull(resource.schemaUrl)
     }
+
+    @Test
+    fun `create with attributes`() {
+        val resource = factory.create {
+            setStringAttribute("key", "value")
+        }
+        assertEquals("value", resource.attributes["key"])
+    }
+
+    @Test
+    fun `create with schema url and attributes`() {
+        val resource = factory.create(schemaUrl = "https://example.com/schema") {
+            setStringAttribute("service.name", "my-service")
+        }
+        assertEquals("my-service", resource.attributes["service.name"])
+        assertEquals("https://example.com/schema", resource.schemaUrl)
+    }
 }


### PR DESCRIPTION
## Goal

Closes #418 by populating attributes correctly in `CompatResourceFactory`.
