### PR TITLE
Attributes extension -- handle int in map and improved js handling

### DIFF
--- a/api-ext/src/commonMain/kotlin/io/opentelemetry/kotlin/attributes/AttributesMutatorExt.kt
+++ b/api-ext/src/commonMain/kotlin/io/opentelemetry/kotlin/attributes/AttributesMutatorExt.kt
@@ -17,16 +17,21 @@ public fun AttributesMutator.setAttributes(attributes: Map<String, Any>) {
         when (val input = it.value) {
             is String -> setStringAttribute(it.key, input)
             is Boolean -> setBooleanAttribute(it.key, input)
-            is Int -> setLongAttribute(it.key, input.toLong())
             is Long -> setLongAttribute(it.key, input)
-            is Double -> setDoubleAttribute(it.key, input)
-            is Float -> setDoubleAttribute(it.key, input.toDouble())
-            is Number -> setLongAttribute(it.key, input.toLong())
+            is Number -> setNumericAttribute(it.key, input)
             is ByteArray -> setByteArrayAttribute(it.key, input)
             is Collection<*> -> handleCollection(it.key, input.toList())
             is Array<*> -> handleCollection(it.key, input.toList())
             else -> setStringAttribute(it.key, it.value.toString())
         }
+    }
+}
+
+private fun AttributesMutator.setNumericAttribute(key: String, value: Number) {
+    if (value is Long || value.isWholeNumber()) {
+        setLongAttribute(key, value.toLong())
+    } else {
+        setDoubleAttribute(key, value.toDouble())
     }
 }
 
@@ -36,12 +41,23 @@ private fun AttributesMutator.handleCollection(key: String, input: List<*>) {
         input.all { it is String } -> setStringListAttribute(key, input as List<String>)
         input.all { it is Boolean } -> setBooleanListAttribute(key, input as List<Boolean>)
         input.all { it is Long } -> setLongListAttribute(key, input as List<Long>)
-        input.all { it is Double } -> setDoubleListAttribute(key, input as List<Double>)
-        input.all { it is Float } -> setDoubleListAttribute(key, input.filterIsInstance<Float>().map { it.toDouble() })
-        input.all { it is Number && it !is Double && it !is Float } -> setLongListAttribute(
+        input.all { it is Number } -> setNumericListAttribute(
             key,
-            input.filterIsInstance<Number>().map { it.toLong() }
+            input.filterIsInstance<Number>()
         )
         else -> handleCollection(key, input.map { it?.toString() })
     }
+}
+
+private fun AttributesMutator.setNumericListAttribute(key: String, values: List<Number>) {
+    if (values.all { it.isWholeNumber() }) {
+        setLongListAttribute(key, values.map { it.toLong() })
+    } else {
+        setDoubleListAttribute(key, values.map { it.toDouble() })
+    }
+}
+
+private fun Number.isWholeNumber(): Boolean {
+    val doubleValue = toDouble()
+    return doubleValue.isFinite() && doubleValue == toLong().toDouble()
 }

--- a/api-ext/src/commonMain/kotlin/io/opentelemetry/kotlin/attributes/AttributesMutatorExt.kt
+++ b/api-ext/src/commonMain/kotlin/io/opentelemetry/kotlin/attributes/AttributesMutatorExt.kt
@@ -17,6 +17,7 @@ public fun AttributesMutator.setAttributes(attributes: Map<String, Any>) {
         when (val input = it.value) {
             is String -> setStringAttribute(it.key, input)
             is Boolean -> setBooleanAttribute(it.key, input)
+            is Int -> setLongAttribute(it.key, input.toLong())
             is Long -> setLongAttribute(it.key, input)
             is Double -> setDoubleAttribute(it.key, input)
             is Float -> setDoubleAttribute(it.key, input.toDouble())
@@ -41,6 +42,6 @@ private fun AttributesMutator.handleCollection(key: String, input: List<*>) {
             key,
             input.filterIsInstance<Number>().map { it.toLong() }
         )
-        else -> return
+        else -> handleCollection(key, input.map { it?.toString() })
     }
 }

--- a/api-ext/src/commonTest/kotlin/io/opentelemetry/kotlin/attributes/AttributeContainerExtTest.kt
+++ b/api-ext/src/commonTest/kotlin/io/opentelemetry/kotlin/attributes/AttributeContainerExtTest.kt
@@ -19,20 +19,17 @@ internal class AttributeContainerExtTest {
             "boolList" to arrayOf(true),
             "complex" to ComplexObject(),
         )
