### PR TITLE
Scaffold MeterProvider config and compat layer

### DIFF
--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/init/CompatMeterProviderConfig.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/init/CompatMeterProviderConfig.kt
@@ -20,12 +20,9 @@ internal class CompatMeterProviderConfig(
 ) : MeterProviderConfigDsl {
 
     private val builder: OtelJavaSdkMeterProviderBuilder = OtelJavaSdkMeterProvider.builder()
-    private var serviceNameOverride: String? = null
-
-    override var serviceName: String
-        get() = serviceNameOverride ?: "unknown_service"
+    override var serviceName: String = "unknown_service"
         set(value) {
-            serviceNameOverride = value
+            field = value
             resourceAttrs.setStringAttribute(ServiceAttributes.SERVICE_NAME, value)
         }
 

--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/init/CompatMeterProviderConfig.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/init/CompatMeterProviderConfig.kt
@@ -1,0 +1,59 @@
+package io.opentelemetry.kotlin.init
+
+import io.opentelemetry.kotlin.Clock
+import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.aliases.OtelJavaResource
+import io.opentelemetry.kotlin.aliases.OtelJavaSdkMeterProvider
+import io.opentelemetry.kotlin.aliases.OtelJavaSdkMeterProviderBuilder
+import io.opentelemetry.kotlin.attributes.AttributesMutator
+import io.opentelemetry.kotlin.attributes.CompatAttributesModel
+import io.opentelemetry.kotlin.attributes.setAttributes
+import io.opentelemetry.kotlin.metrics.MeterProvider
+import io.opentelemetry.kotlin.metrics.MeterProviderAdapter
+import io.opentelemetry.kotlin.resource.Resource
+import io.opentelemetry.kotlin.resource.ResourceAdapter
+import io.opentelemetry.kotlin.semconv.ServiceAttributes
+
+@ExperimentalApi
+internal class CompatMeterProviderConfig(
+    private val clock: Clock,
+) : MeterProviderConfigDsl {
+
+    private val builder: OtelJavaSdkMeterProviderBuilder = OtelJavaSdkMeterProvider.builder()
+    private var serviceNameOverride: String? = null
+
+    override var serviceName: String
+        get() = serviceNameOverride ?: "unknown_service"
+        set(value) {
+            serviceNameOverride = value
+            resourceAttrs.setStringAttribute(ServiceAttributes.SERVICE_NAME, value)
+        }
+
+    private val resourceAttrs = CompatAttributesModel()
+    private var resourceSchemaUrl: String? = null
+
+    override fun resource(schemaUrl: String?, attributes: AttributesMutator.() -> Unit) {
+        resourceSchemaUrl = schemaUrl
+        resourceAttrs.apply(attributes)
+    }
+
+    override fun resource(map: Map<String, Any>) {
+        resourceAttrs.apply { setAttributes(map) }
+    }
+
+    fun build(
+        clock: Clock = this.clock,
+        baseResource: Resource = ResourceAdapter(OtelJavaResource.builder().build()),
+    ): MeterProvider {
+        val resource = ResourceAdapter(
+            OtelJavaResource.create(resourceAttrs.otelJavaAttributes(), resourceSchemaUrl)
+        )
+        val merged = baseResource.merge(resource)
+        if (merged.attributes.isNotEmpty() || merged.schemaUrl != null) {
+            val attrs = CompatAttributesModel().apply { setAttributes(merged.attributes) }.otelJavaAttributes()
+            builder.setResource(OtelJavaResource.create(attrs, merged.schemaUrl))
+        }
+        builder.setClock(OtelJavaClockWrapper(clock))
+        return MeterProviderAdapter(builder.build())
+    }
+}

--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/metrics/MeterAdapter.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/metrics/MeterAdapter.kt
@@ -1,0 +1,9 @@
+package io.opentelemetry.kotlin.metrics
+
+import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.aliases.OtelJavaMeter
+
+@ExperimentalApi
+internal class MeterAdapter(
+    @Suppress("UnusedPrivateProperty") private val impl: OtelJavaMeter,
+) : Meter

--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/metrics/MeterProviderAdapter.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/metrics/MeterProviderAdapter.kt
@@ -1,0 +1,31 @@
+package io.opentelemetry.kotlin.metrics
+
+import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.ThreadSafe
+import io.opentelemetry.kotlin.aliases.OtelJavaMeterProvider
+import io.opentelemetry.kotlin.attributes.AttributesMutator
+import java.util.concurrent.ConcurrentHashMap
+
+@ThreadSafe
+@ExperimentalApi
+internal class MeterProviderAdapter(
+    private val impl: OtelJavaMeterProvider
+) : MeterProvider {
+
+    private val map = ConcurrentHashMap<String, MeterAdapter>()
+
+    override fun getMeter(
+        name: String,
+        version: String?,
+        schemaUrl: String?,
+        attributes: (AttributesMutator.() -> Unit)?,
+    ): Meter {
+        val key = name.plus(version).plus(schemaUrl)
+        return map.getOrPut(key) {
+            val builder = impl.meterBuilder(name)
+            schemaUrl?.let(builder::setSchemaUrl)
+            version?.let(builder::setInstrumentationVersion)
+            MeterAdapter(builder.build())
+        }
+    }
+}

--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/metrics/OtelJavaMeterAdapter.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/metrics/OtelJavaMeterAdapter.kt
@@ -1,0 +1,15 @@
+package io.opentelemetry.kotlin.metrics
+
+import io.opentelemetry.kotlin.aliases.OtelJavaMeter
+import io.opentelemetry.kotlin.aliases.OtelJavaMeterProvider
+
+/**
+ * Adapts a Kotlin [Meter] to a Java [OtelJavaMeter].
+ *
+ * TODO Until instruments are implemented on the Kotlin side, all instrument-builder calls delegate
+ *  to Java OTel's no-op meter — i.e., builders, instruments, and observables are valid types
+ *  but record nothing.
+ */
+internal class OtelJavaMeterAdapter(
+    @Suppress("UnusedPrivateProperty") private val impl: Meter,
+) : OtelJavaMeter by OtelJavaMeterProvider.noop().get("")

--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/metrics/OtelJavaMeterBuilderAdapter.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/metrics/OtelJavaMeterBuilderAdapter.kt
@@ -1,0 +1,32 @@
+package io.opentelemetry.kotlin.metrics
+
+import io.opentelemetry.kotlin.aliases.OtelJavaMeter
+import io.opentelemetry.kotlin.aliases.OtelJavaMeterBuilder
+
+internal class OtelJavaMeterBuilderAdapter(
+    private val meterProvider: MeterProvider,
+    private val instrumentationScopeName: String
+) : OtelJavaMeterBuilder {
+
+    private var schemaUrl: String? = null
+    private var instrumentationScopeVersion: String? = null
+
+    override fun setSchemaUrl(schemaUrl: String): OtelJavaMeterBuilder {
+        this.schemaUrl = schemaUrl
+        return this
+    }
+
+    override fun setInstrumentationVersion(instrumentationScopeVersion: String): OtelJavaMeterBuilder {
+        this.instrumentationScopeVersion = instrumentationScopeVersion
+        return this
+    }
+
+    override fun build(): OtelJavaMeter {
+        val impl = meterProvider.getMeter(
+            instrumentationScopeName,
+            instrumentationScopeVersion,
+            schemaUrl
+        )
+        return OtelJavaMeterAdapter(impl)
+    }
+}

--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/metrics/OtelJavaMeterProviderAdapter.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/metrics/OtelJavaMeterProviderAdapter.kt
@@ -1,0 +1,12 @@
+package io.opentelemetry.kotlin.metrics
+
+import io.opentelemetry.kotlin.aliases.OtelJavaMeterBuilder
+import io.opentelemetry.kotlin.aliases.OtelJavaMeterProvider
+
+internal class OtelJavaMeterProviderAdapter(
+    private val meterProvider: MeterProvider
+) : OtelJavaMeterProvider {
+
+    override fun meterBuilder(instrumentationScopeName: String): OtelJavaMeterBuilder =
+        OtelJavaMeterBuilderAdapter(meterProvider, instrumentationScopeName)
+}

--- a/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/init/CompatMeterProviderConfigTest.kt
+++ b/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/init/CompatMeterProviderConfigTest.kt
@@ -1,0 +1,56 @@
+package io.opentelemetry.kotlin.init
+
+import io.opentelemetry.kotlin.clock.FakeClock
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertSame
+
+internal class CompatMeterProviderConfigTest {
+
+    private val clock = FakeClock()
+
+    @Test
+    fun `default service name is unknown_service`() {
+        val cfg = CompatMeterProviderConfig(clock)
+        assertEquals("unknown_service", cfg.serviceName)
+    }
+
+    @Test
+    fun `serviceName setter updates getter`() {
+        val cfg = CompatMeterProviderConfig(clock).apply {
+            serviceName = "my-service"
+        }
+        assertEquals("my-service", cfg.serviceName)
+    }
+
+    @Test
+    fun `built MeterProvider caches meters by scope name`() {
+        val provider = CompatMeterProviderConfig(clock).build(clock)
+        val first = provider.getMeter("name")
+        val second = provider.getMeter("name")
+        val third = provider.getMeter("other")
+        assertSame(first, second)
+        assertNotEquals(first, third)
+    }
+
+    @Test
+    fun `built MeterProvider caches meters by version`() {
+        val provider = CompatMeterProviderConfig(clock).build(clock)
+        val first = provider.getMeter(name = "name", version = "0.1.0")
+        val second = provider.getMeter(name = "name", version = "0.1.0")
+        val third = provider.getMeter(name = "name", version = "0.2.0")
+        assertSame(first, second)
+        assertNotEquals(first, third)
+    }
+
+    @Test
+    fun `built MeterProvider caches meters by schemaUrl`() {
+        val provider = CompatMeterProviderConfig(clock).build(clock)
+        val first = provider.getMeter(name = "name", schemaUrl = "https://example.com/foo")
+        val second = provider.getMeter(name = "name", schemaUrl = "https://example.com/foo")
+        val third = provider.getMeter(name = "name", schemaUrl = "https://example.com/bar")
+        assertSame(first, second)
+        assertNotEquals(first, third)
+    }
+}

--- a/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/metrics/MeterProviderAdapterTest.kt
+++ b/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/metrics/MeterProviderAdapterTest.kt
@@ -1,0 +1,44 @@
+package io.opentelemetry.kotlin.metrics
+
+import io.opentelemetry.kotlin.aliases.OtelJavaSdkMeterProvider
+import kotlin.test.Test
+import kotlin.test.assertNotEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertSame
+
+internal class MeterProviderAdapterTest {
+
+    private val adapter = MeterProviderAdapter(OtelJavaSdkMeterProvider.builder().build())
+
+    @Test
+    fun testMinimalMeterProvider() {
+        assertNotNull(adapter.getMeter(name = ""))
+    }
+
+    @Test
+    fun testDupeMeterProviderName() {
+        val first = adapter.getMeter(name = "name")
+        val second = adapter.getMeter(name = "name")
+        val third = adapter.getMeter(name = "other")
+        assertSame(first, second)
+        assertNotEquals(first, third)
+    }
+
+    @Test
+    fun testDupeMeterProviderVersion() {
+        val first = adapter.getMeter(name = "name", version = "0.1.0")
+        val second = adapter.getMeter(name = "name", version = "0.1.0")
+        val third = adapter.getMeter(name = "name", version = "0.2.0")
+        assertSame(first, second)
+        assertNotEquals(first, third)
+    }
+
+    @Test
+    fun testDupeMeterProviderSchemaUrl() {
+        val first = adapter.getMeter(name = "name", schemaUrl = "https://example.com/foo")
+        val second = adapter.getMeter(name = "name", schemaUrl = "https://example.com/foo")
+        val third = adapter.getMeter(name = "name", schemaUrl = "https://example.com/bar")
+        assertSame(first, second)
+        assertNotEquals(first, third)
+    }
+}

--- a/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/metrics/OtelJavaMeterBuilderAdapterTest.kt
+++ b/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/metrics/OtelJavaMeterBuilderAdapterTest.kt
@@ -1,0 +1,84 @@
+package io.opentelemetry.kotlin.metrics
+
+import io.opentelemetry.kotlin.attributes.AttributesMutator
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertSame
+
+internal class OtelJavaMeterBuilderAdapterTest {
+
+    @Test
+    fun `setSchemaUrl returns this for chaining`() {
+        val builder = OtelJavaMeterBuilderAdapter(CapturingMeterProvider(), "scope")
+        assertSame(builder, builder.setSchemaUrl("https://example.com/schema"))
+    }
+
+    @Test
+    fun `setInstrumentationVersion returns this for chaining`() {
+        val builder = OtelJavaMeterBuilderAdapter(CapturingMeterProvider(), "scope")
+        assertSame(builder, builder.setInstrumentationVersion("0.1.0"))
+    }
+
+    @Test
+    fun `build calls getMeter with scope name`() {
+        val provider = CapturingMeterProvider()
+        OtelJavaMeterBuilderAdapter(provider, "my-scope").build()
+        assertEquals("my-scope", provider.capturedName)
+    }
+
+    @Test
+    fun `build passes null version and schemaUrl when unset`() {
+        val provider = CapturingMeterProvider()
+        OtelJavaMeterBuilderAdapter(provider, "scope").build()
+        assertNull(provider.capturedVersion)
+        assertNull(provider.capturedSchemaUrl)
+    }
+
+    @Test
+    fun `build passes configured version`() {
+        val provider = CapturingMeterProvider()
+        OtelJavaMeterBuilderAdapter(provider, "scope")
+            .setInstrumentationVersion("0.1.0")
+            .build()
+        assertEquals("0.1.0", provider.capturedVersion)
+    }
+
+    @Test
+    fun `build passes configured schemaUrl`() {
+        val provider = CapturingMeterProvider()
+        OtelJavaMeterBuilderAdapter(provider, "scope")
+            .setSchemaUrl("https://example.com/schema")
+            .build()
+        assertEquals("https://example.com/schema", provider.capturedSchemaUrl)
+    }
+
+    @Test
+    fun `build passes both version and schemaUrl when both set`() {
+        val provider = CapturingMeterProvider()
+        OtelJavaMeterBuilderAdapter(provider, "scope")
+            .setInstrumentationVersion("0.1.0")
+            .setSchemaUrl("https://example.com/schema")
+            .build()
+        assertEquals("0.1.0", provider.capturedVersion)
+        assertEquals("https://example.com/schema", provider.capturedSchemaUrl)
+    }
+
+    private class CapturingMeterProvider : MeterProvider {
+        var capturedName: String? = null
+        var capturedVersion: String? = null
+        var capturedSchemaUrl: String? = null
+
+        override fun getMeter(
+            name: String,
+            version: String?,
+            schemaUrl: String?,
+            attributes: (AttributesMutator.() -> Unit)?
+        ): Meter {
+            capturedName = name
+            capturedVersion = version
+            capturedSchemaUrl = schemaUrl
+            return object : Meter {}
+        }
+    }
+}

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/MeterProviderConfigImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/MeterProviderConfigImpl.kt
@@ -1,0 +1,13 @@
+package io.opentelemetry.kotlin.init
+
+import io.opentelemetry.kotlin.init.config.MetricsConfig
+import io.opentelemetry.kotlin.resource.Resource
+
+internal class MeterProviderConfigImpl(
+    private val resourceConfigImpl: ResourceConfigImpl = ResourceConfigImpl()
+) : MeterProviderConfigDsl, ResourceConfigDsl by resourceConfigImpl {
+
+    fun generateMetricsConfig(base: Resource): MetricsConfig = MetricsConfig(
+        resource = base.merge(resourceConfigImpl.generateResource()),
+    )
+}

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/config/MetricsConfig.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/config/MetricsConfig.kt
@@ -1,0 +1,16 @@
+package io.opentelemetry.kotlin.init.config
+
+import io.opentelemetry.kotlin.ThreadSafe
+import io.opentelemetry.kotlin.resource.Resource
+
+/**
+ * Configuration for the Metrics API.
+ */
+@ThreadSafe
+internal class MetricsConfig(
+
+    /**
+     * A resource to append to metrics.
+     */
+    val resource: Resource,
+)

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/init/MeterProviderConfigImplTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/init/MeterProviderConfigImplTest.kt
@@ -1,0 +1,105 @@
+package io.opentelemetry.kotlin.init
+
+import io.opentelemetry.kotlin.assertHasSdkDefaultAttributes
+import io.opentelemetry.kotlin.attributes.DEFAULT_ATTRIBUTE_LIMIT
+import io.opentelemetry.kotlin.sdkDefaultAttributes
+import io.opentelemetry.kotlin.semconv.ServiceAttributes
+import io.opentelemetry.kotlin.semconv.TelemetryAttributes
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+internal class MeterProviderConfigImplTest {
+
+    private val base = sdkDefaultResource()
+
+    @Test
+    fun testDefaultMetricsConfig() {
+        val cfg = MeterProviderConfigImpl().generateMetricsConfig(base)
+        assertEquals(sdkDefaultAttributes, cfg.resource.attributes)
+        assertNull(cfg.resource.schemaUrl)
+    }
+
+    @Test
+    fun testSdkDefaultAttributes() {
+        val cfg = MeterProviderConfigImpl().generateMetricsConfig(base)
+        assertHasSdkDefaultAttributes(cfg.resource.attributes)
+    }
+
+    @Test
+    fun testOverrideMetricsConfig() {
+        val schemaUrl = "https://example.com/schema"
+
+        val cfg = MeterProviderConfigImpl().apply {
+            resource(schemaUrl) {
+                setStringAttribute("key", "value")
+            }
+        }.generateMetricsConfig(base)
+
+        assertEquals(schemaUrl, cfg.resource.schemaUrl)
+        assertEquals(sdkDefaultAttributes + mapOf("key" to "value"), cfg.resource.attributes)
+    }
+
+    @Test
+    fun testResourceOverride() {
+        val cfg = MeterProviderConfigImpl().apply {
+            resource(mapOf("extra" to true))
+        }.generateMetricsConfig(base)
+        assertEquals(sdkDefaultAttributes + mapOf("extra" to true), cfg.resource.attributes)
+    }
+
+    @Test
+    fun testSimpleResourceConfig() {
+        val cfg = MeterProviderConfigImpl().apply {
+            resource(mapOf("key" to "value"))
+        }.generateMetricsConfig(base)
+        assertEquals(sdkDefaultAttributes + mapOf("key" to "value"), cfg.resource.attributes)
+    }
+
+    @Test
+    fun testNoResourceLimit() {
+        val count = DEFAULT_ATTRIBUTE_LIMIT + 3
+        val attrs = (0 until count).associate { "key$it" to "value$it" }
+        val cfg = MeterProviderConfigImpl().apply {
+            resource(attrs)
+        }.generateMetricsConfig(base)
+        assertEquals(count + sdkDefaultAttributes.size, cfg.resource.attributes.size)
+    }
+
+    @Test
+    fun testSdkDefaultAttributesOverride() {
+        val value = "my-custom-sdk"
+        val cfg = MeterProviderConfigImpl().apply {
+            resource(mapOf(TelemetryAttributes.TELEMETRY_SDK_NAME to value))
+        }.generateMetricsConfig(base)
+        assertEquals(value, cfg.resource.attributes[TelemetryAttributes.TELEMETRY_SDK_NAME])
+    }
+
+    @Test
+    fun testServiceNameDefaults() {
+        val value = "my-service"
+        val cfg = MeterProviderConfigImpl().apply {
+            resource(mapOf(ServiceAttributes.SERVICE_NAME to value))
+        }.generateMetricsConfig(base)
+        assertEquals(value, cfg.resource.attributes[ServiceAttributes.SERVICE_NAME])
+    }
+
+    @Test
+    fun testServiceNameOverride() {
+        val value = "my-service"
+        val cfg = MeterProviderConfigImpl().apply {
+            serviceName = value
+        }.generateMetricsConfig(base)
+        assertEquals(value, cfg.resource.attributes[ServiceAttributes.SERVICE_NAME])
+    }
+
+    @Test
+    fun testServiceNamePrecedence() {
+        val value = "custom"
+        val cfg = MeterProviderConfigImpl().apply {
+            resource(mapOf(ServiceAttributes.SERVICE_NAME to "res"))
+            serviceName = value
+        }.generateMetricsConfig(base)
+        assertEquals(value, cfg.resource.attributes[ServiceAttributes.SERVICE_NAME])
+    }
+}

--- a/java-typealiases/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/aliases/Aliases.kt
+++ b/java-typealiases/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/aliases/Aliases.kt
@@ -16,6 +16,9 @@ import io.opentelemetry.api.logs.Logger
 import io.opentelemetry.api.logs.LoggerBuilder
 import io.opentelemetry.api.logs.LoggerProvider
 import io.opentelemetry.api.logs.Severity
+import io.opentelemetry.api.metrics.Meter
+import io.opentelemetry.api.metrics.MeterBuilder
+import io.opentelemetry.api.metrics.MeterProvider
 import io.opentelemetry.api.trace.Span
 import io.opentelemetry.api.trace.SpanBuilder
 import io.opentelemetry.api.trace.SpanContext
@@ -50,6 +53,8 @@ import io.opentelemetry.sdk.logs.SdkLoggerProviderBuilder
 import io.opentelemetry.sdk.logs.data.Body
 import io.opentelemetry.sdk.logs.data.LogRecordData
 import io.opentelemetry.sdk.logs.export.LogRecordExporter
+import io.opentelemetry.sdk.metrics.SdkMeterProvider
+import io.opentelemetry.sdk.metrics.SdkMeterProviderBuilder
 import io.opentelemetry.sdk.resources.Resource
 import io.opentelemetry.sdk.resources.ResourceBuilder
 import io.opentelemetry.sdk.trace.IdGenerator
@@ -109,6 +114,11 @@ typealias OtelJavaSpanProcessor = SpanProcessor
 typealias OtelJavaOpenTelemetrySdk = OpenTelemetrySdk
 typealias OtelJavaSdkLoggerProvider = SdkLoggerProvider
 typealias OtelJavaSdkLoggerProviderBuilder = SdkLoggerProviderBuilder
+typealias OtelJavaMeterProvider = MeterProvider
+typealias OtelJavaMeterBuilder = MeterBuilder
+typealias OtelJavaMeter = Meter
+typealias OtelJavaSdkMeterProvider = SdkMeterProvider
+typealias OtelJavaSdkMeterProviderBuilder = SdkMeterProviderBuilder
 typealias OtelJavaSdkTracerProvider = SdkTracerProvider
 typealias OtelJavaSdkTracerProviderBuilder = SdkTracerProviderBuilder
 typealias OtelJavaBody = Body

--- a/sdk-api/api/jvm/sdk-api.api
+++ b/sdk-api/api/jvm/sdk-api.api
@@ -119,6 +119,9 @@ public abstract interface class io/opentelemetry/kotlin/init/LoggerProviderConfi
 	public abstract fun logLimits (Lkotlin/jvm/functions/Function1;)V
 }
 
