### PR TITLE
Implement getAll() on TextMapGetter

### DIFF
--- a/api/api/jvm/api.api
+++ b/api/api/jvm/api.api
@@ -171,6 +171,7 @@ public abstract interface class io/opentelemetry/kotlin/propagation/PropagatorFa
 
 public abstract interface class io/opentelemetry/kotlin/propagation/TextMapGetter {
 	public abstract fun get (Ljava/lang/Object;Ljava/lang/String;)Ljava/lang/String;
+	public abstract fun getAll (Ljava/lang/Object;Ljava/lang/String;)Ljava/util/List;
 	public abstract fun keys (Ljava/lang/Object;)Ljava/util/Collection;
 }
 

--- a/api/src/commonMain/kotlin/io/opentelemetry/kotlin/propagation/TextMapGetter.kt
+++ b/api/src/commonMain/kotlin/io/opentelemetry/kotlin/propagation/TextMapGetter.kt
@@ -22,4 +22,10 @@ public interface TextMapGetter<C> {
      * Key lookup must be case-insensitive for HTTP carriers.
      */
     public fun get(carrier: C, key: String): String?
+
+    /**
+     * Returns all values associated with [key] in [carrier], in the order they appear,
+     * or an empty list if absent.
+     */
+    public fun getAll(carrier: C, key: String): List<String>
 }

--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/propagation/TextMapGetterAdapter.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/propagation/TextMapGetterAdapter.kt
@@ -9,4 +9,7 @@ internal class TextMapGetterAdapter<C : Any>(
     override fun keys(carrier: C): Collection<String> = delegate.keys(carrier).toList()
 
     override fun get(carrier: C, key: String): String? = delegate.get(carrier, key)
+
+    override fun getAll(carrier: C, key: String): List<String> =
+        get(carrier, key)?.let { listOf(it) } ?: emptyList()
 }

