### PR TITLE
Allow a custom HttpClient for OTLP export

### DIFF
--- a/exporters-otlp/api/jvm/exporters-otlp.api
+++ b/exporters-otlp/api/jvm/exporters-otlp.api
@@ -1,9 +1,11 @@
 public final class io/opentelemetry/kotlin/logging/export/OtlpLogRecordExporterApiKt {
+	public static final fun otlpHttpLogRecordExporter (Lio/opentelemetry/kotlin/init/LogExportConfigDsl;Ljava/lang/String;Lio/ktor/client/HttpClient;)Lio/opentelemetry/kotlin/logging/export/LogRecordExporter;
 	public static final fun otlpHttpLogRecordExporter (Lio/opentelemetry/kotlin/init/LogExportConfigDsl;Ljava/lang/String;Lio/ktor/client/engine/HttpClientEngine;J)Lio/opentelemetry/kotlin/logging/export/LogRecordExporter;
 	public static synthetic fun otlpHttpLogRecordExporter$default (Lio/opentelemetry/kotlin/init/LogExportConfigDsl;Ljava/lang/String;Lio/ktor/client/engine/HttpClientEngine;JILjava/lang/Object;)Lio/opentelemetry/kotlin/logging/export/LogRecordExporter;
 }
 
 public final class io/opentelemetry/kotlin/tracing/export/OtlpSpanExporterApiKt {
+	public static final fun otlpHttpSpanExporter (Lio/opentelemetry/kotlin/init/TraceExportConfigDsl;Ljava/lang/String;Lio/ktor/client/HttpClient;)Lio/opentelemetry/kotlin/tracing/export/SpanExporter;
 	public static final fun otlpHttpSpanExporter (Lio/opentelemetry/kotlin/init/TraceExportConfigDsl;Ljava/lang/String;Lio/ktor/client/engine/HttpClientEngine;J)Lio/opentelemetry/kotlin/tracing/export/SpanExporter;
 	public static synthetic fun otlpHttpSpanExporter$default (Lio/opentelemetry/kotlin/init/TraceExportConfigDsl;Ljava/lang/String;Lio/ktor/client/engine/HttpClientEngine;JILjava/lang/Object;)Lio/opentelemetry/kotlin/tracing/export/SpanExporter;
 }

--- a/exporters-otlp/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/OtlpLogRecordExporterApi.kt
+++ b/exporters-otlp/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/OtlpLogRecordExporterApi.kt
@@ -1,6 +1,7 @@
 
 package io.opentelemetry.kotlin.logging.export
 
+import io.ktor.client.HttpClient
 import io.ktor.client.engine.HttpClientEngine
 import io.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.kotlin.export.EXPORT_INITIAL_DELAY_MS
