### PR TITLE
Begin implementing the Propagator API

### DIFF
--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/propagation/CompositeTextMapPropagator.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/propagation/CompositeTextMapPropagator.kt
@@ -1,0 +1,28 @@
+package io.opentelemetry.kotlin.propagation
+
+import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.context.Context
+
+@OptIn(ExperimentalApi::class)
+internal class CompositeTextMapPropagator(
+    private val delegates: List<TextMapPropagator>,
+) : TextMapPropagator {
+
+    private val fields: List<String> = delegates.flatMap(TextMapPropagator::fields).distinct()
+
+    override fun fields(): Collection<String> = fields
+
+    override fun <T> inject(context: Context, carrier: T, setter: TextMapSetter<T>) {
+        delegates.forEach { delegate ->
+            delegate.inject(context, carrier, setter)
+        }
+    }
+
+    override fun <T> extract(context: Context, carrier: T, getter: TextMapGetter<T>): Context {
+        var result = context
+        delegates.forEach { delegate ->
+            result = delegate.extract(result, carrier, getter)
+        }
+        return result
+    }
+}

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/propagation/PropagatorFactoryImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/propagation/PropagatorFactoryImpl.kt
@@ -1,0 +1,26 @@
+package io.opentelemetry.kotlin.propagation
+
+import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.context.Context
+
+@OptIn(ExperimentalApi::class)
+internal class PropagatorFactoryImpl : PropagatorFactory {
+
+    override fun composite(vararg propagators: TextMapPropagator): TextMapPropagator {
+        return composite(propagators.toList())
+    }
+
+    override fun composite(propagators: List<TextMapPropagator>): TextMapPropagator {
+        return when (propagators.size) {
+            0 -> EmptyTextMapPropagator
+            1 -> propagators.single()
+            else -> CompositeTextMapPropagator(propagators.toList())
+        }
+    }
+
+    private object EmptyTextMapPropagator : TextMapPropagator {
+        override fun fields(): Collection<String> = emptyList()
+        override fun <T> inject(context: Context, carrier: T, setter: TextMapSetter<T>) {}
+        override fun <T> extract(context: Context, carrier: T, getter: TextMapGetter<T>): Context = context
+    }
+}

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/propagation/MapCarrierFixtures.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/propagation/MapCarrierFixtures.kt
@@ -1,0 +1,16 @@
+package io.opentelemetry.kotlin.propagation
+
+import io.opentelemetry.kotlin.ExperimentalApi
+
+@OptIn(ExperimentalApi::class)
+internal object MapTextMapGetter : TextMapGetter<Map<String, String>> {
+    override fun keys(carrier: Map<String, String>): Collection<String> = carrier.keys
+    override fun get(carrier: Map<String, String>, key: String): String? = carrier[key]
+}
+
+@OptIn(ExperimentalApi::class)
+internal object MapTextMapSetter : TextMapSetter<MutableMap<String, String>> {
+    override fun set(carrier: MutableMap<String, String>, key: String, value: String) {
+        carrier[key] = value
+    }
+}

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/propagation/PropagatorFactoryImplTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/propagation/PropagatorFactoryImplTest.kt
@@ -1,0 +1,130 @@
+package io.opentelemetry.kotlin.propagation
+
+import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.context.Context
+import io.opentelemetry.kotlin.context.ContextKey
+import io.opentelemetry.kotlin.factory.ContextFactoryImpl
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalApi::class)
+internal class PropagatorFactoryImplTest {
+
+    private val factory = PropagatorFactoryImpl()
+    private val contextFactory = ContextFactoryImpl()
+
+    @Test
+    fun `composite of zero propagators returns empty propagator`() {
+        val composite = factory.composite()
+        assertTrue(composite.fields().isEmpty())
+
+        val root = contextFactory.root()
+        val carrier = mutableMapOf<String, String>()
+        composite.inject(root, carrier, MapTextMapSetter)
+        assertTrue(carrier.isEmpty())
+
+        val ctx = composite.extract(root, carrier, MapTextMapGetter)
+        assertSame(root, ctx)
+    }
+
+    @Test
+    fun `composite of single propagator returns same instance`() {
+        val single = RecordingPropagator(listOf("foo"))
+        assertSame(single, factory.composite(single))
+        assertSame(single, factory.composite(listOf(single)))
+    }
+
+    @Test
+    fun `composite of many returns deduped union of fields preserving order`() {
+        val a = RecordingPropagator(listOf("a", "shared"))
+        val b = RecordingPropagator(listOf("b", "shared", "c"))
+        val composite = factory.composite(a, b)
+        assertEquals(listOf("a", "shared", "b", "c"), composite.fields().toList())
+    }
+
+    @Test
+    fun `composite invokes inject on all delegates in order`() {
+        val a = RecordingPropagator(listOf("a"))
+        val b = RecordingPropagator(listOf("b"))
+        val composite = factory.composite(a, b)
+        val carrier = mutableMapOf<String, String>()
+        composite.inject(contextFactory.root(), carrier, MapTextMapSetter)
+        assertEquals(listOf("a", "b"), carrier.keys.toList())
+        assertTrue(a.injectCalled)
+        assertTrue(b.injectCalled)
+    }
+
+    @Test
+    fun `composite threads context through extract delegates left-to-right`() {
+        val keyA: ContextKey<String> = contextFactory.createKey("a")
+        val keyB: ContextKey<String> = contextFactory.createKey("b")
+        val a = ContextWritingPropagator(keyA, "alpha")
+        val b = ContextWritingPropagator(keyB, "beta")
+        val composite = factory.composite(a, b)
+        val result = composite.extract(contextFactory.root(), emptyMap(), MapTextMapGetter)
+        assertEquals("alpha", result.get(keyA))
+        assertEquals("beta", result.get(keyB))
+    }
+
+    @Test
+    fun `composite extract observes upstream context modifications`() {
+        val key: ContextKey<String> = contextFactory.createKey("k")
+        val writer = ContextWritingPropagator(key, "set-by-writer")
+        val reader = ContextReadingPropagator(key)
+        factory.composite(writer, reader).extract(contextFactory.root(), emptyMap(), MapTextMapGetter)
+        assertEquals("set-by-writer", reader.observedValue)
+    }
+
+    @Test
+    fun `vararg and list overloads behave identically`() {
+        val a = RecordingPropagator(listOf("a"))
+        val b = RecordingPropagator(listOf("b"))
+        val viaVararg = factory.composite(a, b)
+        val viaList = factory.composite(listOf(a, b))
+        assertEquals(viaVararg.fields().toList(), viaList.fields().toList())
+    }
+}
+
+@OptIn(ExperimentalApi::class)
+private class RecordingPropagator(private val keys: List<String>) : TextMapPropagator {
+    var injectCalled: Boolean = false
+        private set
+
+    override fun fields(): Collection<String> = keys
+
+    override fun <T> inject(context: Context, carrier: T, setter: TextMapSetter<T>) {
+        injectCalled = true
+        keys.forEach { k ->
+            setter.set(carrier, k, "set-by-$k")
+        }
+    }
+
+    override fun <T> extract(context: Context, carrier: T, getter: TextMapGetter<T>): Context = context
+}
+
+@OptIn(ExperimentalApi::class)
+private class ContextWritingPropagator(
+    private val key: ContextKey<String>,
+    private val value: String,
+) : TextMapPropagator {
+    override fun fields(): Collection<String> = emptyList()
+    override fun <T> inject(context: Context, carrier: T, setter: TextMapSetter<T>) {}
+    override fun <T> extract(context: Context, carrier: T, getter: TextMapGetter<T>): Context {
+        return context.set(key, value)
+    }
+}
+
+@OptIn(ExperimentalApi::class)
+private class ContextReadingPropagator(private val key: ContextKey<String>) : TextMapPropagator {
+    var observedValue: String? = null
+        private set
+
+    override fun fields(): Collection<String> = emptyList()
+    override fun <T> inject(context: Context, carrier: T, setter: TextMapSetter<T>) {}
+    override fun <T> extract(context: Context, carrier: T, getter: TextMapGetter<T>): Context {
+        observedValue = context.get(key)
+        return context
+    }
+}


### PR DESCRIPTION
## Goal

Starts an implementation of the `TextMapPropagator` API by creating a `PropagatorFactory` and `CompositePropagator` implementation.

## Testing

Added unit tests.
