### PR TITLE
Alter how spans are stored on Context

### DIFF
--- a/api/api/jvm/api.api
+++ b/api/api/jvm/api.api
@@ -57,9 +57,11 @@ public abstract interface class io/opentelemetry/kotlin/context/Context {
 	public abstract fun attach ()Lio/opentelemetry/kotlin/context/Scope;
 	public abstract fun clearBaggage ()Lio/opentelemetry/kotlin/context/Context;
 	public abstract fun extractBaggage ()Lio/opentelemetry/kotlin/baggage/Baggage;
+	public abstract fun extractSpan ()Lio/opentelemetry/kotlin/tracing/Span;
 	public abstract fun get (Lio/opentelemetry/kotlin/context/ContextKey;)Ljava/lang/Object;
 	public abstract fun set (Lio/opentelemetry/kotlin/context/ContextKey;Ljava/lang/Object;)Lio/opentelemetry/kotlin/context/Context;
 	public abstract fun storeBaggage (Lio/opentelemetry/kotlin/baggage/Baggage;)Lio/opentelemetry/kotlin/context/Context;
+	public abstract fun storeSpan (Lio/opentelemetry/kotlin/tracing/Span;)Lio/opentelemetry/kotlin/context/Context;
 }
 
 public abstract interface class io/opentelemetry/kotlin/context/ContextKey {
@@ -77,9 +79,7 @@ public abstract interface class io/opentelemetry/kotlin/factory/BaggageFactory {
 public abstract interface class io/opentelemetry/kotlin/factory/ContextFactory {
 	public abstract fun createKey (Ljava/lang/String;)Lio/opentelemetry/kotlin/context/ContextKey;
 	public abstract fun implicit ()Lio/opentelemetry/kotlin/context/Context;
-	public abstract fun makeCurrent (Lio/opentelemetry/kotlin/tracing/Span;)Lio/opentelemetry/kotlin/context/Scope;
 	public abstract fun root ()Lio/opentelemetry/kotlin/context/Context;
-	public abstract fun storeSpan (Lio/opentelemetry/kotlin/context/Context;Lio/opentelemetry/kotlin/tracing/Span;)Lio/opentelemetry/kotlin/context/Context;
 }
 
 public abstract interface class io/opentelemetry/kotlin/factory/SpanContextFactory {
@@ -89,7 +89,6 @@ public abstract interface class io/opentelemetry/kotlin/factory/SpanContextFacto
 }
 
 public abstract interface class io/opentelemetry/kotlin/factory/SpanFactory {
-	public abstract fun fromContext (Lio/opentelemetry/kotlin/context/Context;)Lio/opentelemetry/kotlin/tracing/Span;
 	public abstract fun fromSpanContext (Lio/opentelemetry/kotlin/tracing/SpanContext;)Lio/opentelemetry/kotlin/tracing/Span;
 	public abstract fun getInvalid ()Lio/opentelemetry/kotlin/tracing/Span;
 }

--- a/api/src/commonMain/kotlin/io/opentelemetry/kotlin/context/Context.kt
+++ b/api/src/commonMain/kotlin/io/opentelemetry/kotlin/context/Context.kt
@@ -3,6 +3,7 @@ package io.opentelemetry.kotlin.context
 import io.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.kotlin.ThreadSafe
 import io.opentelemetry.kotlin.baggage.Baggage
+import io.opentelemetry.kotlin.tracing.Span
 
 /**
  * Immutable propagation mechanism that carries values across concerns.
@@ -43,6 +44,22 @@ public interface Context {
      */
     @ThreadSafe
     public fun attach(): Scope
+
+    /**
+     * Returns a new [Context] derived from this one with [span] stored under a pre-defined key.
+     *
+     * https://opentelemetry.io/docs/specs/otel/trace/api/#context-interaction
+     */
+    @ThreadSafe
+    public fun storeSpan(span: Span): Context
+
+    /**
+     * Returns the [Span] stored in this [Context], or an invalid [Span] if none is present.
+     *
+     * https://opentelemetry.io/docs/specs/otel/trace/api/#context-interaction
+     */
+    @ThreadSafe
+    public fun extractSpan(): Span
 
     /**
      * Returns a new [Context] derived from this one with [baggage] stored under a pre-defined key.

--- a/api/src/commonMain/kotlin/io/opentelemetry/kotlin/factory/ContextFactory.kt
+++ b/api/src/commonMain/kotlin/io/opentelemetry/kotlin/factory/ContextFactory.kt
@@ -3,8 +3,6 @@ package io.opentelemetry.kotlin.factory
 import io.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.kotlin.context.Context
 import io.opentelemetry.kotlin.context.ContextKey
-import io.opentelemetry.kotlin.context.Scope
-import io.opentelemetry.kotlin.tracing.Span
 
 /**
  * A factory for retrieving [Context] instances.
@@ -23,25 +21,10 @@ public interface ContextFactory {
     public fun implicit(): Context
 
     /**
-     * Stores a span and returns a new [Context], using a pre-defined key.
-     */
-    public fun storeSpan(context: Context, span: Span): Context
-
-    /**
      * Creates a new [ContextKey] with the given name. The name is used for debugging and does NOT
      * uniquely identify values - use the [ContextKey] itself for that.
      *
      * [T] represents the type of the value that is stored in the context.
      */
     public fun <T> createKey(name: String): ContextKey<T>
-
-    /**
-     * Stores [span] in a new [Context] derived from [implicit] and sets
-     * the new [Context] as the implicit context.
-     *
-     * Returns a [Scope]. Neglecting to detach the [Scope] is a programming error.
-     *
-     * https://opentelemetry.io/docs/specs/otel/trace/api/#context-interaction
-     */
-    public fun makeCurrent(span: Span): Scope
 }

--- a/api/src/commonMain/kotlin/io/opentelemetry/kotlin/factory/SpanFactory.kt
+++ b/api/src/commonMain/kotlin/io/opentelemetry/kotlin/factory/SpanFactory.kt
@@ -1,7 +1,6 @@
 package io.opentelemetry.kotlin.factory
 
 import io.opentelemetry.kotlin.ExperimentalApi
-import io.opentelemetry.kotlin.context.Context
 import io.opentelemetry.kotlin.tracing.Span
 import io.opentelemetry.kotlin.tracing.SpanContext
 
@@ -21,10 +20,4 @@ public interface SpanFactory {
      * object will be returned.
      */
     public fun fromSpanContext(spanContext: SpanContext): Span
-
-    /**
-     * Returns a span from the supplied [Context]. If the context has no span an invalid span
-     * object will be returned.
-     */
-    public fun fromContext(context: Context): Span
 }

--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/context/ContextAdapter.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/context/ContextAdapter.kt
@@ -1,9 +1,17 @@
+@file:Suppress("DiscouragedImport")
+
 package io.opentelemetry.kotlin.context
 
 import io.opentelemetry.kotlin.aliases.OtelJavaBaggage
 import io.opentelemetry.kotlin.aliases.OtelJavaContext
+import io.opentelemetry.kotlin.aliases.OtelJavaSpan
+import io.opentelemetry.kotlin.aliases.OtelJavaSpanContext
 import io.opentelemetry.kotlin.baggage.Baggage
 import io.opentelemetry.kotlin.baggage.BaggageAdapter
+import io.opentelemetry.kotlin.tracing.NonRecordingSpan
+import io.opentelemetry.kotlin.tracing.Span
+import io.opentelemetry.kotlin.tracing.ext.storeInContext
+import io.opentelemetry.kotlin.tracing.model.SpanContextAdapter
 
 internal class ContextAdapter(
     val impl: OtelJavaContext,
@@ -22,6 +30,16 @@ internal class ContextAdapter(
 
     override fun attach(): Scope {
         return ScopeAdapter(impl.makeCurrent())
+    }
+
+    override fun storeSpan(span: Span): Context = span.storeInContext(this)
+
+    override fun extractSpan(): Span {
+        val javaSpan = OtelJavaSpan.fromContext(impl)
+        return NonRecordingSpan(
+            SpanContextAdapter(OtelJavaSpanContext.getInvalid()),
+            SpanContextAdapter(javaSpan.spanContext),
+        )
     }
 
     override fun storeBaggage(baggage: Baggage): Context {

--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/factory/CompatContextFactory.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/factory/CompatContextFactory.kt
@@ -5,23 +5,13 @@ import io.opentelemetry.kotlin.aliases.OtelJavaContextKey
 import io.opentelemetry.kotlin.context.Context
 import io.opentelemetry.kotlin.context.ContextKey
 import io.opentelemetry.kotlin.context.ContextKeyAdapter
-import io.opentelemetry.kotlin.context.Scope
 import io.opentelemetry.kotlin.context.toOtelKotlinContext
-import io.opentelemetry.kotlin.tracing.Span
-import io.opentelemetry.kotlin.tracing.ext.storeInContext
 
 internal class CompatContextFactory : ContextFactory {
 
     override fun root(): Context = OtelJavaContext.root().toOtelKotlinContext()
 
-    override fun storeSpan(
-        context: Context,
-        span: Span
-    ): Context = span.storeInContext(context)
-
     override fun implicit(): Context = OtelJavaContext.current().toOtelKotlinContext()
 
     override fun <T> createKey(name: String): ContextKey<T> = ContextKeyAdapter(OtelJavaContextKey.named(name))
-
-    override fun makeCurrent(span: Span): Scope = storeSpan(implicit(), span).attach()
 }

--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/factory/CompatSpanFactory.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/factory/CompatSpanFactory.kt
@@ -1,16 +1,8 @@
-@file:Suppress("DiscouragedImport")
-
 package io.opentelemetry.kotlin.factory
 
-import io.opentelemetry.api.trace.otelJavaSpanContextKey
-import io.opentelemetry.kotlin.aliases.OtelJavaContext
-import io.opentelemetry.kotlin.aliases.OtelJavaSpan
-import io.opentelemetry.kotlin.context.Context
-import io.opentelemetry.kotlin.context.ContextAdapter
 import io.opentelemetry.kotlin.tracing.NonRecordingSpan
 import io.opentelemetry.kotlin.tracing.Span
 import io.opentelemetry.kotlin.tracing.SpanContext
-import io.opentelemetry.kotlin.tracing.model.SpanContextAdapter
 
 internal class CompatSpanFactory(spanContextFactory: SpanContextFactory) : SpanFactory {
 
@@ -21,12 +13,5 @@ internal class CompatSpanFactory(spanContextFactory: SpanContextFactory) : SpanF
     override fun fromSpanContext(spanContext: SpanContext): Span = when {
         spanContext.isValid -> NonRecordingSpan(invalidSpanContext, spanContext)
         else -> invalid
-    }
-
-    override fun fromContext(context: Context): Span {
-        val otelJavaCtx = (context as? ContextAdapter)?.impl ?: OtelJavaContext.root()
-        val span: OtelJavaSpan =
-            otelJavaCtx.get(otelJavaSpanContextKey) ?: OtelJavaSpan.getInvalid()
-        return NonRecordingSpan(invalid.parent, SpanContextAdapter(span.spanContext))
     }
 }

--- a/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/factory/ContextFactoryImplTest.kt
+++ b/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/factory/ContextFactoryImplTest.kt
@@ -10,7 +10,6 @@ import kotlin.test.assertSame
 internal class ContextFactoryImplTest {
 
     private val contextFactory = CompatContextFactory()
-    private val spanFactory = CompatSpanFactory(CompatSpanContextFactory())
 
     @Test
     fun `test root`() {
@@ -21,8 +20,8 @@ internal class ContextFactoryImplTest {
     fun `test store span`() {
         val tracer = createCompatOpenTelemetry().tracerProvider.getTracer("tracer")
         val span = tracer.startSpan("span")
-        val ctx = contextFactory.storeSpan(contextFactory.root(), span)
-        val retrievedSpan = spanFactory.fromContext(ctx)
+        val ctx = contextFactory.root().storeSpan(span)
+        val retrievedSpan = ctx.extractSpan()
         assertSpanContextsMatch(span.spanContext, retrievedSpan.spanContext)
     }
 

--- a/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/factory/SpanFactoryImplTest.kt
+++ b/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/factory/SpanFactoryImplTest.kt
@@ -21,7 +21,7 @@ internal class SpanFactoryImplTest {
     @Test
     fun `test from context`() {
         val ctx = contextFactory.root()
-        val span = spanFactory.fromContext(ctx)
+        val span = ctx.extractSpan()
         assertFalse(span.spanContext.isValid)
     }
 

--- a/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/tracing/SpanExtTest.kt
+++ b/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/tracing/SpanExtTest.kt
@@ -57,7 +57,7 @@ internal class SpanExtTest {
 
     @Test
     fun `test from context invalid`() {
-        val span = spanFactory.fromContext(contextFactory.root())
+        val span = contextFactory.root().extractSpan()
         assertSpanContextsMatch(spanContextFactory.invalid, span.spanContext)
     }
 
@@ -79,10 +79,10 @@ internal class SpanExtTest {
         )
         val root = contextFactory.root()
         val ctx = span.storeInContext(root)
-        val observed = spanFactory.fromContext(root).spanContext
+        val observed = root.extractSpan().spanContext
         assertSpanContextsMatch(spanContextFactory.invalid, observed)
 
-        val retrievedSpan = spanFactory.fromContext(ctx)
+        val retrievedSpan = ctx.extractSpan()
         assertSpanContextsMatch(SpanContextAdapter(spanContext), retrievedSpan.spanContext)
     }
 }

--- a/examples/example-app/src/composeMain/kotlin/io/opentelemetry/example/app/ui/SpanScreen.kt
+++ b/examples/example-app/src/composeMain/kotlin/io/opentelemetry/example/app/ui/SpanScreen.kt
@@ -238,10 +238,7 @@ private fun startSpan(otel: OpenTelemetry, form: SpanFormState): Pair<Span, Scop
 
     // Set span as implicit context if requested
     val scope = if (form.setAsImplicitContext) {
-        val contextFactory = otel.context
-        val currentContext = contextFactory.implicit()
-        val spanContext = contextFactory.storeSpan(currentContext, span)
-        spanContext.attach()
+        otel.context.implicit().storeSpan(span).attach()
     } else {
         null
     }

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/OpenTelemetryImplEntrypoint.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/OpenTelemetryImplEntrypoint.kt
@@ -48,14 +48,13 @@ internal fun createOpenTelemetryImpl(
     val spanContext = SpanContextFactoryImpl(idGenerator, traceFlags, traceState)
 
     val cfg = OpenTelemetryConfigImpl(clock).apply(config)
-    val contextFactory = ContextFactoryImpl(cfg.contextConfig::generateStorage)
-    val span = SpanFactoryImpl(spanContext, contextFactory.spanKey)
+    val span = SpanFactoryImpl(spanContext)
+    val contextFactory = ContextFactoryImpl(span, cfg.contextConfig::generateStorage)
     cfg.propagatorCfg.installFactories(
         traceFlagsFactory = traceFlags,
         traceStateFactory = traceState,
         spanContextFactory = spanContext,
         spanFactory = span,
-        contextFactory = contextFactory,
     )
 
     val tracingConfig = cfg.generateTracingConfig()
@@ -75,7 +74,6 @@ internal fun createOpenTelemetryImpl(
             loggingConfig = loggingConfig,
             contextFactory = contextFactory,
             spanContextFactory = spanContext,
-            spanFactory = span,
         ),
         clock = clock,
         spanContext = spanContext,

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/context/ContextImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/context/ContextImpl.kt
@@ -2,11 +2,15 @@ package io.opentelemetry.kotlin.context
 
 import io.opentelemetry.kotlin.baggage.Baggage
 import io.opentelemetry.kotlin.baggage.BaggageImpl
+import io.opentelemetry.kotlin.factory.SpanFactory
+import io.opentelemetry.kotlin.tracing.Span
 
 private val BAGGAGE_KEY: ContextKey<Baggage> = ContextKeyImpl("otel-kotlin-baggage")
+private val SPAN_KEY: ContextKey<Span> = ContextKeyImpl("otel-kotlin-span")
 
 internal class ContextImpl(
     private val storage: ImplicitContextStorage,
+    private val spanFactory: SpanFactory,
     private val impl: Map<ContextKey<*>, Any?> = emptyMap()
 ) : Context {
 
@@ -15,7 +19,7 @@ internal class ContextImpl(
         value: T?
     ): Context {
         val newValues = impl.plus(Pair(key, value))
-        return ContextImpl(storage, newValues)
+        return ContextImpl(storage, spanFactory, newValues)
     }
 
     @Suppress("UNCHECKED_CAST")
@@ -31,6 +35,10 @@ internal class ContextImpl(
         storage.setImplicitContext(this)
         return ScopeImpl(current, this, storage)
     }
+
+    override fun storeSpan(span: Span): Context = set(SPAN_KEY, span)
+
+    override fun extractSpan(): Span = get(SPAN_KEY) ?: spanFactory.invalid
 
     override fun storeBaggage(baggage: Baggage): Context = set(BAGGAGE_KEY, baggage)
 

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/factory/ContextFactoryImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/factory/ContextFactoryImpl.kt
@@ -6,26 +6,18 @@ import io.opentelemetry.kotlin.context.ContextKey
 import io.opentelemetry.kotlin.context.ContextKeyImpl
 import io.opentelemetry.kotlin.context.DefaultImplicitContextStorage
 import io.opentelemetry.kotlin.context.ImplicitContextStorage
-import io.opentelemetry.kotlin.context.Scope
-import io.opentelemetry.kotlin.tracing.Span
 
 internal class ContextFactoryImpl(
+    private val spanFactory: SpanFactory,
     storageFactory: (supplier: () -> Context) -> ImplicitContextStorage = ::DefaultImplicitContextStorage,
 ) : ContextFactory {
 
     private val storage: ImplicitContextStorage = storageFactory { root }
-    private val root by lazy { ContextImpl(storage) }
-    internal val spanKey by lazy { createKey<Span>("otel-kotlin-span") }
+    private val root by lazy { ContextImpl(storage, spanFactory) }
 
     override fun root(): Context = root
-
-    override fun storeSpan(context: Context, span: Span): Context {
-        return context.set(spanKey, span)
-    }
 
     override fun implicit(): Context = storage.implicitContext()
 
     override fun <T> createKey(name: String): ContextKey<T> = ContextKeyImpl(name)
-
-    override fun makeCurrent(span: Span): Scope = storeSpan(implicit(), span).attach()
 }

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/factory/SpanFactoryImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/factory/SpanFactoryImpl.kt
@@ -1,14 +1,11 @@
 package io.opentelemetry.kotlin.factory
 
-import io.opentelemetry.kotlin.context.Context
-import io.opentelemetry.kotlin.context.ContextKey
 import io.opentelemetry.kotlin.tracing.NonRecordingSpan
 import io.opentelemetry.kotlin.tracing.Span
 import io.opentelemetry.kotlin.tracing.SpanContext
 
 internal class SpanFactoryImpl(
     spanContextFactory: SpanContextFactory,
-    private val spanKey: ContextKey<Span>
 ) : SpanFactory {
 
     private val invalidSpanContext by lazy { spanContextFactory.invalid }
@@ -17,8 +14,4 @@ internal class SpanFactoryImpl(
 
     override fun fromSpanContext(spanContext: SpanContext): Span =
         NonRecordingSpan(invalidSpanContext, spanContext)
-
-    override fun fromContext(context: Context): Span {
-        return context.get(spanKey) ?: invalid
-    }
 }

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/PropagatorConfigImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/PropagatorConfigImpl.kt
@@ -3,7 +3,6 @@ package io.opentelemetry.kotlin.init
 import io.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.kotlin.NoopOpenTelemetry
 import io.opentelemetry.kotlin.context.Context
-import io.opentelemetry.kotlin.factory.ContextFactory
 import io.opentelemetry.kotlin.factory.SpanContextFactory
 import io.opentelemetry.kotlin.factory.SpanFactory
 import io.opentelemetry.kotlin.factory.TraceFlagsFactory
@@ -43,14 +42,12 @@ internal class PropagatorConfigImpl : PropagatorConfigDsl {
         traceStateFactory: TraceStateFactory,
         spanContextFactory: SpanContextFactory,
         spanFactory: SpanFactory,
-        contextFactory: ContextFactory,
     ) {
         w3cTraceContext.delegate = W3CTraceContextPropagator(
             traceFlagsFactory = traceFlagsFactory,
             traceStateFactory = traceStateFactory,
             spanContextFactory = spanContextFactory,
             spanFactory = spanFactory,
-            contextFactory = contextFactory,
         )
     }
 

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/config/TracingConfig.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/config/TracingConfig.kt
@@ -31,5 +31,5 @@ internal class TracingConfig(
     /**
      * Factory that produces the sampler to use when creating spans.
      */
-    val samplerFactory: (SpanFactory) -> Sampler = { AlwaysOnSampler(it) },
+    val samplerFactory: (SpanFactory) -> Sampler = { _ -> AlwaysOnSampler() },
 )

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/LoggerImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/LoggerImpl.kt
@@ -8,7 +8,6 @@ import io.opentelemetry.kotlin.context.Context
 import io.opentelemetry.kotlin.export.ShutdownState
 import io.opentelemetry.kotlin.factory.ContextFactory
 import io.opentelemetry.kotlin.factory.SpanContextFactory
-import io.opentelemetry.kotlin.factory.SpanFactory
 import io.opentelemetry.kotlin.init.config.LogLimitConfig
 import io.opentelemetry.kotlin.logging.export.LogRecordProcessor
 import io.opentelemetry.kotlin.logging.model.LogRecordModel
@@ -20,7 +19,6 @@ internal class LoggerImpl(
     private val processor: LogRecordProcessor?,
     contextFactory: ContextFactory,
     spanContextFactory: SpanContextFactory,
-    spanFactory: SpanFactory,
     private val key: InstrumentationScopeInfo,
     private val resource: Resource,
     private val logLimitConfig: LogLimitConfig,
@@ -30,7 +28,6 @@ internal class LoggerImpl(
     private val contextFactory = contextFactory
     private val root = contextFactory.root()
     private val invalidSpanContext = spanContextFactory.invalid
-    private val spanFactory = spanFactory
 
     override fun enabled(
         context: Context?,
@@ -83,7 +80,7 @@ internal class LoggerImpl(
             val ctx = context ?: contextFactory.implicit()
             val spanContext = when (ctx) {
                 root -> invalidSpanContext
-                else -> spanFactory.fromContext(ctx).spanContext
+                else -> ctx.extractSpan().spanContext
             }
 
             val now = clock.now()

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/LoggerProviderImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/LoggerProviderImpl.kt
@@ -11,7 +11,6 @@ import io.opentelemetry.kotlin.export.TelemetryCloseable
 import io.opentelemetry.kotlin.export.runWithTimeout
 import io.opentelemetry.kotlin.factory.ContextFactory
 import io.opentelemetry.kotlin.factory.SpanContextFactory
-import io.opentelemetry.kotlin.factory.SpanFactory
 import io.opentelemetry.kotlin.init.config.LoggingConfig
 import io.opentelemetry.kotlin.provider.ApiProviderImpl
 
@@ -20,7 +19,6 @@ internal class LoggerProviderImpl(
     loggingConfig: LoggingConfig,
     contextFactory: ContextFactory,
     spanContextFactory: SpanContextFactory,
-    spanFactory: SpanFactory,
 ) : LoggerProvider, TelemetryCloseable {
 
     private val shutdownState: MutableShutdownState = MutableShutdownState()
@@ -36,7 +34,6 @@ internal class LoggerProviderImpl(
                 loggingConfig.processor,
                 contextFactory,
                 spanContextFactory,
-                spanFactory,
                 key,
                 loggingConfig.resource,
                 loggingConfig.logLimits,

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/propagation/W3CTraceContextPropagator.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/propagation/W3CTraceContextPropagator.kt
@@ -2,7 +2,6 @@ package io.opentelemetry.kotlin.propagation
 
 import io.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.kotlin.context.Context
-import io.opentelemetry.kotlin.factory.ContextFactory
 import io.opentelemetry.kotlin.factory.SpanContextFactory
 import io.opentelemetry.kotlin.factory.SpanFactory
 import io.opentelemetry.kotlin.factory.TraceFlagsFactory
@@ -19,13 +18,12 @@ internal class W3CTraceContextPropagator(
     private val traceStateFactory: TraceStateFactory,
     private val spanContextFactory: SpanContextFactory,
     private val spanFactory: SpanFactory,
-    private val contextFactory: ContextFactory,
 ) : TextMapPropagator {
 
     override fun fields(): Collection<String> = FIELDS
 
     override fun <T> inject(context: Context, carrier: T, setter: TextMapSetter<T>) {
-        val spanContext = spanFactory.fromContext(context).spanContext
+        val spanContext = context.extractSpan().spanContext
         if (!spanContext.isValid) {
             return
         }
@@ -63,7 +61,7 @@ internal class W3CTraceContextPropagator(
         if (!spanContext.isValid) {
             return context
         }
-        return contextFactory.storeSpan(context, spanFactory.fromSpanContext(spanContext))
+        return context.storeSpan(spanFactory.fromSpanContext(spanContext))
     }
 
     private companion object {

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/TracerImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/TracerImpl.kt
@@ -10,7 +10,6 @@ import io.opentelemetry.kotlin.export.ShutdownState
 import io.opentelemetry.kotlin.factory.ContextFactory
 import io.opentelemetry.kotlin.factory.IdGenerator
 import io.opentelemetry.kotlin.factory.SpanContextFactory
-import io.opentelemetry.kotlin.factory.SpanFactory
 import io.opentelemetry.kotlin.factory.TraceFlagsFactory
 import io.opentelemetry.kotlin.factory.toHexString
 import io.opentelemetry.kotlin.init.config.SpanLimitConfig
@@ -29,13 +28,12 @@ internal class TracerImpl(
     private val contextFactory: ContextFactory,
     spanContextFactory: SpanContextFactory,
     traceFlagsFactory: TraceFlagsFactory,
-    private val spanFactory: SpanFactory,
     private val idGenerator: IdGenerator,
     private val scope: InstrumentationScopeInfo,
     private val resource: Resource,
     private val spanLimitConfig: SpanLimitConfig,
     private val shutdownState: ShutdownState,
-    private val sampler: Sampler = AlwaysOnSampler(spanFactory),
+    private val sampler: Sampler = AlwaysOnSampler(),
 ) : Tracer {
 
     private val noopSpan = NoopOpenTelemetry.tracerProvider.getTracer("").startSpan("")
@@ -55,7 +53,7 @@ internal class TracerImpl(
 
             val parentSpanContext = when (ctx) {
                 root -> invalidSpanContext
-                else -> spanFactory.fromContext(ctx).spanContext
+                else -> ctx.extractSpan().spanContext
             }
             val traceIdBytes = when {
                 parentSpanContext.isValid -> parentSpanContext.traceIdBytes

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/TracerProviderImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/TracerProviderImpl.kt
@@ -42,7 +42,6 @@ internal class TracerProviderImpl(
             contextFactory = contextFactory,
             spanContextFactory = spanContextFactory,
             traceFlagsFactory = traceFlagsFactory,
-            spanFactory = spanFactory,
             scope = key,
             resource = tracingConfig.resource,
             spanLimitConfig = tracingConfig.spanLimits,

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/sampling/AlwaysOffSampler.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/sampling/AlwaysOffSampler.kt
@@ -3,12 +3,11 @@ package io.opentelemetry.kotlin.tracing.sampling
 import io.opentelemetry.kotlin.attributes.AttributeContainer
 import io.opentelemetry.kotlin.attributes.AttributesModel
 import io.opentelemetry.kotlin.context.Context
-import io.opentelemetry.kotlin.factory.SpanFactory
 import io.opentelemetry.kotlin.tracing.SpanKind
 import io.opentelemetry.kotlin.tracing.model.SpanLink
 import io.opentelemetry.kotlin.tracing.sampling.SamplingResult.Decision
 
-internal class AlwaysOffSampler(private val spanFactory: SpanFactory) : Sampler {
+internal class AlwaysOffSampler : Sampler {
 
     override val description: String = "AlwaysOffSampler"
 
@@ -20,7 +19,7 @@ internal class AlwaysOffSampler(private val spanFactory: SpanFactory) : Sampler 
         attributes: AttributeContainer,
         links: List<SpanLink>,
     ): SamplingResult {
-        val parentTraceState = spanFactory.fromContext(context).spanContext.traceState
+        val parentTraceState = context.extractSpan().spanContext.traceState
         return SamplingResultImpl(
             decision = Decision.DROP,
             attributes = AttributesModel(),

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/sampling/AlwaysOnSampler.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/sampling/AlwaysOnSampler.kt
@@ -3,12 +3,11 @@ package io.opentelemetry.kotlin.tracing.sampling
 import io.opentelemetry.kotlin.attributes.AttributeContainer
 import io.opentelemetry.kotlin.attributes.AttributesModel
 import io.opentelemetry.kotlin.context.Context
-import io.opentelemetry.kotlin.factory.SpanFactory
 import io.opentelemetry.kotlin.tracing.SpanKind
 import io.opentelemetry.kotlin.tracing.model.SpanLink
 import io.opentelemetry.kotlin.tracing.sampling.SamplingResult.Decision
 
-internal class AlwaysOnSampler(private val spanFactory: SpanFactory) : Sampler {
+internal class AlwaysOnSampler : Sampler {
 
     override val description: String = "AlwaysOnSampler"
 
@@ -20,7 +19,7 @@ internal class AlwaysOnSampler(private val spanFactory: SpanFactory) : Sampler {
         attributes: AttributeContainer,
         links: List<SpanLink>,
     ): SamplingResult {
-        val parentTraceState = spanFactory.fromContext(context).spanContext.traceState
+        val parentTraceState = context.extractSpan().spanContext.traceState
         return SamplingResultImpl(
             decision = Decision.RECORD_AND_SAMPLE,
             attributes = AttributesModel(),

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/sampling/BuiltInSamplerApi.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/sampling/BuiltInSamplerApi.kt
@@ -9,7 +9,7 @@ import io.opentelemetry.kotlin.init.SamplerConfigDsl
  * https://opentelemetry.io/docs/specs/otel/trace/sdk/#alwayson
  */
 @ExperimentalApi
-public fun SamplerConfigDsl.alwaysOn(): Sampler = AlwaysOnSampler(spanFactory)
+public fun SamplerConfigDsl.alwaysOn(): Sampler = AlwaysOnSampler()
 
 /**
  * Configures sampling so that spans are never recorded and sampled.
@@ -17,7 +17,7 @@ public fun SamplerConfigDsl.alwaysOn(): Sampler = AlwaysOnSampler(spanFactory)
  * https://opentelemetry.io/docs/specs/otel/trace/sdk/#alwaysoff
  */
 @ExperimentalApi
-public fun SamplerConfigDsl.alwaysOff(): Sampler = AlwaysOffSampler(spanFactory)
+public fun SamplerConfigDsl.alwaysOff(): Sampler = AlwaysOffSampler()
 
 /**
  * Configures sampling based on the parent span's sampling decision.
@@ -32,7 +32,6 @@ public fun SamplerConfigDsl.parentBased(
     localParentSampled: Sampler = alwaysOn(),
     localParentNotSampled: Sampler = alwaysOff(),
 ): Sampler = ParentBasedSampler(
-    spanFactory = spanFactory,
     root = root,
     remoteParentSampled = remoteParentSampled,
     remoteParentNotSampled = remoteParentNotSampled,

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/sampling/ParentBasedSampler.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/sampling/ParentBasedSampler.kt
@@ -2,12 +2,10 @@ package io.opentelemetry.kotlin.tracing.sampling
 
 import io.opentelemetry.kotlin.attributes.AttributeContainer
 import io.opentelemetry.kotlin.context.Context
-import io.opentelemetry.kotlin.factory.SpanFactory
 import io.opentelemetry.kotlin.tracing.SpanKind
 import io.opentelemetry.kotlin.tracing.model.SpanLink
 
 internal class ParentBasedSampler(
-    private val spanFactory: SpanFactory,
     private val root: Sampler,
     private val remoteParentSampled: Sampler,
     private val remoteParentNotSampled: Sampler,
@@ -32,7 +30,7 @@ internal class ParentBasedSampler(
         attributes: AttributeContainer,
         links: List<SpanLink>,
     ): SamplingResult {
-        val parent = spanFactory.fromContext(context).spanContext
+        val parent = context.extractSpan().spanContext
         val delegate = when {
             !parent.isValid -> root
             parent.isRemote && parent.traceFlags.isSampled -> remoteParentSampled

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/sampling/ProbabilitySampler.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/sampling/ProbabilitySampler.kt
@@ -3,7 +3,6 @@ package io.opentelemetry.kotlin.tracing.sampling
 import io.opentelemetry.kotlin.attributes.AttributeContainer
 import io.opentelemetry.kotlin.attributes.AttributesModel
 import io.opentelemetry.kotlin.context.Context
-import io.opentelemetry.kotlin.factory.SpanFactory
 import io.opentelemetry.kotlin.platformLog
 import io.opentelemetry.kotlin.tracing.SpanKind
 import io.opentelemetry.kotlin.tracing.model.SpanLink
@@ -11,7 +10,7 @@ import io.opentelemetry.kotlin.tracing.sampling.SamplingResult.Decision
 import kotlin.concurrent.Volatile
 import kotlin.math.max
 
-internal class ProbabilitySampler(private val spanFactory: SpanFactory, ratio: Double) : Sampler {
+internal class ProbabilitySampler(ratio: Double) : Sampler {
 
     private companion object {
         private const val MAX_THRESHOLD: Long = 1L shl 56
@@ -39,7 +38,7 @@ internal class ProbabilitySampler(private val spanFactory: SpanFactory, ratio: D
         attributes: AttributeContainer,
         links: List<SpanLink>
     ): SamplingResult {
-        val parentSpanContext = spanFactory.fromContext(context).spanContext
+        val parentSpanContext = context.extractSpan().spanContext
         val traceState = parentSpanContext.traceState
         val otelTraceState = OtelTraceState.parse(traceState.get("ot"))
 

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/baggage/BaggageContextStorageTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/baggage/BaggageContextStorageTest.kt
@@ -2,6 +2,9 @@ package io.opentelemetry.kotlin.baggage
 
 import io.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.kotlin.factory.ContextFactoryImpl
+import io.opentelemetry.kotlin.factory.IdGeneratorImpl
+import io.opentelemetry.kotlin.factory.SpanContextFactoryImpl
+import io.opentelemetry.kotlin.factory.SpanFactoryImpl
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotSame
@@ -12,7 +15,7 @@ import kotlin.test.assertTrue
 @OptIn(ExperimentalApi::class)
 internal class BaggageContextStorageTest {
 
-    private val factory = ContextFactoryImpl()
+    private val factory = ContextFactoryImpl(SpanFactoryImpl(SpanContextFactoryImpl(IdGeneratorImpl())))
 
     @Test
     fun `extractBaggage on root returns empty baggage`() {

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/context/ContextImplTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/context/ContextImplTest.kt
@@ -1,20 +1,27 @@
 package io.opentelemetry.kotlin.context
 
 import io.opentelemetry.kotlin.factory.ContextFactoryImpl
+import io.opentelemetry.kotlin.factory.IdGeneratorImpl
+import io.opentelemetry.kotlin.factory.SpanContextFactoryImpl
+import io.opentelemetry.kotlin.factory.SpanFactoryImpl
+import io.opentelemetry.kotlin.tracing.FakeSpan
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
+import kotlin.test.assertNotSame
 import kotlin.test.assertNull
 import kotlin.test.assertSame
 
 internal class ContextImplTest {
 
     private lateinit var factory: ContextFactoryImpl
+    private lateinit var spanFactory: SpanFactoryImpl
 
     @BeforeTest
     fun setUp() {
-        factory = ContextFactoryImpl()
+        spanFactory = SpanFactoryImpl(SpanContextFactoryImpl(IdGeneratorImpl()))
+        factory = ContextFactoryImpl(spanFactory)
     }
 
     @Test
@@ -91,5 +98,26 @@ internal class ContextImplTest {
     fun testImplicitContext() {
         val ctx = factory.root()
         assertSame(ctx, factory.implicit())
+    }
+
+    @Test
+    fun testExtractSpanFromRootReturnsInvalid() {
+        assertSame(spanFactory.invalid, factory.root().extractSpan())
+    }
+
+    @Test
+    fun testStoreSpanRoundTrip() {
+        val span = FakeSpan()
+        val ctx = factory.root().storeSpan(span)
+        assertSame(span, ctx.extractSpan())
+    }
+
+    @Test
+    fun testStoreSpanReturnsNewContext() {
+        val span = FakeSpan()
+        val root = factory.root()
+        val derived = root.storeSpan(span)
+        assertNotSame(root, derived)
+        assertSame(spanFactory.invalid, root.extractSpan())
     }
 }

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/context/DefaultImplicitContextStorageImplTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/context/DefaultImplicitContextStorageImplTest.kt
@@ -1,6 +1,9 @@
 package io.opentelemetry.kotlin.context
 
 import io.opentelemetry.kotlin.factory.ContextFactoryImpl
+import io.opentelemetry.kotlin.factory.IdGeneratorImpl
+import io.opentelemetry.kotlin.factory.SpanContextFactoryImpl
+import io.opentelemetry.kotlin.factory.SpanFactoryImpl
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertSame
@@ -12,7 +15,7 @@ internal class DefaultImplicitContextStorageImplTest {
 
     @BeforeTest
     fun setUp() {
-        factory = ContextFactoryImpl()
+        factory = ContextFactoryImpl(SpanFactoryImpl(SpanContextFactoryImpl(IdGeneratorImpl())))
         storage = DefaultImplicitContextStorage(factory::root)
     }
 

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/context/ImplicitContextTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/context/ImplicitContextTest.kt
@@ -2,6 +2,9 @@ package io.opentelemetry.kotlin.context
 
 import io.opentelemetry.kotlin.factory.ContextFactory
 import io.opentelemetry.kotlin.factory.ContextFactoryImpl
+import io.opentelemetry.kotlin.factory.IdGeneratorImpl
+import io.opentelemetry.kotlin.factory.SpanContextFactoryImpl
+import io.opentelemetry.kotlin.factory.SpanFactoryImpl
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertFailsWith
@@ -15,7 +18,7 @@ internal class ImplicitContextTest {
 
     @BeforeTest
     fun setUp() {
-        factory = ContextFactoryImpl()
+        factory = ContextFactoryImpl(SpanFactoryImpl(SpanContextFactoryImpl(IdGeneratorImpl())))
     }
 
     @Test

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/context/SpanStorageTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/context/SpanStorageTest.kt
@@ -10,16 +10,15 @@ import kotlin.test.assertSame
 
 internal class SpanStorageTest {
 
-    private val contextFactory = ContextFactoryImpl()
-    private val spanFactory = SpanFactoryImpl(SpanContextFactoryImpl(IdGeneratorImpl()), contextFactory.spanKey)
+    private val spanFactory = SpanFactoryImpl(SpanContextFactoryImpl(IdGeneratorImpl()))
+    private val contextFactory = ContextFactoryImpl(spanFactory)
 
     @Test
     fun testSpanStorage() {
         val span = FakeSpan()
         val root = contextFactory.root()
-        val newCtx = contextFactory.storeSpan(root, span)
-        val retrievedSpan = spanFactory.fromContext(newCtx)
-        assertSame(span, retrievedSpan)
+        val newCtx = root.storeSpan(span)
+        assertSame(span, newCtx.extractSpan())
     }
 
     @Test
@@ -27,10 +26,9 @@ internal class SpanStorageTest {
         val span = FakeSpan("a")
         val otherSpan = FakeSpan("b")
         val root = contextFactory.root()
-        val newCtx = contextFactory.storeSpan(root, span)
+        val newCtx = root.storeSpan(span)
 
-        val finalCtx = contextFactory.storeSpan(newCtx, otherSpan)
-        val retrievedSpan = spanFactory.fromContext(finalCtx)
-        assertSame(otherSpan, retrievedSpan)
+        val finalCtx = newCtx.storeSpan(otherSpan)
+        assertSame(otherSpan, finalCtx.extractSpan())
     }
 }

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/factory/MakeCurrentTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/factory/MakeCurrentTest.kt
@@ -8,20 +8,19 @@ import kotlin.test.assertSame
 internal class MakeCurrentTest {
 
     private lateinit var contextFactory: ContextFactoryImpl
-    private lateinit var spanFactory: SpanFactoryImpl
 
     @BeforeTest
     fun setUp() {
-        contextFactory = ContextFactoryImpl()
-        spanFactory = SpanFactoryImpl(SpanContextFactoryImpl(IdGeneratorImpl()), contextFactory.spanKey)
+        val spanFactory = SpanFactoryImpl(SpanContextFactoryImpl(IdGeneratorImpl()))
+        contextFactory = ContextFactoryImpl(spanFactory)
     }
 
     @Test
     fun testMakeCurrent() {
         val span = FakeSpan()
-        val scope = contextFactory.makeCurrent(span)
+        val scope = contextFactory.implicit().storeSpan(span).attach()
         try {
-            assertSame(span, spanFactory.fromContext(contextFactory.implicit()))
+            assertSame(span, contextFactory.implicit().extractSpan())
         } finally {
             scope.detach()
         }
@@ -31,7 +30,7 @@ internal class MakeCurrentTest {
     fun testMakeCurrentDetach() {
         val root = contextFactory.root()
         val span = FakeSpan()
-        val scope = contextFactory.makeCurrent(span)
+        val scope = contextFactory.implicit().storeSpan(span).attach()
         scope.detach()
         assertSame(root, contextFactory.implicit())
     }
@@ -41,14 +40,14 @@ internal class MakeCurrentTest {
         val span1 = FakeSpan("a")
         val span2 = FakeSpan("b")
 
-        val scope1 = contextFactory.makeCurrent(span1)
-        assertSame(span1, spanFactory.fromContext(contextFactory.implicit()))
+        val scope1 = contextFactory.implicit().storeSpan(span1).attach()
+        assertSame(span1, contextFactory.implicit().extractSpan())
 
-        val scope2 = contextFactory.makeCurrent(span2)
-        assertSame(span2, spanFactory.fromContext(contextFactory.implicit()))
+        val scope2 = contextFactory.implicit().storeSpan(span2).attach()
+        assertSame(span2, contextFactory.implicit().extractSpan())
 
         scope2.detach()
-        assertSame(span1, spanFactory.fromContext(contextFactory.implicit()))
+        assertSame(span1, contextFactory.implicit().extractSpan())
 
         scope1.detach()
         assertSame(contextFactory.root(), contextFactory.implicit())

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/factory/SpanFactoryImplTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/factory/SpanFactoryImplTest.kt
@@ -7,8 +7,7 @@ import kotlin.test.assertFalse
 
 internal class SpanFactoryImplTest {
 
-    private val contextFactory = ContextFactoryImpl()
-    private val factory = SpanFactoryImpl(SpanContextFactoryImpl(IdGeneratorImpl()), contextFactory.spanKey)
+    private val factory = SpanFactoryImpl(SpanContextFactoryImpl(IdGeneratorImpl()))
 
     @Test
     fun testInvalidSpan() {

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/integration/test/logging/LogProcessorNaughtyExportTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/integration/test/logging/LogProcessorNaughtyExportTest.kt
@@ -54,7 +54,7 @@ internal class LogProcessorNaughtyExportTest {
     private fun prepareContext(): Context {
         val span = harness.tracer.startSpan("span")
         val contextFactory = harness.kotlinApi.context
-        val ctx = contextFactory.storeSpan(contextFactory.root(), span)
+        val ctx = contextFactory.root().storeSpan(span)
         return ctx
     }
 

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/integration/test/logging/LogProcessorOnEmitTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/integration/test/logging/LogProcessorOnEmitTest.kt
@@ -54,7 +54,7 @@ internal class LogProcessorOnEmitTest {
     private fun prepareContext(): Context {
         val span = harness.tracer.startSpan("span")
         val contextFactory = harness.kotlinApi.context
-        val ctx = contextFactory.storeSpan(contextFactory.root(), span)
+        val ctx = contextFactory.root().storeSpan(span)
         return ctx
     }
 

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/integration/test/logging/LoggerExportTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/integration/test/logging/LoggerExportTest.kt
@@ -68,7 +68,7 @@ internal class LoggerExportTest {
     fun testLogWithParentSpanInContext() = runTest {
         val span = harness.tracer.startSpan("span")
         val contextFactory = harness.kotlinApi.context
-        val ctx = contextFactory.storeSpan(contextFactory.root(), span)
+        val ctx = contextFactory.root().storeSpan(span)
         harness.logger.emit("test", context = ctx)
         harness.assertLogRecords(1, "log_span_context.json")
     }

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/integration/test/tracing/TracerExportTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/integration/test/tracing/TracerExportTest.kt
@@ -149,7 +149,7 @@ internal class TracerExportTest {
         val childName = "child"
         val parentSpan = harness.tracer.startSpan(parentName)
         val contextFactory = harness.kotlinApi.context
-        val parentCtx = contextFactory.storeSpan(contextFactory.root(), parentSpan)
+        val parentCtx = contextFactory.root().storeSpan(parentSpan)
         val childSpan = harness.tracer.startSpan(childName, parentContext = parentCtx)
         parentSpan.end()
         childSpan.end()

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/LogAttributesTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/LogAttributesTest.kt
@@ -6,7 +6,6 @@ import io.opentelemetry.kotlin.clock.FakeClock
 import io.opentelemetry.kotlin.export.MutableShutdownState
 import io.opentelemetry.kotlin.factory.FakeContextFactory
 import io.opentelemetry.kotlin.factory.FakeSpanContextFactory
-import io.opentelemetry.kotlin.factory.FakeSpanFactory
 import io.opentelemetry.kotlin.init.config.LogLimitConfig
 import io.opentelemetry.kotlin.logging.export.FakeLogRecordProcessor
 import io.opentelemetry.kotlin.resource.FakeResource
@@ -40,7 +39,6 @@ internal class LogAttributesTest {
             processor = processor,
             contextFactory = FakeContextFactory(),
             spanContextFactory = FakeSpanContextFactory(),
-            spanFactory = FakeSpanFactory(),
             key = key,
             resource = FakeResource(),
             logLimitConfig = LogLimitConfig(
@@ -133,7 +131,6 @@ internal class LogAttributesTest {
         processor = processor,
         contextFactory = FakeContextFactory(),
         spanContextFactory = FakeSpanContextFactory(),
-        spanFactory = FakeSpanFactory(),
         key = key,
         resource = FakeResource(),
         logLimitConfig = LogLimitConfig(

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/LogContextTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/LogContextTest.kt
@@ -43,15 +43,13 @@ internal class LogContextTest {
         val traceFlags = TraceFlagsFactoryImpl()
         val traceState = TraceStateFactoryImpl()
         spanContextFactory = SpanContextFactoryImpl(idGenerator, traceFlags, traceState)
-        contextFactory = ContextFactoryImpl()
-        spanFactory =
-            SpanFactoryImpl(spanContextFactory, (contextFactory as ContextFactoryImpl).spanKey)
+        spanFactory = SpanFactoryImpl(spanContextFactory)
+        contextFactory = ContextFactoryImpl(spanFactory)
         logger = LoggerImpl(
             clock,
             processor,
             contextFactory,
             spanContextFactory,
-            spanFactory,
             key,
             FakeResource(),
             fakeLogLimitsConfig,
@@ -63,7 +61,6 @@ internal class LogContextTest {
             contextFactory = contextFactory,
             spanContextFactory = spanContextFactory,
             traceFlagsFactory = traceFlags,
-            spanFactory = spanFactory,
             scope = key,
             resource = FakeResource(),
             spanLimitConfig = fakeSpanLimitsConfig,
@@ -76,14 +73,14 @@ internal class LogContextTest {
     fun testDefaultContext() {
         logger.emit()
         val log = processor.logs.single()
-        val root = spanFactory.fromContext(contextFactory.root()).spanContext
+        val root = contextFactory.root().extractSpan().spanContext
         assertSame(root, log.spanContext)
     }
 
     @Test
     fun testOverrideContext() {
         val span = tracer.startSpan("span")
-        val ctx = contextFactory.storeSpan(contextFactory.root(), span)
+        val ctx = contextFactory.root().storeSpan(span)
         logger.emit(
             context = ctx,
         )
@@ -95,7 +92,7 @@ internal class LogContextTest {
     @Test
     fun testImplicitContext() {
         val span = tracer.startSpan("span")
-        val ctx = contextFactory.storeSpan(contextFactory.root(), span)
+        val ctx = contextFactory.root().storeSpan(span)
         val scope = ctx.attach()
         logger.emit()
 

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/LogMetaPropertiesTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/LogMetaPropertiesTest.kt
@@ -5,7 +5,6 @@ import io.opentelemetry.kotlin.clock.FakeClock
 import io.opentelemetry.kotlin.export.MutableShutdownState
 import io.opentelemetry.kotlin.factory.FakeContextFactory
 import io.opentelemetry.kotlin.factory.FakeSpanContextFactory
-import io.opentelemetry.kotlin.factory.FakeSpanFactory
 import io.opentelemetry.kotlin.logging.export.FakeLogRecordProcessor
 import io.opentelemetry.kotlin.resource.FakeResource
 import io.opentelemetry.kotlin.tracing.fakeLogLimitsConfig
@@ -30,7 +29,6 @@ internal class LogMetaPropertiesTest {
             processor = processor,
             contextFactory = FakeContextFactory(),
             spanContextFactory = FakeSpanContextFactory(),
-            spanFactory = FakeSpanFactory(),
             key = key,
             resource = fakeResource,
             logLimitConfig = fakeLogLimitsConfig,

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/LogSimplePropertiesTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/LogSimplePropertiesTest.kt
@@ -5,7 +5,6 @@ import io.opentelemetry.kotlin.clock.FakeClock
 import io.opentelemetry.kotlin.export.MutableShutdownState
 import io.opentelemetry.kotlin.factory.FakeContextFactory
 import io.opentelemetry.kotlin.factory.FakeSpanContextFactory
-import io.opentelemetry.kotlin.factory.FakeSpanFactory
 import io.opentelemetry.kotlin.logging.export.FakeLogRecordProcessor
 import io.opentelemetry.kotlin.resource.FakeResource
 import io.opentelemetry.kotlin.tracing.fakeLogLimitsConfig
@@ -30,7 +29,6 @@ internal class LogSimplePropertiesTest {
             processor = processor,
             contextFactory = FakeContextFactory(),
             spanContextFactory = FakeSpanContextFactory(),
-            spanFactory = FakeSpanFactory(),
             key = key,
             resource = FakeResource(),
             logLimitConfig = fakeLogLimitsConfig,

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/LoggerEnabledTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/LoggerEnabledTest.kt
@@ -6,7 +6,6 @@ import io.opentelemetry.kotlin.context.FakeContext
 import io.opentelemetry.kotlin.export.MutableShutdownState
 import io.opentelemetry.kotlin.factory.FakeContextFactory
 import io.opentelemetry.kotlin.factory.FakeSpanContextFactory
-import io.opentelemetry.kotlin.factory.FakeSpanFactory
 import io.opentelemetry.kotlin.logging.export.FakeLogRecordProcessor
 import io.opentelemetry.kotlin.resource.FakeResource
 import io.opentelemetry.kotlin.tracing.fakeLogLimitsConfig
@@ -58,7 +57,6 @@ internal class LoggerEnabledTest {
             processor = processor,
             contextFactory = FakeContextFactory(),
             spanContextFactory = FakeSpanContextFactory(),
-            spanFactory = FakeSpanFactory(),
             key = key,
             resource = FakeResource(),
             logLimitConfig = fakeLogLimitsConfig,

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/LoggerProviderImplTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/LoggerProviderImplTest.kt
@@ -5,7 +5,6 @@ import io.opentelemetry.kotlin.clock.FakeClock
 import io.opentelemetry.kotlin.export.OperationResultCode
 import io.opentelemetry.kotlin.factory.FakeContextFactory
 import io.opentelemetry.kotlin.factory.FakeSpanContextFactory
-import io.opentelemetry.kotlin.factory.FakeSpanFactory
 import io.opentelemetry.kotlin.init.config.LogLimitConfig
 import io.opentelemetry.kotlin.init.config.LoggingConfig
 import io.opentelemetry.kotlin.logging.export.FakeLogRecordProcessor
@@ -30,12 +29,11 @@ internal class LoggerProviderImplTest {
     )
     private val contextFactory = FakeContextFactory()
     private val spanContextFactory = FakeSpanContextFactory()
-    private val spanFactory = FakeSpanFactory()
     private lateinit var impl: LoggerProviderImpl
 
     @BeforeTest
     fun setup() {
-        impl = LoggerProviderImpl(clock, loggingConfig, contextFactory, spanContextFactory, spanFactory)
+        impl = LoggerProviderImpl(clock, loggingConfig, contextFactory, spanContextFactory)
     }
 
     @Test
@@ -123,7 +121,7 @@ internal class LoggerProviderImplTest {
             LogLimitConfig(100, 100),
             FakeResource(),
         )
-        impl = LoggerProviderImpl(clock, config, contextFactory, spanContextFactory, spanFactory)
+        impl = LoggerProviderImpl(clock, config, contextFactory, spanContextFactory)
         impl.getLogger(name = "test")
 
         val result = impl.forceFlush()
@@ -145,7 +143,7 @@ internal class LoggerProviderImplTest {
             LogLimitConfig(100, 100),
             FakeResource(),
         )
-        impl = LoggerProviderImpl(clock, config, contextFactory, spanContextFactory, spanFactory)
+        impl = LoggerProviderImpl(clock, config, contextFactory, spanContextFactory)
         impl.getLogger(name = "test")
 
         val result = impl.shutdown()
@@ -168,7 +166,7 @@ internal class LoggerProviderImplTest {
             LogLimitConfig(100, 100),
             FakeResource(),
         )
-        impl = LoggerProviderImpl(clock, config, contextFactory, spanContextFactory, spanFactory)
+        impl = LoggerProviderImpl(clock, config, contextFactory, spanContextFactory)
         val logger = impl.getLogger(name = "test")
         impl.shutdown()
         logger.emit(body = "should not emit")

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/propagation/CorePropagatorApiTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/propagation/CorePropagatorApiTest.kt
@@ -20,11 +20,11 @@ import kotlin.test.assertTrue
 internal class CorePropagatorApiTest {
 
     private val dsl = PropagatorConfigImpl()
-    private val contextFactory = ContextFactoryImpl()
     private val traceFlagsFactory = TraceFlagsFactoryImpl()
     private val traceStateFactory = TraceStateFactoryImpl()
     private val spanContextFactory = SpanContextFactoryImpl(IdGeneratorImpl(), traceFlagsFactory, traceStateFactory)
-    private val spanFactory = SpanFactoryImpl(spanContextFactory, contextFactory.spanKey)
+    private val spanFactory = SpanFactoryImpl(spanContextFactory)
+    private val contextFactory = ContextFactoryImpl(spanFactory)
 
     @Test
     fun `composite with single propagator wraps in CompositeTextMapPropagator`() {
@@ -103,7 +103,6 @@ internal class CorePropagatorApiTest {
             traceStateFactory = traceStateFactory,
             spanContextFactory = spanContextFactory,
             spanFactory = spanFactory,
-            contextFactory = contextFactory,
         )
     }
 }

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/propagation/W3CBaggagePropagatorTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/propagation/W3CBaggagePropagatorTest.kt
@@ -6,6 +6,9 @@ import io.opentelemetry.kotlin.baggage.BaggageEntryMetadataImpl
 import io.opentelemetry.kotlin.baggage.BaggageImpl
 import io.opentelemetry.kotlin.context.Context
 import io.opentelemetry.kotlin.factory.ContextFactoryImpl
+import io.opentelemetry.kotlin.factory.IdGeneratorImpl
+import io.opentelemetry.kotlin.factory.SpanContextFactoryImpl
+import io.opentelemetry.kotlin.factory.SpanFactoryImpl
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
@@ -17,7 +20,7 @@ import kotlin.test.assertTrue
 internal class W3CBaggagePropagatorTest {
 
     private val propagator = W3CBaggagePropagator
-    private val contextFactory = ContextFactoryImpl()
+    private val contextFactory = ContextFactoryImpl(SpanFactoryImpl(SpanContextFactoryImpl(IdGeneratorImpl())))
 
     @Test
     fun `fields returns only the baggage header`() {

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/propagation/W3CTraceContextPropagatorTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/propagation/W3CTraceContextPropagatorTest.kt
@@ -29,15 +29,14 @@ internal class W3CTraceContextPropagatorTest {
     private val traceFlagsFactory = TraceFlagsFactoryImpl()
     private val traceStateFactory = TraceStateFactoryImpl()
     private val spanContextFactory = SpanContextFactoryImpl(idGenerator, traceFlagsFactory, traceStateFactory)
-    private val contextFactory = ContextFactoryImpl()
-    private val spanFactory = SpanFactoryImpl(spanContextFactory, contextFactory.spanKey)
+    private val spanFactory = SpanFactoryImpl(spanContextFactory)
+    private val contextFactory = ContextFactoryImpl(spanFactory)
 
     private val propagator = W3CTraceContextPropagator(
         traceFlagsFactory = traceFlagsFactory,
         traceStateFactory = traceStateFactory,
         spanContextFactory = spanContextFactory,
         spanFactory = spanFactory,
-        contextFactory = contextFactory,
     )
 
     private val traceId = "0af7651916cd43dd8448eb211c80319c"
@@ -58,7 +57,7 @@ internal class W3CTraceContextPropagatorTest {
     @Test
     fun `inject does nothing when current span is invalid`() {
         val carrier = mutableMapOf<String, String>()
-        val context = contextFactory.storeSpan(contextFactory.root(), spanFactory.invalid)
+        val context = contextFactory.root().storeSpan(spanFactory.invalid)
         propagator.inject(context, carrier, MapTextMapSetter)
         assertTrue(carrier.isEmpty())
     }
@@ -184,7 +183,7 @@ internal class W3CTraceContextPropagatorTest {
     fun `extract produces a SpanContext with isRemote=true`() {
         val carrier = mapOf("traceparent" to "00-$traceId-$spanId-01")
         val result = propagator.extract(contextFactory.root(), carrier, MapTextMapGetter)
-        val sc = spanFactory.fromContext(result).spanContext
+        val sc = result.extractSpan().spanContext
         assertTrue(sc.isRemote)
     }
 
@@ -193,11 +192,11 @@ internal class W3CTraceContextPropagatorTest {
         val sampledCarrier = mapOf("traceparent" to "00-$traceId-$spanId-01")
         val unsampledCarrier = mapOf("traceparent" to "00-$traceId-$spanId-00")
 
-        val sampled = spanFactory
-            .fromContext(propagator.extract(contextFactory.root(), sampledCarrier, MapTextMapGetter))
+        val sampled = propagator.extract(contextFactory.root(), sampledCarrier, MapTextMapGetter)
+            .extractSpan()
             .spanContext
-        val unsampled = spanFactory
-            .fromContext(propagator.extract(contextFactory.root(), unsampledCarrier, MapTextMapGetter))
+        val unsampled = propagator.extract(contextFactory.root(), unsampledCarrier, MapTextMapGetter)
+            .extractSpan()
             .spanContext
 
         assertTrue(sampled.traceFlags.isSampled)
@@ -208,7 +207,7 @@ internal class W3CTraceContextPropagatorTest {
     fun `extract attaches an empty TraceState when tracestate header is absent`() {
         val carrier = mapOf("traceparent" to "00-$traceId-$spanId-01")
         val result = propagator.extract(contextFactory.root(), carrier, MapTextMapGetter)
-        val sc = spanFactory.fromContext(result).spanContext
+        val sc = result.extractSpan().spanContext
         assertTrue(sc.traceState.asMap().isEmpty())
     }
 
@@ -219,7 +218,7 @@ internal class W3CTraceContextPropagatorTest {
             "tracestate" to "foo=bar,baz=qux",
         )
         val result = propagator.extract(contextFactory.root(), carrier, MapTextMapGetter)
-        val sc = spanFactory.fromContext(result).spanContext
+        val sc = result.extractSpan().spanContext
         assertEquals(mapOf("foo" to "bar", "baz" to "qux"), sc.traceState.asMap())
     }
 
@@ -230,7 +229,7 @@ internal class W3CTraceContextPropagatorTest {
             "tracestate" to "foo=bar,bogus,baz=qux",
         )
         val result = propagator.extract(contextFactory.root(), carrier, MapTextMapGetter)
-        val sc = spanFactory.fromContext(result).spanContext
+        val sc = result.extractSpan().spanContext
         assertEquals(mapOf("foo" to "bar", "baz" to "qux"), sc.traceState.asMap())
     }
 
@@ -238,7 +237,7 @@ internal class W3CTraceContextPropagatorTest {
     fun `extract attaches a non-recording span on the returned context`() {
         val carrier = mapOf("traceparent" to "00-$traceId-$spanId-01")
         val result = propagator.extract(contextFactory.root(), carrier, MapTextMapGetter)
-        val span = spanFactory.fromContext(result)
+        val span = result.extractSpan()
         assertFalse(span.isRecording())
         assertEquals(traceId, span.spanContext.traceId)
         assertEquals(spanId, span.spanContext.spanId)
@@ -253,7 +252,7 @@ internal class W3CTraceContextPropagatorTest {
         )
         val carrier = injectInto(contextWithSpan(original))
         val extracted = propagator.extract(contextFactory.root(), carrier, MapTextMapGetter)
-        val sc = spanFactory.fromContext(extracted).spanContext
+        val sc = extracted.extractSpan().spanContext
 
         assertEquals(original.traceId, sc.traceId)
         assertEquals(original.spanId, sc.spanId)
@@ -274,7 +273,7 @@ internal class W3CTraceContextPropagatorTest {
     )
 
     private fun contextWithSpan(spanContext: SpanContext): Context =
-        contextFactory.storeSpan(contextFactory.root(), spanFactory.fromSpanContext(spanContext))
+        contextFactory.root().storeSpan(spanFactory.fromSpanContext(spanContext))
 
     private fun injectInto(context: Context): MutableMap<String, String> {
         val carrier = mutableMapOf<String, String>()

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/SpanAttributesTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/SpanAttributesTest.kt
@@ -7,7 +7,6 @@ import io.opentelemetry.kotlin.export.MutableShutdownState
 import io.opentelemetry.kotlin.factory.FakeContextFactory
 import io.opentelemetry.kotlin.factory.FakeIdGenerator
 import io.opentelemetry.kotlin.factory.FakeSpanContextFactory
-import io.opentelemetry.kotlin.factory.FakeSpanFactory
 import io.opentelemetry.kotlin.factory.FakeTraceFlagsFactory
 import io.opentelemetry.kotlin.init.config.SpanLimitConfig
 import io.opentelemetry.kotlin.resource.FakeResource
@@ -51,7 +50,6 @@ internal class SpanAttributesTest {
             contextFactory = FakeContextFactory(),
             spanContextFactory = FakeSpanContextFactory(),
             traceFlagsFactory = FakeTraceFlagsFactory(),
-            spanFactory = FakeSpanFactory(),
             scope = key,
             resource = FakeResource(),
             spanLimitConfig = spanLimitConfig,
@@ -184,7 +182,6 @@ internal class SpanAttributesTest {
             contextFactory = FakeContextFactory(),
             spanContextFactory = FakeSpanContextFactory(),
             traceFlagsFactory = FakeTraceFlagsFactory(),
-            spanFactory = FakeSpanFactory(),
             scope = key,
             resource = FakeResource(),
             spanLimitConfig = config,

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/SpanContextOverrideTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/SpanContextOverrideTest.kt
@@ -35,15 +35,14 @@ internal class SpanContextOverrideTest {
         traceStateFactory = TraceStateFactoryImpl()
         spanContextFactory =
             SpanContextFactoryImpl(idGenerator, traceFlagsFactory, traceStateFactory)
-        val contextFactory = ContextFactoryImpl()
-        val spanFactory = SpanFactoryImpl(spanContextFactory, contextFactory.spanKey)
+        val spanFactory = SpanFactoryImpl(spanContextFactory)
+        val contextFactory = ContextFactoryImpl(spanFactory)
         tracer = TracerImpl(
             clock = FakeClock(),
             processor = processor,
             contextFactory = contextFactory,
             spanContextFactory = spanContextFactory,
             traceFlagsFactory = traceFlagsFactory,
-            spanFactory = spanFactory,
             scope = scope,
             resource = FakeResource(),
             spanLimitConfig = fakeSpanLimitsConfig,

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/SpanDataTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/SpanDataTest.kt
@@ -6,7 +6,6 @@ import io.opentelemetry.kotlin.export.MutableShutdownState
 import io.opentelemetry.kotlin.factory.FakeContextFactory
 import io.opentelemetry.kotlin.factory.FakeIdGenerator
 import io.opentelemetry.kotlin.factory.FakeSpanContextFactory
-import io.opentelemetry.kotlin.factory.FakeSpanFactory
 import io.opentelemetry.kotlin.factory.FakeTraceFlagsFactory
 import io.opentelemetry.kotlin.resource.FakeResource
 import io.opentelemetry.kotlin.tracing.data.SpanData
@@ -42,7 +41,6 @@ internal class SpanDataTest {
             contextFactory = FakeContextFactory(),
             spanContextFactory = FakeSpanContextFactory(),
             traceFlagsFactory = FakeTraceFlagsFactory(),
-            spanFactory = FakeSpanFactory(),
             scope = key,
             resource = fakeResource,
             spanLimitConfig = fakeSpanLimitsConfig,

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/SpanEndTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/SpanEndTest.kt
@@ -6,7 +6,6 @@ import io.opentelemetry.kotlin.export.MutableShutdownState
 import io.opentelemetry.kotlin.factory.FakeContextFactory
 import io.opentelemetry.kotlin.factory.FakeIdGenerator
 import io.opentelemetry.kotlin.factory.FakeSpanContextFactory
-import io.opentelemetry.kotlin.factory.FakeSpanFactory
 import io.opentelemetry.kotlin.factory.FakeTraceFlagsFactory
 import io.opentelemetry.kotlin.resource.FakeResource
 import io.opentelemetry.kotlin.tracing.export.FakeSpanProcessor
@@ -33,7 +32,6 @@ internal class SpanEndTest {
             contextFactory = FakeContextFactory(),
             spanContextFactory = FakeSpanContextFactory(),
             traceFlagsFactory = FakeTraceFlagsFactory(),
-            spanFactory = FakeSpanFactory(),
             scope = key,
             resource = FakeResource(),
             spanLimitConfig = fakeSpanLimitsConfig,

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/SpanEventTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/SpanEventTest.kt
@@ -6,7 +6,6 @@ import io.opentelemetry.kotlin.export.MutableShutdownState
 import io.opentelemetry.kotlin.factory.FakeContextFactory
 import io.opentelemetry.kotlin.factory.FakeIdGenerator
 import io.opentelemetry.kotlin.factory.FakeSpanContextFactory
-import io.opentelemetry.kotlin.factory.FakeSpanFactory
 import io.opentelemetry.kotlin.factory.FakeTraceFlagsFactory
 import io.opentelemetry.kotlin.init.config.SpanLimitConfig
 import io.opentelemetry.kotlin.resource.FakeResource
@@ -43,7 +42,6 @@ internal class SpanEventTest {
             contextFactory = FakeContextFactory(),
             spanContextFactory = FakeSpanContextFactory(),
             traceFlagsFactory = FakeTraceFlagsFactory(),
-            spanFactory = FakeSpanFactory(),
             scope = key,
             resource = FakeResource(),
             spanLimitConfig = spanLimitConfig,

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/SpanLinkTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/SpanLinkTest.kt
@@ -6,7 +6,6 @@ import io.opentelemetry.kotlin.export.MutableShutdownState
 import io.opentelemetry.kotlin.factory.FakeContextFactory
 import io.opentelemetry.kotlin.factory.FakeIdGenerator
 import io.opentelemetry.kotlin.factory.FakeSpanContextFactory
-import io.opentelemetry.kotlin.factory.FakeSpanFactory
 import io.opentelemetry.kotlin.factory.FakeTraceFlagsFactory
 import io.opentelemetry.kotlin.factory.hexToByteArray
 import io.opentelemetry.kotlin.init.config.SpanLimitConfig
@@ -47,7 +46,6 @@ internal class SpanLinkTest {
             contextFactory = FakeContextFactory(),
             spanContextFactory = FakeSpanContextFactory(),
             traceFlagsFactory = FakeTraceFlagsFactory(),
-            spanFactory = FakeSpanFactory(),
             scope = key,
             resource = FakeResource(),
             spanLimitConfig = spanLimitConfig,

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/SpanMetaPropertiesTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/SpanMetaPropertiesTest.kt
@@ -6,7 +6,6 @@ import io.opentelemetry.kotlin.export.MutableShutdownState
 import io.opentelemetry.kotlin.factory.FakeContextFactory
 import io.opentelemetry.kotlin.factory.FakeIdGenerator
 import io.opentelemetry.kotlin.factory.FakeSpanContextFactory
-import io.opentelemetry.kotlin.factory.FakeSpanFactory
 import io.opentelemetry.kotlin.factory.FakeTraceFlagsFactory
 import io.opentelemetry.kotlin.resource.FakeResource
 import io.opentelemetry.kotlin.tracing.export.FakeSpanProcessor
@@ -32,7 +31,6 @@ internal class SpanMetaPropertiesTest {
             contextFactory = FakeContextFactory(),
             spanContextFactory = FakeSpanContextFactory(),
             traceFlagsFactory = FakeTraceFlagsFactory(),
-            spanFactory = FakeSpanFactory(),
             scope = key,
             resource = fakeResource,
             spanLimitConfig = fakeSpanLimitsConfig,

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/SpanSimplePropertiesTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/SpanSimplePropertiesTest.kt
@@ -6,7 +6,6 @@ import io.opentelemetry.kotlin.export.MutableShutdownState
 import io.opentelemetry.kotlin.factory.FakeContextFactory
 import io.opentelemetry.kotlin.factory.FakeIdGenerator
 import io.opentelemetry.kotlin.factory.FakeSpanContextFactory
-import io.opentelemetry.kotlin.factory.FakeSpanFactory
 import io.opentelemetry.kotlin.factory.FakeTraceFlagsFactory
 import io.opentelemetry.kotlin.resource.FakeResource
 import io.opentelemetry.kotlin.tracing.export.FakeSpanProcessor
@@ -29,7 +28,6 @@ internal class SpanSimplePropertiesTest {
             contextFactory = FakeContextFactory(),
             spanContextFactory = FakeSpanContextFactory(),
             traceFlagsFactory = FakeTraceFlagsFactory(),
-            spanFactory = FakeSpanFactory(),
             scope = key,
             resource = FakeResource(),
             spanLimitConfig = fakeSpanLimitsConfig,

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/TracerSamplerTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/TracerSamplerTest.kt
@@ -45,12 +45,12 @@ internal class TracerSamplerTest {
         val traceFlags = TraceFlagsFactoryImpl()
         val traceState = TraceStateFactoryImpl()
         spanContextFactory = SpanContextFactoryImpl(idGenerator, traceFlags, traceState)
-        contextFactory = ContextFactoryImpl()
-        spanFactory = SpanFactoryImpl(spanContextFactory, (contextFactory as ContextFactoryImpl).spanKey)
+        spanFactory = SpanFactoryImpl(spanContextFactory)
+        contextFactory = ContextFactoryImpl(spanFactory)
     }
 
     private fun buildTracer(
-        sampler: Sampler = AlwaysOnSampler(spanFactory),
+        sampler: Sampler = AlwaysOnSampler(),
         limitsCfg: SpanLimitConfig = fakeSpanLimitsConfig
     ) = TracerImpl(
         clock = clock,
@@ -58,7 +58,6 @@ internal class TracerSamplerTest {
         contextFactory = contextFactory,
         spanContextFactory = spanContextFactory,
         traceFlagsFactory = TraceFlagsFactoryImpl(),
-        spanFactory = spanFactory,
         scope = key,
         resource = FakeResource(),
         spanLimitConfig = limitsCfg,

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/TracerSpanContextTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/TracerSpanContextTest.kt
@@ -44,15 +44,14 @@ internal class TracerSpanContextTest {
         val traceFlags = TraceFlagsFactoryImpl()
         val traceState = TraceStateFactoryImpl()
         spanContextFactory = SpanContextFactoryImpl(idGenerator, traceFlags, traceState)
-        contextFactory = ContextFactoryImpl()
-        spanFactory = SpanFactoryImpl(spanContextFactory, (contextFactory as ContextFactoryImpl).spanKey)
+        spanFactory = SpanFactoryImpl(spanContextFactory)
+        contextFactory = ContextFactoryImpl(spanFactory)
         tracer = TracerImpl(
             clock = clock,
             processor = processor,
             contextFactory = contextFactory,
             spanContextFactory = spanContextFactory,
             traceFlagsFactory = traceFlags,
-            spanFactory = spanFactory,
             scope = key,
             resource = FakeResource(),
             spanLimitConfig = fakeSpanLimitsConfig,
@@ -73,7 +72,7 @@ internal class TracerSpanContextTest {
     fun testExplicitParentContextOfInvalidSpan() {
         val invalidSpan = spanFactory.invalid
         assertFalse(invalidSpan.spanContext.isValid)
-        val parentCtx = contextFactory.storeSpan(contextFactory.root(), invalidSpan)
+        val parentCtx = contextFactory.root().storeSpan(invalidSpan)
         val span = tracer.startSpan(
             "test",
             parentContext = parentCtx,
@@ -87,7 +86,7 @@ internal class TracerSpanContextTest {
     @Test
     fun testExplicitParentContextOfValidSpan() {
         val parentSpan = tracer.startSpan("parent")
-        val parentCtx = contextFactory.storeSpan(contextFactory.root(), parentSpan)
+        val parentCtx = contextFactory.root().storeSpan(parentSpan)
         val span = tracer.startSpan(
             "test",
             parentContext = parentCtx,
@@ -103,7 +102,7 @@ internal class TracerSpanContextTest {
     @Test
     fun testImplicitContext() {
         val span = tracer.startSpan("span")
-        val ctx = contextFactory.storeSpan(contextFactory.root(), span)
+        val ctx = contextFactory.root().storeSpan(span)
         val scope = ctx.attach()
 
         val first = tracer.startSpan("first")

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/sampling/BuiltInSamplersTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/sampling/BuiltInSamplersTest.kt
@@ -31,8 +31,8 @@ internal class BuiltInSamplersTest {
     private val traceFlagsFactory = TraceFlagsFactoryImpl()
     private val traceStateFactory = TraceStateFactoryImpl()
     private val spanContextFactory = SpanContextFactoryImpl(idGenerator, traceFlagsFactory, traceStateFactory)
-    private val contextFactory = ContextFactoryImpl()
-    private val spanFactory = SpanFactoryImpl(spanContextFactory, contextFactory.spanKey)
+    private val spanFactory = SpanFactoryImpl(spanContextFactory)
+    private val contextFactory = ContextFactoryImpl(spanFactory)
     private val scope = InstrumentationScopeInfoImpl("test", null, null, emptyMap())
 
     private val samplerDsl = object : SamplerConfigDsl {
@@ -45,7 +45,6 @@ internal class BuiltInSamplersTest {
         contextFactory = contextFactory,
         spanContextFactory = spanContextFactory,
         traceFlagsFactory = traceFlagsFactory,
-        spanFactory = spanFactory,
         scope = scope,
         resource = FakeResource(),
         spanLimitConfig = fakeSpanLimitsConfig,
@@ -67,19 +66,19 @@ internal class BuiltInSamplersTest {
             isRemote = isRemote,
         )
         val parentSpan = NonRecordingSpan(spanContextFactory.invalid, parentSpanContext)
-        return contextFactory.storeSpan(contextFactory.root(), parentSpan)
+        return contextFactory.root().storeSpan(parentSpan)
     }
 
     @Test
     fun testAlwaysOnRecordsAndSamplesSpan() {
-        val span = buildTracer(AlwaysOnSampler(spanFactory)).startSpan("span")
+        val span = buildTracer(AlwaysOnSampler()).startSpan("span")
         assertTrue(span.isRecording())
         assertTrue(span.spanContext.traceFlags.isSampled)
     }
 
     @Test
     fun testAlwaysOffDropsSpan() {
-        val span = buildTracer(AlwaysOffSampler(spanFactory)).startSpan("span")
+        val span = buildTracer(AlwaysOffSampler()).startSpan("span")
         assertFalse(span.isRecording())
         assertFalse(span.spanContext.traceFlags.isSampled)
     }

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/sampling/ProbabilitySamplerTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/sampling/ProbabilitySamplerTest.kt
@@ -24,8 +24,8 @@ internal class ProbabilitySamplerTest {
     private val traceFlagsFactory = TraceFlagsFactoryImpl()
     private val traceStateFactory = TraceStateFactoryImpl()
     private val spanContextFactory = SpanContextFactoryImpl(idGenerator, traceFlagsFactory, traceStateFactory)
-    private val contextFactory = ContextFactoryImpl()
-    private val spanFactory = SpanFactoryImpl(spanContextFactory, contextFactory.spanKey)
+    private val spanFactory = SpanFactoryImpl(spanContextFactory)
+    private val contextFactory = ContextFactoryImpl(spanFactory)
 
     private fun createParentContext(traceId: String, otTraceStateValue: String, flags: TraceFlags): Context {
         val traceState = traceStateFactory.default.put("ot", otTraceStateValue)
@@ -36,15 +36,12 @@ internal class ProbabilitySamplerTest {
             traceState = traceState,
             isRemote = true,
         )
-        return contextFactory.storeSpan(
-            contextFactory.root(),
-            spanFactory.fromSpanContext(parentSpanContext),
-        )
+        return contextFactory.root().storeSpan(spanFactory.fromSpanContext(parentSpanContext))
     }
 
     @Test
     fun testRecordsAndSamplesSpan() {
-        val result = ProbabilitySampler(spanFactory, 0.5).shouldSample(
+        val result = ProbabilitySampler(0.5).shouldSample(
             context = contextFactory.root(),
             traceId = "000000000000000000ffffffffffffff",
             name = "span",
@@ -57,7 +54,7 @@ internal class ProbabilitySamplerTest {
 
     @Test
     fun testDropsSpan() {
-        val result = ProbabilitySampler(spanFactory, 0.5).shouldSample(
+        val result = ProbabilitySampler(0.5).shouldSample(
             context = contextFactory.root(),
             traceId = "ffffffffffffffffff00000000000000",
             name = "span",
@@ -71,7 +68,7 @@ internal class ProbabilitySamplerTest {
     @Test
     fun testRecordsAndSamplesSpanAtMinimumRatio() {
         val ratio = 1.0 / (1L shl 56).toDouble()
-        val result = ProbabilitySampler(spanFactory, ratio).shouldSample(
+        val result = ProbabilitySampler(ratio).shouldSample(
             context = contextFactory.root(),
             traceId = "000000000000000000ffffffffffffff",
             name = "span",
@@ -85,7 +82,7 @@ internal class ProbabilitySamplerTest {
     @Test
     fun testDropsSpanAtMinimumRatio() {
         val ratio = 1.0 / (1L shl 56).toDouble()
-        val result = ProbabilitySampler(spanFactory, ratio).shouldSample(
+        val result = ProbabilitySampler(ratio).shouldSample(
             context = contextFactory.root(),
             traceId = "000000000000000000fffffffffffffe",
             name = "span",
@@ -99,10 +96,10 @@ internal class ProbabilitySamplerTest {
     @Test
     fun testThrowsOnInvalidRatio() {
         assertFailsWith(IllegalArgumentException::class) {
-            ProbabilitySampler(spanFactory, 0.0)
+            ProbabilitySampler(0.0)
         }
         assertFailsWith(IllegalArgumentException::class) {
-            ProbabilitySampler(spanFactory, 2.0)
+            ProbabilitySampler(2.0)
         }
     }
 
@@ -117,7 +114,7 @@ internal class ProbabilitySamplerTest {
             otTraceStateValue = "rv:$aboveThreshold",
             flags = traceFlagsFactory.default
         )
-        val result = ProbabilitySampler(spanFactory, ratio).shouldSample(
+        val result = ProbabilitySampler(ratio).shouldSample(
             context = context,
             traceId = traceId,
             name = "span",
@@ -136,7 +133,7 @@ internal class ProbabilitySamplerTest {
             otTraceStateValue = "rv:garbage",
             flags = traceFlagsFactory.default
         )
-        val result = ProbabilitySampler(spanFactory, 0.5).shouldSample(
+        val result = ProbabilitySampler(0.5).shouldSample(
             context = context,
             traceId = traceId,
             name = "span",
@@ -155,7 +152,7 @@ internal class ProbabilitySamplerTest {
             otTraceStateValue = "th:123",
             flags = traceFlagsFactory.default
         )
-        val result = ProbabilitySampler(spanFactory, 0.5).shouldSample(
+        val result = ProbabilitySampler(0.5).shouldSample(
             context = context,
             traceId = traceId,
             name = "span",
@@ -174,7 +171,7 @@ internal class ProbabilitySamplerTest {
             otTraceStateValue = "rv:a0000000000000;th:c", // rv < th
             flags = TraceFlagsImpl(isSampled = true, traceFlagsFactory.default.isRandom),
         )
-        val result = ProbabilitySampler(spanFactory, 0.5).shouldSample(
+        val result = ProbabilitySampler(0.5).shouldSample(
             context = context,
             traceId = traceId,
             name = "span",

--- a/implementation/src/commonTest/resources/span_complex_java_api.json
+++ b/implementation/src/commonTest/resources/span_complex_java_api.json
@@ -15,7 +15,7 @@
     "parentSpanContext": {
       "traceId": "00000000000000000000000000000000",
       "spanId": "0000000000000000",
-      "traceFlags": "01",
+      "traceFlags": "00",
       "traceState": {}
     },
     "startTimestamp": 0,
@@ -60,7 +60,7 @@
     "parentSpanContext": {
       "traceId": "00000000000000000000000000000000",
       "spanId": "0000000000000000",
-      "traceFlags": "01",
+      "traceFlags": "00",
       "traceState": {}
     },
     "startTimestamp": 0,
@@ -105,7 +105,7 @@
     "parentSpanContext": {
       "traceId": "00000000000000000000000000000000",
       "spanId": "0000000000000000",
-      "traceFlags": "01",
+      "traceFlags": "00",
       "traceState": {}
     },
     "startTimestamp": 0,

--- a/implementation/src/commonTest/resources/span_java_api.json
+++ b/implementation/src/commonTest/resources/span_java_api.json
@@ -15,7 +15,7 @@
     "parentSpanContext": {
       "traceId": "00000000000000000000000000000000",
       "spanId": "0000000000000000",
-      "traceFlags": "01",
+      "traceFlags": "00",
       "traceState": {}
     },
     "startTimestamp": 0,

--- a/noop/src/commonMain/kotlin/io/opentelemetry/kotlin/context/NoopContext.kt
+++ b/noop/src/commonMain/kotlin/io/opentelemetry/kotlin/context/NoopContext.kt
@@ -2,6 +2,8 @@ package io.opentelemetry.kotlin.context
 
 import io.opentelemetry.kotlin.baggage.Baggage
 import io.opentelemetry.kotlin.baggage.NoopBaggage
+import io.opentelemetry.kotlin.tracing.NoopSpan
+import io.opentelemetry.kotlin.tracing.Span
 
 internal object NoopContext : Context {
 
@@ -14,6 +16,10 @@ internal object NoopContext : Context {
     }
 
     override fun attach(): Scope = NoopScope
+
+    override fun storeSpan(span: Span): Context = this
+
+    override fun extractSpan(): Span = NoopSpan
 
     override fun storeBaggage(baggage: Baggage): Context = this
 

--- a/noop/src/commonMain/kotlin/io/opentelemetry/kotlin/factory/NoopContextFactory.kt
+++ b/noop/src/commonMain/kotlin/io/opentelemetry/kotlin/factory/NoopContextFactory.kt
@@ -4,22 +4,12 @@ import io.opentelemetry.kotlin.context.Context
 import io.opentelemetry.kotlin.context.ContextKey
 import io.opentelemetry.kotlin.context.NoopContext
 import io.opentelemetry.kotlin.context.NoopContextKey
-import io.opentelemetry.kotlin.context.NoopScope
-import io.opentelemetry.kotlin.context.Scope
-import io.opentelemetry.kotlin.tracing.Span
 
 internal object NoopContextFactory : ContextFactory {
 
     override fun root(): Context = NoopContext
 
-    override fun storeSpan(
-        context: Context,
-        span: Span
-    ): Context = NoopContext
-
     override fun implicit(): Context = NoopContext
 
     override fun <T> createKey(name: String): ContextKey<T> = NoopContextKey(name)
-
-    override fun makeCurrent(span: Span): Scope = NoopScope
 }

--- a/noop/src/commonMain/kotlin/io/opentelemetry/kotlin/factory/NoopSpanFactory.kt
+++ b/noop/src/commonMain/kotlin/io/opentelemetry/kotlin/factory/NoopSpanFactory.kt
@@ -1,6 +1,5 @@
 package io.opentelemetry.kotlin.factory
 
-import io.opentelemetry.kotlin.context.Context
 import io.opentelemetry.kotlin.tracing.NoopSpan
 import io.opentelemetry.kotlin.tracing.Span
 import io.opentelemetry.kotlin.tracing.SpanContext
@@ -8,5 +7,4 @@ import io.opentelemetry.kotlin.tracing.SpanContext
 internal object NoopSpanFactory : SpanFactory {
     override val invalid: Span = NoopSpan
     override fun fromSpanContext(spanContext: SpanContext): Span = NoopSpan
-    override fun fromContext(context: Context): Span = NoopSpan
 }

--- a/noop/src/commonTest/kotlin/io/opentelemetry/kotlin/NoopTests.kt
+++ b/noop/src/commonTest/kotlin/io/opentelemetry/kotlin/NoopTests.kt
@@ -174,7 +174,7 @@ internal class NoopTests {
     fun testStoreSpan() {
         val otel = NoopOpenTelemetry
         val span = otel.tracerProvider.getTracer("tracer").startSpan("span")
-        val ctx = otel.context.storeSpan(otel.context.root(), span)
+        val ctx = otel.context.root().storeSpan(span)
         assertTrue(ctx is NoopContext)
     }
 
@@ -197,7 +197,7 @@ internal class NoopTests {
         val second = otel.span.fromSpanContext(otel.spanContext.invalid)
         assertTrue(second is NoopSpan)
 
-        val third = otel.span.fromContext(otel.context.root())
+        val third = otel.context.root().extractSpan()
         assertTrue(third is NoopSpan)
     }
 

--- a/test-fakes/src/commonMain/kotlin/io/opentelemetry/kotlin/context/FakeContext.kt
+++ b/test-fakes/src/commonMain/kotlin/io/opentelemetry/kotlin/context/FakeContext.kt
@@ -2,6 +2,8 @@ package io.opentelemetry.kotlin.context
 
 import io.opentelemetry.kotlin.baggage.Baggage
 import io.opentelemetry.kotlin.baggage.FakeBaggage
+import io.opentelemetry.kotlin.tracing.FakeSpan
+import io.opentelemetry.kotlin.tracing.Span
 
 class FakeContext(
     val attrs: Map<ContextKey<*>, Any?> = emptyMap(),
@@ -21,6 +23,10 @@ class FakeContext(
         onAttach()
         return FakeScope(onDetach)
     }
+
+    override fun storeSpan(span: Span): Context = FakeContext(attrs, onAttach, onDetach)
+
+    override fun extractSpan(): Span = FakeSpan()
 
     override fun storeBaggage(baggage: Baggage): Context = FakeContext(attrs, onAttach, onDetach)
 

--- a/test-fakes/src/commonMain/kotlin/io/opentelemetry/kotlin/factory/FakeContextFactory.kt
+++ b/test-fakes/src/commonMain/kotlin/io/opentelemetry/kotlin/factory/FakeContextFactory.kt
@@ -4,21 +4,12 @@ import io.opentelemetry.kotlin.context.Context
 import io.opentelemetry.kotlin.context.ContextKey
 import io.opentelemetry.kotlin.context.FakeContext
 import io.opentelemetry.kotlin.context.FakeContextKey
-import io.opentelemetry.kotlin.context.Scope
-import io.opentelemetry.kotlin.tracing.Span
 
 class FakeContextFactory : ContextFactory {
 
     override fun root(): Context = FakeContext()
 
-    override fun storeSpan(
-        context: Context,
-        span: Span
-    ): Context = FakeContext()
-
     override fun implicit(): Context = FakeContext()
 
     override fun <T> createKey(name: String): ContextKey<T> = FakeContextKey(name)
-
-    override fun makeCurrent(span: Span): Scope = storeSpan(implicit(), span).attach()
 }

--- a/test-fakes/src/commonMain/kotlin/io/opentelemetry/kotlin/factory/FakeSpanFactory.kt
+++ b/test-fakes/src/commonMain/kotlin/io/opentelemetry/kotlin/factory/FakeSpanFactory.kt
@@ -1,6 +1,5 @@
 package io.opentelemetry.kotlin.factory
 
-import io.opentelemetry.kotlin.context.Context
 import io.opentelemetry.kotlin.tracing.FakeSpan
 import io.opentelemetry.kotlin.tracing.Span
 import io.opentelemetry.kotlin.tracing.SpanContext
@@ -8,5 +7,4 @@ import io.opentelemetry.kotlin.tracing.SpanContext
 class FakeSpanFactory : SpanFactory {
     override val invalid: Span = FakeSpan()
     override fun fromSpanContext(spanContext: SpanContext): Span = FakeSpan()
-    override fun fromContext(context: Context): Span = FakeSpan()
 }


### PR DESCRIPTION
## Goal

This changeset alters how span objects are stored and extracted from `Context`. Previously the syntax for extracting a span would look like this:

```
val ctx = otel.context.makeCurrent(span)
val retrievedSpan = otel.spanFactory.fromContext(otel.context.implicit())
```

Whereas after the changes the API looks like this:

```
val root = otel.context.root()
val ctx = root.storeSpan(span)
val retrievedSpan = root.extractSpan()
```

IMO this is preferable to the previous API as it's more obvious that spans can be stored/retrieved on a `Context` object. Additionally, it matches the API used for `Baggage`.