### PR TITLE
Truncate byte array attribute values

### DIFF
--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/attributes/AttributesModel.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/attributes/AttributesModel.kt
@@ -72,7 +72,11 @@ internal class AttributesModel(
 
     override fun setByteArrayAttribute(key: String, value: ByteArray) {
         if (canAddAttribute(key)) {
-            attrs[key] = value
+            attrs[key] = if (value.size > attributeValueLengthLimit) {
+                value.copyOf(attributeValueLengthLimit)
+            } else {
+                value
+            }
         }
     }
 

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/attributes/AttributesMutatorImplTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/attributes/AttributesMutatorImplTest.kt
@@ -101,6 +101,25 @@ internal class AttributesMutatorImplTest {
     }
 
     @Test
+    fun testByteArrayValueTruncated() {
+        val attrs = AttributesModel(attributeLimit = attributeLimit, attributeValueLengthLimit = 3).apply {
+            setByteArrayAttribute("bytes", byteArrayOf(0x01, 0x02, 0x03, 0x04, 0x05, 0x06))
+        }.attributes
+        val stored = attrs["bytes"] as ByteArray
+        assertTrue(stored.contentEquals(byteArrayOf(0x01, 0x02, 0x03)))
+    }
+
+    @Test
+    fun testByteArrayValueAtLimit() {
+        val bytes = byteArrayOf(0x01, 0x02, 0x03, 0x04, 0x05)
+        val attrs = AttributesModel(attributeLimit = attributeLimit, attributeValueLengthLimit = 5).apply {
+            setByteArrayAttribute("bytes", bytes)
+        }.attributes
+        val stored = attrs["bytes"] as ByteArray
+        assertTrue(stored.contentEquals(bytes))
+    }
+
+    @Test
     fun testEmptyKeyIgnoredForAllTypes() {
         val attrs = AttributesModel(attributeLimit).apply {
             setBooleanAttribute("", true)


### PR DESCRIPTION
## Goal

Truncates byte array values in attributes so that they follow the [attribute limits](https://opentelemetry.io/docs/specs/otel/common/#attribute-limits) defined in the spec.

## Testing

Added unit tests.
