### PR TITLE
Implement storage of baggage on context

### DIFF
--- a/api/api/jvm/api.api
+++ b/api/api/jvm/api.api
@@ -45,8 +45,11 @@ public abstract interface class io/opentelemetry/kotlin/baggage/BaggageEntryMeta
 
 public abstract interface class io/opentelemetry/kotlin/context/Context {
 	public abstract fun attach ()Lio/opentelemetry/kotlin/context/Scope;
+	public abstract fun clearBaggage ()Lio/opentelemetry/kotlin/context/Context;
+	public abstract fun extractBaggage ()Lio/opentelemetry/kotlin/baggage/Baggage;
 	public abstract fun get (Lio/opentelemetry/kotlin/context/ContextKey;)Ljava/lang/Object;
 	public abstract fun set (Lio/opentelemetry/kotlin/context/ContextKey;Ljava/lang/Object;)Lio/opentelemetry/kotlin/context/Context;
+	public abstract fun storeBaggage (Lio/opentelemetry/kotlin/baggage/Baggage;)Lio/opentelemetry/kotlin/context/Context;
 }
 
 public abstract interface class io/opentelemetry/kotlin/context/ContextKey {

--- a/api/src/commonMain/kotlin/io/opentelemetry/kotlin/context/Context.kt
+++ b/api/src/commonMain/kotlin/io/opentelemetry/kotlin/context/Context.kt
@@ -2,6 +2,7 @@ package io.opentelemetry.kotlin.context
 
 import io.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.kotlin.ThreadSafe
+import io.opentelemetry.kotlin.baggage.Baggage
 
 /**
  * Immutable propagation mechanism that carries values across concerns.
@@ -42,4 +43,28 @@ public interface Context {
      */
     @ThreadSafe
     public fun attach(): Scope
+
+    /**
+     * Returns a new [Context] derived from this one with [baggage] stored under a pre-defined key.
+     *
+     * https://opentelemetry.io/docs/specs/otel/baggage/api/#context-interaction
+     */
+    @ThreadSafe
+    public fun storeBaggage(baggage: Baggage): Context
+
+    /**
+     * Returns the [Baggage] stored in this [Context], or an empty [Baggage] if none is present.
+     *
+     * https://opentelemetry.io/docs/specs/otel/baggage/api/#context-interaction
+     */
+    @ThreadSafe
+    public fun extractBaggage(): Baggage
+
+    /**
+     * Returns a new [Context] derived from this one with all baggage entries removed.
+     *
+     * https://opentelemetry.io/docs/specs/otel/baggage/api/#context-interaction
+     */
+    @ThreadSafe
+    public fun clearBaggage(): Context
 }

--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/context/ContextAdapter.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/context/ContextAdapter.kt
@@ -1,6 +1,9 @@
 package io.opentelemetry.kotlin.context
 
+import io.opentelemetry.kotlin.aliases.OtelJavaBaggage
 import io.opentelemetry.kotlin.aliases.OtelJavaContext
