### PR TITLE
Implement ThreadLocal implicit context storage

### DIFF
--- a/implementation/src/appleMain/kotlin/io/opentelemetry/kotlin/context/ThreadLocalImplicitContextStorage.apple.kt
+++ b/implementation/src/appleMain/kotlin/io/opentelemetry/kotlin/context/ThreadLocalImplicitContextStorage.apple.kt
@@ -1,0 +1,27 @@
+package io.opentelemetry.kotlin.context
+
+import io.opentelemetry.kotlin.AtomicLong
+import platform.Foundation.NSNumber
+import platform.Foundation.NSThread
+import platform.Foundation.numberWithLong
+
+private val instanceCounter = AtomicLong()
+
+internal actual fun threadLocalImplicitContextStorage(
+    rootSupplier: () -> Context,
+): ImplicitContextStorage = AppleThreadLocalImplicitContextStorage(rootSupplier)
+
+private class AppleThreadLocalImplicitContextStorage(
+    rootSupplier: () -> Context,
+) : ImplicitContextStorage {
+
+    private val root by lazy { rootSupplier() }
+    private val key: NSNumber = NSNumber.numberWithLong(instanceCounter.incrementAndGet())
+
+    override fun setImplicitContext(context: Context) {
+        NSThread.currentThread.threadDictionary.setObject(context, key)
+    }
+
+    override fun implicitContext(): Context =
+        NSThread.currentThread.threadDictionary.objectForKey(key) as? Context ?: root
+}

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/context/ThreadLocalImplicitContextStorage.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/context/ThreadLocalImplicitContextStorage.kt
@@ -1,0 +1,5 @@
+package io.opentelemetry.kotlin.context
+
+internal expect fun threadLocalImplicitContextStorage(
+    rootSupplier: () -> Context,
+): ImplicitContextStorage

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/ContextConfigImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/ContextConfigImpl.kt
@@ -4,6 +4,7 @@ import io.opentelemetry.kotlin.context.Context
 import io.opentelemetry.kotlin.context.DefaultImplicitContextStorage
 import io.opentelemetry.kotlin.context.ImplicitContextStorage
 import io.opentelemetry.kotlin.context.ImplicitContextStorageMode
+import io.opentelemetry.kotlin.context.threadLocalImplicitContextStorage
 
 internal class ContextConfigImpl : ContextConfigDsl {
     override var storageMode: ImplicitContextStorageMode = ImplicitContextStorageMode.GLOBAL
@@ -18,6 +19,7 @@ internal class ContextConfigImpl : ContextConfigDsl {
         customStorage?.let { return it() }
         return when (storageMode) {
             ImplicitContextStorageMode.GLOBAL -> DefaultImplicitContextStorage(rootSupplier)
+            ImplicitContextStorageMode.THREAD_LOCAL -> threadLocalImplicitContextStorage(rootSupplier)
         }
     }
 }

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/context/ThreadLocalImplicitContextStorageTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/context/ThreadLocalImplicitContextStorageTest.kt
@@ -1,0 +1,43 @@
+package io.opentelemetry.kotlin.context
+
+import io.opentelemetry.kotlin.factory.ContextFactoryImpl
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertNotSame
+import kotlin.test.assertSame
+
+internal class ThreadLocalImplicitContextStorageTest {
+
+    private lateinit var factory: ContextFactoryImpl
+    private lateinit var storage: ImplicitContextStorage
+
+    @BeforeTest
+    fun setUp() {
+        factory = ContextFactoryImpl()
+        storage = threadLocalImplicitContextStorage(factory::root)
+    }
+
+    @Test
+    fun testRootReturnedWhenNoContextSet() {
+        assertSame(factory.root(), storage.implicitContext())
+    }
+
+    @Test
+    fun testSetContextReturnedOnSameThread() {
+        val other = FakeContext()
+        storage.setImplicitContext(other)
+        assertSame(other, storage.implicitContext())
+    }
+
+    @Test
+    fun testSeparateInstancesAreIndependent() {
+        val first = FakeContext()
+        val second = FakeContext()
+        val otherStorage = threadLocalImplicitContextStorage(factory::root)
+        storage.setImplicitContext(first)
+        otherStorage.setImplicitContext(second)
+        assertSame(first, storage.implicitContext())
+        assertSame(second, otherStorage.implicitContext())
+        assertNotSame(storage.implicitContext(), otherStorage.implicitContext())
+    }
+}

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/init/OpenTelemetryConfigImplTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/init/OpenTelemetryConfigImplTest.kt
@@ -122,6 +122,20 @@ internal class OpenTelemetryConfigImplTest {
     }
 
     @Test
