### PR TITLE
Handle unexpected types in attributes

### DIFF
--- a/api-ext/src/commonMain/kotlin/io/opentelemetry/kotlin/attributes/AttributesMutatorExt.kt
+++ b/api-ext/src/commonMain/kotlin/io/opentelemetry/kotlin/attributes/AttributesMutatorExt.kt
@@ -19,6 +19,8 @@ public fun AttributesMutator.setAttributes(attributes: Map<String, Any>) {
             is Boolean -> setBooleanAttribute(it.key, input)
             is Long -> setLongAttribute(it.key, input)
             is Double -> setDoubleAttribute(it.key, input)
+            is Float -> setDoubleAttribute(it.key, input.toDouble())
+            is Number -> setLongAttribute(it.key, input.toLong())
             is Collection<*> -> handleCollection(it.key, input.toList())
             is Array<*> -> handleCollection(it.key, input.toList())
             else -> setStringAttribute(it.key, it.value.toString())
@@ -31,8 +33,13 @@ private fun AttributesMutator.handleCollection(key: String, input: List<*>) {
     when {
         input.all { it is String } -> setStringListAttribute(key, input as List<String>)
         input.all { it is Boolean } -> setBooleanListAttribute(key, input as List<Boolean>)
-        input.all { it is Double } -> setDoubleListAttribute(key, input as List<Double>)
         input.all { it is Long } -> setLongListAttribute(key, input as List<Long>)
+        input.all { it is Double } -> setDoubleListAttribute(key, input as List<Double>)
+        input.all { it is Float } -> setDoubleListAttribute(key, input.filterIsInstance<Float>().map { it.toDouble() })
+        input.all { it is Number && it !is Double && it !is Float } -> setLongListAttribute(
+            key,
+            input.filterIsInstance<Number>().map { it.toLong() }
+        )
         else -> return
     }
 }

--- a/api-ext/src/commonTest/kotlin/io/opentelemetry/kotlin/attributes/AttributeContainerExtTest.kt
+++ b/api-ext/src/commonTest/kotlin/io/opentelemetry/kotlin/attributes/AttributeContainerExtTest.kt
@@ -35,6 +35,42 @@ internal class AttributeContainerExtTest {
         assertEquals(expected, observed)
     }
 
+    @Test
+    fun testIntAttributeStorage() {
+        val attrs = FakeAttributesMutator()
+        val i = 5
+        attrs.setAttributes(mapOf("int" to i))
+        val value = attrs.attributes["int"] as Number
+        assertEquals(i.toLong(), value.toLong())
+    }
+
+    @Test
+    fun testFloatAttributeStorage() {
+        val attrs = FakeAttributesMutator()
+        val f = 1.5f
+        attrs.setAttributes(mapOf("float" to f))
+        val value = attrs.attributes["float"] as Number
+        assertEquals(f.toDouble(), value.toDouble())
+    }
+
+    @Test
+    fun testByteAttributeStorage() {
+        val attrs = FakeAttributesMutator()
+        val b = 1.toByte()
+        attrs.setAttributes(mapOf("byte" to b))
+        val value = attrs.attributes["byte"] as Number
+        assertEquals(b.toLong(), value.toLong())
+    }
+
+    @Test
+    fun testShortAttributeStorage() {
+        val attrs = FakeAttributesMutator()
+        val s = 1.toShort()
+        attrs.setAttributes(mapOf("short" to s))
+        val value = attrs.attributes["short"] as Number
+        assertEquals(s.toLong(), value.toLong())
+    }
+
     private class ComplexObject {
         override fun toString(): String = "ComplexObject"
     }

--- a/exporters-protobuf/src/commonMain/kotlin/io/opentelemetry/kotlin/export/conversion/AttributesProtobufConversion.kt
+++ b/exporters-protobuf/src/commonMain/kotlin/io/opentelemetry/kotlin/export/conversion/AttributesProtobufConversion.kt
@@ -34,6 +34,8 @@ private fun convertAttributeValue(value: Any): AnyValue = when (value) {
     is String -> AnyValue(string_value = value)
     is Long -> AnyValue(int_value = value)
     is Double -> AnyValue(double_value = value)
+    is Float -> AnyValue(double_value = value.toDouble())
+    is Number -> AnyValue(int_value = value.toLong())
     is Boolean -> AnyValue(bool_value = value)
     is List<*> -> AnyValue(array_value = handleList(value as List<Any>))
     else -> throw UnsupportedOperationException()

--- a/exporters-protobuf/src/commonTest/kotlin/io/opentelemetry/kotlin/export/conversion/AttributeProtobufConversionTest.kt
+++ b/exporters-protobuf/src/commonTest/kotlin/io/opentelemetry/kotlin/export/conversion/AttributeProtobufConversionTest.kt
@@ -7,7 +7,6 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
-import kotlin.test.assertTrue
 
 class AttributeProtobufConversionTest {
 
@@ -33,6 +32,39 @@ class AttributeProtobufConversionTest {
         assertNotNull(array)
         assertEquals(array[0].string_value, "val")
         assertEquals(array[1].int_value, 32L)
+    }
+
+    @Test
+    fun testIntValueDoesNotThrow() {
+        val value = 42
+        val keyValue = createForValue(value)
+        val anyValue = checkNotNull(keyValue.value_)
+        val numericValue = anyValue.int_value ?: anyValue.double_value?.toLong()
+        assertEquals(42L, numericValue)
+    }
+
+    @Test
+    fun testFloatValueDoesNotThrow() {
+        val keyValue = createForValue(1.5f)
+        val anyValue = keyValue.value_
+        checkNotNull(anyValue)
+        assertEquals(1.5, anyValue.double_value)
+    }
+
+    @Test
+    fun testShortValueDoesNotThrow() {
+        val keyValue = createForValue(1.toShort())
+        val anyValue = checkNotNull(keyValue.value_)
+        val numericValue = anyValue.int_value ?: anyValue.double_value?.toLong()
+        assertEquals(1L, numericValue)
+    }
+
+    @Test
+    fun testByteValueDoesNotThrow() {
+        val keyValue = createForValue(1.toByte())
+        val anyValue = checkNotNull(keyValue.value_)
+        val numericValue = anyValue.int_value ?: anyValue.double_value?.toLong()
+        assertEquals(1L, numericValue)
     }
 
     @Test

--- a/sdk-common/src/commonMain/kotlin/io/opentelemetry/kotlin/attributes/AttributeContainerExt.kt
+++ b/sdk-common/src/commonMain/kotlin/io/opentelemetry/kotlin/attributes/AttributeContainerExt.kt
@@ -7,19 +7,15 @@ public fun AttributesMutator.setAttributes(container: AttributeContainer) {
             is String -> setStringAttribute(key, value)
             is Long -> setLongAttribute(key, value)
             is Double -> setDoubleAttribute(key, value)
+            is Float -> setDoubleAttribute(key, value.toDouble())
+            is Number -> setLongAttribute(key, value.toLong())
             is List<*> -> when (value.firstOrNull()) {
-                is Boolean ->
-                    @Suppress("UNCHECKED_CAST")
-                    setBooleanListAttribute(key, value as List<Boolean>)
-                is String ->
-                    @Suppress("UNCHECKED_CAST")
-                    setStringListAttribute(key, value as List<String>)
-                is Long ->
-                    @Suppress("UNCHECKED_CAST")
-                    setLongListAttribute(key, value as List<Long>)
-                is Double ->
-                    @Suppress("UNCHECKED_CAST")
-                    setDoubleListAttribute(key, value as List<Double>)
+                is Boolean -> setBooleanListAttribute(key, value.filterIsInstance<Boolean>())
+                is String -> setStringListAttribute(key, value.filterIsInstance<String>())
+                is Long -> setLongListAttribute(key, value.filterIsInstance<Long>())
+                is Double -> setDoubleListAttribute(key, value.filterIsInstance<Double>())
+                is Float -> setDoubleListAttribute(key, value.filterIsInstance<Float>().map(Float::toDouble))
+                is Number -> setLongListAttribute(key, value.filterIsInstance<Number>().map(Number::toLong))
                 else -> {}
             }
             else -> {}


### PR DESCRIPTION
## Goal

Handles unexpected types in attributes by casting them to either `Long` or `Double`. Closes #409.

## Testing

Added unit tests.
