### PR TITLE
Add fuzz tests for trace context

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -29,6 +29,7 @@ wire = "6.2.0"
 buildKonfig = "0.19.0"
 composeMultiplatform = "1.10.3"
 androidxActivityCompose = "1.13.0"
+kotest = "6.1.11"
 
 [libraries]
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
@@ -67,6 +68,7 @@ androidx-benchmark-junit4 = { group = "androidx.benchmark", name = "benchmark-ju
 protobuf-kotlin = { module = "com.google.protobuf:protobuf-kotlin", version.ref = "protobufKotlin" }
 wire-runtime = { module = "com.squareup.wire:wire-runtime", version.ref = "wire" }
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidxActivityCompose" }
+kotest-property = { module = "io.kotest:kotest-property", version.ref = "kotest" }
 
 [plugins]
 android-kotlin-multiplatform-library = { id = "com.android.kotlin.multiplatform.library", version.ref = "agp" }

--- a/implementation/build.gradle.kts
+++ b/implementation/build.gradle.kts
@@ -41,6 +41,7 @@ kotlin {
                 implementation(project(":test-fakes"))
                 implementation(project(":integration-test"))
                 implementation(libs.kotlinx.coroutines.test)
+                implementation(libs.kotest.property)
             }
         }
         val jvmTest by getting {

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/propagation/W3CTraceContextPropagatorFuzzTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/propagation/W3CTraceContextPropagatorFuzzTest.kt
@@ -16,6 +16,7 @@ import io.opentelemetry.kotlin.tracing.TraceFlagsImpl
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 /**
@@ -105,6 +106,8 @@ internal class W3CTraceContextPropagatorFuzzTest {
                     extracted.extractSpan().spanContext.isValid,
                     "non-root context with invalid SpanContext from carrier=$carrier",
                 )
+            } else {
+                assertFalse(extracted.extractSpan().spanContext.isValid)
             }
         }
     }

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/propagation/W3CTraceContextPropagatorFuzzTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/propagation/W3CTraceContextPropagatorFuzzTest.kt
@@ -1,0 +1,164 @@
+package io.opentelemetry.kotlin.propagation
+
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.arbitrary
+import io.kotest.property.arbitrary.boolean
+import io.kotest.property.arbitrary.filter
+import io.kotest.property.checkAll
+import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.factory.ContextFactoryImpl
+import io.opentelemetry.kotlin.factory.IdGeneratorImpl
+import io.opentelemetry.kotlin.factory.SpanContextFactoryImpl
+import io.opentelemetry.kotlin.factory.SpanFactoryImpl
+import io.opentelemetry.kotlin.factory.TraceFlagsFactoryImpl
+import io.opentelemetry.kotlin.factory.TraceStateFactoryImpl
+import io.opentelemetry.kotlin.tracing.TraceFlagsImpl
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Property-based fuzz tests for [W3CTraceContextPropagator] using Kotest's
+ * [io.kotest.property.Arb] generators with [checkAll]. Runs across every KMP target
+ * (JVM, Android host, iOS, JS). Kotest's seed reporting + automatic shrinking surface
+ * a minimal failing input on regression.
+ */
+@OptIn(ExperimentalApi::class)
+internal class W3CTraceContextPropagatorFuzzTest {
+
+    private val idGenerator = IdGeneratorImpl()
+    private val traceFlagsFactory = TraceFlagsFactoryImpl()
+    private val traceStateFactory = TraceStateFactoryImpl()
+    private val spanContextFactory = SpanContextFactoryImpl(idGenerator, traceFlagsFactory, traceStateFactory)
+    private val spanFactory = SpanFactoryImpl(spanContextFactory)
+    private val contextFactory = ContextFactoryImpl(spanFactory)
+
+    private val propagator = W3CTraceContextPropagator(
+        traceFlagsFactory = traceFlagsFactory,
+        traceStateFactory = traceStateFactory,
+        spanContextFactory = spanContextFactory,
+        spanFactory = spanFactory,
+    )
+
+    private val headerArb = arbitrary { rs ->
+        val len = rs.random.nextInt(0, MAX_HEADER_LEN + 1)
+        buildString(len) {
+            repeat(len) {
+                val ch = if (rs.random.nextBoolean()) {
+                    NEAR_VALID_CHARS[rs.random.nextInt(NEAR_VALID_CHARS.length)]
+                } else {
+                    rs.random.nextInt(PRINTABLE_ASCII_MIN, PRINTABLE_ASCII_MAX + 1).toChar()
+                }
+                append(ch)
+            }
+        }
+    }
+
+    private val traceIdArb = arbitrary { rs ->
+        buildString(TRACE_ID_LEN) {
+            repeat(TRACE_ID_LEN) { append(HEX_CHARS[rs.random.nextInt(HEX_CHARS.length)]) }
+        }
+    }.filter { id -> id.any { it != '0' } }
+
+    private val spanIdArb = arbitrary { rs ->
+        buildString(SPAN_ID_LEN) {
+            repeat(SPAN_ID_LEN) { append(HEX_CHARS[rs.random.nextInt(HEX_CHARS.length)]) }
+        }
+    }.filter { id -> id.any { it != '0' } }
+
+    private val traceStateEntriesArb = arbitrary { rs ->
+        val seen = mutableSetOf<String>()
+        val entries = mutableListOf<Pair<String, String>>()
+        repeat(rs.random.nextInt(0, MAX_TRACESTATE_ENTRIES + 1)) {
+            val keyLen = 1 + rs.random.nextInt(MAX_TRACESTATE_KEY_LEN)
+            val key = buildString(keyLen) {
+                append(LOWERCASE_LETTERS[rs.random.nextInt(LOWERCASE_LETTERS.length)])
+                repeat(keyLen - 1) { append(KEY_CHARS[rs.random.nextInt(KEY_CHARS.length)]) }
+            }
+            if (seen.add(key)) {
+                val valLen = 1 + rs.random.nextInt(MAX_TRACESTATE_VALUE_LEN)
+                val value = buildString(valLen) {
+                    repeat(valLen) { append(VALUE_CHARS[rs.random.nextInt(VALUE_CHARS.length)]) }
+                }
+                entries += key to value
+            }
+        }
+        entries
+    }
+
+    @Test
+    fun `extract does not throw for arbitrary header inputs`() = runTest {
+        val root = contextFactory.root()
+        checkAll(ITERATIONS, headerArb, headerArb, Arb.boolean(), Arb.boolean()) { tp, ts, hasTp, hasTs ->
+            val carrier = buildMap {
+                if (hasTp) {
+                    put("traceparent", tp)
+                }
+                if (hasTs) {
+                    put("tracestate", ts)
+                }
+            }
+            val extracted = propagator.extract(root, carrier, MapTextMapGetter)
+            if (extracted != root) {
+                assertTrue(
+                    extracted.extractSpan().spanContext.isValid,
+                    "non-root context with invalid SpanContext from carrier=$carrier",
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `inject extract round-trip preserves randomized valid SpanContexts`() = runTest {
+        checkAll(
+            ITERATIONS,
+            traceIdArb,
+            spanIdArb,
+            Arb.boolean(),
+            Arb.boolean(),
+            traceStateEntriesArb,
+        ) { traceId, spanId, isSampled, isRandom, entries ->
+            val flags = TraceFlagsImpl(isSampled = isSampled, isRandom = isRandom)
+            val state = entries.fold(traceStateFactory.default) { acc, (k, v) -> acc.put(k, v) }
+
+            val original = spanContextFactory.create(
+                traceId = traceId,
+                spanId = spanId,
+                traceFlags = flags,
+                traceState = state,
+                isRemote = false,
+            )
+            val context = contextFactory.root().storeSpan(spanFactory.fromSpanContext(original))
+
+            val carrier = mutableMapOf<String, String>()
+            propagator.inject(context, carrier, MapTextMapSetter)
+
+            val extracted = propagator.extract(contextFactory.root(), carrier, MapTextMapGetter)
+            val sc = extracted.extractSpan().spanContext
+
+            assertEquals(traceId, sc.traceId)
+            assertEquals(spanId, sc.spanId)
+            assertEquals(flags.isSampled, sc.traceFlags.isSampled)
+            assertEquals(state.asMap(), sc.traceState.asMap())
+            assertTrue(sc.isRemote)
+        }
+    }
+
+    private companion object {
+        const val ITERATIONS = 1024
+        const val MAX_HEADER_LEN = 128
+        const val PRINTABLE_ASCII_MIN = 0x20
+        const val PRINTABLE_ASCII_MAX = 0x7E
+        const val TRACE_ID_LEN = 32
+        const val SPAN_ID_LEN = 16
+        const val MAX_TRACESTATE_ENTRIES = 4
+        const val MAX_TRACESTATE_KEY_LEN = 16
+        const val MAX_TRACESTATE_VALUE_LEN = 16
+        const val HEX_CHARS = "0123456789abcdef"
+        const val NEAR_VALID_CHARS = "0123456789abcdef-"
+        const val LOWERCASE_LETTERS = "abcdefghijklmnopqrstuvwxyz"
+        const val KEY_CHARS = "abcdefghijklmnopqrstuvwxyz0123456789_*/-"
+        const val VALUE_CHARS = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!_-"
+    }
+}

--- a/implementation/src/jvmTest/kotlin/io/opentelemetry/kotlin/propagation/W3CTraceContextPropagatorKFuzzTest.kt
+++ b/implementation/src/jvmTest/kotlin/io/opentelemetry/kotlin/propagation/W3CTraceContextPropagatorKFuzzTest.kt
@@ -1,0 +1,5 @@
+package io.opentelemetry.kotlin.propagation
+
+// Intentionally empty. Previously held a kotlinx.fuzz attempt before discovering its
+// publishing channel (plan-maven.apal-research.com) is unreachable. Fuzz tests now
+// live in commonTest using Kotest property-based testing for KMP coverage.

--- a/implementation/src/jvmTest/kotlin/io/opentelemetry/kotlin/propagation/W3CTraceContextPropagatorKFuzzTest.kt
+++ b/implementation/src/jvmTest/kotlin/io/opentelemetry/kotlin/propagation/W3CTraceContextPropagatorKFuzzTest.kt
@@ -1,5 +1,0 @@
-package io.opentelemetry.kotlin.propagation
-
-// Intentionally empty. Previously held a kotlinx.fuzz attempt before discovering its
-// publishing channel (plan-maven.apal-research.com) is unreachable. Fuzz tests now
-// live in commonTest using Kotest property-based testing for KMP coverage.


### PR DESCRIPTION
## Goal

Closes #471 by adding fuzz tests for W3C trace context, [using Kotest](https://kotest.io/).
