### PR TITLE
Invalid configs should not throw exceptions

### DIFF
--- a/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/export/BatchTelemetryConfig.kt
+++ b/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/export/BatchTelemetryConfig.kt
@@ -1,0 +1,83 @@
+package io.opentelemetry.kotlin.export
+
+import io.opentelemetry.kotlin.config.validateOrUseDefault
+import io.opentelemetry.kotlin.error.NoopSdkErrorHandler
+import io.opentelemetry.kotlin.error.SdkErrorHandler
+
+internal class BatchTelemetryConfig(
+    maxQueueSize: Int = BatchTelemetryDefaults.MAX_QUEUE_SIZE,
+    scheduleDelayMs: Long = BatchTelemetryDefaults.SCHEDULE_DELAY_MS,
+    exportTimeoutMs: Long = BatchTelemetryDefaults.EXPORT_TIMEOUT_MS,
+    maxExportBatchSize: Int = BatchTelemetryDefaults.MAX_EXPORT_BATCH_SIZE,
+    forceFlushTimeoutMs: Long = BatchTelemetryDefaults.FORCE_FLUSH_TIMEOUT_MS,
+    sdkErrorHandler: SdkErrorHandler = NoopSdkErrorHandler,
+) {
+    /**
+     * Maximum number of telemetry items the queue can hold before items are dropped.
+     */
+    val maxQueueSize: Int = validateOrUseDefault(
+        sdkErrorHandler = sdkErrorHandler,
+        api = API,
+        configParameterName = "maxQueueSize",
+        value = maxQueueSize,
+        default = BatchTelemetryDefaults.MAX_QUEUE_SIZE,
+    ) { it >= 0 }
+
+    /**
+     * Delay between scheduled flushes, in milliseconds.
+     */
+    val scheduleDelayMs: Long = validateOrUseDefault(
+        sdkErrorHandler = sdkErrorHandler,
+        api = API,
+        configParameterName = "scheduleDelayMs",
+        value = scheduleDelayMs,
+        default = BatchTelemetryDefaults.SCHEDULE_DELAY_MS,
+    ) { it > 0 }
+
+    /**
+     * Timeout for a single export operation, in milliseconds.
+     */
+    val exportTimeoutMs: Long = validateOrUseDefault(
+        sdkErrorHandler = sdkErrorHandler,
+        api = API,
+        configParameterName = "exportTimeoutMs",
+        value = exportTimeoutMs,
+        default = BatchTelemetryDefaults.EXPORT_TIMEOUT_MS,
+    ) { it >= 0 }
+
+    /**
+     * Maximum number of telemetry items to export per batch. Will be capped at maxQueueSize if it exceeds it.
+     */
+    val maxExportBatchSize: Int = if (maxExportBatchSize < 0) {
+        validateOrUseDefault(
+            sdkErrorHandler = sdkErrorHandler,
+            api = API,
+            configParameterName = "maxExportBatchSize",
+            value = maxExportBatchSize,
+            default = BatchTelemetryDefaults.MAX_EXPORT_BATCH_SIZE,
+        ) { it >= 0 }
+    } else {
+        validateOrUseDefault(
+            sdkErrorHandler = sdkErrorHandler,
+            api = API,
+            configParameterName = "maxExportBatchSize",
+            value = maxExportBatchSize,
+            default = this.maxQueueSize,
+        ) { it <= this.maxQueueSize }
+    }
+
+    /**
+     * Timeout for forceFlush, in milliseconds.
+     */
+    val forceFlushTimeoutMs: Long = validateOrUseDefault(
+        sdkErrorHandler = sdkErrorHandler,
+        api = API,
+        configParameterName = "forceFlushTimeoutMs",
+        value = forceFlushTimeoutMs,
+        default = BatchTelemetryDefaults.FORCE_FLUSH_TIMEOUT_MS,
+    ) { it >= 0 }
+
+    private companion object {
+        const val API = "BatchTelemetryConfig"
+    }
+}

