### PR TITLE
Allow supplying a custom implicit context storage mechanism

### DIFF
--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/OpenTelemetryImplEntrypoint.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/OpenTelemetryImplEntrypoint.kt
@@ -46,10 +46,11 @@ internal fun createOpenTelemetryImpl(
     val traceFlags = TraceFlagsFactoryImpl()
     val traceState = TraceStateFactoryImpl()
     val spanContext = SpanContextFactoryImpl(idGenerator, traceFlags, traceState)
-    val contextFactory = ContextFactoryImpl()
-    val span = SpanFactoryImpl(spanContext, contextFactory.spanKey)
 
     val cfg = OpenTelemetryConfigImpl(clock).apply(config)
+    val contextFactory = ContextFactoryImpl(cfg.contextConfig::generateStorage)
+    val span = SpanFactoryImpl(spanContext, contextFactory.spanKey)
+
     val tracingConfig = cfg.generateTracingConfig()
     val loggingConfig = cfg.generateLoggingConfig()
     return OpenTelemetryImpl(

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/factory/ContextFactoryImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/factory/ContextFactoryImpl.kt
@@ -9,9 +9,11 @@ import io.opentelemetry.kotlin.context.ImplicitContextStorage
 import io.opentelemetry.kotlin.context.Scope
 import io.opentelemetry.kotlin.tracing.Span
 
-internal class ContextFactoryImpl : ContextFactory {
+internal class ContextFactoryImpl(
+    storageFactory: (supplier: () -> Context) -> ImplicitContextStorage = ::DefaultImplicitContextStorage,
+) : ContextFactory {
 
-    private val storage: ImplicitContextStorage = DefaultImplicitContextStorage { root }
+    private val storage: ImplicitContextStorage = storageFactory { root }
     private val root by lazy { ContextImpl(storage) }
     internal val spanKey by lazy { createKey<Span>("otel-kotlin-span") }
 

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/ContextConfigImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/ContextConfigImpl.kt
@@ -1,7 +1,23 @@
 package io.opentelemetry.kotlin.init
 
+import io.opentelemetry.kotlin.context.Context
+import io.opentelemetry.kotlin.context.DefaultImplicitContextStorage
+import io.opentelemetry.kotlin.context.ImplicitContextStorage
 import io.opentelemetry.kotlin.context.ImplicitContextStorageMode
 
 internal class ContextConfigImpl : ContextConfigDsl {
     override var storageMode: ImplicitContextStorageMode = ImplicitContextStorageMode.GLOBAL
+
+    private var customStorage: (() -> ImplicitContextStorage)? = null
+
+    override fun storage(action: () -> ImplicitContextStorage) {
+        customStorage = action
+    }
+
+    internal fun generateStorage(rootSupplier: () -> Context): ImplicitContextStorage {
+        customStorage?.let { return it() }
+        return when (storageMode) {
+            ImplicitContextStorageMode.GLOBAL -> DefaultImplicitContextStorage(rootSupplier)
+        }
+    }
 }

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/init/OpenTelemetryConfigImplTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/init/OpenTelemetryConfigImplTest.kt
@@ -3,6 +3,9 @@ package io.opentelemetry.kotlin.init
 import io.opentelemetry.kotlin.attributes.DEFAULT_ATTRIBUTE_LIMIT
 import io.opentelemetry.kotlin.attributes.DEFAULT_ATTRIBUTE_VALUE_LENGTH_LIMIT
 import io.opentelemetry.kotlin.clock.FakeClock
+import io.opentelemetry.kotlin.context.DefaultImplicitContextStorage
+import io.opentelemetry.kotlin.context.FakeContext
+import io.opentelemetry.kotlin.context.FakeImplicitContextStorage
 import io.opentelemetry.kotlin.context.ImplicitContextStorageMode
 import io.opentelemetry.kotlin.logging.export.FakeLogRecordProcessor
 import io.opentelemetry.kotlin.tracing.export.FakeSpanProcessor
@@ -10,6 +13,8 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
 
 internal class OpenTelemetryConfigImplTest {
 
@@ -83,6 +88,37 @@ internal class OpenTelemetryConfigImplTest {
             assertEquals(256, attributeValueLengthLimit)
         }
         assertEquals(64, cfg.generateLoggingConfig().logLimits.attributeCountLimit)
+    }
+
+    @Test
+    fun testDefaultStorage() {
+        val cfg = OpenTelemetryConfigImpl(clock)
+        val rootContext = FakeContext()
+        val storage = cfg.contextConfig.generateStorage { rootContext }
+        assertTrue(storage is DefaultImplicitContextStorage)
+    }
+
+    @Test
+    fun testCustomStorage() {
+        val custom = FakeImplicitContextStorage()
+        val cfg = OpenTelemetryConfigImpl(clock).apply {
+            context {
+                storage { custom }
+            }
+        }
+        assertSame(custom, cfg.contextConfig.generateStorage(::FakeContext))
+    }
+
+    @Test
+    fun testCustomStorageOverridesStorageMode() {
+        val custom = FakeImplicitContextStorage()
+        val cfg = OpenTelemetryConfigImpl(clock).apply {
+            context {
+                storageMode = ImplicitContextStorageMode.GLOBAL
+                storage { custom }
+            }
+        }
+        assertSame(custom, cfg.contextConfig.generateStorage(::FakeContext))
     }
 
     @Test

--- a/sdk-api/api/jvm/sdk-api.api
+++ b/sdk-api/api/jvm/sdk-api.api
@@ -103,6 +103,7 @@ public abstract interface annotation class io/opentelemetry/kotlin/init/ConfigDs
 public abstract interface class io/opentelemetry/kotlin/init/ContextConfigDsl {
 	public abstract fun getStorageMode ()Lio/opentelemetry/kotlin/context/ImplicitContextStorageMode;
 	public abstract fun setStorageMode (Lio/opentelemetry/kotlin/context/ImplicitContextStorageMode;)V
+	public abstract fun storage (Lkotlin/jvm/functions/Function0;)V
 }
 
 public abstract interface class io/opentelemetry/kotlin/init/LogExportConfigDsl {

--- a/sdk-api/src/commonMain/kotlin/io/opentelemetry/kotlin/init/ContextConfigDsl.kt
+++ b/sdk-api/src/commonMain/kotlin/io/opentelemetry/kotlin/init/ContextConfigDsl.kt
@@ -1,6 +1,7 @@
 package io.opentelemetry.kotlin.init
 
 import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.context.ImplicitContextStorage
 import io.opentelemetry.kotlin.context.ImplicitContextStorageMode
 
 /**
@@ -11,7 +12,14 @@ import io.opentelemetry.kotlin.context.ImplicitContextStorageMode
 public interface ContextConfigDsl {
 
     /**
-     * Defines the storage mechanism used for the implicit context.
+     * Selects among the built-in [ImplicitContextStorage] implementations. Ignored when a custom
+     * implementation is supplied via [storage].
      */
     public var storageMode: ImplicitContextStorageMode
+
+    /**
+     * Plugs in a custom [ImplicitContextStorage] implementation. When set, this takes precedence
+     * over [storageMode]. May only be called once.
+     */
+    public fun storage(action: () -> ImplicitContextStorage)
 }


### PR DESCRIPTION
## Goal

Allows users instantiating the SDK to supply a custom storage mechanism for implicit context.

## Testing

Added unit tests.
