### PR TITLE
Implement W3CBaggagePropagator

### DIFF
--- a/api/api/jvm/api.api
+++ b/api/api/jvm/api.api
@@ -152,6 +152,7 @@ public final class io/opentelemetry/kotlin/metrics/MeterProvider$DefaultImpls {
 public abstract interface class io/opentelemetry/kotlin/propagation/PropagatorFactory {
 	public abstract fun composite (Ljava/util/List;)Lio/opentelemetry/kotlin/propagation/TextMapPropagator;
 	public abstract fun composite ([Lio/opentelemetry/kotlin/propagation/TextMapPropagator;)Lio/opentelemetry/kotlin/propagation/TextMapPropagator;
+	public abstract fun w3cBaggage ()Lio/opentelemetry/kotlin/propagation/TextMapPropagator;
 }
 
 public abstract interface class io/opentelemetry/kotlin/propagation/TextMapGetter {

--- a/api/src/commonMain/kotlin/io/opentelemetry/kotlin/propagation/PropagatorFactory.kt
+++ b/api/src/commonMain/kotlin/io/opentelemetry/kotlin/propagation/PropagatorFactory.kt
@@ -23,4 +23,12 @@ public interface PropagatorFactory {
      * https://opentelemetry.io/docs/specs/otel/context/api-propagators/#composite-propagator
      */
     public fun composite(propagators: List<TextMapPropagator>): TextMapPropagator
+
+    /**
+     * Returns a [TextMapPropagator] that injects and extracts [io.opentelemetry.kotlin.baggage.Baggage]
+     * via the W3C `baggage` HTTP header.
+     *
+     * https://www.w3.org/TR/baggage/
+     */
+    public fun w3cBaggage(): TextMapPropagator
 }

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/propagation/PropagatorFactoryImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/propagation/PropagatorFactoryImpl.kt
@@ -18,6 +18,8 @@ internal class PropagatorFactoryImpl : PropagatorFactory {
         }
     }
 
+    override fun w3cBaggage(): TextMapPropagator = W3CBaggagePropagator
+
     private object EmptyTextMapPropagator : TextMapPropagator {
         override fun fields(): Collection<String> = emptyList()
         override fun <T> inject(context: Context, carrier: T, setter: TextMapSetter<T>) {}

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/propagation/W3CBaggagePropagator.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/propagation/W3CBaggagePropagator.kt
@@ -1,0 +1,253 @@
+package io.opentelemetry.kotlin.propagation
+
+import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.baggage.Baggage
+import io.opentelemetry.kotlin.baggage.BaggageEntry
+import io.opentelemetry.kotlin.baggage.BaggageEntryMetadataImpl
+import io.opentelemetry.kotlin.baggage.BaggageImpl
+import io.opentelemetry.kotlin.context.Context
+
+/**
+ * W3C Baggage HTTP header propagator.
+ *
+ * https://www.w3.org/TR/baggage/
+ */
+@OptIn(ExperimentalApi::class)
+internal object W3CBaggagePropagator : TextMapPropagator {
+
+    private const val FIELD = "baggage"
+    private const val ENTRY_DELIMITER = ','
+    private const val KEY_VALUE_DELIMITER = '='
+    private const val METADATA_DELIMITER = ';'
+    private const val PERCENT_CHAR = '%'
+    private const val SPACE = ' '
+    private const val HTAB = '\t'
+    private const val MAX_HEADER_BYTES = 8192
+    private const val MAX_ENTRY_BYTES = 4096
+    private const val MAX_ENTRIES = 180
+
+    private val FIELDS = listOf(FIELD)
+
+    override fun fields(): Collection<String> = FIELDS
+
+    override fun <T> inject(context: Context, carrier: T, setter: TextMapSetter<T>) {
+        val entries = context.extractBaggage().asMap()
+        if (entries.isEmpty()) {
+            return
+        }
+        val header = encode(entries) ?: return
+        setter.set(carrier, FIELD, header)
+    }
+
+    override fun <T> extract(context: Context, carrier: T, getter: TextMapGetter<T>): Context {
+        val header = getter.get(carrier, FIELD) ?: return context
+        val baggage = decode(header) ?: return context
+        return context.storeBaggage(baggage)
+    }
+
+    private fun encode(entries: Map<String, BaggageEntry>): String? {
+        val builder = StringBuilder()
+        var count = 0
+        for ((name, entry) in entries) {
+            if (count >= MAX_ENTRIES) {
+                break
+            }
+            val piece = encodeIfFits(name, entry, builder.length)
+            if (piece != null) {
+                if (builder.isNotEmpty()) {
+                    builder.append(ENTRY_DELIMITER)
+                }
+                builder.append(piece)
+                count++
+            }
+        }
+        return builder.takeIf(StringBuilder::isNotEmpty)?.toString()
+    }
+
+    private fun encodeIfFits(name: String, entry: BaggageEntry, currentLength: Int): String? {
+        if (!isValidToken(name)) {
+            return null
+        }
+        val piece = encodeEntry(name, entry.value, entry.metadata.value)
+        if (piece.length > MAX_ENTRY_BYTES) {
+            return null
+        }
+        val separator = when (currentLength) {
+            0 -> 0
+            else -> 1
+        }
+        if (currentLength + separator + piece.length > MAX_HEADER_BYTES) {
+            return null
+        }
+        return piece
+    }
+
+    private fun encodeEntry(key: String, value: String, metadata: String): String {
+        val sb = StringBuilder()
+        sb.append(key).append(KEY_VALUE_DELIMITER).append(percentEncode(value))
+        if (metadata.isNotEmpty()) {
+            sb.append(METADATA_DELIMITER).append(metadata)
+        }
+        return sb.toString()
+    }
+
+    private fun decode(header: String): Baggage? {
+        var baggage: Baggage = BaggageImpl.EMPTY
+        var added = false
+        for (rawElement in header.split(ENTRY_DELIMITER)) {
+            val parsed = parseElement(rawElement)
+            if (parsed != null) {
+                baggage = baggage.set(parsed.key, parsed.value, BaggageEntryMetadataImpl(parsed.metadata))
+                added = true
+            }
+        }
+        return baggage.takeIf { added }
+    }
+
+    private fun parseElement(rawElement: String): ParsedEntry? {
+        val element = rawElement.trim(SPACE, HTAB)
+        if (element.isEmpty()) {
+            return null
+        }
+        return decodeEntry(element)
+    }
+
+    private fun decodeEntry(element: String): ParsedEntry? {
+        val firstSemi = element.indexOf(METADATA_DELIMITER)
+        val keyValuePart: String
+        val metadata: String
+        if (firstSemi == -1) {
+            keyValuePart = element
+            metadata = ""
+        } else {
+            keyValuePart = element.substring(0, firstSemi)
+            metadata = element.substring(firstSemi + 1)
+        }
+        val eq = keyValuePart.indexOf(KEY_VALUE_DELIMITER)
+        if (eq <= 0) {
+            return null
+        }
+        val key = keyValuePart.substring(0, eq).trim(SPACE, HTAB)
+        val rawValue = keyValuePart.substring(eq + 1).trim(SPACE, HTAB)
+        if (key.isEmpty() || !isValidToken(key)) {
+            return null
+        }
+        val value = percentDecode(rawValue) ?: return null
+        return ParsedEntry(key, value, metadata.trim(SPACE, HTAB))
+    }
+
+    private class ParsedEntry(val key: String, val value: String, val metadata: String)
+
+    /**
+     * Percent-encode bytes outside `baggage-octet`. The `%` byte is also encoded so the
+     * decoder can unambiguously distinguish literals from `%HH` sequences.
+     *
+     * baggage-octet = %x21 / %x23-2B / %x2D-3A / %x3C-5B / %x5D-7E
+     */
+    private fun percentEncode(value: String): String {
+        val sb = StringBuilder(value.length)
+        for (byte in value.encodeToByteArray()) {
+            val b = byte.toInt() and BYTE_MASK
+            if (b == PERCENT || !isBaggageOctet(b)) {
+                sb.append(PERCENT_CHAR)
+                sb.append(HEX[b ushr HEX_SHIFT])
+                sb.append(HEX[b and HEX_MASK])
+            } else {
+                sb.append(b.toChar())
+            }
+        }
+        return sb.toString()
+    }
+
+    private fun percentDecode(value: String): String? {
+        if (!value.contains(PERCENT_CHAR)) {
+            return value
+        }
+        val bytes = ByteArray(value.length)
+        var pos = 0
+        var i = 0
+        while (i < value.length) {
+            val c = value[i]
+            if (c == PERCENT_CHAR) {
+                val decoded = decodeHexPair(value, i) ?: return null
+                bytes[pos++] = decoded.toByte()
+                i += PERCENT_SEQUENCE_LENGTH
+            } else {
+                bytes[pos++] = c.code.toByte()
+                i++
+            }
+        }
+        return bytes.decodeToString(0, pos)
+    }
+
+    private fun decodeHexPair(value: String, start: Int): Int? {
+        if (start + 2 >= value.length) {
+            return null
+        }
+        val hi = hexDigit(value[start + 1])
+        val lo = hexDigit(value[start + 2])
+        if (hi < 0 || lo < 0) {
+            return null
+        }
+        return (hi shl HEX_SHIFT) or lo
+    }
+
+    private fun isBaggageOctet(b: Int): Boolean = when (b) {
+        OCTET_EXCLAIM -> true
+        in OCTET_HASH..OCTET_PLUS -> true
+        in OCTET_DASH..OCTET_COLON -> true
+        in OCTET_LT..OCTET_LBRACKET -> true
+        in OCTET_RBRACKET..OCTET_TILDE -> true
+        else -> false
+    }
+
+    /**
+     * RFC 7230 token: 1*tchar.
+     * tchar = "!" / "#" / "$" / "%" / "&" / "'" / "*" / "+" / "-" / "." / "^" / "_" / "`" / "|" / "~" / DIGIT / ALPHA
+     */
+    private fun isValidToken(name: String): Boolean {
+        if (name.isEmpty()) {
+            return false
+        }
+        return name.all(::isTChar)
+    }
+
+    private fun isTChar(c: Char): Boolean {
+        if (c in 'a'..'z' || c in 'A'..'Z' || c in '0'..'9') {
+            return true
+        }
+        return c in TCHAR_SPECIALS
+    }
+
+    private fun hexDigit(c: Char): Int = when (c) {
+        in '0'..'9' -> c - '0'
+        in 'a'..'f' -> c - 'a' + DECIMAL_BASE
+        in 'A'..'F' -> c - 'A' + DECIMAL_BASE
+        else -> -1
+    }
+
+    private const val PERCENT = 0x25
+    private const val BYTE_MASK = 0xFF
+    private const val HEX_SHIFT = 4
+    private const val HEX_MASK = 0xF
+    private const val DECIMAL_BASE = 10
+    private const val PERCENT_SEQUENCE_LENGTH = 3
+    private const val OCTET_EXCLAIM = 0x21
+    private const val OCTET_HASH = 0x23
+    private const val OCTET_PLUS = 0x2B
+    private const val OCTET_DASH = 0x2D
+    private const val OCTET_COLON = 0x3A
+    private const val OCTET_LT = 0x3C
+    private const val OCTET_LBRACKET = 0x5B
+    private const val OCTET_RBRACKET = 0x5D
+    private const val OCTET_TILDE = 0x7E
+
+    private val HEX = charArrayOf(
+        '0', '1', '2', '3', '4', '5', '6', '7',
+        '8', '9', 'A', 'B', 'C', 'D', 'E', 'F',
+    )
+
+    private val TCHAR_SPECIALS = setOf(
+        '!', '#', '$', '%', '&', '\'', '*', '+', '-', '.', '^', '_', '`', '|', '~',
+    )
+}

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/propagation/PropagatorFactoryImplTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/propagation/PropagatorFactoryImplTest.kt
@@ -78,6 +78,11 @@ internal class PropagatorFactoryImplTest {
     }
 
     @Test
+    fun `w3cBaggage returns the W3C baggage propagator`() {
+        assertSame(W3CBaggagePropagator, factory.w3cBaggage())
+    }
+
+    @Test
     fun `vararg and list overloads behave identically`() {
         val a = RecordingPropagator(listOf("a"))
         val b = RecordingPropagator(listOf("b"))

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/propagation/W3CBaggagePropagatorTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/propagation/W3CBaggagePropagatorTest.kt
@@ -1,0 +1,277 @@
+package io.opentelemetry.kotlin.propagation
+
+import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.baggage.Baggage
+import io.opentelemetry.kotlin.baggage.BaggageEntryMetadataImpl
+import io.opentelemetry.kotlin.baggage.BaggageImpl
+import io.opentelemetry.kotlin.context.Context
+import io.opentelemetry.kotlin.factory.ContextFactoryImpl
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalApi::class)
+internal class W3CBaggagePropagatorTest {
+
+    private val propagator = W3CBaggagePropagator
+    private val contextFactory = ContextFactoryImpl()
+
+    @Test
+    fun `fields returns only the baggage header`() {
+        assertEquals(listOf("baggage"), propagator.fields().toList())
+    }
+
+    @Test
+    fun `inject does nothing when baggage is empty`() {
+        val carrier = mutableMapOf<String, String>()
+        propagator.inject(contextFactory.root(), carrier, MapTextMapSetter)
+        assertTrue(carrier.isEmpty())
+    }
+
+    @Test
+    fun `inject writes a single entry`() {
+        val carrier = injectInto(BaggageImpl.EMPTY.set("k", "v"))
+        assertEquals("k=v", carrier["baggage"])
+    }
+
+    @Test
+    fun `inject preserves entry insertion order`() {
+        val baggage = BaggageImpl.EMPTY.set("a", "1").set("b", "2").set("c", "3")
+        val carrier = injectInto(baggage)
+        assertEquals("a=1,b=2,c=3", carrier["baggage"])
+    }
+
+    @Test
+    fun `inject percent-encodes reserved characters in value`() {
+        val baggage = BaggageImpl.EMPTY.set("k", "hello world,with;chars")
+        val carrier = injectInto(baggage)
+        assertEquals("k=hello%20world%2Cwith%3Bchars", carrier["baggage"])
+    }
+
+    @Test
+    fun `inject percent-encodes the percent character`() {
+        val baggage = BaggageImpl.EMPTY.set("k", "100%")
+        val carrier = injectInto(baggage)
+        assertEquals("k=100%25", carrier["baggage"])
+    }
+
+    @Test
+    fun `inject percent-encodes utf-8 multibyte characters`() {
+        val baggage = BaggageImpl.EMPTY.set("k", "café")
+        val carrier = injectInto(baggage)
+        assertEquals("k=caf%C3%A9", carrier["baggage"])
+    }
+
+    @Test
+    fun `inject appends metadata when non-empty`() {
+        val baggage = BaggageImpl.EMPTY.set("k", "v", BaggageEntryMetadataImpl("propagation=public"))
+        val carrier = injectInto(baggage)
+        assertEquals("k=v;propagation=public", carrier["baggage"])
+    }
+
+    @Test
+    fun `inject omits metadata separator when metadata is empty`() {
+        val baggage = BaggageImpl.EMPTY.set("k", "v", BaggageEntryMetadataImpl(""))
+        val carrier = injectInto(baggage)
+        assertEquals("k=v", carrier["baggage"])
+    }
+
+    @Test
+    fun `inject skips entry whose key is not a valid token`() {
+        val baggage = BaggageImpl.EMPTY.set("good", "g").set("bad key", "b")
+        val carrier = injectInto(baggage)
+        assertEquals("good=g", carrier["baggage"])
+    }
+
+    @Test
+    fun `inject skips entry whose serialized form exceeds per-entry limit`() {
+        val oversize = "x".repeat(5000)
+        val baggage = BaggageImpl.EMPTY.set("ok", "v").set("big", oversize)
+        val carrier = injectInto(baggage)
+        assertEquals("ok=v", carrier["baggage"])
+    }
+
+    @Test
+    fun `inject truncates when total header would exceed 8192 bytes`() {
+        val builder = (0 until 20).fold(BaggageImpl.EMPTY) { acc, idx ->
+            acc.set("k$idx", "v".repeat(500))
+        }
+        val carrier = injectInto(builder)
+        val header = carrier["baggage"]
+        assertTrue(header != null)
+        assertTrue(header.length <= 8192)
+        assertTrue(header.startsWith("k0=vv"))
+    }
+
+    @Test
+    fun `inject does not write header when nothing fits`() {
+        val baggage = BaggageImpl.EMPTY.set("oversized", "x".repeat(5000))
+        val carrier = injectInto(baggage)
+        assertTrue(carrier.isEmpty())
+    }
+
+    @Test
+    fun `inject caps at 180 entries even when bytes remain`() {
+        val baggage = (0 until 181).fold(BaggageImpl.EMPTY) { acc, idx ->
+            acc.set("k$idx", "v")
+        }
+        val carrier = injectInto(baggage)
+        val header = carrier["baggage"]
+        assertNotNull(header)
+        assertEquals(180, header.split(",").size)
+    }
+
+    @Test
+    fun `inject skips entry with empty name`() {
+        val baggage = BaggageImpl.EMPTY.set("", "v").set("ok", "g")
+        val carrier = injectInto(baggage)
+        assertEquals("ok=g", carrier["baggage"])
+    }
+
+    @Test
+    fun `inject preserves baggage-octets in the hash-to-plus range`() {
+        val baggage = BaggageImpl.EMPTY.set("k", "#\$&'()*+")
+        val carrier = injectInto(baggage)
+        assertEquals("k=#\$&'()*+", carrier["baggage"])
+    }
+
+    @Test
+    fun `inject preserves uppercase token characters in keys`() {
+        val baggage = BaggageImpl.EMPTY.set("X-Trace-Id", "v")
+        val carrier = injectInto(baggage)
+        assertEquals("X-Trace-Id=v", carrier["baggage"])
+    }
+
+    @Test
+    fun `extract returns original context when header is absent`() {
+        val ctx = contextFactory.root()
+        val result = propagator.extract(ctx, emptyMap(), MapTextMapGetter)
+        assertSame(ctx, result)
+    }
+
+    @Test
+    fun `extract parses a single entry`() {
+        val baggage = extract("k=v")
+        assertEquals("v", baggage.getValue("k"))
+    }
+
+    @Test
+    fun `extract parses multiple comma-separated entries`() {
+        val baggage = extract("a=1,b=2,c=3")
+        assertEquals("1", baggage.getValue("a"))
+        assertEquals("2", baggage.getValue("b"))
+        assertEquals("3", baggage.getValue("c"))
+    }
+
+    @Test
+    fun `extract trims optional whitespace around delimiters`() {
+        val baggage = extract(" a = 1 , b = 2 ")
+        assertEquals("1", baggage.getValue("a"))
+        assertEquals("2", baggage.getValue("b"))
+    }
+
+    @Test
+    fun `extract decodes percent-encoded utf-8 values`() {
+        val baggage = extract("k=caf%C3%A9")
+        assertEquals("café", baggage.getValue("k"))
+    }
+
+    @Test
+    fun `extract preserves metadata opaquely`() {
+        val baggage = extract("k=v;propagation=public;ttl=1")
+        assertEquals("v", baggage.getValue("k"))
+        assertEquals("propagation=public;ttl=1", baggage.asMap()["k"]?.metadata?.value)
+    }
+
+    @Test
+    fun `extract skips malformed entries but keeps valid ones`() {
+        val baggage = extract("ok=v,=missingkey,no-equals,=,k2=v2")
+        assertEquals("v", baggage.getValue("ok"))
+        assertEquals("v2", baggage.getValue("k2"))
+        assertNull(baggage.getValue(""))
+        assertEquals(2, baggage.asMap().size)
+    }
+
+    @Test
+    fun `extract returns original context when all entries are malformed`() {
+        val ctx = contextFactory.root()
+        val result = propagator.extract(ctx, mapOf("baggage" to "=,;,no-equals"), MapTextMapGetter)
+        assertSame(ctx, result)
+    }
+
+    @Test
+    fun `extract returns original context for invalid percent encoding`() {
+        val ctx = contextFactory.root()
+        val result = propagator.extract(ctx, mapOf("baggage" to "k=%ZZ"), MapTextMapGetter)
+        assertSame(ctx, result)
+    }
+
+    @Test
+    fun `extract skips empty element between commas`() {
+        val baggage = extract("a=1,,b=2")
+        assertEquals("1", baggage.getValue("a"))
+        assertEquals("2", baggage.getValue("b"))
+        assertEquals(2, baggage.asMap().size)
+    }
+
+    @Test
+    fun `extract skips entry whose key contains an invalid token character`() {
+        val baggage = extract("bad key=v,ok=g")
+        assertNull(baggage.getValue("bad key"))
+        assertEquals("g", baggage.getValue("ok"))
+        assertEquals(1, baggage.asMap().size)
+    }
+
+    @Test
+    fun `extract returns original context for truncated percent encoding`() {
+        val ctx = contextFactory.root()
+        val result = propagator.extract(ctx, mapOf("baggage" to "k=%A"), MapTextMapGetter)
+        assertSame(ctx, result)
+    }
+
+    @Test
+    fun `extract returns original context when only the low hex digit is invalid`() {
+        val ctx = contextFactory.root()
+        val result = propagator.extract(ctx, mapOf("baggage" to "k=%AZ"), MapTextMapGetter)
+        assertSame(ctx, result)
+    }
+
+    @Test
+    fun `extract decodes percent-encoded values with lowercase hex`() {
+        val baggage = extract("k=caf%c3%a9")
+        assertEquals("café", baggage.getValue("k"))
+    }
+
+    @Test
+    fun `inject and extract round-trip preserves entries and metadata`() {
+        val original = BaggageImpl.EMPTY
+            .set("user.id", "alice", BaggageEntryMetadataImpl("propagation=public"))
+            .set("session", "café 1!2@3")
+        val carrier = injectInto(original)
+
+        val ctx = contextFactory.root()
+        val extracted = propagator.extract(ctx, carrier, MapTextMapGetter).extractBaggage()
+        assertEquals("alice", extracted.getValue("user.id"))
+        assertEquals("propagation=public", extracted.asMap()["user.id"]?.metadata?.value)
+        assertEquals("café 1!2@3", extracted.getValue("session"))
+    }
+
+    private fun injectInto(baggage: Baggage): MutableMap<String, String> {
+        val carrier = mutableMapOf<String, String>()
+        val ctx: Context = contextFactory.root().storeBaggage(baggage)
+        propagator.inject(ctx, carrier, MapTextMapSetter)
+        return carrier
+    }
+
+    private fun extract(header: String): Baggage {
+        val ctx = propagator.extract(
+            contextFactory.root(),
+            mapOf("baggage" to header),
+            MapTextMapGetter,
+        )
+        return ctx.extractBaggage()
+    }
+}

--- a/noop/src/commonMain/kotlin/io/opentelemetry/kotlin/propagation/NoopPropagatorFactory.kt
+++ b/noop/src/commonMain/kotlin/io/opentelemetry/kotlin/propagation/NoopPropagatorFactory.kt
@@ -10,4 +10,6 @@ internal object NoopPropagatorFactory : PropagatorFactory {
 
     override fun composite(propagators: List<TextMapPropagator>): TextMapPropagator =
         NoopTextMapPropagator
+
+    override fun w3cBaggage(): TextMapPropagator = NoopTextMapPropagator
 }

--- a/noop/src/commonTest/kotlin/io/opentelemetry/kotlin/NoopTests.kt
+++ b/noop/src/commonTest/kotlin/io/opentelemetry/kotlin/NoopTests.kt
@@ -245,6 +245,7 @@ internal class NoopTests {
     fun testNoopPropagatorFactory() {
         assertSame(NoopTextMapPropagator, NoopPropagatorFactory.composite(NoopTextMapPropagator))
         assertSame(NoopTextMapPropagator, NoopPropagatorFactory.composite(listOf(NoopTextMapPropagator)))
+        assertSame(NoopTextMapPropagator, NoopPropagatorFactory.w3cBaggage())
     }
 
     private fun verifySpanOperationsAreNoop(span: NoopSpan) {


### PR DESCRIPTION
## Goal

Adds an implementation for the W3CBaggagePropagator as defined in the spec: https://opentelemetry.io/docs/specs/otel/context/api-propagators/#propagators-distribution

## Testing

Added unit tests.