### PR TITLE
Add MeterProvider API

### DIFF
--- a/api/api/jvm/api.api
+++ b/api/api/jvm/api.api
@@ -137,6 +137,14 @@ public final class io/opentelemetry/kotlin/logging/SeverityNumber : java/lang/En
 public abstract interface class io/opentelemetry/kotlin/metrics/Meter {
 }
 
+public abstract interface class io/opentelemetry/kotlin/metrics/MeterProvider {
+	public abstract fun getMeter (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lio/opentelemetry/kotlin/metrics/Meter;
+}
+
+public final class io/opentelemetry/kotlin/metrics/MeterProvider$DefaultImpls {
+	public static synthetic fun getMeter$default (Lio/opentelemetry/kotlin/metrics/MeterProvider;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lio/opentelemetry/kotlin/metrics/Meter;
+}
+
 public abstract interface class io/opentelemetry/kotlin/propagation/PropagatorFactory {
 	public abstract fun composite (Ljava/util/List;)Lio/opentelemetry/kotlin/propagation/TextMapPropagator;
 	public abstract fun composite ([Lio/opentelemetry/kotlin/propagation/TextMapPropagator;)Lio/opentelemetry/kotlin/propagation/TextMapPropagator;

--- a/api/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/MeterProvider.kt
+++ b/api/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/MeterProvider.kt
@@ -1,0 +1,29 @@
+package io.opentelemetry.kotlin.metrics
+
+import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.ThreadSafe
+import io.opentelemetry.kotlin.attributes.AttributesMutator
+
+/**
+ * MeterProvider is a factory for retrieving instances of [Meter].
+ *
+ * https://opentelemetry.io/docs/specs/otel/metrics/api/#meterprovider
+ */
+@ExperimentalApi
+@ThreadSafe
+public interface MeterProvider {
+
+    /**
+     * Returns a [Meter] matching the given name. An optional version, schema URL, and attributes describing
+     * the [Meter] can be supplied.
+     *
+     * The name must document the instrumentation scope: https://opentelemetry.io/docs/specs/otel/glossary/#instrumentation-scope
+     */
+    @ThreadSafe
+    public fun getMeter(
+        name: String,
+        version: String? = null,
+        schemaUrl: String? = null,
+        attributes: (AttributesMutator.() -> Unit)? = null,
+    ): Meter
+}

--- a/noop/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/NoopMeterProvider.kt
+++ b/noop/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/NoopMeterProvider.kt
@@ -1,0 +1,14 @@
+package io.opentelemetry.kotlin.metrics
+
+import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.attributes.AttributesMutator
+
+@ExperimentalApi
+internal object NoopMeterProvider : MeterProvider {
+    override fun getMeter(
+        name: String,
+        version: String?,
+        schemaUrl: String?,
+        attributes: (AttributesMutator.() -> Unit)?
+    ): Meter = NoopMeter
+}


### PR DESCRIPTION
## Goal

Adds the `MeterProvider` interface. Wiring with the OpenTelemetry entry point will be added in a subsequent PR.
Partially addresses https://github.com/open-telemetry/opentelemetry-kotlin/issues/376.

## Testing

Since this PR only adds the API surface, no behavioral impact is expected. Build and detekt checks pass.