### PR TITLE
Don't throw when using the DSL to configure exporters and processors

### DIFF
--- a/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/CoreLogRecordExporterApi.kt
+++ b/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/CoreLogRecordExporterApi.kt
@@ -5,6 +5,7 @@ import io.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.kotlin.error.NoopSdkErrorHandler
 import io.opentelemetry.kotlin.export.BatchTelemetryDefaults
 import io.opentelemetry.kotlin.init.LogExportConfigDsl
+import io.opentelemetry.kotlin.platformLog
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -15,7 +16,10 @@ import kotlinx.coroutines.SupervisorJob
  */
 @ExperimentalApi
 public fun LogExportConfigDsl.compositeLogRecordProcessor(vararg processors: LogRecordProcessor): LogRecordProcessor {
-    require(processors.isNotEmpty()) { "At least one processor must be provided" }
+    if (processors.isEmpty()) {
+        platformLog("At least one processor must be provided")
+        return NoopLogRecordProcessor
+    }
     return CompositeLogRecordProcessor(processors.toList(), NoopSdkErrorHandler)
 }
 
@@ -34,7 +38,10 @@ public fun LogExportConfigDsl.simpleLogRecordProcessor(exporter: LogRecordExport
  */
 @ExperimentalApi
 public fun LogExportConfigDsl.compositeLogRecordExporter(vararg exporters: LogRecordExporter): LogRecordExporter {
-    require(exporters.isNotEmpty()) { "At least one exporter must be provided" }
+    if (exporters.isEmpty()) {
+        platformLog("At least one exporter must be provided")
+        return NoopLogRecordExporter
+    }
     return CompositeLogRecordExporter(exporters.toList(), NoopSdkErrorHandler)
 }
 

--- a/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/NoopLogRecordExporter.kt
+++ b/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/NoopLogRecordExporter.kt
@@ -1,0 +1,10 @@
+package io.opentelemetry.kotlin.logging.export
+
+import io.opentelemetry.kotlin.export.OperationResultCode
+import io.opentelemetry.kotlin.logging.model.ReadableLogRecord
+
+internal object NoopLogRecordExporter : LogRecordExporter {
+    override suspend fun export(telemetry: List<ReadableLogRecord>): OperationResultCode = OperationResultCode.Failure
+    override suspend fun forceFlush(): OperationResultCode = OperationResultCode.Success
+    override suspend fun shutdown(): OperationResultCode = OperationResultCode.Success
+}

--- a/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/NoopLogRecordProcessor.kt
+++ b/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/NoopLogRecordProcessor.kt
@@ -1,0 +1,19 @@
+package io.opentelemetry.kotlin.logging.export
+
+import io.opentelemetry.kotlin.InstrumentationScopeInfo
+import io.opentelemetry.kotlin.context.Context
+import io.opentelemetry.kotlin.export.OperationResultCode
+import io.opentelemetry.kotlin.logging.SeverityNumber
+import io.opentelemetry.kotlin.logging.model.ReadWriteLogRecord
+
+internal object NoopLogRecordProcessor : LogRecordProcessor {
+    override fun onEmit(log: ReadWriteLogRecord, context: Context) = Unit
+    override fun enabled(
+        context: Context,
+        instrumentationScopeInfo: InstrumentationScopeInfo,
+        severityNumber: SeverityNumber?,
+        eventName: String?,
+    ): Boolean = false
+    override suspend fun forceFlush(): OperationResultCode = OperationResultCode.Success
+    override suspend fun shutdown(): OperationResultCode = OperationResultCode.Success
+}

--- a/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/CoreSpanExporterApi.kt
+++ b/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/CoreSpanExporterApi.kt
@@ -4,6 +4,7 @@ import io.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.kotlin.error.NoopSdkErrorHandler
 import io.opentelemetry.kotlin.export.BatchTelemetryDefaults
 import io.opentelemetry.kotlin.init.TraceExportConfigDsl
+import io.opentelemetry.kotlin.platformLog
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -14,7 +15,10 @@ import kotlinx.coroutines.SupervisorJob
  */
 @ExperimentalApi
 public fun TraceExportConfigDsl.compositeSpanProcessor(vararg processors: SpanProcessor): SpanProcessor {
-    require(processors.isNotEmpty()) { "At least one processor must be provided" }
+    if (processors.isEmpty()) {
+        platformLog("At least one processor must be provided")
+        return NoopSpanProcessor
+    }
     return CompositeSpanProcessor(processors.toList(), NoopSdkErrorHandler)
 }
 
@@ -33,7 +37,10 @@ public fun TraceExportConfigDsl.simpleSpanProcessor(exporter: SpanExporter): Spa
  */
 @ExperimentalApi
 public fun TraceExportConfigDsl.compositeSpanExporter(vararg exporters: SpanExporter): SpanExporter {
-    require(exporters.isNotEmpty()) { "At least one exporter must be provided" }
+    if (exporters.isEmpty()) {
+        platformLog("At least one exporter must be provided")
+        return NoopSpanExporter
+    }
     return CompositeSpanExporter(exporters.toList(), NoopSdkErrorHandler)
 }
 

--- a/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/NoopSpanExporter.kt
+++ b/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/NoopSpanExporter.kt
@@ -1,0 +1,10 @@
+package io.opentelemetry.kotlin.tracing.export
+
+import io.opentelemetry.kotlin.export.OperationResultCode
+import io.opentelemetry.kotlin.tracing.data.SpanData
+
+internal object NoopSpanExporter : SpanExporter {
+    override suspend fun export(telemetry: List<SpanData>): OperationResultCode = OperationResultCode.Failure
+    override suspend fun forceFlush(): OperationResultCode = OperationResultCode.Success
+    override suspend fun shutdown(): OperationResultCode = OperationResultCode.Success
+}

--- a/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/NoopSpanProcessor.kt
+++ b/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/NoopSpanProcessor.kt
@@ -1,0 +1,16 @@
+package io.opentelemetry.kotlin.tracing.export
+
+import io.opentelemetry.kotlin.context.Context
+import io.opentelemetry.kotlin.export.OperationResultCode
+import io.opentelemetry.kotlin.tracing.model.ReadWriteSpan
+import io.opentelemetry.kotlin.tracing.model.ReadableSpan
+
+internal object NoopSpanProcessor : SpanProcessor {
+    override fun onStart(span: ReadWriteSpan, parentContext: Context) = Unit
+    override fun onEnding(span: ReadWriteSpan) = Unit
+    override fun onEnd(span: ReadableSpan) = Unit
+    override fun isStartRequired(): Boolean = false
+    override fun isEndRequired(): Boolean = false
+    override suspend fun forceFlush(): OperationResultCode = OperationResultCode.Success
+    override suspend fun shutdown(): OperationResultCode = OperationResultCode.Success
+}

--- a/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/export/CoreLogRecordExporterApiTest.kt
+++ b/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/export/CoreLogRecordExporterApiTest.kt
@@ -1,20 +1,42 @@
 package io.opentelemetry.kotlin.logging.export
 
+import io.opentelemetry.kotlin.FakeInstrumentationScopeInfo
+import io.opentelemetry.kotlin.context.FakeContext
 import io.opentelemetry.kotlin.export.FakeLogExportConfig
+import io.opentelemetry.kotlin.export.OperationResultCode
+import io.opentelemetry.kotlin.logging.model.FakeReadWriteLogRecord
+import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertSame
 
 internal class CoreLogRecordExporterApiTest {
 
     private val config = FakeLogExportConfig()
+    private val fakeLogRecord = FakeReadWriteLogRecord()
+    private val fakeContext = FakeContext()
+    private val scopeInfo = FakeInstrumentationScopeInfo()
 
     @Test
-    fun compositeLogRecordProcessorEmptyReturnsNoop() {
-        assertSame(NoopLogRecordProcessor, config.compositeLogRecordProcessor())
+    fun compositeLogRecordProcessorEmptyReturnsNoopWithoutThrowing() = runTest {
+        val emptyProcessor = config.compositeLogRecordProcessor().apply {
+            onEmit(fakeLogRecord, fakeContext)
+            assertFalse(enabled(fakeContext, scopeInfo, null, null))
+            assertEquals(OperationResultCode.Success, forceFlush())
+            assertEquals(OperationResultCode.Success, shutdown())
+        }
+
+        assertSame(NoopLogRecordProcessor, emptyProcessor)
     }
 
     @Test
-    fun compositeLogRecordExporterEmptyReturnsNoop() {
-        assertSame(NoopLogRecordExporter, config.compositeLogRecordExporter())
+    fun compositeLogRecordExporterEmptyReturnsNoopWithoutThrowing() = runTest {
+        val emptyExporter = config.compositeLogRecordExporter().apply {
+            assertEquals(OperationResultCode.Failure, export(listOf(fakeLogRecord)))
+            assertEquals(OperationResultCode.Success, forceFlush())
+            assertEquals(OperationResultCode.Success, shutdown())
+        }
+        assertSame(NoopLogRecordExporter, emptyExporter)
     }
 }

--- a/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/export/CoreLogRecordExporterApiTest.kt
+++ b/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/export/CoreLogRecordExporterApiTest.kt
@@ -2,23 +2,19 @@ package io.opentelemetry.kotlin.logging.export
 
 import io.opentelemetry.kotlin.export.FakeLogExportConfig
 import kotlin.test.Test
-import kotlin.test.assertFailsWith
+import kotlin.test.assertSame
 
 internal class CoreLogRecordExporterApiTest {
 
     private val config = FakeLogExportConfig()
 
     @Test
-    fun compositeLogRecordProcessorEmpty() {
-        assertFailsWith<IllegalArgumentException> {
-            config.compositeLogRecordProcessor()
-        }
+    fun compositeLogRecordProcessorEmptyReturnsNoop() {
+        assertSame(NoopLogRecordProcessor, config.compositeLogRecordProcessor())
     }
 
     @Test
-    fun compositeLogRecordExporterEmpty() {
-        assertFailsWith<IllegalArgumentException> {
-            config.compositeLogRecordExporter()
-        }
+    fun compositeLogRecordExporterEmptyReturnsNoop() {
+        assertSame(NoopLogRecordExporter, config.compositeLogRecordExporter())
     }
 }

--- a/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/export/CoreSpanExporterApiTest.kt
+++ b/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/export/CoreSpanExporterApiTest.kt
@@ -2,23 +2,19 @@ package io.opentelemetry.kotlin.tracing.export
 
 import io.opentelemetry.kotlin.export.FakeTraceExportConfig
 import kotlin.test.Test
-import kotlin.test.assertFailsWith
+import kotlin.test.assertSame
 
 internal class CoreSpanExporterApiTest {
 
     private val config = FakeTraceExportConfig()
 
     @Test
-    fun compositeSpanProcessorEmpty() {
-        assertFailsWith<IllegalArgumentException> {
-            config.compositeSpanProcessor()
-        }
+    fun compositeSpanProcessorEmptyReturnsNoop() {
+        assertSame(NoopSpanProcessor, config.compositeSpanProcessor())
     }
 
     @Test
-    fun compositeSpanExporterEmpty() {
-        assertFailsWith<IllegalArgumentException> {
-            config.compositeSpanExporter()
-        }
+    fun compositeSpanExporterEmptyReturnsNoop() {
+        assertSame(NoopSpanExporter, config.compositeSpanExporter())
     }
 }

--- a/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/export/CoreSpanExporterApiTest.kt
+++ b/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/export/CoreSpanExporterApiTest.kt
@@ -1,20 +1,40 @@
 package io.opentelemetry.kotlin.tracing.export
 
+import io.opentelemetry.kotlin.context.FakeContext
 import io.opentelemetry.kotlin.export.FakeTraceExportConfig
+import io.opentelemetry.kotlin.export.OperationResultCode
+import io.opentelemetry.kotlin.tracing.FakeReadWriteSpan
+import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertSame
 
 internal class CoreSpanExporterApiTest {
 
     private val config = FakeTraceExportConfig()
+    private val fakeSpan = FakeReadWriteSpan()
+    private val fakeContext = FakeContext()
 
     @Test
-    fun compositeSpanProcessorEmptyReturnsNoop() {
-        assertSame(NoopSpanProcessor, config.compositeSpanProcessor())
+    fun compositeSpanProcessorEmptyReturnsNoopWithoutThrowing() = runTest {
+        val emptyProcessor = config.compositeSpanProcessor().apply {
+            onStart(fakeSpan, fakeContext)
+            onEnding(fakeSpan)
+            onEnd(fakeSpan)
+            assertEquals(OperationResultCode.Success, forceFlush())
+            assertEquals(OperationResultCode.Success, shutdown())
+        }
+
+        assertSame(NoopSpanProcessor, emptyProcessor)
     }
 
     @Test
-    fun compositeSpanExporterEmptyReturnsNoop() {
-        assertSame(NoopSpanExporter, config.compositeSpanExporter())
+    fun compositeSpanExporterEmptyReturnsNoopWithoutThrowing() = runTest {
+        val emptyExporter = config.compositeSpanExporter().apply {
+            assertEquals(OperationResultCode.Failure, export(listOf(fakeSpan)))
+            assertEquals(OperationResultCode.Success, forceFlush())
+            assertEquals(OperationResultCode.Success, shutdown())
+        }
+        assertSame(NoopSpanExporter, emptyExporter)
     }
 }

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/LoggerProviderConfigImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/LoggerProviderConfigImpl.kt
@@ -4,6 +4,7 @@ import io.opentelemetry.kotlin.Clock
 import io.opentelemetry.kotlin.init.config.LogLimitConfig
 import io.opentelemetry.kotlin.init.config.LoggingConfig
 import io.opentelemetry.kotlin.logging.export.LogRecordProcessor
+import io.opentelemetry.kotlin.platformLog
 import io.opentelemetry.kotlin.resource.Resource
 
 internal class LoggerProviderConfigImpl(
@@ -15,7 +16,10 @@ internal class LoggerProviderConfigImpl(
     private var logLimitsAction: LogLimitsConfigDsl.() -> Unit = {}
 
     override fun export(action: LogExportConfigDsl.() -> LogRecordProcessor) {
-        require(processor == null) { "export() should only be called once." }
+        if (processor != null) {
+            platformLog("export() should only be called once.")
+            return
+        }
         processor = LogExportConfigImpl(clock).action()
     }
 

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/TracerProviderConfigImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/TracerProviderConfigImpl.kt
@@ -4,6 +4,7 @@ import io.opentelemetry.kotlin.Clock
 import io.opentelemetry.kotlin.factory.SpanFactory
 import io.opentelemetry.kotlin.init.config.SpanLimitConfig
 import io.opentelemetry.kotlin.init.config.TracingConfig
+import io.opentelemetry.kotlin.platformLog
 import io.opentelemetry.kotlin.resource.Resource
 import io.opentelemetry.kotlin.tracing.export.SpanProcessor
 import io.opentelemetry.kotlin.tracing.sampling.Sampler
@@ -23,7 +24,10 @@ internal class TracerProviderConfigImpl(
     }
 
     override fun export(action: TraceExportConfigDsl.() -> SpanProcessor) {
-        require(processor == null) { "export() should only be called once." }
+        if (processor != null) {
+            platformLog("export() should only be called once.")
+            return
+        }
         processor = TraceExportConfigImpl(clock).action()
     }
 

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/init/LoggerProviderConfigImplTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/init/LoggerProviderConfigImplTest.kt
@@ -3,6 +3,8 @@ package io.opentelemetry.kotlin.init
 import io.opentelemetry.kotlin.attributes.DEFAULT_ATTRIBUTE_LIMIT
 import io.opentelemetry.kotlin.clock.FakeClock
 import io.opentelemetry.kotlin.logging.export.FakeLogRecordProcessor
+import io.opentelemetry.kotlin.logging.export.LogRecordExporter
+import io.opentelemetry.kotlin.logging.export.LogRecordProcessor
 import io.opentelemetry.kotlin.logging.export.compositeLogRecordProcessor
 import io.opentelemetry.kotlin.logging.export.simpleLogRecordProcessor
 import io.opentelemetry.kotlin.logging.export.stdoutLogRecordExporter
@@ -11,9 +13,10 @@ import io.opentelemetry.kotlin.semconv.ServiceAttributes
 import io.opentelemetry.kotlin.semconv.TelemetryAttributes
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
+import kotlin.test.assertNotSame
 import kotlin.test.assertNull
+import kotlin.test.assertSame
 
 internal class LoggerProviderConfigImplTest {
 
@@ -65,13 +68,23 @@ internal class LoggerProviderConfigImplTest {
     }
 
     @Test
-    fun testDoubleExportConfig() {
-        assertFailsWith(IllegalArgumentException::class) {
-            LoggerProviderConfigImpl(clock).apply {
-                export { simpleLogRecordProcessor(stdoutLogRecordExporter()) }
-                export { simpleLogRecordProcessor(stdoutLogRecordExporter()) }
+    fun testDoubleExportConfigKeepsFirst() {
+        var first: LogRecordProcessor? = null
+        var second: LogRecordProcessor? = null
+        val cfg = LoggerProviderConfigImpl(clock).apply {
+            export {
+                simpleLogRecordProcessor(stdoutLogRecordExporter()).apply {
+                    first = this
+                }
             }
-        }
+            export {
+                simpleLogRecordProcessor(stdoutLogRecordExporter()).apply {
+                    second = this
+                }
+            }
+        }.generateLoggingConfig(base)
+        assertSame(first, cfg.processor)
+        assertNotSame(second, cfg.processor)
     }
 
     @Test

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/init/LoggerProviderConfigImplTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/init/LoggerProviderConfigImplTest.kt
@@ -3,7 +3,6 @@ package io.opentelemetry.kotlin.init
 import io.opentelemetry.kotlin.attributes.DEFAULT_ATTRIBUTE_LIMIT
 import io.opentelemetry.kotlin.clock.FakeClock
 import io.opentelemetry.kotlin.logging.export.FakeLogRecordProcessor
-import io.opentelemetry.kotlin.logging.export.LogRecordExporter
 import io.opentelemetry.kotlin.logging.export.LogRecordProcessor
 import io.opentelemetry.kotlin.logging.export.compositeLogRecordProcessor
 import io.opentelemetry.kotlin.logging.export.simpleLogRecordProcessor

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/init/TracerProviderConfigImplTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/init/TracerProviderConfigImplTest.kt
@@ -8,17 +8,16 @@ import io.opentelemetry.kotlin.sdkDefaultAttributes
 import io.opentelemetry.kotlin.semconv.ServiceAttributes
 import io.opentelemetry.kotlin.semconv.TelemetryAttributes
 import io.opentelemetry.kotlin.tracing.export.FakeSpanProcessor
+import io.opentelemetry.kotlin.tracing.export.SpanProcessor
 import io.opentelemetry.kotlin.tracing.export.compositeSpanProcessor
-import io.opentelemetry.kotlin.tracing.export.simpleSpanProcessor
-import io.opentelemetry.kotlin.tracing.export.stdoutSpanExporter
 import io.opentelemetry.kotlin.tracing.sampling.AlwaysOnSampler
 import io.opentelemetry.kotlin.tracing.sampling.FakeSampler
 import io.opentelemetry.kotlin.tracing.sampling.alwaysOn
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
 import kotlin.test.assertIs
 import kotlin.test.assertNotNull
+import kotlin.test.assertNotSame
 import kotlin.test.assertNull
 import kotlin.test.assertSame
 
@@ -119,13 +118,23 @@ internal class TracerProviderConfigImplTest {
     }
 
     @Test
-    fun testDoubleExportConfig() {
-        assertFailsWith(IllegalArgumentException::class) {
-            TracerProviderConfigImpl(clock).apply {
-                export { simpleSpanProcessor(stdoutSpanExporter()) }
-                export { simpleSpanProcessor(stdoutSpanExporter()) }
+    fun testDoubleExportConfigKeepsFirst() {
+        var first: SpanProcessor? = null
+        var second: SpanProcessor? = null
+        val cfg = TracerProviderConfigImpl(clock).apply {
+            export {
+                compositeSpanProcessor(FakeSpanProcessor()).apply {
+                    first = this
+                }
             }
-        }
+            export {
+                compositeSpanProcessor(FakeSpanProcessor()).apply {
+                    second = this
+                }
+            }
+        }.generateTracingConfig(base)
+        assertSame(first, cfg.processor)
+        assertNotSame(second, cfg.processor)
     }
 
     @Test


### PR DESCRIPTION
Instead of throwing when composites aren't initialized with concrete processors and exporters to wrap, add in a no-op implementation and log platform error instead.

I suppose throwing at build time isn't the worst thing and surfaces configuration errors more loudly, but this seems a slight overstep. Interested to hear what y'all think. Once we figure out the parameters, I can submit the other changes that follow a similar pattern (at runtime) where we don't throw but error out in a less destructive way.

Partially addresses #502 