+import io.opentelemetry.kotlin.baggage.Baggage
+import io.opentelemetry.kotlin.baggage.BaggageAdapter
 
 internal class ContextAdapter(
     val impl: OtelJavaContext,
@@ -20,4 +23,13 @@ internal class ContextAdapter(
     override fun attach(): Scope {
         return ScopeAdapter(impl.makeCurrent())
     }
+
+    override fun storeBaggage(baggage: Baggage): Context {
+        return ContextAdapter((baggage as BaggageAdapter).impl.storeInContext(impl), repository)
+    }
+
+    override fun extractBaggage(): Baggage = BaggageAdapter(OtelJavaBaggage.fromContext(impl))
+
+    override fun clearBaggage(): Context =
+        ContextAdapter(OtelJavaBaggage.empty().storeInContext(impl), repository)
 }

--- a/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/factory/CompatContextFactoryBaggageTest.kt
+++ b/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/factory/CompatContextFactoryBaggageTest.kt
@@ -1,0 +1,63 @@
+package io.opentelemetry.kotlin.factory
+
+import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.aliases.OtelJavaBaggage
+import io.opentelemetry.kotlin.baggage.BaggageAdapter
+import io.opentelemetry.kotlin.context.toOtelJavaContext
+import io.opentelemetry.kotlin.context.toOtelKotlinContext
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalApi::class)
+internal class CompatContextFactoryBaggageTest {
+
+    private val factory = CompatContextFactory()
+
+    @Test
+    fun `extractBaggage on root returns empty baggage`() {
+        assertTrue(factory.root().extractBaggage().asMap().isEmpty())
+    }
+
+    @Test
+    fun `storeBaggage then extractBaggage round-trips entries`() {
+        val baggage = BaggageAdapter(
+            OtelJavaBaggage.builder().put("user", "alice").put("region", "eu").build()
+        )
+
+        val extracted = factory.root().storeBaggage(baggage).extractBaggage()
+
+        assertEquals("alice", extracted.getValue("user"))
+        assertEquals("eu", extracted.getValue("region"))
+    }
+
+    @Test
+    fun `clearBaggage on populated context yields empty baggage`() {
+        val baggage = BaggageAdapter(OtelJavaBaggage.builder().put("user", "alice").build())
+        val cleared = factory.root().storeBaggage(baggage).clearBaggage()
+
+        assertTrue(cleared.extractBaggage().asMap().isEmpty())
+        assertNull(cleared.extractBaggage().getValue("user"))
+    }
+
+    @Test
+    fun `kotlin storeBaggage interops with otel-java fromContext`() {
+        val baggage = BaggageAdapter(OtelJavaBaggage.builder().put("user", "alice").build())
+        val stored = factory.root().storeBaggage(baggage)
+
+        val javaBaggage = OtelJavaBaggage.fromContext(stored.toOtelJavaContext())
+
+        assertEquals("alice", javaBaggage.getEntryValue("user"))
+    }
+
+    @Test
+    fun `otel-java storeInContext interops with kotlin extractBaggage`() {
+        val javaBaggage = OtelJavaBaggage.builder().put("user", "alice").build()
+        val javaCtx = javaBaggage.storeInContext(factory.root().toOtelJavaContext())
+
+        val extracted = javaCtx.toOtelKotlinContext().extractBaggage()
+
+        assertEquals("alice", extracted.getValue("user"))
+    }
+}

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/context/ContextImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/context/ContextImpl.kt
@@ -1,4 +1,10 @@
 package io.opentelemetry.kotlin.context