+    fun testThreadLocalStorage() {
+        val cfg = OpenTelemetryConfigImpl(clock).apply {
+            context {
+                storageMode = ImplicitContextStorageMode.THREAD_LOCAL
+            }
+        }
+        val storage = cfg.contextConfig.generateStorage(::FakeContext)
+        val root = FakeContext()
+        val rootStorage = cfg.contextConfig.generateStorage { root }
+        assertNotNull(storage)
+        assertSame(root, rootStorage.implicitContext())
+    }
+
+    @Test
     fun testCustomStorage() {
         val custom = FakeImplicitContextStorage()
         val cfg = OpenTelemetryConfigImpl(clock).apply {

--- a/implementation/src/jsMain/kotlin/io/opentelemetry/kotlin/context/ThreadLocalImplicitContextStorage.js.kt
+++ b/implementation/src/jsMain/kotlin/io/opentelemetry/kotlin/context/ThreadLocalImplicitContextStorage.js.kt
@@ -1,0 +1,5 @@
+package io.opentelemetry.kotlin.context
+
+internal actual fun threadLocalImplicitContextStorage(
+    rootSupplier: () -> Context,
+): ImplicitContextStorage = DefaultImplicitContextStorage(rootSupplier)

--- a/implementation/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/context/ThreadLocalImplicitContextStorage.jvmAndAndroid.kt
+++ b/implementation/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/context/ThreadLocalImplicitContextStorage.jvmAndAndroid.kt
@@ -1,0 +1,19 @@
+package io.opentelemetry.kotlin.context
+
+internal actual fun threadLocalImplicitContextStorage(
+    rootSupplier: () -> Context,
+): ImplicitContextStorage = JvmThreadLocalImplicitContextStorage(rootSupplier)
+
+private class JvmThreadLocalImplicitContextStorage(
+    rootSupplier: () -> Context,
+) : ImplicitContextStorage {
+
+    private val root by lazy { rootSupplier() }
+    private val current = ThreadLocal<Context>()
+
+    override fun setImplicitContext(context: Context) {
+        current.set(context)
+    }
+
+    override fun implicitContext(): Context = current.get() ?: root
+}

--- a/implementation/src/jvmTest/kotlin/io/opentelemetry/kotlin/context/JvmThreadLocalImplicitContextStorageTest.kt
+++ b/implementation/src/jvmTest/kotlin/io/opentelemetry/kotlin/context/JvmThreadLocalImplicitContextStorageTest.kt
@@ -1,0 +1,33 @@
+package io.opentelemetry.kotlin.context
+
+import io.opentelemetry.kotlin.factory.ContextFactoryImpl
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.test.Test
+import kotlin.test.assertNotSame
+import kotlin.test.assertSame
+
+internal class JvmThreadLocalImplicitContextStorageTest {
+
+    @Test
+    fun testContextIsIsolatedPerThread() {
+        val factory = ContextFactoryImpl()
+        val storage = threadLocalImplicitContextStorage(factory::root)
+
+        val mainContext = FakeContext()
+        storage.setImplicitContext(mainContext)
+
+        val observedFromOtherThread = AtomicReference<Context>()
+        val otherContext = FakeContext()
+
+        val thread = Thread {
+            observedFromOtherThread.set(storage.implicitContext())
+            storage.setImplicitContext(otherContext)
+        }
+        thread.start()
+        thread.join()
+
+        assertSame(factory.root(), observedFromOtherThread.get())
+        assertNotSame(mainContext, observedFromOtherThread.get())
+        assertSame(mainContext, storage.implicitContext())
+    }
+}

--- a/sdk-api/api/jvm/sdk-api.api
+++ b/sdk-api/api/jvm/sdk-api.api
@@ -26,6 +26,7 @@ public abstract interface class io/opentelemetry/kotlin/context/ImplicitContextS
 
 public final class io/opentelemetry/kotlin/context/ImplicitContextStorageMode : java/lang/Enum {
 	public static final field GLOBAL Lio/opentelemetry/kotlin/context/ImplicitContextStorageMode;
+	public static final field THREAD_LOCAL Lio/opentelemetry/kotlin/context/ImplicitContextStorageMode;
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lio/opentelemetry/kotlin/context/ImplicitContextStorageMode;
 	public static fun values ()[Lio/opentelemetry/kotlin/context/ImplicitContextStorageMode;

--- a/sdk-api/src/commonMain/kotlin/io/opentelemetry/kotlin/context/ImplicitContextStorageMode.kt
+++ b/sdk-api/src/commonMain/kotlin/io/opentelemetry/kotlin/context/ImplicitContextStorageMode.kt
@@ -12,5 +12,12 @@ public enum class ImplicitContextStorageMode {
      * Implicit context is stored via an in-memory property. Any thread/coroutine can
      * set the context for any others. This is the default storage mechanism.
      */
-    GLOBAL
+    GLOBAL,
+
+    /**
+     * Implicit context is stored per-thread i.e. each thread observes its own current context
+     * independently of others. This is useful if you primarily use a thread-based execution model
+     * rather than using coroutines.
+     */
+    THREAD_LOCAL
 }


### PR DESCRIPTION
## Goal

Implements a storage solution for implicit context that uses `ThreadLocal`. This is _not_ made the default behavior in this changeset and is included to gain parity with opentelemetry-java's feature set. A future changeset will attempt to add a coroutine-based implicit context storage which will arguably be more suitable for a KMP library. However, no solution will get automatic context 100% right in all cases, so I feel it's sensible to offer multiple solutions and allows library consumers to pick the most appropriate for their needs.

Closes #477.

## Testing

Added unit tests.
