### PR TITLE
Implement W3C TraceContext Propagator

### DIFF
--- a/api/api/jvm/api.api
+++ b/api/api/jvm/api.api
@@ -167,6 +167,7 @@ public abstract interface class io/opentelemetry/kotlin/propagation/PropagatorFa
 	public abstract fun composite (Ljava/util/List;)Lio/opentelemetry/kotlin/propagation/TextMapPropagator;
 	public abstract fun composite ([Lio/opentelemetry/kotlin/propagation/TextMapPropagator;)Lio/opentelemetry/kotlin/propagation/TextMapPropagator;
 	public abstract fun w3cBaggage ()Lio/opentelemetry/kotlin/propagation/TextMapPropagator;
+	public abstract fun w3cTraceContext ()Lio/opentelemetry/kotlin/propagation/TextMapPropagator;
 }
 
 public abstract interface class io/opentelemetry/kotlin/propagation/TextMapGetter {

--- a/api/src/commonMain/kotlin/io/opentelemetry/kotlin/propagation/PropagatorFactory.kt
+++ b/api/src/commonMain/kotlin/io/opentelemetry/kotlin/propagation/PropagatorFactory.kt
@@ -31,4 +31,12 @@ public interface PropagatorFactory {
      * https://www.w3.org/TR/baggage/
      */
     public fun w3cBaggage(): TextMapPropagator
+
+    /**
+     * Returns a [TextMapPropagator] that injects and extracts the current span context
+     * via the W3C `traceparent` and `tracestate` HTTP headers.
+     *
+     * https://www.w3.org/TR/trace-context/
+     */
+    public fun w3cTraceContext(): TextMapPropagator
 }

--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/factory/CompatPropagatorFactory.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/factory/CompatPropagatorFactory.kt
@@ -1,6 +1,7 @@
 package io.opentelemetry.kotlin.factory
 
 import io.opentelemetry.api.baggage.propagation.W3CBaggagePropagator
+import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator
 import io.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.kotlin.aliases.OtelJavaTextMapPropagator
 import io.opentelemetry.kotlin.propagation.OtelJavaTextMapPropagatorAdapter
@@ -21,6 +22,10 @@ internal class CompatPropagatorFactory : PropagatorFactory {
 
     override fun w3cBaggage(): TextMapPropagator {
         return TextMapPropagatorAdapter(W3CBaggagePropagator.getInstance())
+    }
+
+    override fun w3cTraceContext(): TextMapPropagator {
+        return TextMapPropagatorAdapter(W3CTraceContextPropagator.getInstance())
     }
 
     private fun TextMapPropagator.toOtelJava(): OtelJavaTextMapPropagator =

--- a/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/factory/CompatPropagatorFactoryTest.kt
+++ b/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/factory/CompatPropagatorFactoryTest.kt
@@ -98,6 +98,29 @@ internal class CompatPropagatorFactoryTest {
 
         assertEquals(viaVararg.fields().toList(), viaList.fields().toList())
     }
+
+    @Test
+    fun `w3cTraceContext returns an adapter for traceparent and tracestate fields`() {
+        val propagator = factory.w3cTraceContext()
+        assertTrue(propagator is TextMapPropagatorAdapter)
+        assertEquals(listOf("traceparent", "tracestate"), propagator.fields().toList())
+    }
+
+    @Test
+    fun `w3cTraceContext round-trips a traceparent header through inject and extract`() {
+        val propagator = factory.w3cTraceContext()
+        val incoming = mapOf(
+            "traceparent" to "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01",
+            "tracestate" to "vendor=value",
+        )
+        val extracted = propagator.extract(contextFactory.root(), incoming, MapTextMapGetter)
+
+        val outgoing = mutableMapOf<String, String>()
+        propagator.inject(extracted, outgoing, MapTextMapSetter)
+
+        assertEquals(incoming["traceparent"], outgoing["traceparent"])
+        assertEquals(incoming["tracestate"], outgoing["tracestate"])
+    }
 }
 
 @OptIn(ExperimentalApi::class)

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/propagation/PropagatorFactoryImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/propagation/PropagatorFactoryImpl.kt
@@ -2,9 +2,30 @@ package io.opentelemetry.kotlin.propagation
 
 import io.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.kotlin.context.Context
+import io.opentelemetry.kotlin.factory.ContextFactory
+import io.opentelemetry.kotlin.factory.SpanContextFactory
+import io.opentelemetry.kotlin.factory.SpanFactory
+import io.opentelemetry.kotlin.factory.TraceFlagsFactory
+import io.opentelemetry.kotlin.factory.TraceStateFactory
 
 @OptIn(ExperimentalApi::class)
-internal class PropagatorFactoryImpl : PropagatorFactory {
+internal class PropagatorFactoryImpl(
+    private val traceFlagsFactory: TraceFlagsFactory,
+    private val traceStateFactory: TraceStateFactory,
+    private val spanContextFactory: SpanContextFactory,
+    private val spanFactory: SpanFactory,
+    private val contextFactory: ContextFactory,
+) : PropagatorFactory {
+
+    private val traceContextPropagator: TextMapPropagator by lazy {
+        W3CTraceContextPropagator(
+            traceFlagsFactory = traceFlagsFactory,
+            traceStateFactory = traceStateFactory,
+            spanContextFactory = spanContextFactory,
+            spanFactory = spanFactory,
+            contextFactory = contextFactory,
+        )
+    }
 
     override fun composite(vararg propagators: TextMapPropagator): TextMapPropagator {
         return composite(propagators.toList())
@@ -19,6 +40,8 @@ internal class PropagatorFactoryImpl : PropagatorFactory {
     }
 
     override fun w3cBaggage(): TextMapPropagator = W3CBaggagePropagator
+
+    override fun w3cTraceContext(): TextMapPropagator = traceContextPropagator
 
     private object EmptyTextMapPropagator : TextMapPropagator {
         override fun fields(): Collection<String> = emptyList()

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/propagation/TraceParentImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/propagation/TraceParentImpl.kt
@@ -10,7 +10,7 @@ import io.opentelemetry.kotlin.tracing.TraceFlags
  * https://www.w3.org/TR/trace-context/#traceparent-header
  */
 @OptIn(ExperimentalApi::class)
-internal class TraceParent(
+internal class TraceParentImpl(
     val version: String,
     val traceId: String,
     val spanId: String,
@@ -57,7 +57,7 @@ internal class TraceParent(
         private const val FLAG_RANDOM = 0b0000_0010
         private const val HEX_RADIX = 16
 
-        fun decode(header: String, traceFlagsFactory: TraceFlagsFactory): TraceParent? {
+        fun decode(header: String, traceFlagsFactory: TraceFlagsFactory): TraceParentImpl? {
             if (header.length < LEN_V00) {
                 return null
             }
@@ -82,7 +82,7 @@ internal class TraceParent(
             }
 
             return try {
-                TraceParent(
+                TraceParentImpl(
                     version = version,
                     traceId = parts[1],
                     spanId = parts[2],

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/propagation/TraceStateImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/propagation/TraceStateImpl.kt
@@ -1,0 +1,67 @@
+package io.opentelemetry.kotlin.propagation
+
+import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.factory.TraceStateFactory
+import io.opentelemetry.kotlin.tracing.TraceState
+
+/**
+ * Implementation of a W3C `tracestate` header.
+ *
+ * https://www.w3.org/TR/trace-context-2/#tracestate-header
+ */
+@OptIn(ExperimentalApi::class)
+internal class TraceStateImpl(traceState: TraceState) {
+
+    private val state by lazy {
+        traceState.asMap()
+    }
+
+    fun encode(): String = buildString {
+        state.forEach {
+            if (isNotEmpty()) {
+                append(LIST_MEMBER_SEPARATOR)
+            }
+            append(it.key)
+            append(KEY_VALUE_SEPARATOR)
+            append(it.value)
+        }
+    }
+
+    companion object {
+        private const val LIST_MEMBER_SEPARATOR = ','
+        private const val KEY_VALUE_SEPARATOR = '='
+        private const val OWS_SPACE = ' '
+        private const val OWS_HTAB = '\t'
+
+        fun decode(header: String, traceStateFactory: TraceStateFactory): TraceStateImpl {
+            var state = traceStateFactory.default
+            val seen = mutableSetOf<String>()
+            val split = header.split(LIST_MEMBER_SEPARATOR)
+            split.forEach { raw ->
+                val parsed = parseMember(raw, seen) ?: return@forEach
+                val (key, value) = parsed
+                val next = state.put(key, value)
+                if (next.get(key) == value) {
+                    state = next
+                }
+            }
+            return TraceStateImpl(state)
+        }
+
+        private fun parseMember(raw: String, seen: MutableSet<String>): Pair<String, String>? {
+            val member = raw.trim(OWS_SPACE, OWS_HTAB)
+            if (member.isEmpty()) {
+                return null
+            }
+            val eq = member.indexOf(KEY_VALUE_SEPARATOR)
+            if (eq <= 0 || eq == member.length - 1) {
+                return null
+            }
+            val key = member.substring(0, eq)
+            if (!seen.add(key)) {
+                return null
+            }
+            return key to member.substring(eq + 1)
+        }
+    }
+}

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/propagation/TraceStateImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/propagation/TraceStateImpl.kt
@@ -10,7 +10,7 @@ import io.opentelemetry.kotlin.tracing.TraceState
  * https://www.w3.org/TR/trace-context-2/#tracestate-header
  */
 @OptIn(ExperimentalApi::class)
-internal class TraceStateImpl(traceState: TraceState) {
+internal class TraceStateImpl(internal val traceState: TraceState) {
 
     private val state by lazy {
         traceState.asMap()

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/propagation/W3CTraceContextPropagator.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/propagation/W3CTraceContextPropagator.kt
@@ -1,0 +1,74 @@
+package io.opentelemetry.kotlin.propagation
+
+import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.context.Context
+import io.opentelemetry.kotlin.factory.ContextFactory
+import io.opentelemetry.kotlin.factory.SpanContextFactory
+import io.opentelemetry.kotlin.factory.SpanFactory
+import io.opentelemetry.kotlin.factory.TraceFlagsFactory
+import io.opentelemetry.kotlin.factory.TraceStateFactory
+
+/**
+ * W3C Trace Context HTTP header propagator.
+ *
+ * https://www.w3.org/TR/trace-context/
+ */
+@OptIn(ExperimentalApi::class)
+internal class W3CTraceContextPropagator(
+    private val traceFlagsFactory: TraceFlagsFactory,
+    private val traceStateFactory: TraceStateFactory,
+    private val spanContextFactory: SpanContextFactory,
+    private val spanFactory: SpanFactory,
+    private val contextFactory: ContextFactory,
+) : TextMapPropagator {
+
+    override fun fields(): Collection<String> = FIELDS
+
+    override fun <T> inject(context: Context, carrier: T, setter: TextMapSetter<T>) {
+        val spanContext = spanFactory.fromContext(context).spanContext
+        if (!spanContext.isValid) {
+            return
+        }
+        val traceparent = TraceParentImpl(
+            version = TraceParentImpl.VERSION_00,
+            traceId = spanContext.traceId,
+            spanId = spanContext.spanId,
+            traceFlags = spanContext.traceFlags,
+        ).encode()
+        setter.set(carrier, TRACEPARENT, traceparent)
+
+        val tracestate = TraceStateImpl(spanContext.traceState).encode()
+        if (tracestate.isNotEmpty()) {
+            setter.set(carrier, TRACESTATE, tracestate)
+        }
+    }
+
+    override fun <T> extract(context: Context, carrier: T, getter: TextMapGetter<T>): Context {
+        val rawTraceparent = getter.get(carrier, TRACEPARENT) ?: return context
+        val parsed = TraceParentImpl.decode(rawTraceparent, traceFlagsFactory) ?: return context
+
+        val rawTracestate = getter.get(carrier, TRACESTATE)
+        val traceState = when (rawTracestate) {
+            null -> traceStateFactory.default
+            else -> TraceStateImpl.decode(rawTracestate, traceStateFactory).traceState
+        }
+
+        val spanContext = spanContextFactory.create(
+            traceId = parsed.traceId,
+            spanId = parsed.spanId,
+            traceFlags = parsed.traceFlags,
+            traceState = traceState,
+            isRemote = true,
+        )
+        if (!spanContext.isValid) {
+            return context
+        }
+        return contextFactory.storeSpan(context, spanFactory.fromSpanContext(spanContext))
+    }
+
+    private companion object {
+        const val TRACEPARENT = "traceparent"
+        const val TRACESTATE = "tracestate"
+        val FIELDS = listOf(TRACEPARENT, TRACESTATE)
+    }
+}

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/propagation/PropagatorFactoryImplTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/propagation/PropagatorFactoryImplTest.kt
@@ -4,6 +4,11 @@ import io.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.kotlin.context.Context
 import io.opentelemetry.kotlin.context.ContextKey
 import io.opentelemetry.kotlin.factory.ContextFactoryImpl
+import io.opentelemetry.kotlin.factory.IdGeneratorImpl
+import io.opentelemetry.kotlin.factory.SpanContextFactoryImpl
+import io.opentelemetry.kotlin.factory.SpanFactoryImpl
+import io.opentelemetry.kotlin.factory.TraceFlagsFactoryImpl
+import io.opentelemetry.kotlin.factory.TraceStateFactoryImpl
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertSame
@@ -12,8 +17,19 @@ import kotlin.test.assertTrue
 @OptIn(ExperimentalApi::class)
 internal class PropagatorFactoryImplTest {
 
-    private val factory = PropagatorFactoryImpl()
+    private val traceFlagsFactory = TraceFlagsFactoryImpl()
+    private val traceStateFactory = TraceStateFactoryImpl()
+    private val spanContextFactory = SpanContextFactoryImpl(IdGeneratorImpl(), traceFlagsFactory, traceStateFactory)
     private val contextFactory = ContextFactoryImpl()
+    private val spanFactory = SpanFactoryImpl(spanContextFactory, contextFactory.spanKey)
+
+    private val factory = PropagatorFactoryImpl(
+        traceFlagsFactory = traceFlagsFactory,
+        traceStateFactory = traceStateFactory,
+        spanContextFactory = spanContextFactory,
+        spanFactory = spanFactory,
+        contextFactory = contextFactory,
+    )
 
     @Test
     fun `composite of zero propagators returns empty propagator`() {
@@ -80,6 +96,17 @@ internal class PropagatorFactoryImplTest {
     @Test
     fun `w3cBaggage returns the W3C baggage propagator`() {
         assertSame(W3CBaggagePropagator, factory.w3cBaggage())
+    }
+
+    @Test
+    fun `w3cTraceContext returns a propagator for traceparent and tracestate fields`() {
+        val propagator = factory.w3cTraceContext()
+        assertEquals(listOf("traceparent", "tracestate"), propagator.fields().toList())
+    }
+
+    @Test
+    fun `w3cTraceContext returns the same instance on repeated calls`() {
+        assertSame(factory.w3cTraceContext(), factory.w3cTraceContext())
     }
 
     @Test

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/propagation/TraceParentImplTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/propagation/TraceParentImplTest.kt
@@ -16,7 +16,7 @@ import kotlin.test.assertTrue
  * https://www.w3.org/TR/trace-context/#traceparent-header
  */
 @OptIn(ExperimentalApi::class)
-internal class TraceParentTest {
+internal class TraceParentImplTest {
 
     private val flagsFactory = TraceFlagsFactoryImpl()
     private val traceId = "0af7651916cd43dd8448eb211c80319c"
@@ -25,7 +25,7 @@ internal class TraceParentTest {
 
     @Test
     fun `encode produces the canonical version 00 traceparent header`() {
-        val tp = TraceParent(
+        val tp = TraceParentImpl(
             version = "00",
             traceId = traceId,
             spanId = spanId,
@@ -36,7 +36,7 @@ internal class TraceParentTest {
 
     @Test
     fun `encoded header is exactly 55 chars for version 00`() {
-        val tp = TraceParent(
+        val tp = TraceParentImpl(
             version = "00",
             traceId = traceId,
             spanId = spanId,
@@ -47,7 +47,7 @@ internal class TraceParentTest {
 
     @Test
     fun `encode renders flags 00 when neither sampled nor random`() {
-        val tp = TraceParent(
+        val tp = TraceParentImpl(
             version = "00",
             traceId = traceId,
             spanId = spanId,
@@ -58,7 +58,7 @@ internal class TraceParentTest {
 
     @Test
     fun `encode renders flags 02 when only random bit set`() {
-        val tp = TraceParent(
+        val tp = TraceParentImpl(
             version = "00",
             traceId = traceId,
             spanId = spanId,
@@ -69,7 +69,7 @@ internal class TraceParentTest {
 
     @Test
     fun `encode renders flags 03 when sampled and random bits set`() {
-        val tp = TraceParent(
+        val tp = TraceParentImpl(
             version = "00",
             traceId = traceId,
             spanId = spanId,
@@ -80,7 +80,7 @@ internal class TraceParentTest {
 
     @Test
     fun `encoded flags are always two lowercase hex characters`() {
-        val tp = TraceParent(
+        val tp = TraceParentImpl(
             version = "00",
             traceId = traceId,
             spanId = spanId,
@@ -93,7 +93,7 @@ internal class TraceParentTest {
 
     @Test
     fun `decode parses the canonical version 00 traceparent header`() {
-        val tp = TraceParent.decode(canonicalHeader, flagsFactory)
+        val tp = TraceParentImpl.decode(canonicalHeader, flagsFactory)
         assertNotNull(tp)
         assertEquals("00", tp.version)
         assertEquals(traceId, tp.traceId)
@@ -104,7 +104,7 @@ internal class TraceParentTest {
 
     @Test
     fun `decode populates flags via the supplied factory`() {
-        val tp = TraceParent.decode("00-$traceId-$spanId-03", flagsFactory)
+        val tp = TraceParentImpl.decode("00-$traceId-$spanId-03", flagsFactory)
         assertNotNull(tp)
         assertTrue(tp.traceFlags.isSampled)
         assertTrue(tp.traceFlags.isRandom)
@@ -112,7 +112,7 @@ internal class TraceParentTest {
 
     @Test
     fun `decode handles flags 00 by reporting both flags off`() {
-        val tp = TraceParent.decode("00-$traceId-$spanId-00", flagsFactory)
+        val tp = TraceParentImpl.decode("00-$traceId-$spanId-00", flagsFactory)
         assertNotNull(tp)
         assertFalse(tp.traceFlags.isSampled)
         assertFalse(tp.traceFlags.isRandom)
@@ -120,7 +120,7 @@ internal class TraceParentTest {
 
     @Test
     fun `decode round-trips into encode without loss`() {
-        val tp = TraceParent.decode(canonicalHeader, flagsFactory)
+        val tp = TraceParentImpl.decode(canonicalHeader, flagsFactory)
         assertNotNull(tp)
         assertEquals(canonicalHeader, tp.encode())
     }
@@ -131,7 +131,7 @@ internal class TraceParentTest {
         // these headers may carry additional `-`-separated fields after flags,
         // so length and field count constraints from version 00 do not apply.
         val header = "01-$traceId-$spanId-01-extra"
-        val tp = TraceParent.decode(header, flagsFactory)
+        val tp = TraceParentImpl.decode(header, flagsFactory)
         assertNotNull(tp)
         assertEquals("01", tp.version)
         assertEquals(traceId, tp.traceId)
@@ -141,99 +141,99 @@ internal class TraceParentTest {
 
     @Test
     fun `decode rejects an empty header`() {
-        assertNull(TraceParent.decode("", flagsFactory))
+        assertNull(TraceParentImpl.decode("", flagsFactory))
     }
 
     @Test
     fun `decode rejects a header shorter than 55 chars`() {
         val header = "00-$traceId-${spanId.dropLast(1)}-01"
         assertTrue(header.length < 55)
-        assertNull(TraceParent.decode(header, flagsFactory))
+        assertNull(TraceParentImpl.decode(header, flagsFactory))
     }
 
     @Test
     fun `decode rejects any uppercase character per spec`() {
         val uppercaseTraceId = traceId.replaceFirst('a', 'A')
-        assertNull(TraceParent.decode("00-$uppercaseTraceId-$spanId-01", flagsFactory))
+        assertNull(TraceParentImpl.decode("00-$uppercaseTraceId-$spanId-01", flagsFactory))
     }
 
     @Test
     fun `decode rejects header with fewer than four fields`() {
         val header = "0".repeat(55)
-        assertNull(TraceParent.decode(header, flagsFactory))
+        assertNull(TraceParentImpl.decode(header, flagsFactory))
     }
 
     @Test
     fun `decode rejects forbidden ff version per spec`() {
-        assertNull(TraceParent.decode("ff-$traceId-$spanId-01", flagsFactory))
+        assertNull(TraceParentImpl.decode("ff-$traceId-$spanId-01", flagsFactory))
     }
 
     @Test
     fun `decode rejects non-hex version`() {
-        assertNull(TraceParent.decode("0g-$traceId-$spanId-01", flagsFactory))
+        assertNull(TraceParentImpl.decode("0g-$traceId-$spanId-01", flagsFactory))
     }
 
     @Test
     fun `decode rejects version of wrong length`() {
         val header = "001-$traceId-$spanId-01"
-        assertNull(TraceParent.decode(header, flagsFactory))
+        assertNull(TraceParentImpl.decode(header, flagsFactory))
     }
 
     @Test
     fun `decode rejects version 00 with an additional field`() {
         val header = "00-$traceId-$spanId-01-extra"
-        assertNull(TraceParent.decode(header, flagsFactory))
+        assertNull(TraceParentImpl.decode(header, flagsFactory))
     }
 
     @Test
     fun `decode rejects trace id of wrong length`() {
         val longTrace = "0".repeat(33)
-        assertNull(TraceParent.decode("01-$longTrace-$spanId-01", flagsFactory))
+        assertNull(TraceParentImpl.decode("01-$longTrace-$spanId-01", flagsFactory))
     }
 
     @Test
     fun `decode rejects non-hex trace id`() {
         val invalidTraceId = traceId.replaceFirst('a', 'g')
-        assertNull(TraceParent.decode("00-$invalidTraceId-$spanId-01", flagsFactory))
+        assertNull(TraceParentImpl.decode("00-$invalidTraceId-$spanId-01", flagsFactory))
     }
 
     @Test
     fun `decode rejects span id of wrong length`() {
         val longSpan = "0".repeat(17)
-        assertNull(TraceParent.decode("01-$traceId-$longSpan-01", flagsFactory))
+        assertNull(TraceParentImpl.decode("01-$traceId-$longSpan-01", flagsFactory))
     }
 
     @Test
     fun `decode rejects non-hex span id`() {
         val invalidSpanId = spanId.replaceFirst('b', 'g')
-        assertNull(TraceParent.decode("00-$traceId-$invalidSpanId-01", flagsFactory))
+        assertNull(TraceParentImpl.decode("00-$traceId-$invalidSpanId-01", flagsFactory))
     }
 
     @Test
     fun `decode rejects flags of wrong length`() {
-        assertNull(TraceParent.decode("01-$traceId-$spanId-001", flagsFactory))
+        assertNull(TraceParentImpl.decode("01-$traceId-$spanId-001", flagsFactory))
     }
 
     @Test
     fun `decode rejects non-hex flags`() {
-        assertNull(TraceParent.decode("00-$traceId-$spanId-zz", flagsFactory))
+        assertNull(TraceParentImpl.decode("00-$traceId-$spanId-zz", flagsFactory))
     }
 
     @Test
     fun `decode rejects header with uppercase version`() {
         val header = "0A-$traceId-$spanId-01"
-        assertNull(TraceParent.decode(header, flagsFactory))
+        assertNull(TraceParentImpl.decode(header, flagsFactory))
     }
 
     @Test
     fun `decode rejects header with uppercase flags`() {
         val header = "00-$traceId-$spanId-0A"
-        assertNull(TraceParent.decode(header, flagsFactory))
+        assertNull(TraceParentImpl.decode(header, flagsFactory))
     }
 
     @Test
     fun `constructor accepts canonical fields`() {
-        val tp = TraceParent(
+        val tp = TraceParentImpl(
             version = "00",
             traceId = traceId,
             spanId = spanId,
@@ -245,7 +245,7 @@ internal class TraceParentTest {
     @Test
     fun `constructor rejects version of wrong length`() {
         assertFailsWith<IllegalArgumentException> {
-            TraceParent(
+            TraceParentImpl(
                 version = "0",
                 traceId = traceId,
                 spanId = spanId,
@@ -257,7 +257,7 @@ internal class TraceParentTest {
     @Test
     fun `constructor rejects non-hex version`() {
         assertFailsWith<IllegalArgumentException> {
-            TraceParent(
+            TraceParentImpl(
                 version = "0g",
                 traceId = traceId,
                 spanId = spanId,
@@ -269,7 +269,7 @@ internal class TraceParentTest {
     @Test
     fun `constructor rejects uppercase hex version`() {
         assertFailsWith<IllegalArgumentException> {
-            TraceParent(
+            TraceParentImpl(
                 version = "0A",
                 traceId = traceId,
                 spanId = spanId,
@@ -281,7 +281,7 @@ internal class TraceParentTest {
     @Test
     fun `constructor rejects forbidden ff version`() {
         assertFailsWith<IllegalArgumentException> {
-            TraceParent(
+            TraceParentImpl(
                 version = "ff",
                 traceId = traceId,
                 spanId = spanId,
@@ -293,7 +293,7 @@ internal class TraceParentTest {
     @Test
     fun `constructor rejects trace id of wrong length`() {
         assertFailsWith<IllegalArgumentException> {
-            TraceParent(
+            TraceParentImpl(
                 version = "00",
                 traceId = "0".repeat(31),
                 spanId = spanId,
@@ -305,7 +305,7 @@ internal class TraceParentTest {
     @Test
     fun `constructor rejects non-hex trace id`() {
         assertFailsWith<IllegalArgumentException> {
-            TraceParent(
+            TraceParentImpl(
                 version = "00",
                 traceId = traceId.replaceFirst('a', 'g'),
                 spanId = spanId,
@@ -317,7 +317,7 @@ internal class TraceParentTest {
     @Test
     fun `constructor rejects uppercase hex trace id`() {
         assertFailsWith<IllegalArgumentException> {
-            TraceParent(
+            TraceParentImpl(
                 version = "00",
                 traceId = traceId.uppercase(),
                 spanId = spanId,
@@ -329,7 +329,7 @@ internal class TraceParentTest {
     @Test
     fun `constructor rejects span id of wrong length`() {
         assertFailsWith<IllegalArgumentException> {
-            TraceParent(
+            TraceParentImpl(
                 version = "00",
                 traceId = traceId,
                 spanId = "0".repeat(15),
@@ -341,7 +341,7 @@ internal class TraceParentTest {
     @Test
     fun `constructor rejects non-hex span id`() {
         assertFailsWith<IllegalArgumentException> {
-            TraceParent(
+            TraceParentImpl(
                 version = "00",
                 traceId = traceId,
                 spanId = spanId.replaceFirst('b', 'g'),
@@ -353,7 +353,7 @@ internal class TraceParentTest {
     @Test
     fun `constructor rejects uppercase hex span id`() {
         assertFailsWith<IllegalArgumentException> {
-            TraceParent(
+            TraceParentImpl(
                 version = "00",
                 traceId = traceId,
                 spanId = spanId.uppercase(),
@@ -365,7 +365,7 @@ internal class TraceParentTest {
     @Test
     fun `constructor rejects empty version`() {
         assertFailsWith<IllegalArgumentException> {
-            TraceParent(
+            TraceParentImpl(
                 version = "",
                 traceId = traceId,
                 spanId = spanId,
@@ -377,7 +377,7 @@ internal class TraceParentTest {
     @Test
     fun `constructor rejects empty trace id`() {
         assertFailsWith<IllegalArgumentException> {
-            TraceParent(
+            TraceParentImpl(
                 version = "00",
                 traceId = "",
                 spanId = spanId,
@@ -389,7 +389,7 @@ internal class TraceParentTest {
     @Test
     fun `constructor rejects empty span id`() {
         assertFailsWith<IllegalArgumentException> {
-            TraceParent(
+            TraceParentImpl(
                 version = "00",
                 traceId = traceId,
                 spanId = "",

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/propagation/TraceStateImplTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/propagation/TraceStateImplTest.kt
@@ -1,0 +1,160 @@
+package io.opentelemetry.kotlin.propagation
+
+import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.factory.TraceStateFactoryImpl
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Asserts behaviour against the W3C `tracestate` spec:
+ * https://www.w3.org/TR/trace-context-2/#tracestate-header
+ */
+@OptIn(ExperimentalApi::class)
+internal class TraceStateImplTest {
+
+    private val factory = TraceStateFactoryImpl()
+
+    @Test
+    fun `encode produces a single key=value list-member`() {
+        val ts = TraceStateImpl(factory.default.put("foo", "bar"))
+        assertEquals("foo=bar", ts.encode())
+    }
+
+    @Test
+    fun `encode joins multiple list-members with comma and preserves insertion order`() {
+        val state = factory.default
+            .put("foo", "1")
+            .put("bar", "2")
+            .put("baz", "3")
+        val ts = TraceStateImpl(state)
+        assertEquals("foo=1,bar=2,baz=3", ts.encode())
+    }
+
+    @Test
+    fun `encode of an empty state returns an empty string`() {
+        val ts = TraceStateImpl(factory.default)
+        assertEquals("", ts.encode())
+    }
+
+    @Test
+    fun `encode supports multi-tenant keys`() {
+        val state = factory.default.put("tenant@vendor", "value")
+        val ts = TraceStateImpl(state)
+        assertEquals("tenant@vendor=value", ts.encode())
+    }
+
+    @Test
+    fun `decode parses a single canonical list-member`() {
+        val ts = TraceStateImpl.decode("foo=bar", factory)
+        assertEquals("foo=bar", ts.encode())
+    }
+
+    @Test
+    fun `decode parses multiple list-members preserving order`() {
+        val ts = TraceStateImpl.decode("foo=1,bar=2,baz=3", factory)
+        assertEquals("foo=1,bar=2,baz=3", ts.encode())
+    }
+
+    @Test
+    fun `decode round-trips into encode without loss`() {
+        val header = "foo=1,bar=2,baz=3"
+        val ts = TraceStateImpl.decode(header, factory)
+        assertEquals(header, ts.encode())
+    }
+
+    @Test
+    fun `decode accepts multi-tenant keys`() {
+        val ts = TraceStateImpl.decode("tenant@vendor=value", factory)
+        assertEquals("tenant@vendor=value", ts.encode())
+    }
+
+    @Test
+    fun `decode accepts the maximum 32 list-members`() {
+        val header = (1..32).joinToString(",") { "k$it=v$it" }
+        val ts = TraceStateImpl.decode(header, factory)
+        assertEquals(header, ts.encode())
+    }
+
+    @Test
+    fun `decode of an empty header returns an empty TraceState`() {
+        val ts = TraceStateImpl.decode("", factory)
+        assertEquals("", ts.encode())
+    }
+
+    @Test
+    fun `decode of a header containing only commas returns an empty TraceState`() {
+        val ts = TraceStateImpl.decode(",,,", factory)
+        assertEquals("", ts.encode())
+    }
+
+    @Test
+    fun `decode of a header containing only whitespace returns an empty TraceState`() {
+        val ts = TraceStateImpl.decode("   \t  ", factory)
+        assertEquals("", ts.encode())
+    }
+
+    @Test
+    fun `decode trims leading and trailing OWS around list-members`() {
+        val ts = TraceStateImpl.decode(" foo=bar ,\tbaz=qux\t", factory)
+        assertEquals("foo=bar,baz=qux", ts.encode())
+    }
+
+    @Test
+    fun `decode skips empty list-members between valid ones`() {
+        val ts = TraceStateImpl.decode("foo=bar,,baz=qux", factory)
+        assertEquals("foo=bar,baz=qux", ts.encode())
+    }
+
+    @Test
+    fun `decode skips members lacking an equals sign and keeps the rest`() {
+        val ts = TraceStateImpl.decode("foo=bar,nokey,baz=qux", factory)
+        assertEquals("foo=bar,baz=qux", ts.encode())
+    }
+
+    @Test
+    fun `decode skips members with an empty key`() {
+        val ts = TraceStateImpl.decode("=value,foo=bar", factory)
+        assertEquals("foo=bar", ts.encode())
+    }
+
+    @Test
+    fun `decode skips members with an empty value`() {
+        val ts = TraceStateImpl.decode("foo=,bar=baz", factory)
+        assertEquals("bar=baz", ts.encode())
+    }
+
+    @Test
+    fun `decode skips members with invalid keys and keeps the rest`() {
+        // Uppercase keys are invalid per W3C spec
+        val ts = TraceStateImpl.decode("FOO=bad,baz=qux", factory)
+        assertEquals("baz=qux", ts.encode())
+    }
+
+    @Test
+    fun `decode skips multi-at-sign keys and keeps the rest`() {
+        val ts = TraceStateImpl.decode("a@b@c=bad,foo=bar", factory)
+        assertEquals("foo=bar", ts.encode())
+    }
+
+    @Test
+    fun `decode skips members whose value contains an equals sign`() {
+        // Splitting at the first = treats the rest as the value; '=' is forbidden in values
+        // so put rejects it. Other entries are kept.
+        val ts = TraceStateImpl.decode("foo=bar=baz,ok=yes", factory)
+        assertEquals("ok=yes", ts.encode())
+    }
+
+    @Test
+    fun `decode keeps the first occurrence of a duplicate key and drops later ones`() {
+        val ts = TraceStateImpl.decode("foo=first,foo=second", factory)
+        assertEquals("foo=first", ts.encode())
+    }
+
+    @Test
+    fun `decode silently drops list-members beyond the 32-entry cap`() {
+        val header = (1..33).joinToString(",") { "k$it=v$it" }
+        val expected = (1..32).joinToString(",") { "k$it=v$it" }
+        val ts = TraceStateImpl.decode(header, factory)
+        assertEquals(expected, ts.encode())
+    }
+}

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/propagation/W3CTraceContextPropagatorTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/propagation/W3CTraceContextPropagatorTest.kt
@@ -1,0 +1,284 @@
+package io.opentelemetry.kotlin.propagation
+
+import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.context.Context
+import io.opentelemetry.kotlin.factory.ContextFactoryImpl
+import io.opentelemetry.kotlin.factory.IdGeneratorImpl
+import io.opentelemetry.kotlin.factory.SpanContextFactoryImpl
+import io.opentelemetry.kotlin.factory.SpanFactoryImpl
+import io.opentelemetry.kotlin.factory.TraceFlagsFactoryImpl
+import io.opentelemetry.kotlin.factory.TraceStateFactoryImpl
+import io.opentelemetry.kotlin.tracing.SpanContext
+import io.opentelemetry.kotlin.tracing.TraceFlagsImpl
+import io.opentelemetry.kotlin.tracing.TraceState
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+/**
+ * Asserts behaviour against the W3C Trace Context spec:
+ * https://www.w3.org/TR/trace-context/
+ */
+@OptIn(ExperimentalApi::class)
+internal class W3CTraceContextPropagatorTest {
+
+    private val idGenerator = IdGeneratorImpl()
+    private val traceFlagsFactory = TraceFlagsFactoryImpl()
+    private val traceStateFactory = TraceStateFactoryImpl()
+    private val spanContextFactory = SpanContextFactoryImpl(idGenerator, traceFlagsFactory, traceStateFactory)
+    private val contextFactory = ContextFactoryImpl()
+    private val spanFactory = SpanFactoryImpl(spanContextFactory, contextFactory.spanKey)
+
+    private val propagator = W3CTraceContextPropagator(
+        traceFlagsFactory = traceFlagsFactory,
+        traceStateFactory = traceStateFactory,
+        spanContextFactory = spanContextFactory,
+        spanFactory = spanFactory,
+        contextFactory = contextFactory,
+    )
+
+    private val traceId = "0af7651916cd43dd8448eb211c80319c"
+    private val spanId = "b7ad6b7169203331"
+
+    @Test
+    fun `fields returns traceparent and tracestate in order`() {
+        assertEquals(listOf("traceparent", "tracestate"), propagator.fields().toList())
+    }
+
+    @Test
+    fun `inject does nothing on root context with no span`() {
+        val carrier = mutableMapOf<String, String>()
+        propagator.inject(contextFactory.root(), carrier, MapTextMapSetter)
+        assertTrue(carrier.isEmpty())
+    }
+
+    @Test
+    fun `inject does nothing when current span is invalid`() {
+        val carrier = mutableMapOf<String, String>()
+        val context = contextFactory.storeSpan(contextFactory.root(), spanFactory.invalid)
+        propagator.inject(context, carrier, MapTextMapSetter)
+        assertTrue(carrier.isEmpty())
+    }
+
+    @Test
+    fun `inject writes canonical traceparent for a valid sampled span`() {
+        val context = contextWithSpan(
+            spanContext(
+                traceFlags = TraceFlagsImpl(isSampled = true, isRandom = false),
+            ),
+        )
+        val carrier = injectInto(context)
+        assertEquals("00-$traceId-$spanId-01", carrier["traceparent"])
+    }
+
+    @Test
+    fun `inject writes flags 00 when not sampled`() {
+        val context = contextWithSpan(
+            spanContext(
+                traceFlags = TraceFlagsImpl(isSampled = false, isRandom = false),
+            ),
+        )
+        val carrier = injectInto(context)
+        assertEquals("00-$traceId-$spanId-00", carrier["traceparent"])
+    }
+
+    @Test
+    fun `inject writes flags 03 when sampled and random bits set`() {
+        val context = contextWithSpan(
+            spanContext(
+                traceFlags = TraceFlagsImpl(isSampled = true, isRandom = true),
+            ),
+        )
+        val carrier = injectInto(context)
+        assertEquals("00-$traceId-$spanId-03", carrier["traceparent"])
+    }
+
+    @Test
+    fun `inject does not write tracestate when state is empty`() {
+        val context = contextWithSpan(spanContext())
+        val carrier = injectInto(context)
+        assertNull(carrier["tracestate"])
+    }
+
+    @Test
+    fun `inject writes tracestate when state has entries`() {
+        val state = traceStateFactory.default.put("foo", "bar")
+        val context = contextWithSpan(spanContext(traceState = state))
+        val carrier = injectInto(context)
+        assertEquals("foo=bar", carrier["tracestate"])
+    }
+
+    @Test
+    fun `inject preserves multiple tracestate entries in insertion order`() {
+        val state = traceStateFactory.default
+            .put("foo", "1")
+            .put("bar", "2")
+            .put("baz", "3")
+        val context = contextWithSpan(spanContext(traceState = state))
+        val carrier = injectInto(context)
+        assertEquals("foo=1,bar=2,baz=3", carrier["tracestate"])
+    }
+
+    @Test
+    fun `extract returns original context when traceparent header is absent`() {
+        val root = contextFactory.root()
+        val result = propagator.extract(root, emptyMap(), MapTextMapGetter)
+        assertSame(root, result)
+    }
+
+    @Test
+    fun `extract returns original context when traceparent has wrong field count`() {
+        val root = contextFactory.root()
+        val carrier = mapOf("traceparent" to "00-$traceId-$spanId")
+        val result = propagator.extract(root, carrier, MapTextMapGetter)
+        assertSame(root, result)
+    }
+
+    @Test
+    fun `extract returns original context when traceparent contains uppercase hex`() {
+        val root = contextFactory.root()
+        val carrier = mapOf("traceparent" to "00-${traceId.uppercase()}-$spanId-01")
+        val result = propagator.extract(root, carrier, MapTextMapGetter)
+        assertSame(root, result)
+    }
+
+    @Test
+    fun `extract returns original context when traceparent uses forbidden version ff`() {
+        val root = contextFactory.root()
+        val carrier = mapOf("traceparent" to "ff-$traceId-$spanId-01")
+        val result = propagator.extract(root, carrier, MapTextMapGetter)
+        assertSame(root, result)
+    }
+
+    @Test
+    fun `extract returns original context when traceparent has all-zero traceId`() {
+        val root = contextFactory.root()
+        val carrier = mapOf("traceparent" to "00-00000000000000000000000000000000-$spanId-01")
+        val result = propagator.extract(root, carrier, MapTextMapGetter)
+        assertSame(root, result)
+    }
+
+    @Test
+    fun `extract returns original context when traceparent has all-zero spanId`() {
+        val root = contextFactory.root()
+        val carrier = mapOf("traceparent" to "00-$traceId-0000000000000000-01")
+        val result = propagator.extract(root, carrier, MapTextMapGetter)
+        assertSame(root, result)
+    }
+
+    @Test
+    fun `extract ignores tracestate when traceparent is invalid`() {
+        val root = contextFactory.root()
+        val carrier = mapOf(
+            "traceparent" to "ff-$traceId-$spanId-01",
+            "tracestate" to "foo=bar",
+        )
+        val result = propagator.extract(root, carrier, MapTextMapGetter)
+        assertSame(root, result)
+    }
+
+    @Test
+    fun `extract produces a SpanContext with isRemote=true`() {
+        val carrier = mapOf("traceparent" to "00-$traceId-$spanId-01")
+        val result = propagator.extract(contextFactory.root(), carrier, MapTextMapGetter)
+        val sc = spanFactory.fromContext(result).spanContext
+        assertTrue(sc.isRemote)
+    }
+
+    @Test
+    fun `extract reads sampled flag from traceparent flags byte`() {
+        val sampledCarrier = mapOf("traceparent" to "00-$traceId-$spanId-01")
+        val unsampledCarrier = mapOf("traceparent" to "00-$traceId-$spanId-00")
+
+        val sampled = spanFactory
+            .fromContext(propagator.extract(contextFactory.root(), sampledCarrier, MapTextMapGetter))
+            .spanContext
+        val unsampled = spanFactory
+            .fromContext(propagator.extract(contextFactory.root(), unsampledCarrier, MapTextMapGetter))
+            .spanContext
+
+        assertTrue(sampled.traceFlags.isSampled)
+        assertFalse(unsampled.traceFlags.isSampled)
+    }
+
+    @Test
+    fun `extract attaches an empty TraceState when tracestate header is absent`() {
+        val carrier = mapOf("traceparent" to "00-$traceId-$spanId-01")
+        val result = propagator.extract(contextFactory.root(), carrier, MapTextMapGetter)
+        val sc = spanFactory.fromContext(result).spanContext
+        assertTrue(sc.traceState.asMap().isEmpty())
+    }
+
+    @Test
+    fun `extract attaches parsed TraceState when tracestate header is present`() {
+        val carrier = mapOf(
+            "traceparent" to "00-$traceId-$spanId-01",
+            "tracestate" to "foo=bar,baz=qux",
+        )
+        val result = propagator.extract(contextFactory.root(), carrier, MapTextMapGetter)
+        val sc = spanFactory.fromContext(result).spanContext
+        assertEquals(mapOf("foo" to "bar", "baz" to "qux"), sc.traceState.asMap())
+    }
+
+    @Test
+    fun `extract drops malformed tracestate members but keeps valid ones`() {
+        val carrier = mapOf(
+            "traceparent" to "00-$traceId-$spanId-01",
+            "tracestate" to "foo=bar,bogus,baz=qux",
+        )
+        val result = propagator.extract(contextFactory.root(), carrier, MapTextMapGetter)
+        val sc = spanFactory.fromContext(result).spanContext
+        assertEquals(mapOf("foo" to "bar", "baz" to "qux"), sc.traceState.asMap())
+    }
+
+    @Test
+    fun `extract attaches a non-recording span on the returned context`() {
+        val carrier = mapOf("traceparent" to "00-$traceId-$spanId-01")
+        val result = propagator.extract(contextFactory.root(), carrier, MapTextMapGetter)
+        val span = spanFactory.fromContext(result)
+        assertFalse(span.isRecording())
+        assertEquals(traceId, span.spanContext.traceId)
+        assertEquals(spanId, span.spanContext.spanId)
+    }
+
+    @Test
+    fun `inject and extract round-trip preserves traceId spanId flags and tracestate`() {
+        val state = traceStateFactory.default.put("vendor", "value")
+        val original = spanContext(
+            traceFlags = TraceFlagsImpl(isSampled = true, isRandom = false),
+            traceState = state,
+        )
+        val carrier = injectInto(contextWithSpan(original))
+        val extracted = propagator.extract(contextFactory.root(), carrier, MapTextMapGetter)
+        val sc = spanFactory.fromContext(extracted).spanContext
+
+        assertEquals(original.traceId, sc.traceId)
+        assertEquals(original.spanId, sc.spanId)
+        assertEquals(original.traceFlags.isSampled, sc.traceFlags.isSampled)
+        assertEquals(original.traceState.asMap(), sc.traceState.asMap())
+        assertTrue(sc.isRemote)
+    }
+
+    private fun spanContext(
+        traceFlags: io.opentelemetry.kotlin.tracing.TraceFlags = TraceFlagsImpl(isSampled = true, isRandom = false),
+        traceState: TraceState = traceStateFactory.default,
+    ): SpanContext = spanContextFactory.create(
+        traceId = traceId,
+        spanId = spanId,
+        traceFlags = traceFlags,
+        traceState = traceState,
+        isRemote = false,
+    )
+
+    private fun contextWithSpan(spanContext: SpanContext): Context =
+        contextFactory.storeSpan(contextFactory.root(), spanFactory.fromSpanContext(spanContext))
+
+    private fun injectInto(context: Context): MutableMap<String, String> {
+        val carrier = mutableMapOf<String, String>()
+        propagator.inject(context, carrier, MapTextMapSetter)
+        return carrier
+    }
+}

--- a/noop/src/commonMain/kotlin/io/opentelemetry/kotlin/propagation/NoopPropagatorFactory.kt
+++ b/noop/src/commonMain/kotlin/io/opentelemetry/kotlin/propagation/NoopPropagatorFactory.kt
@@ -12,4 +12,6 @@ internal object NoopPropagatorFactory : PropagatorFactory {
         NoopTextMapPropagator
 
     override fun w3cBaggage(): TextMapPropagator = NoopTextMapPropagator
+
+    override fun w3cTraceContext(): TextMapPropagator = NoopTextMapPropagator
 }

--- a/noop/src/commonTest/kotlin/io/opentelemetry/kotlin/NoopTests.kt
+++ b/noop/src/commonTest/kotlin/io/opentelemetry/kotlin/NoopTests.kt
@@ -248,6 +248,7 @@ internal class NoopTests {
         assertSame(NoopTextMapPropagator, NoopPropagatorFactory.composite(NoopTextMapPropagator))
         assertSame(NoopTextMapPropagator, NoopPropagatorFactory.composite(listOf(NoopTextMapPropagator)))
         assertSame(NoopTextMapPropagator, NoopPropagatorFactory.w3cBaggage())
+        assertSame(NoopTextMapPropagator, NoopPropagatorFactory.w3cTraceContext())
     }
 
     @Test


### PR DESCRIPTION
## Goal

Implements a W3C TraceContext Propagator, by building on top of #464.

## Testing

Added unit tests.
