### PR TITLE
Implement equality for ByteArray values in Attributes

### DIFF
--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/attributes/AttributesModel.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/attributes/AttributesModel.kt
@@ -89,10 +89,41 @@ internal class AttributesModel(
         if (other !is AttributesModel) {
             return false
         }
-        return attrs == other.attrs
+        val otherAttrs = other.attrs
+        if (attrs.size != otherAttrs.size) {
+            return false
+        }
+        for ((key, value) in attrs) {
+            val otherValue = otherAttrs[key] ?: return false
+            if (!attributeValuesEqual(value, otherValue)) {
+                return false
+            }
+        }
+        return true
     }
 
-    override fun hashCode(): Int = attrs.hashCode()
+    override fun hashCode(): Int {
+        var result = 0
+        for ((key, value) in attrs) {
+            result += key.hashCode() xor attributeValueHashCode(value)
+        }
+        return result
+    }
+
+    // ByteArray uses identity equality/hashCode, so route through content-aware variants.
+    private fun attributeValuesEqual(a: Any, b: Any): Boolean {
+        if (a is ByteArray && b is ByteArray) {
+            return a.contentEquals(b)
+        }
+        return a == b
+    }
+
+    private fun attributeValueHashCode(value: Any): Int {
+        if (value is ByteArray) {
+            return value.contentHashCode()
+        }
+        return value.hashCode()
+    }
 }
 
 internal const val DEFAULT_ATTRIBUTE_LIMIT: Int = 128

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/attributes/AttributesMutatorImplTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/attributes/AttributesMutatorImplTest.kt
@@ -155,6 +155,29 @@ internal class AttributesMutatorImplTest {
         assertEquals(a.hashCode(), b.hashCode())
     }
 
+    @Test
+    fun testEqualityWithMatchingByteArrayContent() {
+        val a = AttributesModel(attributeLimit).apply {
+            setByteArrayAttribute("bytes", byteArrayOf(0x01, 0x02, 0x03))
+        }
+        val b = AttributesModel(attributeLimit).apply {
+            setByteArrayAttribute("bytes", byteArrayOf(0x01, 0x02, 0x03))
+        }
+        assertEquals(a, b)
+        assertEquals(a.hashCode(), b.hashCode())
+    }
+
+    @Test
+    fun testInequalityWithDifferingByteArrayContent() {
+        val a = AttributesModel(attributeLimit).apply {
+            setByteArrayAttribute("bytes", byteArrayOf(0x01, 0x02, 0x03))
+        }
+        val b = AttributesModel(attributeLimit).apply {
+            setByteArrayAttribute("bytes", byteArrayOf(0x01, 0x02, 0x04))
+        }
+        assertNotEquals(a, b)
+    }
+
     private fun AttributesMutator.addTestAttributes(keyToken: String = "") {
         setStringAttribute("string$keyToken", "value")
         setDoubleAttribute("double$keyToken", 3.14)


### PR DESCRIPTION
## Goal

Ensures that when ByteArray values are in an attributes object equality checks properly reflect this. Closes #441.