--- a/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/export/BatchTelemetryProcessor.kt
+++ b/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/export/BatchTelemetryProcessor.kt
@@ -25,7 +25,7 @@ internal class BatchTelemetryProcessor<T>(
     private val exportAction: suspend (telemetry: List<T>) -> OperationResultCode,
 ) : TelemetryCloseable {
 
-    private val validMaxQueueSize: Int = validateOrUseDefault(
+    private val maxQueueSize: Int = validateOrUseDefault(
         sdkErrorHandler = sdkErrorHandler,
         api = API,
         configParameterName = "maxQueueSize",
@@ -33,7 +33,7 @@ internal class BatchTelemetryProcessor<T>(
         default = BatchTelemetryDefaults.MAX_QUEUE_SIZE,
     ) { it >= 0 }
 
-    private val validScheduleDelayMs: Long = validateOrUseDefault(
+    private val scheduleDelayMs: Long = validateOrUseDefault(
         sdkErrorHandler = sdkErrorHandler,
         api = API,
         configParameterName = "scheduleDelayMs",
@@ -41,7 +41,7 @@ internal class BatchTelemetryProcessor<T>(
         default = BatchTelemetryDefaults.SCHEDULE_DELAY_MS,
     ) { it > 0 }
 
-    private val validExportTimeoutMs: Long = validateOrUseDefault(
+    private val exportTimeoutMs: Long = validateOrUseDefault(
         sdkErrorHandler = sdkErrorHandler,
         api = API,
         configParameterName = "exportTimeoutMs",
@@ -49,7 +49,7 @@ internal class BatchTelemetryProcessor<T>(
         default = BatchTelemetryDefaults.EXPORT_TIMEOUT_MS,
     ) { it >= 0 }
 
-    private val validMaxExportBatchSize: Int = if (maxExportBatchSize < 0) {
+    private val maxExportBatchSize: Int = if (maxExportBatchSize < 0) {
         validateOrUseDefault(
             sdkErrorHandler = sdkErrorHandler,
             api = API,
@@ -63,11 +63,11 @@ internal class BatchTelemetryProcessor<T>(
             api = API,
             configParameterName = "maxExportBatchSize",
             value = maxExportBatchSize,
-            default = validMaxQueueSize,
-        ) { it <= validMaxQueueSize }
+            default = maxQueueSize,
+        ) { it <= maxQueueSize }
     }
 
-    private val validForceFlushTimeoutMs: Long = validateOrUseDefault(
+    private val forceFlushTimeoutMs: Long = validateOrUseDefault(
         sdkErrorHandler = sdkErrorHandler,
         api = API,
         configParameterName = "forceFlushTimeoutMs",
@@ -83,7 +83,7 @@ internal class BatchTelemetryProcessor<T>(
     init {
         scope.launch {
             while (!shutdownState.isShutdown) {
-                delay(this@BatchTelemetryProcessor.validScheduleDelayMs)
+                delay(this@BatchTelemetryProcessor.scheduleDelayMs)
                 flushInternal()
             }
         }
@@ -91,7 +91,7 @@ internal class BatchTelemetryProcessor<T>(
 
     fun processTelemetry(telemetry: T) {
         shutdownState.execute {
-            if (queue.size <= validMaxQueueSize) {
+            if (queue.size <= maxQueueSize) {
                 queue.add(telemetry)
             }
         }
@@ -101,7 +101,7 @@ internal class BatchTelemetryProcessor<T>(
         if (shutdownState.isShutdown) {
             return OperationResultCode.Success
         }
-        return runWithTimeout(validForceFlushTimeoutMs) {
+        return runWithTimeout(forceFlushTimeoutMs) {
             scope.launch { flushInternal() }.join()
             OperationResultCode.Success
         }
@@ -117,13 +117,13 @@ internal class BatchTelemetryProcessor<T>(
         while (queue.isNotEmpty()) {
             val batch = mutableListOf<T>()
             mutex.withLock {
-                val size = minOf(queue.size, validMaxExportBatchSize)
+                val size = minOf(queue.size, maxExportBatchSize)
                 repeat(size) { batch += queue.removeAt(0) }
             }
 
             if (batch.isNotEmpty()) {
                 try {
-                    withTimeout(validExportTimeoutMs) {
+                    withTimeout(exportTimeoutMs) {
                         exportAction(batch)
                     }
                 } catch (ignored: Throwable) {

--- a/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/export/BatchTelemetryProcessor.kt
+++ b/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/export/BatchTelemetryProcessor.kt
@@ -1,8 +1,5 @@
 package io.opentelemetry.kotlin.export
 
-import io.opentelemetry.kotlin.config.validateOrUseDefault
-import io.opentelemetry.kotlin.error.NoopSdkErrorHandler
-import io.opentelemetry.kotlin.error.SdkErrorHandler
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -15,65 +12,10 @@ import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withTimeout
 
 internal class BatchTelemetryProcessor<T>(
-    maxQueueSize: Int,
-    scheduleDelayMs: Long,
-    exportTimeoutMs: Long,
-    maxExportBatchSize: Int,
-    forceFlushTimeoutMs: Long = BatchTelemetryDefaults.FORCE_FLUSH_TIMEOUT_MS,
+    private val config: BatchTelemetryConfig = BatchTelemetryConfig(),
     dispatcher: CoroutineDispatcher = Dispatchers.Default,
-    private val sdkErrorHandler: SdkErrorHandler = NoopSdkErrorHandler,
     private val exportAction: suspend (telemetry: List<T>) -> OperationResultCode,
 ) : TelemetryCloseable {
-
-    private val maxQueueSize: Int = validateOrUseDefault(
-        sdkErrorHandler = sdkErrorHandler,
-        api = API,
-        configParameterName = "maxQueueSize",
-        value = maxQueueSize,
-        default = BatchTelemetryDefaults.MAX_QUEUE_SIZE,
-    ) { it >= 0 }
-
-    private val scheduleDelayMs: Long = validateOrUseDefault(
-        sdkErrorHandler = sdkErrorHandler,
-        api = API,
-        configParameterName = "scheduleDelayMs",
-        value = scheduleDelayMs,
-        default = BatchTelemetryDefaults.SCHEDULE_DELAY_MS,
-    ) { it > 0 }
-
-    private val exportTimeoutMs: Long = validateOrUseDefault(
-        sdkErrorHandler = sdkErrorHandler,
-        api = API,
-        configParameterName = "exportTimeoutMs",
-        value = exportTimeoutMs,
-        default = BatchTelemetryDefaults.EXPORT_TIMEOUT_MS,
-    ) { it >= 0 }
-
-    private val maxExportBatchSize: Int = if (maxExportBatchSize < 0) {
-        validateOrUseDefault(
-            sdkErrorHandler = sdkErrorHandler,
-            api = API,
-            configParameterName = "maxExportBatchSize",
-            value = maxExportBatchSize,
-            default = BatchTelemetryDefaults.MAX_EXPORT_BATCH_SIZE,
-        ) { it >= 0 }
-    } else {
-        validateOrUseDefault(
-            sdkErrorHandler = sdkErrorHandler,
-            api = API,
-            configParameterName = "maxExportBatchSize",
-            value = maxExportBatchSize,
-            default = maxQueueSize,
-        ) { it <= maxQueueSize }
-    }
-
-    private val forceFlushTimeoutMs: Long = validateOrUseDefault(
-        sdkErrorHandler = sdkErrorHandler,
-        api = API,
-        configParameterName = "forceFlushTimeoutMs",
-        value = forceFlushTimeoutMs,
-        default = BatchTelemetryDefaults.FORCE_FLUSH_TIMEOUT_MS,
-    ) { it >= 0 }
 
     private val shutdownState: MutableShutdownState = MutableShutdownState()
     private val scope = CoroutineScope(SupervisorJob() + dispatcher)
@@ -83,7 +25,7 @@ internal class BatchTelemetryProcessor<T>(
     init {
         scope.launch {
             while (!shutdownState.isShutdown) {
-                delay(this@BatchTelemetryProcessor.scheduleDelayMs)
+                delay(config.scheduleDelayMs)
                 flushInternal()
             }
         }
@@ -91,7 +33,7 @@ internal class BatchTelemetryProcessor<T>(
 
     fun processTelemetry(telemetry: T) {
         shutdownState.execute {
-            if (queue.size <= maxQueueSize) {
+            if (queue.size <= config.maxQueueSize) {
                 queue.add(telemetry)
             }
         }
@@ -101,7 +43,7 @@ internal class BatchTelemetryProcessor<T>(
         if (shutdownState.isShutdown) {
             return OperationResultCode.Success
         }
-        return runWithTimeout(forceFlushTimeoutMs) {
+        return runWithTimeout(config.forceFlushTimeoutMs) {
             scope.launch { flushInternal() }.join()
             OperationResultCode.Success
         }
@@ -117,13 +59,13 @@ internal class BatchTelemetryProcessor<T>(
         while (queue.isNotEmpty()) {
             val batch = mutableListOf<T>()
             mutex.withLock {
-                val size = minOf(queue.size, maxExportBatchSize)
+                val size = minOf(queue.size, config.maxExportBatchSize)
                 repeat(size) { batch += queue.removeAt(0) }
             }
 
             if (batch.isNotEmpty()) {
                 try {
-                    withTimeout(exportTimeoutMs) {
+                    withTimeout(config.exportTimeoutMs) {
                         exportAction(batch)
                     }
                 } catch (ignored: Throwable) {
@@ -131,9 +73,5 @@ internal class BatchTelemetryProcessor<T>(
                 }
             }
         }
-    }
-
-    private companion object {
-        const val API = "BatchTelemetryProcessor"
     }
 }

--- a/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/export/BatchTelemetryProcessor.kt
+++ b/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/export/BatchTelemetryProcessor.kt
@@ -25,7 +25,7 @@ internal class BatchTelemetryProcessor<T>(
     private val exportAction: suspend (telemetry: List<T>) -> OperationResultCode,
 ) : TelemetryCloseable {
 
-    private val maxQueueSize: Int = validateOrUseDefault(
+    private val validMaxQueueSize: Int = validateOrUseDefault(
         sdkErrorHandler = sdkErrorHandler,
         api = API,
         configParameterName = "maxQueueSize",
@@ -33,7 +33,7 @@ internal class BatchTelemetryProcessor<T>(
         default = BatchTelemetryDefaults.MAX_QUEUE_SIZE,
     ) { it >= 0 }
 
-    private val scheduleDelayMs: Long = validateOrUseDefault(
+    private val validScheduleDelayMs: Long = validateOrUseDefault(
         sdkErrorHandler = sdkErrorHandler,
         api = API,
         configParameterName = "scheduleDelayMs",
@@ -41,7 +41,7 @@ internal class BatchTelemetryProcessor<T>(
         default = BatchTelemetryDefaults.SCHEDULE_DELAY_MS,
     ) { it > 0 }
 
-    private val exportTimeoutMs: Long = validateOrUseDefault(
+    private val validExportTimeoutMs: Long = validateOrUseDefault(
         sdkErrorHandler = sdkErrorHandler,
         api = API,
         configParameterName = "exportTimeoutMs",
@@ -49,7 +49,7 @@ internal class BatchTelemetryProcessor<T>(
         default = BatchTelemetryDefaults.EXPORT_TIMEOUT_MS,
     ) { it >= 0 }
 
-    private val maxExportBatchSize: Int = if (maxExportBatchSize < 0) {
+    private val validMaxExportBatchSize: Int = if (maxExportBatchSize < 0) {
         validateOrUseDefault(
             sdkErrorHandler = sdkErrorHandler,
             api = API,
@@ -63,11 +63,11 @@ internal class BatchTelemetryProcessor<T>(
             api = API,
             configParameterName = "maxExportBatchSize",
             value = maxExportBatchSize,
-            default = maxQueueSize,
-        ) { it <= maxQueueSize }
+            default = validMaxQueueSize,
+        ) { it <= validMaxQueueSize }
     }
 
-    private val forceFlushTimeoutMs: Long = validateOrUseDefault(
+    private val validForceFlushTimeoutMs: Long = validateOrUseDefault(
         sdkErrorHandler = sdkErrorHandler,
         api = API,
         configParameterName = "forceFlushTimeoutMs",
@@ -83,7 +83,7 @@ internal class BatchTelemetryProcessor<T>(
     init {
         scope.launch {
             while (!shutdownState.isShutdown) {
-                delay(this@BatchTelemetryProcessor.scheduleDelayMs)
+                delay(this@BatchTelemetryProcessor.validScheduleDelayMs)
                 flushInternal()
             }
         }
@@ -91,7 +91,7 @@ internal class BatchTelemetryProcessor<T>(
 
     fun processTelemetry(telemetry: T) {
         shutdownState.execute {
-            if (queue.size <= maxQueueSize) {
+            if (queue.size <= validMaxQueueSize) {
                 queue.add(telemetry)
             }
         }
@@ -101,7 +101,7 @@ internal class BatchTelemetryProcessor<T>(
         if (shutdownState.isShutdown) {
             return OperationResultCode.Success
         }
-        return runWithTimeout(forceFlushTimeoutMs) {
+        return runWithTimeout(validForceFlushTimeoutMs) {
             scope.launch { flushInternal() }.join()
             OperationResultCode.Success
         }
@@ -117,13 +117,13 @@ internal class BatchTelemetryProcessor<T>(
         while (queue.isNotEmpty()) {
             val batch = mutableListOf<T>()
             mutex.withLock {
-                val size = minOf(queue.size, maxExportBatchSize)
+                val size = minOf(queue.size, validMaxExportBatchSize)
                 repeat(size) { batch += queue.removeAt(0) }
             }
 
             if (batch.isNotEmpty()) {
                 try {
-                    withTimeout(exportTimeoutMs) {
+                    withTimeout(validExportTimeoutMs) {
                         exportAction(batch)
                     }
                 } catch (ignored: Throwable) {

--- a/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/export/BatchTelemetryProcessor.kt
+++ b/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/export/BatchTelemetryProcessor.kt
@@ -1,5 +1,8 @@
 package io.opentelemetry.kotlin.export
 
+import io.opentelemetry.kotlin.config.validateOrUseDefault
+import io.opentelemetry.kotlin.error.NoopSdkErrorHandler
+import io.opentelemetry.kotlin.error.SdkErrorHandler
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -12,14 +15,65 @@ import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withTimeout
 
 internal class BatchTelemetryProcessor<T>(
-    private val maxQueueSize: Int,
-    private val scheduleDelayMs: Long,
-    private val exportTimeoutMs: Long,
-    private val maxExportBatchSize: Int,
-    private val forceFlushTimeoutMs: Long = BatchTelemetryDefaults.FORCE_FLUSH_TIMEOUT_MS,
+    maxQueueSize: Int,
+    scheduleDelayMs: Long,
+    exportTimeoutMs: Long,
+    maxExportBatchSize: Int,
+    forceFlushTimeoutMs: Long = BatchTelemetryDefaults.FORCE_FLUSH_TIMEOUT_MS,
     dispatcher: CoroutineDispatcher = Dispatchers.Default,
+    private val sdkErrorHandler: SdkErrorHandler = NoopSdkErrorHandler,
     private val exportAction: suspend (telemetry: List<T>) -> OperationResultCode,
 ) : TelemetryCloseable {
+
+    private val maxQueueSize: Int = validateOrUseDefault(
+        sdkErrorHandler = sdkErrorHandler,
+        api = API,
+        configParameterName = "maxQueueSize",
+        value = maxQueueSize,
+        default = BatchTelemetryDefaults.MAX_QUEUE_SIZE,
+    ) { it >= 0 }
+
+    private val scheduleDelayMs: Long = validateOrUseDefault(
+        sdkErrorHandler = sdkErrorHandler,
+        api = API,
+        configParameterName = "scheduleDelayMs",
+        value = scheduleDelayMs,
+        default = BatchTelemetryDefaults.SCHEDULE_DELAY_MS,
+    ) { it > 0 }
+
+    private val exportTimeoutMs: Long = validateOrUseDefault(
+        sdkErrorHandler = sdkErrorHandler,
+        api = API,
+        configParameterName = "exportTimeoutMs",
+        value = exportTimeoutMs,
+        default = BatchTelemetryDefaults.EXPORT_TIMEOUT_MS,
+    ) { it >= 0 }
+
+    private val maxExportBatchSize: Int = if (maxExportBatchSize < 0) {
+        validateOrUseDefault(
+            sdkErrorHandler = sdkErrorHandler,
+            api = API,
+            configParameterName = "maxExportBatchSize",
+            value = maxExportBatchSize,
+            default = BatchTelemetryDefaults.MAX_EXPORT_BATCH_SIZE,
+        ) { it >= 0 }
+    } else {
+        validateOrUseDefault(
+            sdkErrorHandler = sdkErrorHandler,
+            api = API,
+            configParameterName = "maxExportBatchSize",
+            value = maxExportBatchSize,
+            default = maxQueueSize,
+        ) { it <= maxQueueSize }
+    }
+
+    private val forceFlushTimeoutMs: Long = validateOrUseDefault(
+        sdkErrorHandler = sdkErrorHandler,
+        api = API,
+        configParameterName = "forceFlushTimeoutMs",
+        value = forceFlushTimeoutMs,
+        default = BatchTelemetryDefaults.FORCE_FLUSH_TIMEOUT_MS,
+    ) { it >= 0 }
 
     private val shutdownState: MutableShutdownState = MutableShutdownState()
     private val scope = CoroutineScope(SupervisorJob() + dispatcher)
@@ -27,16 +81,9 @@ internal class BatchTelemetryProcessor<T>(
     private val queue = mutableListOf<T>()
 
     init {
-        require(scheduleDelayMs > 0)
-        require(maxQueueSize >= 0)
-        require(maxExportBatchSize >= 0)
-        require(exportTimeoutMs >= 0)
-        require(forceFlushTimeoutMs >= 0)
-        require(maxExportBatchSize <= maxQueueSize)
-
         scope.launch {
             while (!shutdownState.isShutdown) {
-                delay(scheduleDelayMs)
+                delay(this@BatchTelemetryProcessor.scheduleDelayMs)
                 flushInternal()
             }
         }
@@ -51,7 +98,9 @@ internal class BatchTelemetryProcessor<T>(
     }
 
     override suspend fun forceFlush(): OperationResultCode {
-        if (shutdownState.isShutdown) { return OperationResultCode.Success }
+        if (shutdownState.isShutdown) {
+            return OperationResultCode.Success
+        }
         return runWithTimeout(forceFlushTimeoutMs) {
             scope.launch { flushInternal() }.join()
             OperationResultCode.Success
@@ -82,5 +131,9 @@ internal class BatchTelemetryProcessor<T>(
                 }
             }
         }
+    }
+
+    private companion object {
+        const val API = "BatchTelemetryProcessor"
     }
 }

--- a/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/BatchLogRecordProcessorImpl.kt
+++ b/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/BatchLogRecordProcessorImpl.kt
@@ -2,6 +2,7 @@ package io.opentelemetry.kotlin.logging.export
 
 import io.opentelemetry.kotlin.InstrumentationScopeInfo
 import io.opentelemetry.kotlin.context.Context
+import io.opentelemetry.kotlin.export.BatchTelemetryConfig
 import io.opentelemetry.kotlin.export.BatchTelemetryDefaults
 import io.opentelemetry.kotlin.export.BatchTelemetryProcessor
 import io.opentelemetry.kotlin.export.MutableShutdownState
@@ -13,20 +14,22 @@ import kotlinx.coroutines.Dispatchers
 
 internal class BatchLogRecordProcessorImpl(
     private val exporter: LogRecordExporter,
-    private val maxQueueSize: Int,
-    private val scheduleDelayMs: Long,
-    private val exportTimeoutMs: Long,
-    private val maxExportBatchSize: Int,
+    maxQueueSize: Int,
+    scheduleDelayMs: Long,
+    exportTimeoutMs: Long,
+    maxExportBatchSize: Int,
     dispatcher: CoroutineDispatcher = Dispatchers.Default,
 ) : LogRecordProcessor {
 
     private val shutdownState: MutableShutdownState = MutableShutdownState()
     private val processor =
         BatchTelemetryProcessor(
-            maxQueueSize = maxQueueSize,
-            scheduleDelayMs = scheduleDelayMs,
-            exportTimeoutMs = exportTimeoutMs,
-            maxExportBatchSize = maxExportBatchSize,
+            config = BatchTelemetryConfig(
+                maxQueueSize = maxQueueSize,
+                scheduleDelayMs = scheduleDelayMs,
+                exportTimeoutMs = exportTimeoutMs,
+                maxExportBatchSize = maxExportBatchSize,
+            ),
             dispatcher = dispatcher,
             exportAction = exporter::export
         )

--- a/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/CoreLogRecordExporterApi.kt
+++ b/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/CoreLogRecordExporterApi.kt
@@ -5,6 +5,7 @@ import io.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.kotlin.error.NoopSdkErrorHandler
 import io.opentelemetry.kotlin.export.BatchTelemetryDefaults
 import io.opentelemetry.kotlin.init.LogExportConfigDsl
+import io.opentelemetry.kotlin.platformLog
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -15,7 +16,10 @@ import kotlinx.coroutines.SupervisorJob
  */
 @ExperimentalApi
 public fun LogExportConfigDsl.compositeLogRecordProcessor(vararg processors: LogRecordProcessor): LogRecordProcessor {
-    require(processors.isNotEmpty()) { "At least one processor must be provided" }
+    if (processors.isEmpty()) {
+        platformLog("At least one processor must be provided")
+        return NoopLogRecordProcessor
+    }
     return CompositeLogRecordProcessor(processors.toList(), NoopSdkErrorHandler)
 }
 
@@ -34,7 +38,10 @@ public fun LogExportConfigDsl.simpleLogRecordProcessor(exporter: LogRecordExport
  */
 @ExperimentalApi
 public fun LogExportConfigDsl.compositeLogRecordExporter(vararg exporters: LogRecordExporter): LogRecordExporter {
-    require(exporters.isNotEmpty()) { "At least one exporter must be provided" }
+    if (exporters.isEmpty()) {
+        platformLog("At least one exporter must be provided")
+        return NoopLogRecordExporter
+    }
     return CompositeLogRecordExporter(exporters.toList(), NoopSdkErrorHandler)
 }
 

--- a/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/NoopLogRecordExporter.kt
+++ b/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/NoopLogRecordExporter.kt
@@ -1,0 +1,10 @@
+package io.opentelemetry.kotlin.logging.export
+
+import io.opentelemetry.kotlin.export.OperationResultCode
+import io.opentelemetry.kotlin.logging.model.ReadableLogRecord
+
+internal object NoopLogRecordExporter : LogRecordExporter {
+    override suspend fun export(telemetry: List<ReadableLogRecord>): OperationResultCode = OperationResultCode.Failure
+    override suspend fun forceFlush(): OperationResultCode = OperationResultCode.Success
+    override suspend fun shutdown(): OperationResultCode = OperationResultCode.Success
+}

--- a/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/NoopLogRecordProcessor.kt
+++ b/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/NoopLogRecordProcessor.kt
@@ -1,0 +1,19 @@
+package io.opentelemetry.kotlin.logging.export
+
+import io.opentelemetry.kotlin.InstrumentationScopeInfo
+import io.opentelemetry.kotlin.context.Context
+import io.opentelemetry.kotlin.export.OperationResultCode
+import io.opentelemetry.kotlin.logging.SeverityNumber
+import io.opentelemetry.kotlin.logging.model.ReadWriteLogRecord
+
+internal object NoopLogRecordProcessor : LogRecordProcessor {
+    override fun onEmit(log: ReadWriteLogRecord, context: Context) = Unit
+    override fun enabled(
+        context: Context,
+        instrumentationScopeInfo: InstrumentationScopeInfo,
+        severityNumber: SeverityNumber?,
+        eventName: String?,
+    ): Boolean = false
+    override suspend fun forceFlush(): OperationResultCode = OperationResultCode.Success
+    override suspend fun shutdown(): OperationResultCode = OperationResultCode.Success
+}

--- a/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/BatchSpanProcessorImpl.kt
+++ b/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/BatchSpanProcessorImpl.kt
@@ -1,6 +1,7 @@
 package io.opentelemetry.kotlin.tracing.export
 
 import io.opentelemetry.kotlin.context.Context
+import io.opentelemetry.kotlin.export.BatchTelemetryConfig
 import io.opentelemetry.kotlin.export.BatchTelemetryDefaults
 import io.opentelemetry.kotlin.export.BatchTelemetryProcessor
 import io.opentelemetry.kotlin.export.MutableShutdownState
@@ -12,20 +13,22 @@ import kotlinx.coroutines.Dispatchers
 
 internal class BatchSpanProcessorImpl(
     private val exporter: SpanExporter,
-    private val maxQueueSize: Int,
-    private val scheduleDelayMs: Long,
-    private val exportTimeoutMs: Long,
-    private val maxExportBatchSize: Int,
+    maxQueueSize: Int,
+    scheduleDelayMs: Long,
+    exportTimeoutMs: Long,
+    maxExportBatchSize: Int,
     dispatcher: CoroutineDispatcher = Dispatchers.Default,
 ) : SpanProcessor {
 
     private val shutdownState: MutableShutdownState = MutableShutdownState()
     private val processor =
         BatchTelemetryProcessor(
-            maxQueueSize = maxQueueSize,
-            scheduleDelayMs = scheduleDelayMs,
-            exportTimeoutMs = exportTimeoutMs,
-            maxExportBatchSize = maxExportBatchSize,
+            config = BatchTelemetryConfig(
+                maxQueueSize = maxQueueSize,
+                scheduleDelayMs = scheduleDelayMs,
+                exportTimeoutMs = exportTimeoutMs,
+                maxExportBatchSize = maxExportBatchSize,
+            ),
             dispatcher = dispatcher,
             exportAction = exporter::export
         )

--- a/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/CoreSpanExporterApi.kt
+++ b/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/CoreSpanExporterApi.kt
@@ -4,6 +4,7 @@ import io.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.kotlin.error.NoopSdkErrorHandler
 import io.opentelemetry.kotlin.export.BatchTelemetryDefaults
 import io.opentelemetry.kotlin.init.TraceExportConfigDsl
+import io.opentelemetry.kotlin.platformLog
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -14,7 +15,10 @@ import kotlinx.coroutines.SupervisorJob
  */
 @ExperimentalApi
 public fun TraceExportConfigDsl.compositeSpanProcessor(vararg processors: SpanProcessor): SpanProcessor {
-    require(processors.isNotEmpty()) { "At least one processor must be provided" }
+    if (processors.isEmpty()) {
+        platformLog("At least one processor must be provided")
+        return NoopSpanProcessor
+    }
     return CompositeSpanProcessor(processors.toList(), NoopSdkErrorHandler)
 }
 
@@ -33,7 +37,10 @@ public fun TraceExportConfigDsl.simpleSpanProcessor(exporter: SpanExporter): Spa
  */
 @ExperimentalApi
 public fun TraceExportConfigDsl.compositeSpanExporter(vararg exporters: SpanExporter): SpanExporter {
-    require(exporters.isNotEmpty()) { "At least one exporter must be provided" }
+    if (exporters.isEmpty()) {
+        platformLog("At least one exporter must be provided")
+        return NoopSpanExporter
+    }
     return CompositeSpanExporter(exporters.toList(), NoopSdkErrorHandler)
 }
 

--- a/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/NoopSpanExporter.kt
+++ b/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/NoopSpanExporter.kt
@@ -1,0 +1,10 @@
+package io.opentelemetry.kotlin.tracing.export
+
+import io.opentelemetry.kotlin.export.OperationResultCode
+import io.opentelemetry.kotlin.tracing.data.SpanData
+
+internal object NoopSpanExporter : SpanExporter {
+    override suspend fun export(telemetry: List<SpanData>): OperationResultCode = OperationResultCode.Failure
+    override suspend fun forceFlush(): OperationResultCode = OperationResultCode.Success
+    override suspend fun shutdown(): OperationResultCode = OperationResultCode.Success
+}

--- a/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/NoopSpanProcessor.kt
+++ b/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/NoopSpanProcessor.kt
@@ -1,0 +1,16 @@
+package io.opentelemetry.kotlin.tracing.export
+
+import io.opentelemetry.kotlin.context.Context
+import io.opentelemetry.kotlin.export.OperationResultCode
+import io.opentelemetry.kotlin.tracing.model.ReadWriteSpan
+import io.opentelemetry.kotlin.tracing.model.ReadableSpan
+
+internal object NoopSpanProcessor : SpanProcessor {
+    override fun onStart(span: ReadWriteSpan, parentContext: Context) = Unit
+    override fun onEnding(span: ReadWriteSpan) = Unit
+    override fun onEnd(span: ReadableSpan) = Unit
+    override fun isStartRequired(): Boolean = false
+    override fun isEndRequired(): Boolean = false
+    override suspend fun forceFlush(): OperationResultCode = OperationResultCode.Success
+    override suspend fun shutdown(): OperationResultCode = OperationResultCode.Success
+}

--- a/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/export/BatchTelemetryConfigTest.kt
+++ b/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/export/BatchTelemetryConfigTest.kt
@@ -1,0 +1,38 @@
+package io.opentelemetry.kotlin.export
+
+import io.opentelemetry.kotlin.error.FakeSdkErrorHandler
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+internal class BatchTelemetryConfigTest {
+
+    @Test
+    fun testDefaults() {
+        val cfg = BatchTelemetryConfig()
+        assertEquals(BatchTelemetryDefaults.MAX_QUEUE_SIZE, cfg.maxQueueSize)
+        assertEquals(BatchTelemetryDefaults.SCHEDULE_DELAY_MS, cfg.scheduleDelayMs)
+        assertEquals(BatchTelemetryDefaults.EXPORT_TIMEOUT_MS, cfg.exportTimeoutMs)
+        assertEquals(BatchTelemetryDefaults.MAX_EXPORT_BATCH_SIZE, cfg.maxExportBatchSize)
+        assertEquals(BatchTelemetryDefaults.FORCE_FLUSH_TIMEOUT_MS, cfg.forceFlushTimeoutMs)
+    }
+
+    @Test
+    fun testInvalidConfigDoesNotThrow() {
+        val handler = FakeSdkErrorHandler()
+        val cfg = BatchTelemetryConfig(
+            maxQueueSize = -1,
+            scheduleDelayMs = -1,
+            exportTimeoutMs = -1,
+            maxExportBatchSize = -1,
+            forceFlushTimeoutMs = -1,
+            sdkErrorHandler = handler,
+        )
+        assertEquals(5, handler.apiMisuses.size)
+        val default = BatchTelemetryConfig()
+        assertEquals(default.maxQueueSize, cfg.maxQueueSize)
+        assertEquals(default.scheduleDelayMs, cfg.scheduleDelayMs)
+        assertEquals(default.exportTimeoutMs, cfg.exportTimeoutMs)
+        assertEquals(default.maxExportBatchSize, cfg.maxExportBatchSize)
+        assertEquals(default.forceFlushTimeoutMs, cfg.forceFlushTimeoutMs)
+    }
+}

--- a/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/export/BatchTelemetryProcessorTest.kt
+++ b/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/export/BatchTelemetryProcessorTest.kt
@@ -1,6 +1,7 @@
 package io.opentelemetry.kotlin.export
 
 import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.error.FakeSdkErrorHandler
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -10,75 +11,24 @@ import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
 @OptIn(ExperimentalApi::class, ExperimentalCoroutinesApi::class)
 internal class BatchTelemetryProcessorTest {
 
     @Test
-    fun testInvalidMaxQueueSize() {
-        assertFailsWith<IllegalArgumentException> {
-            BatchTelemetryProcessor<Unit>(
-                maxQueueSize = -1,
-                scheduleDelayMs = 1,
-                exportTimeoutMs = 1,
-                maxExportBatchSize = 1,
-                exportAction = { OperationResultCode.Success }
-            )
-        }
-    }
-
-    @Test
-    fun testInvalidScheduleDelayMs() {
-        assertFailsWith<IllegalArgumentException> {
-            BatchTelemetryProcessor<Unit>(
-                maxQueueSize = 1,
-                scheduleDelayMs = -1,
-                exportTimeoutMs = 1,
-                maxExportBatchSize = 1,
-                exportAction = { OperationResultCode.Success }
-            )
-        }
-    }
-
-    @Test
-    fun testInvalidExportTimeoutMs() {
-        assertFailsWith<IllegalArgumentException> {
-            BatchTelemetryProcessor<Unit>(
-                maxQueueSize = 1,
-                scheduleDelayMs = 1,
-                exportTimeoutMs = -1,
-                maxExportBatchSize = 1,
-                exportAction = { OperationResultCode.Success }
-            )
-        }
-    }
-
-    @Test
-    fun testInvalidMaxExportBatchSize() {
-        assertFailsWith<IllegalArgumentException> {
-            BatchTelemetryProcessor<Unit>(
-                maxQueueSize = 1,
-                scheduleDelayMs = 1,
-                exportTimeoutMs = 1,
-                maxExportBatchSize = -1,
-                exportAction = { OperationResultCode.Success }
-            )
-        }
-    }
-
-    @Test
-    fun testInvalidMaxExportBatchSize2() {
-        assertFailsWith<IllegalArgumentException> {
-            BatchTelemetryProcessor<Unit>(
-                maxQueueSize = 100,
-                scheduleDelayMs = 1,
-                exportTimeoutMs = 1,
-                maxExportBatchSize = 200,
-                exportAction = { OperationResultCode.Success }
-            )
-        }
+    fun testInvalidValuesDoesNotThrow() {
+        val handler = FakeSdkErrorHandler()
+        BatchTelemetryProcessor<Unit>(
+            maxQueueSize = -1,
+            scheduleDelayMs = -1,
+            exportTimeoutMs = -1,
+            maxExportBatchSize = -1,
+            forceFlushTimeoutMs = -1,
+            sdkErrorHandler = handler,
+            exportAction = { OperationResultCode.Success },
+        )
+        assertEquals(5, handler.apiMisuses.size)
     }
 
     @Test

--- a/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/export/BatchTelemetryProcessorTest.kt
+++ b/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/export/BatchTelemetryProcessorTest.kt
@@ -1,7 +1,6 @@
 package io.opentelemetry.kotlin.export
 
 import io.opentelemetry.kotlin.ExperimentalApi
-import io.opentelemetry.kotlin.error.FakeSdkErrorHandler
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -15,21 +14,6 @@ import kotlin.test.assertTrue
 
 @OptIn(ExperimentalApi::class, ExperimentalCoroutinesApi::class)
 internal class BatchTelemetryProcessorTest {
-
-    @Test
-    fun testInvalidValuesDoesNotThrow() {
-        val handler = FakeSdkErrorHandler()
-        BatchTelemetryProcessor<Unit>(
-            maxQueueSize = -1,
-            scheduleDelayMs = -1,
-            exportTimeoutMs = -1,
-            maxExportBatchSize = -1,
-            forceFlushTimeoutMs = -1,
-            sdkErrorHandler = handler,
-            exportAction = { OperationResultCode.Success },
-        )
-        assertEquals(5, handler.apiMisuses.size)
-    }
 
     @Test
     fun testSingleItemInBatch() = runTest {
@@ -63,10 +47,12 @@ internal class BatchTelemetryProcessorTest {
         val exports = mutableListOf<List<Int>>()
         val dispatcher = StandardTestDispatcher(testScheduler)
         val processor = BatchTelemetryProcessor(
-            maxQueueSize = 100,
-            maxExportBatchSize = 1,
-            scheduleDelayMs = 1,
-            exportTimeoutMs = 1000,
+            config = BatchTelemetryConfig(
+                maxQueueSize = 100,
+                maxExportBatchSize = 1,
+                scheduleDelayMs = 1,
+                exportTimeoutMs = 1000,
+            ),
             dispatcher = dispatcher,
             exportAction = {
                 exports.add(it)
@@ -88,10 +74,12 @@ internal class BatchTelemetryProcessorTest {
     fun testShutdownReturnsSuccessOnSecondCall() = runTest {
         val dispatcher = StandardTestDispatcher(testScheduler)
         val processor = BatchTelemetryProcessor<Int>(
-            maxQueueSize = 100,
-            maxExportBatchSize = 1,
-            scheduleDelayMs = 1,
-            exportTimeoutMs = 1000,
+            config = BatchTelemetryConfig(
+                maxQueueSize = 100,
+                maxExportBatchSize = 1,
+                scheduleDelayMs = 1,
+                exportTimeoutMs = 1000,
+            ),
             dispatcher = dispatcher,
             exportAction = { OperationResultCode.Success }
         )
@@ -103,10 +91,12 @@ internal class BatchTelemetryProcessorTest {
     fun testForceFlushWorksAfterShutdown() = runTest {
         val dispatcher = StandardTestDispatcher(testScheduler)
         val processor = BatchTelemetryProcessor<Int>(
-            maxQueueSize = 100,
-            maxExportBatchSize = 1,
-            scheduleDelayMs = 1,
-            exportTimeoutMs = 1000,
+            config = BatchTelemetryConfig(
+                maxQueueSize = 100,
+                maxExportBatchSize = 1,
+                scheduleDelayMs = 1,
+                exportTimeoutMs = 1000,
+            ),
             dispatcher = dispatcher,
             exportAction = { OperationResultCode.Success }
         )
@@ -164,10 +154,12 @@ internal class BatchTelemetryProcessorTest {
         val exports = mutableListOf<List<T>>()
         val dispatcher = StandardTestDispatcher(testScheduler)
         val processor = BatchTelemetryProcessor(
-            maxQueueSize = 20,
-            maxExportBatchSize = batchSize,
-            scheduleDelayMs = 1,
-            exportTimeoutMs = exportTimeoutMs,
+            config = BatchTelemetryConfig(
+                maxQueueSize = 20,
+                maxExportBatchSize = batchSize,
+                scheduleDelayMs = 1,
+                exportTimeoutMs = exportTimeoutMs,
+            ),
             dispatcher = dispatcher,
             exportAction = {
                 exportAction(it)

--- a/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/export/CoreLogRecordExporterApiTest.kt
+++ b/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/export/CoreLogRecordExporterApiTest.kt
@@ -1,20 +1,42 @@
 package io.opentelemetry.kotlin.logging.export
 
+import io.opentelemetry.kotlin.FakeInstrumentationScopeInfo
+import io.opentelemetry.kotlin.context.FakeContext
 import io.opentelemetry.kotlin.export.FakeLogExportConfig
+import io.opentelemetry.kotlin.export.OperationResultCode
+import io.opentelemetry.kotlin.logging.model.FakeReadWriteLogRecord
+import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertSame
 
 internal class CoreLogRecordExporterApiTest {
 
     private val config = FakeLogExportConfig()
+    private val fakeLogRecord = FakeReadWriteLogRecord()
+    private val fakeContext = FakeContext()
+    private val scopeInfo = FakeInstrumentationScopeInfo()
 
     @Test
-    fun compositeLogRecordProcessorEmptyReturnsNoop() {
-        assertSame(NoopLogRecordProcessor, config.compositeLogRecordProcessor())
+    fun compositeLogRecordProcessorEmptyReturnsNoopWithoutThrowing() = runTest {
+        val emptyProcessor = config.compositeLogRecordProcessor().apply {
+            onEmit(fakeLogRecord, fakeContext)
+            assertFalse(enabled(fakeContext, scopeInfo, null, null))
+            assertEquals(OperationResultCode.Success, forceFlush())
+            assertEquals(OperationResultCode.Success, shutdown())
+        }
+
+        assertSame(NoopLogRecordProcessor, emptyProcessor)
     }
 
     @Test
-    fun compositeLogRecordExporterEmptyReturnsNoop() {
-        assertSame(NoopLogRecordExporter, config.compositeLogRecordExporter())
+    fun compositeLogRecordExporterEmptyReturnsNoopWithoutThrowing() = runTest {
+        val emptyExporter = config.compositeLogRecordExporter().apply {
+            assertEquals(OperationResultCode.Failure, export(listOf(fakeLogRecord)))
+            assertEquals(OperationResultCode.Success, forceFlush())
+            assertEquals(OperationResultCode.Success, shutdown())
+        }
+        assertSame(NoopLogRecordExporter, emptyExporter)
     }
 }

--- a/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/export/CoreLogRecordExporterApiTest.kt
+++ b/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/export/CoreLogRecordExporterApiTest.kt
@@ -2,23 +2,19 @@ package io.opentelemetry.kotlin.logging.export
 
 import io.opentelemetry.kotlin.export.FakeLogExportConfig
 import kotlin.test.Test
-import kotlin.test.assertFailsWith
+import kotlin.test.assertSame
 
 internal class CoreLogRecordExporterApiTest {
 
     private val config = FakeLogExportConfig()
 
     @Test
-    fun compositeLogRecordProcessorEmpty() {
-        assertFailsWith<IllegalArgumentException> {
-            config.compositeLogRecordProcessor()
-        }
+    fun compositeLogRecordProcessorEmptyReturnsNoop() {
+        assertSame(NoopLogRecordProcessor, config.compositeLogRecordProcessor())
     }
 
     @Test
-    fun compositeLogRecordExporterEmpty() {
-        assertFailsWith<IllegalArgumentException> {
-            config.compositeLogRecordExporter()
-        }
+    fun compositeLogRecordExporterEmptyReturnsNoop() {
+        assertSame(NoopLogRecordExporter, config.compositeLogRecordExporter())
     }
 }

--- a/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/export/CoreSpanExporterApiTest.kt
+++ b/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/export/CoreSpanExporterApiTest.kt
@@ -2,23 +2,19 @@ package io.opentelemetry.kotlin.tracing.export
 
 import io.opentelemetry.kotlin.export.FakeTraceExportConfig
 import kotlin.test.Test
-import kotlin.test.assertFailsWith
+import kotlin.test.assertSame
 
 internal class CoreSpanExporterApiTest {
 
     private val config = FakeTraceExportConfig()
 
     @Test
-    fun compositeSpanProcessorEmpty() {
-        assertFailsWith<IllegalArgumentException> {
-            config.compositeSpanProcessor()
-        }
+    fun compositeSpanProcessorEmptyReturnsNoop() {
+        assertSame(NoopSpanProcessor, config.compositeSpanProcessor())
     }
 
     @Test
-    fun compositeSpanExporterEmpty() {
-        assertFailsWith<IllegalArgumentException> {
-            config.compositeSpanExporter()
-        }
+    fun compositeSpanExporterEmptyReturnsNoop() {
+        assertSame(NoopSpanExporter, config.compositeSpanExporter())
     }
 }

--- a/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/export/CoreSpanExporterApiTest.kt
+++ b/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/export/CoreSpanExporterApiTest.kt
@@ -1,20 +1,40 @@
 package io.opentelemetry.kotlin.tracing.export
 
+import io.opentelemetry.kotlin.context.FakeContext
 import io.opentelemetry.kotlin.export.FakeTraceExportConfig
+import io.opentelemetry.kotlin.export.OperationResultCode
+import io.opentelemetry.kotlin.tracing.FakeReadWriteSpan
+import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertSame
 
 internal class CoreSpanExporterApiTest {
 
     private val config = FakeTraceExportConfig()
+    private val fakeSpan = FakeReadWriteSpan()
+    private val fakeContext = FakeContext()
 
     @Test
-    fun compositeSpanProcessorEmptyReturnsNoop() {
-        assertSame(NoopSpanProcessor, config.compositeSpanProcessor())
+    fun compositeSpanProcessorEmptyReturnsNoopWithoutThrowing() = runTest {
+        val emptyProcessor = config.compositeSpanProcessor().apply {
+            onStart(fakeSpan, fakeContext)
+            onEnding(fakeSpan)
+            onEnd(fakeSpan)
+            assertEquals(OperationResultCode.Success, forceFlush())
+            assertEquals(OperationResultCode.Success, shutdown())
+        }
+
+        assertSame(NoopSpanProcessor, emptyProcessor)
     }
 
     @Test
-    fun compositeSpanExporterEmptyReturnsNoop() {
-        assertSame(NoopSpanExporter, config.compositeSpanExporter())
+    fun compositeSpanExporterEmptyReturnsNoopWithoutThrowing() = runTest {
+        val emptyExporter = config.compositeSpanExporter().apply {
+            assertEquals(OperationResultCode.Failure, export(listOf(fakeSpan)))
+            assertEquals(OperationResultCode.Success, forceFlush())
+            assertEquals(OperationResultCode.Success, shutdown())
+        }
+        assertSame(NoopSpanExporter, emptyExporter)
     }
 }

--- a/exporters-persistence/src/commonMain/kotlin/io/opentelemetry/kotlin/export/PersistedTelemetryConfig.kt
+++ b/exporters-persistence/src/commonMain/kotlin/io/opentelemetry/kotlin/export/PersistedTelemetryConfig.kt
@@ -1,25 +1,44 @@
 package io.opentelemetry.kotlin.export
 
+import io.opentelemetry.kotlin.config.validateOrUseDefault
+import io.opentelemetry.kotlin.error.NoopSdkErrorHandler
+import io.opentelemetry.kotlin.error.SdkErrorHandler
+
 internal class PersistedTelemetryConfig(
 
     /**
      * Maximum number of batches that should be stored for each telemetry signal. 100 by default.
      * For example, 100 batches of X logs may be stored before old telemetry is deleted.
      */
-    val maxBatchedItemsPerSignal: Int = 100,
+    desiredMaxBatchedItemsPerSignal: Int = DEFAULT_MAX_BATCHED_ITEMS_PER_SIGNAL,
 
     /**
      * Maximum age of telemetry before it should be deleted. Old telemetry is not considered useful
      * so it can be deleted after 30 days by default.
      */
-    val maxTelemetryAgeInDays: Long = 30,
+    desiredMaxTelemetryAgeInDays: Long = DEFAULT_MAX_TELEMETRY_AGE_IN_DAYS,
+
+    sdkErrorHandler: SdkErrorHandler = NoopSdkErrorHandler,
 ) {
-    init {
-        require(maxBatchedItemsPerSignal > 0) {
-            "maxBatchedItemsPerSignal must be positive, was $maxBatchedItemsPerSignal"
-        }
-        require(maxTelemetryAgeInDays > 0) {
-            "maxTelemetryAgeInDays must be positive, was $maxTelemetryAgeInDays"
-        }
+    val maxBatchedItemsPerSignal: Int = validateOrUseDefault(
+        sdkErrorHandler = sdkErrorHandler,
+        api = API,
+        configParameterName = "maxBatchedItemsPerSignal",
+        value = desiredMaxBatchedItemsPerSignal,
+        default = DEFAULT_MAX_BATCHED_ITEMS_PER_SIGNAL,
+    ) { it > 0 }
+
+    val maxTelemetryAgeInDays: Long = validateOrUseDefault(
+        sdkErrorHandler = sdkErrorHandler,
+        api = API,
+        configParameterName = "maxTelemetryAgeInDays",
+        value = desiredMaxTelemetryAgeInDays,
+        default = DEFAULT_MAX_TELEMETRY_AGE_IN_DAYS,
+    ) { it > 0 }
+
+    private companion object {
+        const val API = "PersistedTelemetryConfig"
+        const val DEFAULT_MAX_BATCHED_ITEMS_PER_SIGNAL = 100
+        const val DEFAULT_MAX_TELEMETRY_AGE_IN_DAYS = 30L
     }
 }

--- a/exporters-persistence/src/commonMain/kotlin/io/opentelemetry/kotlin/export/PersistedTelemetryConfig.kt
+++ b/exporters-persistence/src/commonMain/kotlin/io/opentelemetry/kotlin/export/PersistedTelemetryConfig.kt
@@ -5,34 +5,31 @@ import io.opentelemetry.kotlin.error.NoopSdkErrorHandler
 import io.opentelemetry.kotlin.error.SdkErrorHandler
 
 internal class PersistedTelemetryConfig(
-
+    maxBatchedItemsPerSignal: Int = DEFAULT_MAX_BATCHED_ITEMS_PER_SIGNAL,
+    maxTelemetryAgeInDays: Long = DEFAULT_MAX_TELEMETRY_AGE_IN_DAYS,
+    sdkErrorHandler: SdkErrorHandler = NoopSdkErrorHandler,
+) {
     /**
      * Maximum number of batches that should be stored for each telemetry signal. 100 by default.
      * For example, 100 batches of X logs may be stored before old telemetry is deleted.
      */
-    desiredMaxBatchedItemsPerSignal: Int = DEFAULT_MAX_BATCHED_ITEMS_PER_SIGNAL,
+    val maxBatchedItemsPerSignal: Int = validateOrUseDefault(
+        sdkErrorHandler = sdkErrorHandler,
+        api = API,
+        configParameterName = "maxBatchedItemsPerSignal",
+        value = maxBatchedItemsPerSignal,
+        default = DEFAULT_MAX_BATCHED_ITEMS_PER_SIGNAL,
+    ) { it > 0 }
 
     /**
      * Maximum age of telemetry before it should be deleted. Old telemetry is not considered useful
      * so it can be deleted after 30 days by default.
      */
-    desiredMaxTelemetryAgeInDays: Long = DEFAULT_MAX_TELEMETRY_AGE_IN_DAYS,
-
-    sdkErrorHandler: SdkErrorHandler = NoopSdkErrorHandler,
-) {
-    val maxBatchedItemsPerSignal: Int = validateOrUseDefault(
-        sdkErrorHandler = sdkErrorHandler,
-        api = API,
-        configParameterName = "maxBatchedItemsPerSignal",
-        value = desiredMaxBatchedItemsPerSignal,
-        default = DEFAULT_MAX_BATCHED_ITEMS_PER_SIGNAL,
-    ) { it > 0 }
-
     val maxTelemetryAgeInDays: Long = validateOrUseDefault(
         sdkErrorHandler = sdkErrorHandler,
         api = API,
         configParameterName = "maxTelemetryAgeInDays",
-        value = desiredMaxTelemetryAgeInDays,
+        value = maxTelemetryAgeInDays,
         default = DEFAULT_MAX_TELEMETRY_AGE_IN_DAYS,
     ) { it > 0 }
 

--- a/exporters-persistence/src/commonTest/kotlin/io/opentelemetry/kotlin/export/PersistedTelemetryConfigTest.kt
+++ b/exporters-persistence/src/commonTest/kotlin/io/opentelemetry/kotlin/export/PersistedTelemetryConfigTest.kt
@@ -17,8 +17,8 @@ internal class PersistedTelemetryConfigTest {
     fun testInvalidConfigDoesNotThrow() {
         val handler = FakeSdkErrorHandler()
         val cfg = PersistedTelemetryConfig(
-            desiredMaxBatchedItemsPerSignal = 0,
-            desiredMaxTelemetryAgeInDays = 0,
+            maxBatchedItemsPerSignal = 0,
+            maxTelemetryAgeInDays = 0,
             sdkErrorHandler = handler,
         )
         assertEquals(2, handler.apiMisuses.size)

--- a/exporters-persistence/src/commonTest/kotlin/io/opentelemetry/kotlin/export/PersistedTelemetryConfigTest.kt
+++ b/exporters-persistence/src/commonTest/kotlin/io/opentelemetry/kotlin/export/PersistedTelemetryConfigTest.kt
@@ -1,5 +1,6 @@
 package io.opentelemetry.kotlin.export
 
+import io.opentelemetry.kotlin.error.FakeSdkErrorHandler
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -10,5 +11,19 @@ internal class PersistedTelemetryConfigTest {
         val cfg = PersistedTelemetryConfig()
         assertEquals(30, cfg.maxTelemetryAgeInDays)
         assertEquals(100, cfg.maxBatchedItemsPerSignal)
+    }
+
+    @Test
+    fun testInvalidConfigDoesNotThrow() {
+        val handler = FakeSdkErrorHandler()
+        val cfg = PersistedTelemetryConfig(
+            desiredMaxBatchedItemsPerSignal = 0,
+            desiredMaxTelemetryAgeInDays = 0,
+            sdkErrorHandler = handler,
+        )
+        assertEquals(2, handler.apiMisuses.size)
+        val default = PersistedTelemetryConfig()
+        assertEquals(default.maxBatchedItemsPerSignal, cfg.maxBatchedItemsPerSignal)
+        assertEquals(default.maxTelemetryAgeInDays, cfg.maxTelemetryAgeInDays)
     }
 }

--- a/exporters-persistence/src/commonTest/kotlin/io/opentelemetry/kotlin/export/TelemetryRepositoryImplTest.kt
+++ b/exporters-persistence/src/commonTest/kotlin/io/opentelemetry/kotlin/export/TelemetryRepositoryImplTest.kt
@@ -1,11 +1,11 @@
 package io.opentelemetry.kotlin.export
 
 import io.opentelemetry.kotlin.clock.FakeClock
+import io.opentelemetry.kotlin.error.FakeSdkErrorHandler
 import io.opentelemetry.kotlin.export.PersistedTelemetryType.LOGS
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 
@@ -77,23 +77,17 @@ internal class TelemetryRepositoryImplTest {
     }
 
     @Test
-    fun testMaxTelemetryAgeInDays() {
-        assertFailsWith<IllegalArgumentException> {
-            PersistedTelemetryConfig(maxTelemetryAgeInDays = 0)
-        }
-        assertFailsWith<IllegalArgumentException> {
-            PersistedTelemetryConfig(maxTelemetryAgeInDays = -1)
-        }
-    }
+    fun testConfigValueFallback() {
+        val sdkErrorHandler = FakeSdkErrorHandler()
+        val config = PersistedTelemetryConfig(
+            maxBatchedItemsPerSignal = 0,
+            maxTelemetryAgeInDays = 0,
+            sdkErrorHandler = sdkErrorHandler
+        )
 
-    @Test
-    fun testMaxBatchedItemsPerSignal() {
-        assertFailsWith<IllegalArgumentException> {
-            PersistedTelemetryConfig(maxBatchedItemsPerSignal = 0)
-        }
-        assertFailsWith<IllegalArgumentException> {
-            PersistedTelemetryConfig(maxBatchedItemsPerSignal = -1)
-        }
+        assertEquals(100, config.maxBatchedItemsPerSignal)
+        assertEquals(30, config.maxTelemetryAgeInDays)
+        assertEquals(2, sdkErrorHandler.apiMisuses.size)
     }
 
     @Test
@@ -172,7 +166,7 @@ internal class TelemetryRepositoryImplTest {
 
     @Test
     fun testMaxStorageLimitExceeded() {
-        val config = PersistedTelemetryConfig(desiredMaxBatchedItemsPerSignal = 3)
+        val config = PersistedTelemetryConfig(maxBatchedItemsPerSignal = 3)
         val repository = createRepository(config = config)
 
         val items = listOf("first", "second", "third", "fourth")
@@ -192,7 +186,7 @@ internal class TelemetryRepositoryImplTest {
 
     @Test
     fun testOldTelemetryPolicy() {
-        val config = PersistedTelemetryConfig(desiredMaxTelemetryAgeInDays = 7)
+        val config = PersistedTelemetryConfig(maxTelemetryAgeInDays = 7)
         val repository = createRepository(config = config)
 
         repository.store(listOf(FakeTelemetryObject("a")))

--- a/exporters-persistence/src/commonTest/kotlin/io/opentelemetry/kotlin/export/TelemetryRepositoryImplTest.kt
+++ b/exporters-persistence/src/commonTest/kotlin/io/opentelemetry/kotlin/export/TelemetryRepositoryImplTest.kt
@@ -172,7 +172,7 @@ internal class TelemetryRepositoryImplTest {
 
     @Test
     fun testMaxStorageLimitExceeded() {
-        val config = PersistedTelemetryConfig(maxBatchedItemsPerSignal = 3)
+        val config = PersistedTelemetryConfig(desiredMaxBatchedItemsPerSignal = 3)
         val repository = createRepository(config = config)
 
         val items = listOf("first", "second", "third", "fourth")
@@ -192,7 +192,7 @@ internal class TelemetryRepositoryImplTest {
 
     @Test
     fun testOldTelemetryPolicy() {
-        val config = PersistedTelemetryConfig(maxTelemetryAgeInDays = 7)
+        val config = PersistedTelemetryConfig(desiredMaxTelemetryAgeInDays = 7)
         val repository = createRepository(config = config)
 
         repository.store(listOf(FakeTelemetryObject("a")))

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/LoggerProviderConfigImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/LoggerProviderConfigImpl.kt
@@ -4,6 +4,7 @@ import io.opentelemetry.kotlin.Clock
 import io.opentelemetry.kotlin.init.config.LogLimitConfig
 import io.opentelemetry.kotlin.init.config.LoggingConfig
 import io.opentelemetry.kotlin.logging.export.LogRecordProcessor
+import io.opentelemetry.kotlin.platformLog
 import io.opentelemetry.kotlin.resource.Resource
 
 internal class LoggerProviderConfigImpl(
@@ -15,7 +16,10 @@ internal class LoggerProviderConfigImpl(
     private var logLimitsAction: LogLimitsConfigDsl.() -> Unit = {}
 
     override fun export(action: LogExportConfigDsl.() -> LogRecordProcessor) {
-        require(processor == null) { "export() should only be called once." }
+        if (processor != null) {
+            platformLog("export() should only be called once.")
+            return
+        }
         processor = LogExportConfigImpl(clock).action()
     }
 

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/TracerProviderConfigImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/TracerProviderConfigImpl.kt
@@ -4,6 +4,7 @@ import io.opentelemetry.kotlin.Clock
 import io.opentelemetry.kotlin.factory.SpanFactory
 import io.opentelemetry.kotlin.init.config.SpanLimitConfig
 import io.opentelemetry.kotlin.init.config.TracingConfig
+import io.opentelemetry.kotlin.platformLog
 import io.opentelemetry.kotlin.resource.Resource
 import io.opentelemetry.kotlin.tracing.export.SpanProcessor
 import io.opentelemetry.kotlin.tracing.sampling.Sampler
@@ -23,7 +24,10 @@ internal class TracerProviderConfigImpl(
     }
 
     override fun export(action: TraceExportConfigDsl.() -> SpanProcessor) {
-        require(processor == null) { "export() should only be called once." }
+        if (processor != null) {
+            platformLog("export() should only be called once.")
+            return
+        }
         processor = TraceExportConfigImpl(clock).action()
     }
 

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/init/LoggerProviderConfigImplTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/init/LoggerProviderConfigImplTest.kt
@@ -3,6 +3,8 @@ package io.opentelemetry.kotlin.init
 import io.opentelemetry.kotlin.attributes.DEFAULT_ATTRIBUTE_LIMIT
 import io.opentelemetry.kotlin.clock.FakeClock
 import io.opentelemetry.kotlin.logging.export.FakeLogRecordProcessor
+import io.opentelemetry.kotlin.logging.export.LogRecordExporter
+import io.opentelemetry.kotlin.logging.export.LogRecordProcessor
 import io.opentelemetry.kotlin.logging.export.compositeLogRecordProcessor
 import io.opentelemetry.kotlin.logging.export.simpleLogRecordProcessor
 import io.opentelemetry.kotlin.logging.export.stdoutLogRecordExporter
@@ -11,9 +13,10 @@ import io.opentelemetry.kotlin.semconv.ServiceAttributes
 import io.opentelemetry.kotlin.semconv.TelemetryAttributes
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
+import kotlin.test.assertNotSame
 import kotlin.test.assertNull
+import kotlin.test.assertSame
 
 internal class LoggerProviderConfigImplTest {
 
@@ -65,13 +68,23 @@ internal class LoggerProviderConfigImplTest {
     }
 
     @Test
-    fun testDoubleExportConfig() {
-        assertFailsWith(IllegalArgumentException::class) {
-            LoggerProviderConfigImpl(clock).apply {
-                export { simpleLogRecordProcessor(stdoutLogRecordExporter()) }
-                export { simpleLogRecordProcessor(stdoutLogRecordExporter()) }
+    fun testDoubleExportConfigKeepsFirst() {
+        var first: LogRecordProcessor? = null
+        var second: LogRecordProcessor? = null
+        val cfg = LoggerProviderConfigImpl(clock).apply {
+            export {
+                simpleLogRecordProcessor(stdoutLogRecordExporter()).apply {
+                    first = this
+                }
             }
-        }
+            export {
+                simpleLogRecordProcessor(stdoutLogRecordExporter()).apply {
+                    second = this
+                }
+            }
+        }.generateLoggingConfig(base)
+        assertSame(first, cfg.processor)
+        assertNotSame(second, cfg.processor)
     }
 
     @Test

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/init/LoggerProviderConfigImplTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/init/LoggerProviderConfigImplTest.kt
@@ -3,7 +3,6 @@ package io.opentelemetry.kotlin.init
 import io.opentelemetry.kotlin.attributes.DEFAULT_ATTRIBUTE_LIMIT
 import io.opentelemetry.kotlin.clock.FakeClock
 import io.opentelemetry.kotlin.logging.export.FakeLogRecordProcessor
-import io.opentelemetry.kotlin.logging.export.LogRecordExporter
 import io.opentelemetry.kotlin.logging.export.LogRecordProcessor
 import io.opentelemetry.kotlin.logging.export.compositeLogRecordProcessor
 import io.opentelemetry.kotlin.logging.export.simpleLogRecordProcessor

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/init/TracerProviderConfigImplTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/init/TracerProviderConfigImplTest.kt
@@ -8,17 +8,16 @@ import io.opentelemetry.kotlin.sdkDefaultAttributes
 import io.opentelemetry.kotlin.semconv.ServiceAttributes
 import io.opentelemetry.kotlin.semconv.TelemetryAttributes
 import io.opentelemetry.kotlin.tracing.export.FakeSpanProcessor
+import io.opentelemetry.kotlin.tracing.export.SpanProcessor
 import io.opentelemetry.kotlin.tracing.export.compositeSpanProcessor
-import io.opentelemetry.kotlin.tracing.export.simpleSpanProcessor
-import io.opentelemetry.kotlin.tracing.export.stdoutSpanExporter
 import io.opentelemetry.kotlin.tracing.sampling.AlwaysOnSampler
 import io.opentelemetry.kotlin.tracing.sampling.FakeSampler
 import io.opentelemetry.kotlin.tracing.sampling.alwaysOn
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
 import kotlin.test.assertIs
 import kotlin.test.assertNotNull
+import kotlin.test.assertNotSame
 import kotlin.test.assertNull
 import kotlin.test.assertSame
 
@@ -119,13 +118,23 @@ internal class TracerProviderConfigImplTest {
     }
 
     @Test
-    fun testDoubleExportConfig() {
-        assertFailsWith(IllegalArgumentException::class) {
-            TracerProviderConfigImpl(clock).apply {
-                export { simpleSpanProcessor(stdoutSpanExporter()) }
-                export { simpleSpanProcessor(stdoutSpanExporter()) }
+    fun testDoubleExportConfigKeepsFirst() {
+        var first: SpanProcessor? = null
+        var second: SpanProcessor? = null
+        val cfg = TracerProviderConfigImpl(clock).apply {
+            export {
+                compositeSpanProcessor(FakeSpanProcessor()).apply {
+                    first = this
+                }
             }
-        }
+            export {
+                compositeSpanProcessor(FakeSpanProcessor()).apply {
+                    second = this
+                }
+            }
+        }.generateTracingConfig(base)
+        assertSame(first, cfg.processor)
+        assertNotSame(second, cfg.processor)
     }
 
     @Test

--- a/sdk-common/api/jvm/sdk-common.api
+++ b/sdk-common/api/jvm/sdk-common.api
@@ -6,6 +6,10 @@ public final class io/opentelemetry/kotlin/attributes/ExceptionAttributesExtKt {
 	public static final fun setExceptionAttributes (Lio/opentelemetry/kotlin/attributes/AttributesMutator;Ljava/lang/Throwable;)V
 }
 
+public final class io/opentelemetry/kotlin/config/ValidationKt {
+	public static final fun validateOrUseDefault (Lio/opentelemetry/kotlin/error/SdkErrorHandler;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+}
+
 public final class io/opentelemetry/kotlin/export/BatchExportOperationKt {
 	public static final fun batchExportOperation (Ljava/util/List;Lio/opentelemetry/kotlin/error/SdkErrorHandler;Lkotlin/jvm/functions/Function1;)Lio/opentelemetry/kotlin/export/OperationResultCode;
 	public static final fun batchExportOperationSuspend (Ljava/util/List;Lio/opentelemetry/kotlin/error/SdkErrorHandler;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;

--- a/sdk-common/src/commonMain/kotlin/io/opentelemetry/kotlin/config/Validation.kt
+++ b/sdk-common/src/commonMain/kotlin/io/opentelemetry/kotlin/config/Validation.kt
@@ -1,0 +1,25 @@
+package io.opentelemetry.kotlin.config
+
+import io.opentelemetry.kotlin.error.SdkErrorHandler
+import io.opentelemetry.kotlin.error.SdkErrorSeverity
+
+/**
+ * Validate the given value against a validating function, and return that value if it's valid. Otherwise, return the provided default.
+ */
+public fun <T> validateOrUseDefault(
+    sdkErrorHandler: SdkErrorHandler,
+    api: String,
+    configParameterName: String,
+    value: T,
+    default: T,
+    validator: (T) -> Boolean,
+): T = if (validator(value)) {
+    value
+} else {
+    sdkErrorHandler.onApiMisuse(
+        api,
+        "$value is not a valid value for $configParameterName. $default used instead.",
+        SdkErrorSeverity.WARNING,
+    )
+    default
+}

--- a/sdk-common/src/commonTest/kotlin/io/opentelemetry/kotlin/config/ValidationTest.kt
+++ b/sdk-common/src/commonTest/kotlin/io/opentelemetry/kotlin/config/ValidationTest.kt
@@ -1,0 +1,48 @@
+package io.opentelemetry.kotlin.config
+
+import io.opentelemetry.kotlin.error.FakeSdkErrorHandler
+import io.opentelemetry.kotlin.error.SdkErrorSeverity
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+internal class ValidationTest {
+
+    private lateinit var handler: FakeSdkErrorHandler
+
+    @BeforeTest
+    fun setUp() {
+        handler = FakeSdkErrorHandler()
+    }
+
+    @Test
+    fun returnsValueAndReportsNothingWhenValidatorAccepts() {
+        val result = validateOrUseDefault(
+            sdkErrorHandler = handler,
+            api = "TestApi",
+            configParameterName = "size",
+            value = 10,
+            default = 100,
+        ) { it > 0 }
+        assertEquals(10, result)
+        assertTrue(handler.apiMisuses.isEmpty())
+    }
+
+    @Test
+    fun returnsDefaultAndReportsMisuseWhenValidatorRejects() {
+        val result = validateOrUseDefault(
+            sdkErrorHandler = handler,
+            api = "TestApi",
+            configParameterName = "size",
+            value = -1,
+            default = 100,
+        ) { it > 0 }
+        assertEquals(100, result)
+        assertEquals(1, handler.apiMisuses.size)
+        with(handler.apiMisuses.single()) {
+            assertEquals("TestApi", api)
+            assertEquals(SdkErrorSeverity.WARNING, severity)
+        }
+    }
+}


### PR DESCRIPTION
Report and SDK error and fallback to defaults when processor and exporter configs are not valid

While these are still only currently used in the DSL, you can imagine that they may not be in the future.

Partially addresses #502 