### PR TITLE
Add traceparent implementation

### DIFF
--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/propagation/TraceParent.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/propagation/TraceParent.kt
@@ -1,0 +1,109 @@
+package io.opentelemetry.kotlin.propagation
+
+import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.factory.TraceFlagsFactory
+import io.opentelemetry.kotlin.tracing.TraceFlags
+
+/**
+ * Implementation of a W3C `traceparent` header.
+ *
+ * https://www.w3.org/TR/trace-context/#traceparent-header
+ */
+@OptIn(ExperimentalApi::class)
+internal class TraceParent(
+    val version: String,
+    val traceId: String,
+    val spanId: String,
+    val traceFlags: TraceFlags,
+) {
+
+    init {
+        require(version.length == VERSION_LEN && version.isLowerHex()) {
+            "version must be $VERSION_LEN lowercase hex characters"
+        }
+        require(version != FORBIDDEN_VERSION) {
+            "version $FORBIDDEN_VERSION is reserved by the W3C spec"
+        }
+        require(traceId.length == TRACE_ID_LEN && traceId.isLowerHex()) {
+            "traceId must be $TRACE_ID_LEN lowercase hex characters"
+        }
+        require(spanId.length == SPAN_ID_LEN && spanId.isLowerHex()) {
+            "spanId must be $SPAN_ID_LEN lowercase hex characters"
+        }
+    }
+
+    fun encode(): String = buildString {
+        append(version)
+        append(FIELD_SEPARATOR)
+        append(traceId)
+        append(FIELD_SEPARATOR)
+        append(spanId)
+        append(FIELD_SEPARATOR)
+        append(encodeFlags(traceFlags))
+    }
+
+    companion object {
+        const val VERSION_00: String = "00"
+
+        private const val FORBIDDEN_VERSION = "ff"
+        private const val VERSION_LEN = 2
+        private const val TRACE_ID_LEN = 32
+        private const val SPAN_ID_LEN = 16
+        private const val FLAGS_LEN = 2
+        private const val LEN_V00 = 55
+        private const val EXPECTED_FIELD_COUNT = 4
+        private const val FIELD_SEPARATOR = '-'
+        private const val FLAG_SAMPLED = 0b0000_0001
+        private const val FLAG_RANDOM = 0b0000_0010
+        private const val HEX_RADIX = 16
+
+        fun decode(header: String, traceFlagsFactory: TraceFlagsFactory): TraceParent? {
+            if (header.length < LEN_V00) {
+                return null
+            }
+            if (header.any { it.isUpperCase() }) {
+                return null
+            }
+
+            val parts = header.split(FIELD_SEPARATOR)
+            if (parts.size < EXPECTED_FIELD_COUNT) {
+                return null
+            }
+
+            val version = parts[0]
+            if (version == VERSION_00 && (parts.size != EXPECTED_FIELD_COUNT || header.length != LEN_V00)) {
+                // strict for version 00: exactly 4 fields and exactly 55 chars.
+                return null
+            }
+
+            val flagsStr = parts[3]
+            if (flagsStr.length != FLAGS_LEN || !flagsStr.isLowerHex()) {
+                return null
+            }
+
+            return try {
+                TraceParent(
+                    version = version,
+                    traceId = parts[1],
+                    spanId = parts[2],
+                    traceFlags = traceFlagsFactory.fromHex(flagsStr),
+                )
+            } catch (_: IllegalArgumentException) {
+                null
+            }
+        }
+
+        private fun encodeFlags(flags: TraceFlags): String {
+            var byte = 0
+            if (flags.isSampled) {
+                byte = byte or FLAG_SAMPLED
+            }
+            if (flags.isRandom) {
+                byte = byte or FLAG_RANDOM
+            }
+            return byte.toString(HEX_RADIX).padStart(FLAGS_LEN, '0')
+        }
+
+        private fun String.isLowerHex(): Boolean = all { it in '0'..'9' || it in 'a'..'f' }
+    }
+}

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/propagation/TraceParentTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/propagation/TraceParentTest.kt
@@ -1,0 +1,400 @@
+package io.opentelemetry.kotlin.propagation
+
+import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.factory.TraceFlagsFactoryImpl
+import io.opentelemetry.kotlin.tracing.TraceFlagsImpl
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Asserts behaviour against the W3C `traceparent` spec:
+ * https://www.w3.org/TR/trace-context/#traceparent-header
+ */
+@OptIn(ExperimentalApi::class)
+internal class TraceParentTest {
+
+    private val flagsFactory = TraceFlagsFactoryImpl()
+    private val traceId = "0af7651916cd43dd8448eb211c80319c"
+    private val spanId = "b7ad6b7169203331"
+    private val canonicalHeader = "00-$traceId-$spanId-01"
+
+    @Test
+    fun `encode produces the canonical version 00 traceparent header`() {
+        val tp = TraceParent(
+            version = "00",
+            traceId = traceId,
+            spanId = spanId,
+            traceFlags = TraceFlagsImpl(isSampled = true, isRandom = false),
+        )
+        assertEquals(canonicalHeader, tp.encode())
+    }
+
+    @Test
+    fun `encoded header is exactly 55 chars for version 00`() {
+        val tp = TraceParent(
+            version = "00",
+            traceId = traceId,
+            spanId = spanId,
+            traceFlags = TraceFlagsImpl(isSampled = true, isRandom = false),
+        )
+        assertEquals(55, tp.encode().length)
+    }
+
+    @Test
+    fun `encode renders flags 00 when neither sampled nor random`() {
+        val tp = TraceParent(
+            version = "00",
+            traceId = traceId,
+            spanId = spanId,
+            traceFlags = TraceFlagsImpl(isSampled = false, isRandom = false),
+        )
+        assertEquals("00-$traceId-$spanId-00", tp.encode())
+    }
+
+    @Test
+    fun `encode renders flags 02 when only random bit set`() {
+        val tp = TraceParent(
+            version = "00",
+            traceId = traceId,
+            spanId = spanId,
+            traceFlags = TraceFlagsImpl(isSampled = false, isRandom = true),
+        )
+        assertEquals("00-$traceId-$spanId-02", tp.encode())
+    }
+
+    @Test
+    fun `encode renders flags 03 when sampled and random bits set`() {
+        val tp = TraceParent(
+            version = "00",
+            traceId = traceId,
+            spanId = spanId,
+            traceFlags = TraceFlagsImpl(isSampled = true, isRandom = true),
+        )
+        assertEquals("00-$traceId-$spanId-03", tp.encode())
+    }
+
+    @Test
+    fun `encoded flags are always two lowercase hex characters`() {
+        val tp = TraceParent(
+            version = "00",
+            traceId = traceId,
+            spanId = spanId,
+            traceFlags = TraceFlagsImpl(isSampled = false, isRandom = false),
+        )
+        val flags = tp.encode().substringAfterLast('-')
+        assertEquals(2, flags.length)
+        assertTrue(flags.all { it in '0'..'9' || it in 'a'..'f' })
+    }
+
+    @Test
+    fun `decode parses the canonical version 00 traceparent header`() {
+        val tp = TraceParent.decode(canonicalHeader, flagsFactory)
+        assertNotNull(tp)
+        assertEquals("00", tp.version)
+        assertEquals(traceId, tp.traceId)
+        assertEquals(spanId, tp.spanId)
+        assertTrue(tp.traceFlags.isSampled)
+        assertFalse(tp.traceFlags.isRandom)
+    }
+
+    @Test
+    fun `decode populates flags via the supplied factory`() {
+        val tp = TraceParent.decode("00-$traceId-$spanId-03", flagsFactory)
+        assertNotNull(tp)
+        assertTrue(tp.traceFlags.isSampled)
+        assertTrue(tp.traceFlags.isRandom)
+    }
+
+    @Test
+    fun `decode handles flags 00 by reporting both flags off`() {
+        val tp = TraceParent.decode("00-$traceId-$spanId-00", flagsFactory)
+        assertNotNull(tp)
+        assertFalse(tp.traceFlags.isSampled)
+        assertFalse(tp.traceFlags.isRandom)
+    }
+
+    @Test
+    fun `decode round-trips into encode without loss`() {
+        val tp = TraceParent.decode(canonicalHeader, flagsFactory)
+        assertNotNull(tp)
+        assertEquals(canonicalHeader, tp.encode())
+    }
+
+    @Test
+    fun `decode tolerates higher versions with extra fields per forward-compat rule`() {
+        // the W3C spec requires forward-compatible parsing for unknown versions.
+        // these headers may carry additional `-`-separated fields after flags,
+        // so length and field count constraints from version 00 do not apply.
+        val header = "01-$traceId-$spanId-01-extra"
+        val tp = TraceParent.decode(header, flagsFactory)
+        assertNotNull(tp)
+        assertEquals("01", tp.version)
+        assertEquals(traceId, tp.traceId)
+        assertEquals(spanId, tp.spanId)
+        assertTrue(tp.traceFlags.isSampled)
+    }
+
+    @Test
+    fun `decode rejects an empty header`() {
+        assertNull(TraceParent.decode("", flagsFactory))
+    }
+
+    @Test
+    fun `decode rejects a header shorter than 55 chars`() {
+        val header = "00-$traceId-${spanId.dropLast(1)}-01"
+        assertTrue(header.length < 55)
+        assertNull(TraceParent.decode(header, flagsFactory))
+    }
+
+    @Test
+    fun `decode rejects any uppercase character per spec`() {
+        val uppercaseTraceId = traceId.replaceFirst('a', 'A')
+        assertNull(TraceParent.decode("00-$uppercaseTraceId-$spanId-01", flagsFactory))
+    }
+
+    @Test
+    fun `decode rejects header with fewer than four fields`() {
+        val header = "0".repeat(55)
+        assertNull(TraceParent.decode(header, flagsFactory))
+    }
+
+    @Test
+    fun `decode rejects forbidden ff version per spec`() {
+        assertNull(TraceParent.decode("ff-$traceId-$spanId-01", flagsFactory))
+    }
+
+    @Test
+    fun `decode rejects non-hex version`() {
+        assertNull(TraceParent.decode("0g-$traceId-$spanId-01", flagsFactory))
+    }
+
+    @Test
+    fun `decode rejects version of wrong length`() {
+        val header = "001-$traceId-$spanId-01"
+        assertNull(TraceParent.decode(header, flagsFactory))
+    }
+
+    @Test
+    fun `decode rejects version 00 with an additional field`() {
+        val header = "00-$traceId-$spanId-01-extra"
+        assertNull(TraceParent.decode(header, flagsFactory))
+    }
+
+    @Test
+    fun `decode rejects trace id of wrong length`() {
+        val longTrace = "0".repeat(33)
+        assertNull(TraceParent.decode("01-$longTrace-$spanId-01", flagsFactory))
+    }
+
+    @Test
+    fun `decode rejects non-hex trace id`() {
+        val invalidTraceId = traceId.replaceFirst('a', 'g')
+        assertNull(TraceParent.decode("00-$invalidTraceId-$spanId-01", flagsFactory))
+    }
+
+    @Test
+    fun `decode rejects span id of wrong length`() {
+        val longSpan = "0".repeat(17)
+        assertNull(TraceParent.decode("01-$traceId-$longSpan-01", flagsFactory))
+    }
+
+    @Test
+    fun `decode rejects non-hex span id`() {
+        val invalidSpanId = spanId.replaceFirst('b', 'g')
+        assertNull(TraceParent.decode("00-$traceId-$invalidSpanId-01", flagsFactory))
+    }
+
+    @Test
+    fun `decode rejects flags of wrong length`() {
+        assertNull(TraceParent.decode("01-$traceId-$spanId-001", flagsFactory))
+    }
+
+    @Test
+    fun `decode rejects non-hex flags`() {
+        assertNull(TraceParent.decode("00-$traceId-$spanId-zz", flagsFactory))
+    }
+
+    @Test
+    fun `decode rejects header with uppercase version`() {
+        val header = "0A-$traceId-$spanId-01"
+        assertNull(TraceParent.decode(header, flagsFactory))
+    }
+
+    @Test
+    fun `decode rejects header with uppercase flags`() {
+        val header = "00-$traceId-$spanId-0A"
+        assertNull(TraceParent.decode(header, flagsFactory))
+    }
+
+    @Test
+    fun `constructor accepts canonical fields`() {
+        val tp = TraceParent(
+            version = "00",
+            traceId = traceId,
+            spanId = spanId,
+            traceFlags = TraceFlagsImpl(isSampled = true, isRandom = false),
+        )
+        assertEquals(canonicalHeader, tp.encode())
+    }
+
+    @Test
+    fun `constructor rejects version of wrong length`() {
+        assertFailsWith<IllegalArgumentException> {
+            TraceParent(
+                version = "0",
+                traceId = traceId,
+                spanId = spanId,
+                traceFlags = TraceFlagsImpl(isSampled = true, isRandom = false),
+            )
+        }
+    }
+
+    @Test
+    fun `constructor rejects non-hex version`() {
+        assertFailsWith<IllegalArgumentException> {
+            TraceParent(
+                version = "0g",
+                traceId = traceId,
+                spanId = spanId,
+                traceFlags = TraceFlagsImpl(isSampled = true, isRandom = false),
+            )
+        }
+    }
+
+    @Test
+    fun `constructor rejects uppercase hex version`() {
+        assertFailsWith<IllegalArgumentException> {
+            TraceParent(
+                version = "0A",
+                traceId = traceId,
+                spanId = spanId,
+                traceFlags = TraceFlagsImpl(isSampled = true, isRandom = false),
+            )
+        }
+    }
+
+    @Test
+    fun `constructor rejects forbidden ff version`() {
+        assertFailsWith<IllegalArgumentException> {
+            TraceParent(
+                version = "ff",
+                traceId = traceId,
+                spanId = spanId,
+                traceFlags = TraceFlagsImpl(isSampled = true, isRandom = false),
+            )
+        }
+    }
+
+    @Test
+    fun `constructor rejects trace id of wrong length`() {
+        assertFailsWith<IllegalArgumentException> {
+            TraceParent(
+                version = "00",
+                traceId = "0".repeat(31),
+                spanId = spanId,
+                traceFlags = TraceFlagsImpl(isSampled = true, isRandom = false),
+            )
+        }
+    }
+
+    @Test
+    fun `constructor rejects non-hex trace id`() {
+        assertFailsWith<IllegalArgumentException> {
+            TraceParent(
+                version = "00",
+                traceId = traceId.replaceFirst('a', 'g'),
+                spanId = spanId,
+                traceFlags = TraceFlagsImpl(isSampled = true, isRandom = false),
+            )
+        }
+    }
+
+    @Test
+    fun `constructor rejects uppercase hex trace id`() {
+        assertFailsWith<IllegalArgumentException> {
+            TraceParent(
+                version = "00",
+                traceId = traceId.uppercase(),
+                spanId = spanId,
+                traceFlags = TraceFlagsImpl(isSampled = true, isRandom = false),
+            )
+        }
+    }
+
+    @Test
+    fun `constructor rejects span id of wrong length`() {
+        assertFailsWith<IllegalArgumentException> {
+            TraceParent(
+                version = "00",
+                traceId = traceId,
+                spanId = "0".repeat(15),
+                traceFlags = TraceFlagsImpl(isSampled = true, isRandom = false),
+            )
+        }
+    }
+
+    @Test
+    fun `constructor rejects non-hex span id`() {
+        assertFailsWith<IllegalArgumentException> {
+            TraceParent(
+                version = "00",
+                traceId = traceId,
+                spanId = spanId.replaceFirst('b', 'g'),
+                traceFlags = TraceFlagsImpl(isSampled = true, isRandom = false),
+            )
+        }
+    }
+
+    @Test
+    fun `constructor rejects uppercase hex span id`() {
+        assertFailsWith<IllegalArgumentException> {
+            TraceParent(
+                version = "00",
+                traceId = traceId,
+                spanId = spanId.uppercase(),
+                traceFlags = TraceFlagsImpl(isSampled = true, isRandom = false),
+            )
+        }
+    }
+
+    @Test
+    fun `constructor rejects empty version`() {
+        assertFailsWith<IllegalArgumentException> {
+            TraceParent(
+                version = "",
+                traceId = traceId,
+                spanId = spanId,
+                traceFlags = TraceFlagsImpl(isSampled = true, isRandom = false),
+            )
+        }
+    }
+
+    @Test
+    fun `constructor rejects empty trace id`() {
+        assertFailsWith<IllegalArgumentException> {
+            TraceParent(
+                version = "00",
+                traceId = "",
+                spanId = spanId,
+                traceFlags = TraceFlagsImpl(isSampled = true, isRandom = false),
+            )
+        }
+    }
+
+    @Test
+    fun `constructor rejects empty span id`() {
+        assertFailsWith<IllegalArgumentException> {
+            TraceParent(
+                version = "00",
+                traceId = traceId,
+                spanId = "",
+                traceFlags = TraceFlagsImpl(isSampled = true, isRandom = false),
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Goal

Adds an implementation of [traceparent](https://www.w3.org/TR/trace-context/#traceparent-header). This will be required by the trace context propagator. 

## Testing

Added unit tests.