--- a/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/factory/CompatPropagatorFactoryTest.kt
+++ b/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/factory/CompatPropagatorFactoryTest.kt
@@ -135,6 +135,8 @@ private class ContextWritingPropagator(
 private object MapTextMapGetter : TextMapGetter<Map<String, String>> {
     override fun keys(carrier: Map<String, String>): Collection<String> = carrier.keys
     override fun get(carrier: Map<String, String>, key: String): String? = carrier[key]
+    override fun getAll(carrier: Map<String, String>, key: String): List<String> =
+        carrier[key]?.let { listOf(it) } ?: emptyList()
 }
 
 @OptIn(ExperimentalApi::class)

--- a/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/propagation/TextMapPropagatorAdapterTest.kt
+++ b/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/propagation/TextMapPropagatorAdapterTest.kt
@@ -4,6 +4,7 @@ import io.opentelemetry.api.baggage.propagation.W3CBaggagePropagator
 import io.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.kotlin.aliases.OtelJavaBaggage
 import io.opentelemetry.kotlin.aliases.OtelJavaContext
+import io.opentelemetry.kotlin.aliases.OtelJavaTextMapGetter
 import io.opentelemetry.kotlin.aliases.OtelJavaTextMapPropagator
 import io.opentelemetry.kotlin.context.ContextAdapter
 import io.opentelemetry.kotlin.context.FakeContext
@@ -94,6 +95,7 @@ internal class TextMapPropagatorAdapterTest {
 
             override fun keys(carrier: Map<String, String>): Collection<String> = error(errMsg)
             override fun get(carrier: Map<String, String>, key: String): String = error(errMsg)
+            override fun getAll(carrier: Map<String, String>, key: String): List<String> = error(errMsg)
         }
 
         val extracted = TextMapPropagatorAdapter(impl).extract(
@@ -122,6 +124,20 @@ internal class TextMapPropagatorAdapterTest {
     }
 
     @Test
+    fun `kotlin getter adapter returns single value list from getAll when key present`() {
+        val carrier = mapOf("a" to "1")
+        val adapter = TextMapGetterAdapter(JavaMapGetter)
+        assertEquals(listOf("1"), adapter.getAll(carrier, "a"))
+    }
+
+    @Test
+    fun `kotlin getter adapter returns empty list from getAll when key absent`() {
+        val carrier = mapOf("a" to "1")
+        val adapter = TextMapGetterAdapter(JavaMapGetter)
+        assertTrue(adapter.getAll(carrier, "missing").isEmpty())
+    }
+
+    @Test
     fun `getter adapter returns null when carrier is null`() {
         val throwingDelegate = object : TextMapGetter<Map<String, String>> {
             val errMsg = "delegate must not be invoked when carrier is null"
@@ -131,6 +147,10 @@ internal class TextMapPropagatorAdapterTest {
             }
 
             override fun get(carrier: Map<String, String>, key: String): String {
+                error(errMsg)
+            }
+
+            override fun getAll(carrier: Map<String, String>, key: String): List<String> {
                 error(errMsg)
             }
         }
@@ -148,5 +168,12 @@ internal class TextMapPropagatorAdapterTest {
     private object MapGetter : TextMapGetter<Map<String, String>> {
         override fun keys(carrier: Map<String, String>): Collection<String> = carrier.keys
         override fun get(carrier: Map<String, String>, key: String): String? = carrier[key]
+        override fun getAll(carrier: Map<String, String>, key: String): List<String> =
+            carrier[key]?.let { listOf(it) } ?: emptyList()
+    }
+
+    private object JavaMapGetter : OtelJavaTextMapGetter<Map<String, String>> {
+        override fun keys(carrier: Map<String, String>): Iterable<String> = carrier.keys
+        override fun get(carrier: Map<String, String>?, key: String): String? = carrier?.get(key)
     }
 }

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/propagation/W3CBaggagePropagator.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/propagation/W3CBaggagePropagator.kt
@@ -40,8 +40,11 @@ internal object W3CBaggagePropagator : TextMapPropagator {
     }
 
     override fun <T> extract(context: Context, carrier: T, getter: TextMapGetter<T>): Context {
-        val header = getter.get(carrier, FIELD) ?: return context
-        val baggage = decode(header) ?: return context
+        val combined = getter.getAll(carrier, FIELD).joinToString(ENTRY_DELIMITER.toString())
+        if (combined.isEmpty()) {
+            return context
+        }
+        val baggage = decode(combined) ?: return context
         return context.storeBaggage(baggage)
     }
 

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/propagation/MapCarrierFixtures.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/propagation/MapCarrierFixtures.kt
@@ -6,6 +6,8 @@ import io.opentelemetry.kotlin.ExperimentalApi
 internal object MapTextMapGetter : TextMapGetter<Map<String, String>> {
     override fun keys(carrier: Map<String, String>): Collection<String> = carrier.keys
     override fun get(carrier: Map<String, String>, key: String): String? = carrier[key]
+    override fun getAll(carrier: Map<String, String>, key: String): List<String> =
+        carrier[key]?.let { listOf(it) } ?: emptyList()
 }
 
 @OptIn(ExperimentalApi::class)

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/propagation/W3CBaggagePropagatorTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/propagation/W3CBaggagePropagatorTest.kt
@@ -246,6 +246,33 @@ internal class W3CBaggagePropagatorTest {
     }
 
     @Test
+    fun `extract combines multiple baggage headers`() {
+        val carrier = mapOf("baggage" to listOf("a=1", "b=2,c=3"))
+        val ctx = propagator.extract(contextFactory.root(), carrier, MultiValueMapTextMapGetter)
+        val baggage = ctx.extractBaggage()
+        assertEquals("1", baggage.getValue("a"))
+        assertEquals("2", baggage.getValue("b"))
+        assertEquals("3", baggage.getValue("c"))
+        assertEquals(3, baggage.asMap().size)
+    }
+
+    @Test
+    fun `extract reads a single baggage header via getAll`() {
+        val carrier = mapOf("baggage" to listOf("k=v"))
+        val baggage = propagator.extract(contextFactory.root(), carrier, MultiValueMapTextMapGetter)
+            .extractBaggage()
+        assertEquals("v", baggage.getValue("k"))
+        assertEquals(1, baggage.asMap().size)
+    }
+
+    @Test
+    fun `extract returns original context when getAll returns no headers`() {
+        val ctx = contextFactory.root()
+        val result = propagator.extract(ctx, emptyMap(), MultiValueMapTextMapGetter)
+        assertSame(ctx, result)
+    }
+
+    @Test
     fun `inject and extract round-trip preserves entries and metadata`() {
         val original = BaggageImpl.EMPTY
             .set("user.id", "alice", BaggageEntryMetadataImpl("propagation=public"))
@@ -273,5 +300,13 @@ internal class W3CBaggagePropagatorTest {
             MapTextMapGetter,
         )
         return ctx.extractBaggage()
+    }
+
+    private object MultiValueMapTextMapGetter : TextMapGetter<Map<String, List<String>>> {
+        override fun keys(carrier: Map<String, List<String>>): Collection<String> = carrier.keys
+        override fun get(carrier: Map<String, List<String>>, key: String): String? =
+            carrier[key]?.firstOrNull()
+        override fun getAll(carrier: Map<String, List<String>>, key: String): List<String> =
+            carrier[key].orEmpty()
     }
 }

--- a/noop/src/commonTest/kotlin/io/opentelemetry/kotlin/NoopTests.kt
+++ b/noop/src/commonTest/kotlin/io/opentelemetry/kotlin/NoopTests.kt
@@ -239,6 +239,8 @@ internal class NoopTests {
         val getter = object : TextMapGetter<MutableMap<String, String>> {
             override fun keys(carrier: MutableMap<String, String>) = carrier.keys
             override fun get(carrier: MutableMap<String, String>, key: String) = carrier[key]
+            override fun getAll(carrier: MutableMap<String, String>, key: String): List<String> =
+                carrier[key]?.let { listOf(it) } ?: emptyList()
         }
         assertSame(ctx, NoopTextMapPropagator.extract(ctx, carrier, getter))
     }


### PR DESCRIPTION
## Goal

Adds an implementation for `getAll()` on the TextMapGetter interface, as per the spec: https://opentelemetry.io/docs/specs/otel/context/api-propagators/#getall