-        val expected = mapOf(
-            "string" to "value",
-            "long" to 5L,
-            "double" to 10.0,
-            "bool" to true,
-            "stringList" to listOf("value"),
-            "longList" to listOf(5L),
-            "doubleList" to listOf(10.0),
-            "boolList" to listOf(true),
-            "complex" to "ComplexObject"
-        )
         attrs.setAttributes(input)
         val observed = attrs.attributes
-        assertEquals(expected, observed)
+        assertEquals("value", observed["string"])
+        assertEquals(5L, (observed["long"] as Number).toLong())
+        assertEquals(10.0, (observed["double"] as Number).toDouble())
+        assertEquals(true, observed["bool"])
+        assertEquals(listOf("value"), observed["stringList"] as List<*>)
+        assertEquals(listOf(5L), (observed["longList"] as List<*>).map { (it as Number).toLong() })
+        assertEquals(listOf(10.0), (observed["doubleList"] as List<*>).map { (it as Number).toDouble() })
+        assertEquals(listOf(true), observed["boolList"] as List<*>)
+        assertEquals("ComplexObject", observed["complex"])
     }
 
     @Test

--- a/api-ext/src/commonTest/kotlin/io/opentelemetry/kotlin/attributes/AttributesMutatorExtTest.kt
+++ b/api-ext/src/commonTest/kotlin/io/opentelemetry/kotlin/attributes/AttributesMutatorExtTest.kt
@@ -1,0 +1,39 @@
+package io.opentelemetry.kotlin.attributes
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+internal class AttributesMutatorExtTest {
+
+    @Test
+    fun `can set attributes with map`() {
+        val mutator = FakeAttributesMutator()
+        val map = mapOf(
+            Pair("foo", "bar"), Pair("long", 21L),
+            Pair("int", 123), Pair("double", 21.5), Pair("float", 22.5f),
+            Pair("byte", 0x7F.toByte()), Pair("bool", true),
+            Pair("bytearray", byteArrayOf(1, 2, 3)),
+            Pair("list", listOf("foo", "bar", "baz")),
+            Pair("tostring", TestObj("flim", 66L)),
+            Pair("arrayobj", arrayOf(TestObj("one", 1), TestObj("two", 2)))
+        )
+        mutator.setAttributes(map)
+
+        assertEquals("bar", mutator.attributes["foo"])
+        assertEquals(21L, mutator.attributes["long"])
+        assertEquals(123L, mutator.attributes[ "int"])
+        assertEquals(21.5, mutator.attributes["double"])
+        assertEquals(22.5, mutator.attributes["float"])
+        assertEquals(127L, mutator.attributes["byte"])
+        assertTrue(byteArrayOf(1, 2, 3).contentEquals(mutator.attributes["bytearray"] as ByteArray?))
+        assertEquals(listOf("foo", "bar", "baz"), mutator.attributes["list"])
+        assertEquals("TestObj(first=flim, second=66)", mutator.attributes["tostring"])
+        assertEquals(
+            listOf("TestObj(first=one, second=1)", "TestObj(first=two, second=2)"),
+            mutator.attributes["arrayobj"] as List<*>
+        )
+    }
+
+    data class TestObj(val first: String, val second: Long)
+}

--- a/api-ext/src/commonTest/kotlin/io/opentelemetry/kotlin/attributes/AttributesMutatorExtTest.kt
+++ b/api-ext/src/commonTest/kotlin/io/opentelemetry/kotlin/attributes/AttributesMutatorExtTest.kt
@@ -9,6 +9,7 @@ internal class AttributesMutatorExtTest {
     @Test
     fun `can set attributes with map`() {
         val mutator = FakeAttributesMutator()
+        mutator.setLongAttribute("existing", 55.44.toLong())
         val map = mapOf(
             Pair("foo", "bar"), Pair("long", 21L),
             Pair("int", 123), Pair("double", 21.5), Pair("float", 22.5f),
@@ -33,6 +34,7 @@ internal class AttributesMutatorExtTest {
             listOf("TestObj(first=one, second=1)", "TestObj(first=two, second=2)"),
             mutator.attributes["arrayobj"] as List<*>
         )
+        assertEquals(55.44.toLong(), mutator.attributes["existing"])
     }
 
     data class TestObj(val first: String, val second: Long)


### PR DESCRIPTION
There were two cases that seemed to not be working as well as expected with the extension -- Int types in the map and some double/floating values being converted to long by the js backend.