+public abstract interface class io/opentelemetry/kotlin/init/MeterProviderConfigDsl : io/opentelemetry/kotlin/init/ResourceConfigDsl {
+}
+
 public abstract interface class io/opentelemetry/kotlin/init/OpenTelemetryConfigDsl : io/opentelemetry/kotlin/init/ResourceConfigDsl {
 	public abstract fun attributeLimits (Lkotlin/jvm/functions/Function1;)V
 	public abstract fun context (Lkotlin/jvm/functions/Function1;)V

--- a/sdk-api/src/commonMain/kotlin/io/opentelemetry/kotlin/init/MeterProviderConfigDsl.kt
+++ b/sdk-api/src/commonMain/kotlin/io/opentelemetry/kotlin/init/MeterProviderConfigDsl.kt
@@ -1,0 +1,10 @@
+package io.opentelemetry.kotlin.init
+
+import io.opentelemetry.kotlin.ExperimentalApi
+
+/**
+ * Defines configuration for the [io.opentelemetry.kotlin.metrics.MeterProvider].
+ */
+@ExperimentalApi
+@ConfigDsl
+public interface MeterProviderConfigDsl : ResourceConfigDsl


### PR DESCRIPTION
## Goal

Partially addresses #376 by scaffolding `MeterProvider` configuration on the Kotlin implementation and compat layers.

This PR adds:
- `MeterProvider` config DSL + implementation scaffolding
- Java ↔ Kotlin compat adapters for `MeterProvider` / `Meter`
- Java OTel metric typealiases
- Basic compat-layer no-op metric delegation until Kotlin instruments land

Entry-point wiring, metric readers, views, and the aggregation pipeline are intentionally deferred to a subsequent PR.

## Testing

- Added config + adapter unit tests
- Verified `build`, `assembleAndroidTest`, and `apiDump`