### PR TITLE
Create BaggageFactory implementation

### DIFF
--- a/api/api/jvm/api.api
+++ b/api/api/jvm/api.api
@@ -34,6 +34,15 @@ public abstract interface class io/opentelemetry/kotlin/baggage/Baggage {
 	public abstract fun set (Ljava/lang/String;Ljava/lang/String;Lio/opentelemetry/kotlin/baggage/BaggageEntryMetadata;)Lio/opentelemetry/kotlin/baggage/Baggage;
 }
 
+public abstract interface class io/opentelemetry/kotlin/baggage/BaggageCreationAction {
+	public abstract fun put (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public abstract fun remove (Ljava/lang/String;)V
+}
+
+public final class io/opentelemetry/kotlin/baggage/BaggageCreationAction$DefaultImpls {
+	public static synthetic fun put$default (Lio/opentelemetry/kotlin/baggage/BaggageCreationAction;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)V
+}
+
 public abstract interface class io/opentelemetry/kotlin/baggage/BaggageEntry {
 	public abstract fun getMetadata ()Lio/opentelemetry/kotlin/baggage/BaggageEntryMetadata;
 	public abstract fun getValue ()Ljava/lang/String;
@@ -57,6 +66,11 @@ public abstract interface class io/opentelemetry/kotlin/context/ContextKey {
 
 public abstract interface class io/opentelemetry/kotlin/context/Scope {
 	public abstract fun detach ()Z
+}
+
+public abstract interface class io/opentelemetry/kotlin/factory/BaggageFactory {
+	public abstract fun create (Lkotlin/jvm/functions/Function1;)Lio/opentelemetry/kotlin/baggage/Baggage;
+	public abstract fun empty ()Lio/opentelemetry/kotlin/baggage/Baggage;
 }
 
 public abstract interface class io/opentelemetry/kotlin/factory/ContextFactory {

--- a/api/src/commonMain/kotlin/io/opentelemetry/kotlin/baggage/BaggageCreationAction.kt
+++ b/api/src/commonMain/kotlin/io/opentelemetry/kotlin/baggage/BaggageCreationAction.kt
@@ -1,0 +1,30 @@
+package io.opentelemetry.kotlin.baggage
+
+import io.opentelemetry.kotlin.ExperimentalApi
+
+/**
+ * DSL receiver for assembling a [Baggage] instance.
+ *
+ * Obtained via [io.opentelemetry.kotlin.factory.BaggageFactory.create]; callers configure
+ * entries using [put] and [remove] inside the DSL block. The resulting [Baggage] is returned
+ * by the factory once the block completes.
+ *
+ * https://opentelemetry.io/docs/specs/otel/baggage/api/#baggage-builder
+ */
+@ExperimentalApi
+public interface BaggageCreationAction {
+
+    /**
+     * Adds an entry to the baggage. If [name] already has an entry, its value and
+     * metadata are replaced.
+     *
+     * [metadata] is the raw metadata string per the OpenTelemetry specification; an
+     * empty string indicates no metadata.
+     */
+    public fun put(name: String, value: String, metadata: String = "")
+
+    /**
+     * Removes the entry for [name], if present.
+     */
+    public fun remove(name: String)
+}

--- a/api/src/commonMain/kotlin/io/opentelemetry/kotlin/factory/BaggageFactory.kt
+++ b/api/src/commonMain/kotlin/io/opentelemetry/kotlin/factory/BaggageFactory.kt
@@ -1,0 +1,24 @@
+package io.opentelemetry.kotlin.factory
+
+import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.baggage.Baggage
+import io.opentelemetry.kotlin.baggage.BaggageCreationAction
+
+/**
+ * A factory for creating [Baggage] instances.
+ *
+ * https://opentelemetry.io/docs/specs/otel/baggage/api/
+ */
+@ExperimentalApi
+public interface BaggageFactory {
+
+    /**
+     * Returns the empty [Baggage].
+     */
+    public fun empty(): Baggage
+
+    /**
+     * Creates a [Baggage] by configuring entries inside the [action] DSL block.
+     */
+    public fun create(action: BaggageCreationAction.() -> Unit): Baggage
+}

--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/factory/CompatBaggageFactory.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/factory/CompatBaggageFactory.kt
@@ -1,0 +1,34 @@
+package io.opentelemetry.kotlin.factory
+
+import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.aliases.OtelJavaBaggage
+import io.opentelemetry.kotlin.aliases.OtelJavaBaggageBuilder
+import io.opentelemetry.kotlin.aliases.OtelJavaBaggageEntryMetadata
+import io.opentelemetry.kotlin.baggage.Baggage
+import io.opentelemetry.kotlin.baggage.BaggageAdapter
+import io.opentelemetry.kotlin.baggage.BaggageCreationAction
+
+@OptIn(ExperimentalApi::class)
+internal class CompatBaggageFactory : BaggageFactory {
+
+    override fun empty(): Baggage = BaggageAdapter(OtelJavaBaggage.empty())
+
+    override fun create(action: BaggageCreationAction.() -> Unit): Baggage {
+        val builder = OtelJavaBaggage.builder()
+        BaggageCreationActionAdapter(builder).action()
+        return BaggageAdapter(builder.build())
+    }
+
+    private class BaggageCreationActionAdapter(
+        private val builder: OtelJavaBaggageBuilder,
+    ) : BaggageCreationAction {
+
+        override fun put(name: String, value: String, metadata: String) {
+            builder.put(name, value, OtelJavaBaggageEntryMetadata.create(metadata))
+        }
+
+        override fun remove(name: String) {
+            builder.remove(name)
+        }
+    }
+}

--- a/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/factory/CompatBaggageFactoryTest.kt
+++ b/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/factory/CompatBaggageFactoryTest.kt
@@ -1,0 +1,70 @@
+package io.opentelemetry.kotlin.factory
+
+import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.aliases.OtelJavaBaggage
+import io.opentelemetry.kotlin.baggage.BaggageAdapter
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalApi::class)
+internal class CompatBaggageFactoryTest {
+
+    private val factory = CompatBaggageFactory()
+
+    @Test
+    fun `empty wraps OtelJavaBaggage empty`() {
+        val baggage = factory.empty()
+        assertTrue(baggage is BaggageAdapter)
+        assertEquals(OtelJavaBaggage.empty(), baggage.impl)
+        assertEquals(emptyMap(), baggage.asMap())
+    }
+
+    @Test
+    fun `create put adds entries via java builder`() {
+        val baggage = factory.create {
+            put("user", "alice")
+            put("region", "eu")
+        }
+        assertTrue(baggage is BaggageAdapter)
+        assertEquals("alice", baggage.getValue("user"))
+        assertEquals("eu", baggage.getValue("region"))
+        assertEquals(2, baggage.asMap().size)
+    }
+
+    @Test
+    fun `create put with metadata propagates string`() {
+        val baggage = factory.create {
+            put("foo", "bar", metadata = "secure")
+        }
+        assertEquals("secure", baggage.asMap()["foo"]?.metadata?.value)
+    }
+
+    @Test
+    fun `create put without metadata uses empty metadata`() {
+        val baggage = factory.create {
+            put("foo", "bar")
+        }
+        assertEquals("", baggage.asMap()["foo"]?.metadata?.value)
+    }
+
+    @Test
+    fun `create put replaces existing entry`() {
+        val baggage = factory.create {
+            put("k", "old")
+            put("k", "new")
+        }
+        assertEquals("new", baggage.getValue("k"))
+        assertEquals(1, baggage.asMap().size)
+    }
+
+    @Test
+    fun `create remove deletes prior put`() {
+        val baggage = factory.create {
+            put("k", "v")
+            remove("k")
+        }
+        assertNull(baggage.getValue("k"))
+    }
+}

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/baggage/BaggageImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/baggage/BaggageImpl.kt
@@ -3,7 +3,7 @@ package io.opentelemetry.kotlin.baggage
 import io.opentelemetry.kotlin.ExperimentalApi
 
 @OptIn(ExperimentalApi::class)
-internal class BaggageImpl private constructor(
+internal class BaggageImpl(
     private val entries: Map<String, BaggageEntry>,
 ) : Baggage {
 

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/factory/BaggageFactoryImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/factory/BaggageFactoryImpl.kt
@@ -1,0 +1,39 @@
+package io.opentelemetry.kotlin.factory
+
+import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.baggage.Baggage
+import io.opentelemetry.kotlin.baggage.BaggageCreationAction
+import io.opentelemetry.kotlin.baggage.BaggageEntry
+import io.opentelemetry.kotlin.baggage.BaggageEntryImpl
+import io.opentelemetry.kotlin.baggage.BaggageEntryMetadataImpl
+import io.opentelemetry.kotlin.baggage.BaggageImpl
+
+@OptIn(ExperimentalApi::class)
+internal class BaggageFactoryImpl : BaggageFactory {
+
+    override fun empty(): Baggage = BaggageImpl.EMPTY
+
+    override fun create(action: BaggageCreationAction.() -> Unit): Baggage {
+        val builder = BaggageCreationActionImpl()
+        builder.action()
+        return builder.build()
+    }
+
+    private class BaggageCreationActionImpl : BaggageCreationAction {
+
+        private val entries: MutableMap<String, BaggageEntry> = mutableMapOf()
+
+        override fun put(name: String, value: String, metadata: String) {
+            entries[name] = BaggageEntryImpl(value, BaggageEntryMetadataImpl(metadata))
+        }
+
+        override fun remove(name: String) {
+            entries.remove(name)
+        }
+
+        fun build(): Baggage = when {
+            entries.isEmpty() -> BaggageImpl.EMPTY
+            else -> BaggageImpl(entries.toMap())
+        }
+    }
+}

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/factory/BaggageFactoryImplTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/factory/BaggageFactoryImplTest.kt
@@ -1,0 +1,80 @@
+package io.opentelemetry.kotlin.factory
+
+import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.baggage.BaggageImpl
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertSame
+
+@OptIn(ExperimentalApi::class)
+internal class BaggageFactoryImplTest {
+
+    private val factory = BaggageFactoryImpl()
+
+    @Test
+    fun `empty returns the shared empty Baggage`() {
+        assertSame(BaggageImpl.EMPTY, factory.empty())
+        assertEquals(emptyMap(), factory.empty().asMap())
+    }
+
+    @Test
+    fun `create with no operations returns empty`() {
+        assertSame(BaggageImpl.EMPTY, factory.create { })
+    }
+
+    @Test
+    fun `create put adds entries`() {
+        val baggage = factory.create {
+            put("user", "alice")
+            put("region", "eu")
+        }
+        assertEquals("alice", baggage.getValue("user"))
+        assertEquals("eu", baggage.getValue("region"))
+        assertEquals(2, baggage.asMap().size)
+    }
+
+    @Test
+    fun `create put with metadata propagates string`() {
+        val baggage = factory.create {
+            put("foo", "bar", metadata = "secure")
+        }
+        assertEquals("secure", baggage.asMap()["foo"]?.metadata?.value)
+    }
+
+    @Test
+    fun `create put without metadata uses empty metadata`() {
+        val baggage = factory.create {
+            put("foo", "bar")
+        }
+        assertEquals("", baggage.asMap()["foo"]?.metadata?.value)
+    }
+
+    @Test
+    fun `create put replaces existing entry`() {
+        val baggage = factory.create {
+            put("k", "old")
+            put("k", "new")
+        }
+        assertEquals("new", baggage.getValue("k"))
+        assertEquals(1, baggage.asMap().size)
+    }
+
+    @Test
+    fun `create remove deletes prior put`() {
+        val baggage = factory.create {
+            put("k", "v")
+            remove("k")
+        }
+        assertNull(baggage.getValue("k"))
+    }
+
+    @Test
+    fun `create remove of absent key is a no-op`() {
+        val baggage = factory.create {
+            put("k", "v")
+            remove("missing")
+        }
+        assertEquals("v", baggage.getValue("k"))
+    }
+}

--- a/java-typealiases/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/aliases/Aliases.kt
+++ b/java-typealiases/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/aliases/Aliases.kt
@@ -4,6 +4,7 @@ package io.opentelemetry.kotlin.aliases
 
 import io.opentelemetry.api.OpenTelemetry
 import io.opentelemetry.api.baggage.Baggage
+import io.opentelemetry.api.baggage.BaggageBuilder
 import io.opentelemetry.api.baggage.BaggageEntry
 import io.opentelemetry.api.baggage.BaggageEntryMetadata
 import io.opentelemetry.api.common.AttributeKey
@@ -65,6 +66,7 @@ import io.opentelemetry.sdk.trace.samplers.SamplingDecision
 import io.opentelemetry.sdk.trace.samplers.SamplingResult
 
 typealias OtelJavaBaggage = Baggage
+typealias OtelJavaBaggageBuilder = BaggageBuilder
 typealias OtelJavaBaggageEntry = BaggageEntry
 typealias OtelJavaBaggageEntryMetadata = BaggageEntryMetadata
 typealias OtelJavaAttributes = Attributes

--- a/noop/src/commonMain/kotlin/io/opentelemetry/kotlin/factory/NoopBaggageFactory.kt
+++ b/noop/src/commonMain/kotlin/io/opentelemetry/kotlin/factory/NoopBaggageFactory.kt
@@ -1,0 +1,14 @@
+package io.opentelemetry.kotlin.factory
+
+import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.baggage.Baggage
+import io.opentelemetry.kotlin.baggage.BaggageCreationAction
+import io.opentelemetry.kotlin.baggage.NoopBaggage
+
+@OptIn(ExperimentalApi::class)
+internal object NoopBaggageFactory : BaggageFactory {
+
+    override fun empty(): Baggage = NoopBaggage
+
+    override fun create(action: BaggageCreationAction.() -> Unit): Baggage = NoopBaggage
+}

--- a/noop/src/commonTest/kotlin/io/opentelemetry/kotlin/NoopTests.kt
+++ b/noop/src/commonTest/kotlin/io/opentelemetry/kotlin/NoopTests.kt
@@ -1,7 +1,9 @@
 package io.opentelemetry.kotlin
 
+import io.opentelemetry.kotlin.baggage.NoopBaggage
 import io.opentelemetry.kotlin.context.NoopContext
 import io.opentelemetry.kotlin.context.NoopContextKey
+import io.opentelemetry.kotlin.factory.NoopBaggageFactory
 import io.opentelemetry.kotlin.logging.SeverityNumber
 import io.opentelemetry.kotlin.propagation.NoopPropagatorFactory
 import io.opentelemetry.kotlin.propagation.NoopTextMapPropagator
@@ -245,6 +247,12 @@ internal class NoopTests {
     fun testNoopPropagatorFactory() {
         assertSame(NoopTextMapPropagator, NoopPropagatorFactory.composite(NoopTextMapPropagator))
         assertSame(NoopTextMapPropagator, NoopPropagatorFactory.composite(listOf(NoopTextMapPropagator)))
+    }
+
+    @Test
+    fun testNoopBaggageFactory() {
+        assertSame(NoopBaggage, NoopBaggageFactory.empty())
+        assertSame(NoopBaggage, NoopBaggageFactory.create { })
     }
 
     private fun verifySpanOperationsAreNoop(span: NoopSpan) {

--- a/test-fakes/src/commonMain/kotlin/io/opentelemetry/kotlin/factory/FakeBaggageFactory.kt
+++ b/test-fakes/src/commonMain/kotlin/io/opentelemetry/kotlin/factory/FakeBaggageFactory.kt
@@ -1,0 +1,20 @@
+package io.opentelemetry.kotlin.factory
+
+import io.opentelemetry.kotlin.baggage.Baggage
+import io.opentelemetry.kotlin.baggage.BaggageCreationAction
+import io.opentelemetry.kotlin.baggage.FakeBaggage
+
+class FakeBaggageFactory : BaggageFactory {
+
+    override fun empty(): Baggage = FakeBaggage()
+
+    override fun create(action: BaggageCreationAction.() -> Unit): Baggage {
+        FakeBaggageCreationAction.action()
+        return FakeBaggage()
+    }
+
+    private object FakeBaggageCreationAction : BaggageCreationAction {
+        override fun put(name: String, value: String, metadata: String) = Unit
+        override fun remove(name: String) = Unit
+    }
+}


### PR DESCRIPTION
## Goal

Creates a `BaggageFactory` interface and implementations for both modes. This is required for constructing Baggage that can be injected/extracted from the `Context`. I haven't exposed this on the `OpenTelemetry` entrypoint yet, that will come in a future PR. 

## Testing

Added unit tests.