+
+import io.opentelemetry.kotlin.baggage.Baggage
+import io.opentelemetry.kotlin.baggage.BaggageImpl
+
+private val BAGGAGE_KEY: ContextKey<Baggage> = ContextKeyImpl("otel-kotlin-baggage")
+
 internal class ContextImpl(
     private val storage: ImplicitContextStorage,
     private val impl: Map<ContextKey<*>, Any?> = emptyMap()
@@ -25,6 +31,12 @@ internal class ContextImpl(
         storage.setImplicitContext(this)
         return ScopeImpl(current, this, storage)
     }
+
+    override fun storeBaggage(baggage: Baggage): Context = set(BAGGAGE_KEY, baggage)
+
+    override fun extractBaggage(): Baggage = get(BAGGAGE_KEY) ?: BaggageImpl.EMPTY
+
+    override fun clearBaggage(): Context = set(BAGGAGE_KEY, null)
 
     private object NoopScope : Scope {
         override fun detach(): Boolean = true

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/baggage/BaggageContextStorageTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/baggage/BaggageContextStorageTest.kt
@@ -1,0 +1,67 @@
+package io.opentelemetry.kotlin.baggage
+
+import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.factory.ContextFactoryImpl
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotSame
+import kotlin.test.assertNull
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalApi::class)
+internal class BaggageContextStorageTest {
+
+    private val factory = ContextFactoryImpl()
+
+    @Test
+    fun `extractBaggage on root returns empty baggage`() {
+        assertSame(BaggageImpl.EMPTY, factory.root().extractBaggage())
+    }
+
+    @Test
+    fun `storeBaggage then extractBaggage round-trips entries`() {
+        val baggage = BaggageImpl.EMPTY.set("user", "alice").set("region", "eu")
+        val stored = factory.root().storeBaggage(baggage)
+
+        val extracted = stored.extractBaggage()
+
+        assertEquals("alice", extracted.getValue("user"))
+        assertEquals("eu", extracted.getValue("region"))
+    }
+
+    @Test
+    fun `clearBaggage on populated context yields empty baggage`() {
+        val populated = factory.root().storeBaggage(BaggageImpl.EMPTY.set("user", "alice"))
+
+        val cleared = populated.clearBaggage()
+
+        assertSame(BaggageImpl.EMPTY, cleared.extractBaggage())
+        assertNull(cleared.extractBaggage().getValue("user"))
+    }
+
+    @Test
+    fun `storing baggage does not mutate original context`() {
+        val root = factory.root()
+        val derived = root.storeBaggage(BaggageImpl.EMPTY.set("user", "alice"))
+
+        assertNotSame(root, derived)
+        assertSame(BaggageImpl.EMPTY, root.extractBaggage())
+        assertEquals("alice", derived.extractBaggage().getValue("user"))
+    }
+
+    @Test
+    fun `clearBaggage does not mutate original context`() {
+        val populated = factory.root().storeBaggage(BaggageImpl.EMPTY.set("user", "alice"))
+
+        val cleared = populated.clearBaggage()
+
+        assertNotSame(populated, cleared)
+        assertEquals("alice", populated.extractBaggage().getValue("user"))
+    }
+
+    @Test
+    fun `clearBaggage on root context still yields empty baggage`() {
+        assertTrue(factory.root().clearBaggage().extractBaggage().asMap().isEmpty())
+    }
+}

--- a/noop/src/commonMain/kotlin/io/opentelemetry/kotlin/context/NoopContext.kt
+++ b/noop/src/commonMain/kotlin/io/opentelemetry/kotlin/context/NoopContext.kt
@@ -1,4 +1,8 @@
 package io.opentelemetry.kotlin.context
+
+import io.opentelemetry.kotlin.baggage.Baggage
+import io.opentelemetry.kotlin.baggage.NoopBaggage
+
 internal object NoopContext : Context {
 
     override fun <T> set(key: ContextKey<T>, value: T?): Context {
@@ -10,4 +14,10 @@ internal object NoopContext : Context {
     }
 
     override fun attach(): Scope = NoopScope
+
+    override fun storeBaggage(baggage: Baggage): Context = this
+
+    override fun extractBaggage(): Baggage = NoopBaggage
+
+    override fun clearBaggage(): Context = this
 }

--- a/test-fakes/src/commonMain/kotlin/io/opentelemetry/kotlin/baggage/FakeBaggage.kt
+++ b/test-fakes/src/commonMain/kotlin/io/opentelemetry/kotlin/baggage/FakeBaggage.kt
@@ -1,0 +1,11 @@
+package io.opentelemetry.kotlin.baggage
+
+class FakeBaggage(
+    private val entries: Map<String, BaggageEntry> = emptyMap(),
+) : Baggage {
+    override fun getValue(name: String): String? = entries[name]?.value
+    override fun asMap(): Map<String, BaggageEntry> = entries
+    override fun set(name: String, value: String): Baggage = this
+    override fun set(name: String, value: String, metadata: BaggageEntryMetadata): Baggage = this
+    override fun remove(name: String): Baggage = this
+}

--- a/test-fakes/src/commonMain/kotlin/io/opentelemetry/kotlin/context/FakeContext.kt
+++ b/test-fakes/src/commonMain/kotlin/io/opentelemetry/kotlin/context/FakeContext.kt
@@ -1,4 +1,8 @@
 package io.opentelemetry.kotlin.context
+
+import io.opentelemetry.kotlin.baggage.Baggage
+import io.opentelemetry.kotlin.baggage.FakeBaggage
+
 class FakeContext(
     val attrs: Map<ContextKey<*>, Any?> = emptyMap(),
     private val onAttach: () -> Unit = {},
@@ -17,4 +21,10 @@ class FakeContext(
         onAttach()
         return FakeScope(onDetach)
     }
+
+    override fun storeBaggage(baggage: Baggage): Context = FakeContext(attrs, onAttach, onDetach)
+
+    override fun extractBaggage(): Baggage = FakeBaggage()
+
+    override fun clearBaggage(): Context = FakeContext(attrs, onAttach, onDetach)
 }


### PR DESCRIPTION
## Goal

Implements storage of Baggage on the `Context` object, following the rules in [the spec](https://opentelemetry.io/docs/specs/otel/baggage/api/#context-interaction).