### PR TITLE
Alter codecov threshold

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -2,6 +2,8 @@ coverage:
   status:
     project:
       default:
+        target: auto
+        threshold: 1%
         removed_code_behavior: adjust_base
     patch:
       default:


### PR DESCRIPTION
## Goal

Alters the codecov threshold so that CI checks don't show up as failing for trivial deltas. This follows the same approach as in https://github.com/open-telemetry/opentelemetry-android/pull/1732