### PR TITLE
Prevent empty key for attributes

### DIFF
--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/attributes/AttributesModel.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/attributes/AttributesModel.kt
@@ -73,7 +73,8 @@ internal class AttributesModel(
     override val attributes: Map<String, Any>
         get() = attrs.toMap()
 
-    private fun canAddAttribute(key: String): Boolean = attrs.size < attributeLimit || attrs.contains(key)
+    private fun canAddAttribute(key: String): Boolean =
+        key.isNotEmpty() && (attrs.size < attributeLimit || attrs.contains(key))
 }
 
 internal const val DEFAULT_ATTRIBUTE_LIMIT: Int = 128

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/attributes/AttributesMutatorImplTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/attributes/AttributesMutatorImplTest.kt
@@ -88,6 +88,21 @@ internal class AttributesMutatorImplTest {
         assertEquals("abc", attrs["key"])
     }
 
+    @Test
+    fun testEmptyKeyIgnoredForAllTypes() {
+        val attrs = AttributesModel(attributeLimit).apply {
+            setBooleanAttribute("", true)
+            setStringAttribute("", "value")
+            setLongAttribute("", 1L)
+            setDoubleAttribute("", 1.0)
+            setBooleanListAttribute("", listOf(true))
+            setStringListAttribute("", listOf("value"))
+            setLongListAttribute("", listOf(1L))
+            setDoubleListAttribute("", listOf(1.0))
+        }.attributes
+        assertEquals(emptyMap(), attrs)
+    }
+
     private fun AttributesMutator.addTestAttributes(keyToken: String = "") {
         setStringAttribute("string$keyToken", "value")
         setDoubleAttribute("double$keyToken", 3.14)


### PR DESCRIPTION
## Goal

Closes #419 by preventing empty keys from being used in `AttributesModel`.