@@ -23,6 +24,28 @@ public fun LogExportConfigDsl.otlpHttpLogRecordExporter(
 ): LogRecordExporter =
     OtlpHttpLogRecordExporter(
         OtlpClient(baseUrl, createDefaultHttpClient(requestTimeoutMs = timeoutMs, engine = httpClientEngine)),
+        EXPORT_INITIAL_DELAY_MS,
+        EXPORT_MAX_ATTEMPT_INTERVAL_MS,
+        EXPORT_MAX_ATTEMPTS
+    )
+
+/**
+ * Creates a log record exporter that sends telemetry to the specified URL over OTLP using a custom Ktor [HttpClient].
+ *
+ * Use this overload to supply a pre-configured client with custom authentication, interceptors, or certificates.
+ *
+ * It's strongly recommended that the supplied [HttpClient] installs the
+ * [io.ktor.client.plugins.HttpTimeout],
+ * [io.ktor.client.plugins.contentnegotiation.ContentNegotiation] and
+ * [io.ktor.client.plugins.compression.ContentEncoding] plugins and that gzip compression is enabled.
+ */
+@ExperimentalApi
+public fun LogExportConfigDsl.otlpHttpLogRecordExporter(
+    baseUrl: String,
+    httpClient: HttpClient,
+): LogRecordExporter =
+    OtlpHttpLogRecordExporter(
+        OtlpClient(baseUrl, httpClient),
         EXPORT_INITIAL_DELAY_MS,
         EXPORT_MAX_ATTEMPT_INTERVAL_MS,
         EXPORT_MAX_ATTEMPTS

--- a/exporters-otlp/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/OtlpSpanExporterApi.kt
+++ b/exporters-otlp/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/OtlpSpanExporterApi.kt
@@ -1,5 +1,6 @@
 package io.opentelemetry.kotlin.tracing.export
 
+import io.ktor.client.HttpClient
 import io.ktor.client.engine.HttpClientEngine
 import io.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.kotlin.export.EXPORT_INITIAL_DELAY_MS
@@ -21,6 +22,27 @@ public fun TraceExportConfigDsl.otlpHttpSpanExporter(
     timeoutMs: Long = EXPORT_REQUEST_TIMEOUT_MS,
 ): SpanExporter = OtlpHttpSpanExporter(
     OtlpClient(baseUrl, createDefaultHttpClient(requestTimeoutMs = timeoutMs, engine = httpClientEngine)),
+    EXPORT_INITIAL_DELAY_MS,
+    EXPORT_MAX_ATTEMPT_INTERVAL_MS,
+    EXPORT_MAX_ATTEMPTS
+)
+
+/**
+ * Creates a span exporter that sends telemetry to the specified URL over OTLP using a custom Ktor [HttpClient].
+ *
+ * Use this overload to supply a pre-configured client with custom authentication, interceptors, or certificates.
+ *
+ * It's strongly recommended that the supplied [HttpClient] installs the
+ * [io.ktor.client.plugins.HttpTimeout],
+ * [io.ktor.client.plugins.contentnegotiation.ContentNegotiation] and
+ * [io.ktor.client.plugins.compression.ContentEncoding] plugins and that gzip compression is enabled.
+ */
+@ExperimentalApi
+public fun TraceExportConfigDsl.otlpHttpSpanExporter(
+    baseUrl: String,
+    httpClient: HttpClient,
+): SpanExporter = OtlpHttpSpanExporter(
+    OtlpClient(baseUrl, httpClient),
     EXPORT_INITIAL_DELAY_MS,
     EXPORT_MAX_ATTEMPT_INTERVAL_MS,
     EXPORT_MAX_ATTEMPTS

--- a/exporters-otlp/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/export/OtlpHttpLogRecordExporterTest.kt
+++ b/exporters-otlp/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/export/OtlpHttpLogRecordExporterTest.kt
@@ -1,14 +1,21 @@
 package io.opentelemetry.kotlin.logging.export
 
+import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
 import io.ktor.client.engine.mock.toByteArray
+import io.ktor.client.plugins.defaultRequest
 import io.ktor.client.request.HttpRequestData
+import io.ktor.client.request.header
 import io.ktor.http.HttpStatusCode
+import io.ktor.util.toMap
 import io.ktor.utils.io.ByteReadChannel
+import io.opentelemetry.kotlin.Clock
+import io.opentelemetry.kotlin.clock.FakeClock
 import io.opentelemetry.kotlin.export.OperationResultCode
 import io.opentelemetry.kotlin.export.OtlpClient
 import io.opentelemetry.kotlin.export.createDefaultHttpClient
+import io.opentelemetry.kotlin.init.LogExportConfigDsl
 import io.opentelemetry.kotlin.logging.model.FakeReadableLogRecord
 import io.opentelemetry.kotlin.logging.model.ReadableLogRecord
 import kotlinx.coroutines.delay
@@ -86,6 +93,29 @@ internal class OtlpHttpLogRecordExporterTest {
         val code = exporter.export(logRecords)
         assertEquals(OperationResultCode.Success, code)
         assertTelemetryExported(logRecords)
+    }
+
+    @Test
+    fun testCustomHttpClientIsUsed() = runTest {
+        val customServer = MockEngine {
+            respond(content = ByteReadChannel(""), status = HttpStatusCode.OK)
+        }
+        val customClient = HttpClient(customServer) {
+            defaultRequest { header("Authorization", "Bearer test-token") }
+        }
+        val fakeConfig = object : LogExportConfigDsl {
+            override val clock: Clock = FakeClock()
+        }
+        val customExporter = fakeConfig.otlpHttpLogRecordExporter(baseUrl, customClient)
+        customExporter.export(logRecords)
+
+        withTimeout(1000) {
+            while (customServer.requestHistory.isEmpty()) {
+                delay(1L)
+            }
+        }
+        val headers = customServer.requestHistory.single().headers.toMap().mapValues { it.value.joinToString() }
+        assertEquals("Bearer test-token", headers["Authorization"])
     }
 
     private suspend fun waitForExportedTelemetry(

--- a/exporters-otlp/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/export/OtlpHttpSpanExporterTest.kt
+++ b/exporters-otlp/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/export/OtlpHttpSpanExporterTest.kt
@@ -1,14 +1,21 @@
 package io.opentelemetry.kotlin.tracing.export
 
+import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
 import io.ktor.client.engine.mock.toByteArray
+import io.ktor.client.plugins.defaultRequest
 import io.ktor.client.request.HttpRequestData
+import io.ktor.client.request.header
 import io.ktor.http.HttpStatusCode
+import io.ktor.util.toMap
 import io.ktor.utils.io.ByteReadChannel
+import io.opentelemetry.kotlin.Clock
+import io.opentelemetry.kotlin.clock.FakeClock
 import io.opentelemetry.kotlin.export.OperationResultCode
 import io.opentelemetry.kotlin.export.OtlpClient
 import io.opentelemetry.kotlin.export.createDefaultHttpClient
+import io.opentelemetry.kotlin.init.TraceExportConfigDsl
 import io.opentelemetry.kotlin.tracing.data.FakeSpanData
 import io.opentelemetry.kotlin.tracing.data.SpanData
 import kotlinx.coroutines.delay
@@ -86,6 +93,29 @@ internal class OtlpHttpSpanExporterTest {
         val code = exporter.export(spans)
         assertEquals(OperationResultCode.Success, code)
         assertTelemetryExported(spans)
+    }
+
+    @Test
+    fun testCustomHttpClientIsUsed() = runTest {
+        val customServer = MockEngine {
+            respond(content = ByteReadChannel(""), status = HttpStatusCode.OK)
+        }
+        val customClient = HttpClient(customServer) {
+            defaultRequest { header("Authorization", "Bearer test-token") }
+        }
+        val fakeConfig = object : TraceExportConfigDsl {
+            override val clock: Clock = FakeClock()
+        }
+        val customExporter = fakeConfig.otlpHttpSpanExporter(baseUrl, customClient)
+        customExporter.export(spans)
+
+        withTimeout(1000) {
+            while (customServer.requestHistory.isEmpty()) {
+                delay(1L)
+            }
+        }
+        val headers = customServer.requestHistory.single().headers.toMap().mapValues { it.value.joinToString() }
+        assertEquals("Bearer test-token", headers["Authorization"])
     }
 
     private suspend fun waitForExportedTelemetry(


### PR DESCRIPTION
## Goal

Allows a custom HttpClient for OTLP export. Closes #416. 