### PR TITLE
Add an entrypoint for propagators

### DIFF
--- a/api/api/jvm/api.api
+++ b/api/api/jvm/api.api
@@ -4,6 +4,7 @@ public abstract interface annotation class io/opentelemetry/kotlin/ExperimentalA
 public abstract interface class io/opentelemetry/kotlin/OpenTelemetry {
 	public abstract fun getContext ()Lio/opentelemetry/kotlin/factory/ContextFactory;
 	public abstract fun getLoggerProvider ()Lio/opentelemetry/kotlin/logging/LoggerProvider;
+	public abstract fun getPropagators ()Lio/opentelemetry/kotlin/propagation/PropagatorFactory;
 	public abstract fun getSpan ()Lio/opentelemetry/kotlin/factory/SpanFactory;
 	public abstract fun getSpanContext ()Lio/opentelemetry/kotlin/factory/SpanContextFactory;
 	public abstract fun getTraceFlags ()Lio/opentelemetry/kotlin/factory/TraceFlagsFactory;

--- a/api/src/commonMain/kotlin/io/opentelemetry/kotlin/OpenTelemetry.kt
+++ b/api/src/commonMain/kotlin/io/opentelemetry/kotlin/OpenTelemetry.kt
@@ -7,6 +7,7 @@ import io.opentelemetry.kotlin.factory.TraceFlagsFactory
 import io.opentelemetry.kotlin.factory.TraceStateFactory
 import io.opentelemetry.kotlin.logging.Logger
 import io.opentelemetry.kotlin.logging.LoggerProvider
+import io.opentelemetry.kotlin.propagation.PropagatorFactory
 import io.opentelemetry.kotlin.tracing.Tracer
 import io.opentelemetry.kotlin.tracing.TracerProvider
 
@@ -53,4 +54,10 @@ public interface OpenTelemetry {
      * Factory that constructs Span objects.
      */
     public val span: SpanFactory
+
+    /**
+     * Factory that constructs [io.opentelemetry.kotlin.propagation.TextMapPropagator] instances
+     * that to inject and extract context across process boundaries.
+     */
+    public val propagators: PropagatorFactory
 }

--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/CompatOpenTelemetryImpl.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/CompatOpenTelemetryImpl.kt
@@ -8,6 +8,7 @@ import io.opentelemetry.kotlin.factory.SpanFactory
 import io.opentelemetry.kotlin.factory.TraceFlagsFactory
 import io.opentelemetry.kotlin.factory.TraceStateFactory
 import io.opentelemetry.kotlin.logging.LoggerProvider
+import io.opentelemetry.kotlin.propagation.PropagatorFactory
 import io.opentelemetry.kotlin.tracing.TracerProvider
 
 internal class CompatOpenTelemetryImpl(
@@ -21,4 +22,5 @@ internal class CompatOpenTelemetryImpl(
     override val span: SpanFactory,
     override val idGenerator: IdGenerator,
     override val resource: ResourceFactory,
+    override val propagators: PropagatorFactory,
 ) : OpenTelemetrySdk

--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/OpenTelemetryCompatEntrypoint.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/OpenTelemetryCompatEntrypoint.kt
@@ -3,6 +3,7 @@ package io.opentelemetry.kotlin
 import io.opentelemetry.kotlin.clock.ClockAdapter
 import io.opentelemetry.kotlin.factory.CompatContextFactory
 import io.opentelemetry.kotlin.factory.CompatIdGenerator
+import io.opentelemetry.kotlin.factory.CompatPropagatorFactory
 import io.opentelemetry.kotlin.factory.CompatResourceFactory
 import io.opentelemetry.kotlin.factory.CompatSpanContextFactory
 import io.opentelemetry.kotlin.factory.CompatSpanFactory
@@ -58,5 +59,6 @@ internal fun createCompatOpenTelemetryImpl(
         span = span,
         idGenerator = idGenerator,
         resource = CompatResourceFactory,
+        propagators = CompatPropagatorFactory(),
     )
 }

--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/OtelJavaOpenTelemetryExt.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/OtelJavaOpenTelemetryExt.kt
@@ -5,6 +5,7 @@ import io.opentelemetry.kotlin.aliases.OtelJavaOpenTelemetry
 import io.opentelemetry.kotlin.clock.ClockAdapter
 import io.opentelemetry.kotlin.factory.CompatContextFactory
 import io.opentelemetry.kotlin.factory.CompatIdGenerator
+import io.opentelemetry.kotlin.factory.CompatPropagatorFactory
 import io.opentelemetry.kotlin.factory.CompatResourceFactory
 import io.opentelemetry.kotlin.factory.CompatSpanContextFactory
 import io.opentelemetry.kotlin.factory.CompatSpanFactory
@@ -44,5 +45,6 @@ public fun OtelJavaOpenTelemetry.toOtelKotlinApi(): OpenTelemetry {
         span = span,
         idGenerator = idGenerator,
         resource = CompatResourceFactory,
+        propagators = CompatPropagatorFactory(),
     )
 }

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/OpenTelemetryImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/OpenTelemetryImpl.kt
@@ -13,6 +13,7 @@ import io.opentelemetry.kotlin.factory.SpanFactory
 import io.opentelemetry.kotlin.factory.TraceFlagsFactory
 import io.opentelemetry.kotlin.factory.TraceStateFactory
 import io.opentelemetry.kotlin.logging.LoggerProvider
