### PR TITLE
Add the gradle wrapper checksum

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionSha256Sum=553c78f50dafcd54d65b9a444649057857469edf836431389695608536d6b746
 distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.0-bin.zip
 networkTimeout=10000
 retries=0


### PR DESCRIPTION
We have this nice [gradle wrapper workflow](https://github.com/open-telemetry/opentelemetry-kotlin/blob/main/.github/workflows/gradle-wrapper-validation.yml), but I think it requires the checksum to be present to really be meaningful. We have this in other repos, and renovate will update it.