+import io.opentelemetry.kotlin.propagation.PropagatorFactory
 import io.opentelemetry.kotlin.tracing.TracerProvider
 import kotlinx.coroutines.withTimeout
 
@@ -27,6 +28,7 @@ internal class OpenTelemetryImpl(
     override val span: SpanFactory,
     override val idGenerator: IdGenerator,
     override val resource: ResourceFactory,
+    override val propagators: PropagatorFactory,
     private val timeoutMs: Long = 3000,
 ) : OpenTelemetrySdk, TelemetryCloseable {
 

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/OpenTelemetryImplEntrypoint.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/OpenTelemetryImplEntrypoint.kt
@@ -11,6 +11,7 @@ import io.opentelemetry.kotlin.factory.TraceStateFactoryImpl
 import io.opentelemetry.kotlin.init.OpenTelemetryConfigDsl
 import io.opentelemetry.kotlin.init.OpenTelemetryConfigImpl
 import io.opentelemetry.kotlin.logging.LoggerProviderImpl
+import io.opentelemetry.kotlin.propagation.PropagatorFactoryImpl
 import io.opentelemetry.kotlin.tracing.TracerProviderImpl
 
 /**
@@ -48,6 +49,7 @@ internal fun createOpenTelemetryImpl(
     val spanContext = SpanContextFactoryImpl(idGenerator, traceFlags, traceState)
     val contextFactory = ContextFactoryImpl()
     val span = SpanFactoryImpl(spanContext, contextFactory.spanKey)
+    val propagatorFactory = PropagatorFactoryImpl()
 
     val cfg = OpenTelemetryConfigImpl(clock).apply(config)
     val tracingConfig = cfg.generateTracingConfig()
@@ -77,5 +79,6 @@ internal fun createOpenTelemetryImpl(
         span = span,
         idGenerator = idGenerator,
         resource = resourceFactory,
+        propagators = propagatorFactory,
     )
 }

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/OpenTelemetryImplTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/OpenTelemetryImplTest.kt
@@ -7,6 +7,7 @@ import io.opentelemetry.kotlin.export.OperationResultCode.Success
 import io.opentelemetry.kotlin.export.TelemetryCloseable
 import io.opentelemetry.kotlin.factory.FakeContextFactory
 import io.opentelemetry.kotlin.factory.FakeIdGenerator
+import io.opentelemetry.kotlin.factory.FakePropagatorFactory
 import io.opentelemetry.kotlin.factory.FakeResourceFactory
 import io.opentelemetry.kotlin.factory.FakeSpanContextFactory
 import io.opentelemetry.kotlin.factory.FakeSpanFactory
@@ -189,6 +190,7 @@ internal class OpenTelemetryImplTest {
         span = FakeSpanFactory(),
         idGenerator = FakeIdGenerator(),
         resource = FakeResourceFactory(),
+        propagators = FakePropagatorFactory(),
     )
 
     private class FakeCloseableTracerProvider(

--- a/noop/src/commonMain/kotlin/io/opentelemetry/kotlin/NoopOpenTelemetryImpl.kt
+++ b/noop/src/commonMain/kotlin/io/opentelemetry/kotlin/NoopOpenTelemetryImpl.kt
@@ -16,6 +16,8 @@ import io.opentelemetry.kotlin.factory.TraceFlagsFactory
 import io.opentelemetry.kotlin.factory.TraceStateFactory
 import io.opentelemetry.kotlin.logging.LoggerProvider
 import io.opentelemetry.kotlin.logging.NoopLoggerProvider
+import io.opentelemetry.kotlin.propagation.NoopPropagatorFactory
+import io.opentelemetry.kotlin.propagation.PropagatorFactory
 import io.opentelemetry.kotlin.tracing.NoopTracerProvider
 import io.opentelemetry.kotlin.tracing.TracerProvider
 
@@ -31,4 +33,5 @@ internal object NoopOpenTelemetryImpl : OpenTelemetrySdk {
     override val span: SpanFactory = NoopSpanFactory
     override val idGenerator: IdGenerator = NoopIdGenerator
     override val resource: ResourceFactory = NoopResourceFactory
+    override val propagators: PropagatorFactory = NoopPropagatorFactory
 }

--- a/test-fakes/src/commonMain/kotlin/io/opentelemetry/kotlin/FakeOpenTelemetry.kt
+++ b/test-fakes/src/commonMain/kotlin/io/opentelemetry/kotlin/FakeOpenTelemetry.kt
@@ -4,6 +4,7 @@ import io.opentelemetry.kotlin.clock.FakeClock
 import io.opentelemetry.kotlin.factory.ContextFactory
 import io.opentelemetry.kotlin.factory.FakeContextFactory
 import io.opentelemetry.kotlin.factory.FakeIdGenerator
+import io.opentelemetry.kotlin.factory.FakePropagatorFactory
 import io.opentelemetry.kotlin.factory.FakeResourceFactory
 import io.opentelemetry.kotlin.factory.FakeSpanContextFactory
 import io.opentelemetry.kotlin.factory.FakeSpanFactory
@@ -17,6 +18,7 @@ import io.opentelemetry.kotlin.factory.TraceFlagsFactory
 import io.opentelemetry.kotlin.factory.TraceStateFactory
 import io.opentelemetry.kotlin.logging.FakeLoggerProvider
 import io.opentelemetry.kotlin.logging.LoggerProvider
+import io.opentelemetry.kotlin.propagation.PropagatorFactory
 import io.opentelemetry.kotlin.tracing.FakeTracerProvider
 import io.opentelemetry.kotlin.tracing.TracerProvider
 
@@ -31,4 +33,5 @@ class FakeOpenTelemetry : OpenTelemetrySdk {
     override val span: SpanFactory = FakeSpanFactory()
     override val idGenerator: IdGenerator = FakeIdGenerator()
     override val resource: ResourceFactory = FakeResourceFactory()
+    override val propagators: PropagatorFactory = FakePropagatorFactory()
 }

--- a/test-fakes/src/commonMain/kotlin/io/opentelemetry/kotlin/factory/FakePropagatorFactory.kt
+++ b/test-fakes/src/commonMain/kotlin/io/opentelemetry/kotlin/factory/FakePropagatorFactory.kt
@@ -1,0 +1,26 @@
+package io.opentelemetry.kotlin.factory
+
+import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.context.Context
+import io.opentelemetry.kotlin.propagation.PropagatorFactory
+import io.opentelemetry.kotlin.propagation.TextMapGetter
+import io.opentelemetry.kotlin.propagation.TextMapPropagator
+import io.opentelemetry.kotlin.propagation.TextMapSetter
+
+@OptIn(ExperimentalApi::class)
+class FakePropagatorFactory : PropagatorFactory {
+
+    override fun composite(vararg propagators: TextMapPropagator): TextMapPropagator =
+        FakeTextMapPropagator
+
+    override fun composite(propagators: List<TextMapPropagator>): TextMapPropagator =
+        FakeTextMapPropagator
+
+    override fun w3cBaggage(): TextMapPropagator = FakeTextMapPropagator
+
+    private object FakeTextMapPropagator : TextMapPropagator {
+        override fun fields(): Collection<String> = emptyList()
+        override fun <T> inject(context: Context, carrier: T, setter: TextMapSetter<T>) {}
+        override fun <T> extract(context: Context, carrier: T, getter: TextMapGetter<T>): Context = context
+    }
+}


### PR DESCRIPTION
## Goal

Adds an entrypoint on `OpenTelemetry` for accessing the Propagators API.
