### PR TITLE
Remove throws on init in trace and span context usage scenarios

### DIFF
--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/context/ContextImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/context/ContextImpl.kt
@@ -29,11 +29,11 @@ internal class ContextImpl(
 
     override fun attach(): Scope {
         if (storage.implicitContext() == this) {
-            return NoopScope
+            return DetachedScope
         }
         val current = storage.implicitContext()
         storage.setImplicitContext(this)
-        return ScopeImpl(current, this, storage)
+        return ScopeImpl.create(current, this, storage)
     }
 
     override fun storeSpan(span: Span): Context = set(SPAN_KEY, span)
@@ -45,8 +45,4 @@ internal class ContextImpl(
     override fun extractBaggage(): Baggage = get(BAGGAGE_KEY) ?: BaggageImpl.EMPTY
 
     override fun clearBaggage(): Context = set(BAGGAGE_KEY, null)
-
-    private object NoopScope : Scope {
-        override fun detach(): Boolean = true
-    }
 }

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/context/ScopeImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/context/ScopeImpl.kt
@@ -3,32 +3,51 @@ package io.opentelemetry.kotlin.context
 import io.opentelemetry.kotlin.platformLog
 import kotlin.concurrent.Volatile
 
-internal class ScopeImpl(
+internal class ScopeImpl private constructor(
     private val previousContext: Context,
     private val currentContext: Context,
     private val storage: ImplicitContextStorage,
 ) : Scope {
 
-    init {
-        if (previousContext == currentContext) {
-            error("Cannot create scope with two matching contexts")
-        }
-    }
-
     @Volatile
     private var detached = false
 
     override fun detach(): Boolean {
-        if (detached) {
-            platformLog("OpenTelemetry: Scope.detach() called on an already-detached scope")
-            return false
+        return if (detached) {
+            platformLog("Scope.detach() called on an already-detached scope")
+            false
+        } else if (storage.implicitContext() != currentContext) {
+            platformLog("Scope.detach() called out of order — context has already changed")
+            false
+        } else {
+            detached = true
+            storage.setImplicitContext(previousContext)
+            true
         }
-        if (storage.implicitContext() != currentContext) {
-            platformLog("OpenTelemetry: Scope.detach() called out of order — context has already changed")
-            return false
-        }
-        detached = true
-        storage.setImplicitContext(previousContext)
-        return true
     }
+
+    companion object {
+        fun create(
+            previousContext: Context,
+            currentContext: Context,
+            storage: ImplicitContextStorage,
+        ): Scope =
+            if (previousContext == currentContext) {
+                platformLog("Cannot create scope with two matching contexts")
+                DetachedScope
+            } else {
+                ScopeImpl(
+                    previousContext = previousContext,
+                    currentContext = currentContext,
+                    storage = storage
+                )
+            }
+    }
+}
+
+/**
+ * A [Scope] that is always detached
+ */
+internal object DetachedScope : Scope {
+    override fun detach(): Boolean = true
 }

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/PropagatorConfigImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/PropagatorConfigImpl.kt
@@ -7,12 +7,14 @@ import io.opentelemetry.kotlin.factory.SpanContextFactory
 import io.opentelemetry.kotlin.factory.SpanFactory
 import io.opentelemetry.kotlin.factory.TraceFlagsFactory
 import io.opentelemetry.kotlin.factory.TraceStateFactory
+import io.opentelemetry.kotlin.platformLog
 import io.opentelemetry.kotlin.propagation.CompositeTextMapPropagator
 import io.opentelemetry.kotlin.propagation.TextMapGetter
 import io.opentelemetry.kotlin.propagation.TextMapPropagator
 import io.opentelemetry.kotlin.propagation.TextMapSetter
 import io.opentelemetry.kotlin.propagation.W3CBaggagePropagator
 import io.opentelemetry.kotlin.propagation.W3CTraceContextPropagator
+import kotlin.concurrent.Volatile
 
 @OptIn(ExperimentalApi::class)
 internal class PropagatorConfigImpl : PropagatorConfigDsl {
@@ -57,17 +59,29 @@ internal class PropagatorConfigImpl : PropagatorConfigDsl {
 @OptIn(ExperimentalApi::class)
 private class DeferredW3CTraceContextPropagator : TextMapPropagator {
 
+    @Volatile
     var delegate: TextMapPropagator? = null
 
-    private val resolved: TextMapPropagator
-        get() = checkNotNull(delegate) { "W3C trace context propagator has not been initialized." }
+    private var noDelegateWarningLogged = false
 
-    override fun fields(): Collection<String> = resolved.fields()
+    override fun fields(): Collection<String> = resolveDelegate().fields()
 
-    override fun <T> inject(context: Context, carrier: T, setter: TextMapSetter<T>) {
-        resolved.inject(context, carrier, setter)
-    }
+    override fun <T> inject(context: Context, carrier: T, setter: TextMapSetter<T>) =
+        resolveDelegate().inject(context, carrier, setter)
 
     override fun <T> extract(context: Context, carrier: T, getter: TextMapGetter<T>): Context =
-        resolved.extract(context, carrier, getter)
+        resolveDelegate().extract(context, carrier, getter)
+
+    private fun resolveDelegate(): TextMapPropagator {
+        val resolvedDelegate = delegate
+        return if (resolvedDelegate != null) {
+            resolvedDelegate
+        } else {
+            if (!noDelegateWarningLogged) {
+                noDelegateWarningLogged = true
+                platformLog("W3C trace context propagator accessed before SDK init completed")
+            }
+            NoopOpenTelemetry.propagator
+        }
+    }
 }

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/propagation/TraceParent.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/propagation/TraceParent.kt
@@ -2,6 +2,7 @@ package io.opentelemetry.kotlin.propagation
 
 import io.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.kotlin.factory.TraceFlagsFactory
+import io.opentelemetry.kotlin.platformLog
 import io.opentelemetry.kotlin.tracing.TraceFlags
 
 /**
@@ -10,27 +11,12 @@ import io.opentelemetry.kotlin.tracing.TraceFlags
  * https://www.w3.org/TR/trace-context/#traceparent-header
  */
 @OptIn(ExperimentalApi::class)
-internal class TraceParent(
+internal class TraceParent private constructor(
     val version: String,
     val traceId: String,
     val spanId: String,
     val traceFlags: TraceFlags,
 ) {
-
-    init {
-        require(version.length == VERSION_LEN && version.isLowerHex()) {
-            "version must be $VERSION_LEN lowercase hex characters"
-        }
-        require(version != FORBIDDEN_VERSION) {
-            "version $FORBIDDEN_VERSION is reserved by the W3C spec"
-        }
-        require(traceId.length == TRACE_ID_LEN && traceId.isLowerHex()) {
-            "traceId must be $TRACE_ID_LEN lowercase hex characters"
-        }
-        require(spanId.length == SPAN_ID_LEN && spanId.isLowerHex()) {
-            "spanId must be $SPAN_ID_LEN lowercase hex characters"
-        }
-    }
 
     fun encode(): String = buildString {
         append(version)
@@ -57,6 +43,35 @@ internal class TraceParent(
         private const val FLAG_RANDOM = 0b0000_0010
         private const val HEX_RADIX = 16
 
+        /**
+         * Create a [TraceParent] if the given inputs are valid.
+         * Returns null if there is at least one invalid parameter.
+         */
+        fun create(
+            version: String,
+            traceId: String,
+            spanId: String,
+            traceFlags: TraceFlags,
+        ): TraceParent? {
+            val errorMessage =
+                if (version.length != VERSION_LEN || !version.isLowerHex() || version == FORBIDDEN_VERSION) {
+                    "version must be $VERSION_LEN lowercase hex characters and not $FORBIDDEN_VERSION"
+                } else if (traceId.length != TRACE_ID_LEN || !traceId.isLowerHex()) {
+                    "traceId must be $TRACE_ID_LEN lowercase hex characters"
+                } else if (spanId.length != SPAN_ID_LEN || !spanId.isLowerHex()) {
+                    "spanId must be $SPAN_ID_LEN lowercase hex characters"
+                } else {
+                    null
+                }
+
+            return if (errorMessage == null) {
+                TraceParent(version, traceId, spanId, traceFlags)
+            } else {
+                platformLog(errorMessage)
+                null
+            }
+        }
+
         fun decode(header: String, traceFlagsFactory: TraceFlagsFactory): TraceParent? {
             if (header.length < LEN_V00) {
                 return null
@@ -81,16 +96,12 @@ internal class TraceParent(
                 return null
             }
 
-            return try {
-                TraceParent(
-                    version = version,
-                    traceId = parts[1],
-                    spanId = parts[2],
-                    traceFlags = traceFlagsFactory.fromHex(flagsStr),
-                )
-            } catch (_: IllegalArgumentException) {
-                null
-            }
+            return create(
+                version = version,
+                traceId = parts[1],
+                spanId = parts[2],
+                traceFlags = traceFlagsFactory.fromHex(flagsStr),
+            )
         }
 
         private fun encodeFlags(flags: TraceFlags): String {

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/propagation/W3CTraceContextPropagator.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/propagation/W3CTraceContextPropagator.kt
@@ -27,13 +27,15 @@ internal class W3CTraceContextPropagator(
         if (!spanContext.isValid) {
             return
         }
-        val traceparent = TraceParent(
+
+        TraceParent.create(
             version = TraceParent.VERSION_00,
             traceId = spanContext.traceId,
             spanId = spanContext.spanId,
             traceFlags = spanContext.traceFlags,
-        ).encode()
-        setter.set(carrier, TRACEPARENT, traceparent)
+        )?.let {
+            setter.set(carrier, TRACEPARENT, it.encode())
+        }
 
         val tracestate = TraceStateMarshaller(spanContext.traceState).encode()
         if (tracestate.isNotEmpty()) {

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/context/ImplicitContextTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/context/ImplicitContextTest.kt
@@ -7,7 +7,6 @@ import io.opentelemetry.kotlin.factory.SpanContextFactoryImpl
 import io.opentelemetry.kotlin.factory.SpanFactoryImpl
 import kotlin.test.BeforeTest
 import kotlin.test.Test
-import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertSame
 import kotlin.test.assertTrue
@@ -22,14 +21,13 @@ internal class ImplicitContextTest {
     }
 
     @Test
-    fun testSameContexts() {
-        assertFailsWith(IllegalStateException::class) {
-            ScopeImpl(
-                factory.root(),
-                factory.root(),
-                DefaultImplicitContextStorage(factory::root)
-            )
-        }
+    fun testSameContextsScopeIsAlreadyDetached() {
+        val scope = ScopeImpl.create(
+            factory.root(),
+            factory.root(),
+            DefaultImplicitContextStorage(factory::root),
+        )
+        assertTrue(scope.detach())
     }
 
     @Test

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/factory/HexConversionsTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/factory/HexConversionsTest.kt
@@ -1,0 +1,54 @@
+package io.opentelemetry.kotlin.factory
+
+import io.opentelemetry.kotlin.ExperimentalApi
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalApi::class)
+internal class HexConversionsTest {
+
+    @Test
+    fun hexToByteArrayWorks() {
+        val expected = byteArrayOf(0x12, 0x04, 0x80.toByte(), 0xab.toByte(), 0xcd.toByte())
+        assertContentEquals(expected, "120480aBcD".hexToByteArray())
+    }
+
+    @Test
+    fun hexToByteArrayEmptyStringProducesEmptyByteArray() {
+        assertContentEquals(ByteArray(0), "".hexToByteArray())
+    }
+
+    @Test
+    fun hexToByteArrayOddLengthInputReturnsEmptyByteArray() {
+        assertContentEquals(ByteArray(0), "abc".hexToByteArray())
+    }
+
+    @Test
+    fun hexToByteArrayNonHexCharacterReturnsEmptyByteArray() {
+        assertContentEquals(ByteArray(0), "0g".hexToByteArray())
+    }
+
+    @Test
+    fun toHexStringWorks() {
+        assertEquals("120480abcd", byteArrayOf(0x12, 0x04, 0x80.toByte(), 0xab.toByte(), 0xcd.toByte()).toHexString())
+    }
+
+    @Test
+    fun toHexStringEmptyArrayProducesEmptyString() {
+        assertEquals("", ByteArray(0).toHexString())
+    }
+
+    @Test
+    fun toHexStringEmitsLowercaseHex() {
+        val hex = byteArrayOf(0xab.toByte(), 0xcd.toByte(), 0xef.toByte()).toHexString()
+        assertEquals("abcdef", hex)
+        assertEquals(hex, hex.lowercase())
+    }
+
+    @Test
+    fun toHexStringByteArrayDefaultValueProducesAllZeroString() {
+        val bytes = 8
+        assertEquals("0".repeat(bytes * 2), ByteArray(bytes).toHexString())
+    }
+}

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/init/PropagatorConfigImplTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/init/PropagatorConfigImplTest.kt
@@ -1,0 +1,65 @@
+package io.opentelemetry.kotlin.init
+
+import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.factory.ContextFactoryImpl
+import io.opentelemetry.kotlin.factory.IdGeneratorImpl
+import io.opentelemetry.kotlin.factory.SpanContextFactoryImpl
+import io.opentelemetry.kotlin.factory.SpanFactoryImpl
+import io.opentelemetry.kotlin.factory.TraceFlagsFactoryImpl
+import io.opentelemetry.kotlin.factory.TraceStateFactoryImpl
+import io.opentelemetry.kotlin.propagation.MapTextMapGetter
+import io.opentelemetry.kotlin.propagation.MapTextMapSetter
+import io.opentelemetry.kotlin.tracing.FakeSpanContext
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotSame
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalApi::class)
+internal class PropagatorConfigImplTest {
+
+    private val traceFlagsFactory = TraceFlagsFactoryImpl()
+    private val traceStateFactory = TraceStateFactoryImpl()
+    private val idGenerator = IdGeneratorImpl()
+    private val spanContextFactory = SpanContextFactoryImpl(idGenerator, traceFlagsFactory, traceStateFactory)
+    private val spanFactory = SpanFactoryImpl(spanContextFactory)
+    private val contextFactory = ContextFactoryImpl(spanFactory)
+    private val contextWithSpan = contextFactory.root().storeSpan(spanFactory.fromSpanContext(FakeSpanContext.VALID))
+
+    @Test
+    fun `w3cTraceContext does nothing if factories are not installed`() {
+        val propagator = PropagatorConfigImpl().apply { w3cTraceContext() }.buildPropagator()
+        assertEquals(emptyList(), propagator.fields().toList())
+
+        val carrier = mutableMapOf<String, String>()
+        propagator.inject(contextWithSpan, carrier, MapTextMapSetter)
+        assertTrue(carrier.isEmpty())
+
+        val result = propagator.extract(
+            context = contextFactory.root(),
+            carrier = mapOf("traceparent" to "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"),
+            getter = MapTextMapGetter
+        )
+        assertSame(contextFactory.root(), result)
+    }
+
+    @Test
+    fun `w3cTraceContext routes through delegate once factories are installed`() {
+        val config = PropagatorConfigImpl().apply { w3cTraceContext() }
+        config.installFactories(traceFlagsFactory, traceStateFactory, spanContextFactory, spanFactory)
+        val propagator = config.buildPropagator()
+        assertEquals(listOf("traceparent", "tracestate"), propagator.fields().toList())
+
+        val carrier = mutableMapOf<String, String>()
+        propagator.inject(contextWithSpan, carrier, MapTextMapSetter)
+        assertTrue(carrier.contains("traceparent"))
+
+        val result = propagator.extract(
+            context = contextFactory.root(),
+            carrier = mapOf("traceparent" to "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"),
+            getter = MapTextMapGetter
+        )
+        assertNotSame(contextFactory.root(), result)
+    }
+}

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/propagation/TraceParentTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/propagation/TraceParentTest.kt
@@ -5,7 +5,6 @@ import io.opentelemetry.kotlin.factory.TraceFlagsFactoryImpl
 import io.opentelemetry.kotlin.tracing.TraceFlagsImpl
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
@@ -22,70 +21,77 @@ internal class TraceParentTest {
     private val traceId = "0af7651916cd43dd8448eb211c80319c"
     private val spanId = "b7ad6b7169203331"
     private val canonicalHeader = "00-$traceId-$spanId-01"
+    private val traceFlags = TraceFlagsImpl(isSampled = true, isRandom = false)
 
     @Test
     fun `encode produces the canonical version 00 traceparent header`() {
-        val tp = TraceParent(
+        val tp = TraceParent.create(
             version = "00",
             traceId = traceId,
             spanId = spanId,
-            traceFlags = TraceFlagsImpl(isSampled = true, isRandom = false),
+            traceFlags = traceFlags,
         )
+        assertNotNull(tp)
         assertEquals(canonicalHeader, tp.encode())
     }
 
     @Test
     fun `encoded header is exactly 55 chars for version 00`() {
-        val tp = TraceParent(
+        val tp = TraceParent.create(
             version = "00",
             traceId = traceId,
             spanId = spanId,
-            traceFlags = TraceFlagsImpl(isSampled = true, isRandom = false),
+            traceFlags = traceFlags,
         )
+        assertNotNull(tp)
         assertEquals(55, tp.encode().length)
     }
 
     @Test
     fun `encode renders flags 00 when neither sampled nor random`() {
-        val tp = TraceParent(
+        val tp = TraceParent.create(
             version = "00",
             traceId = traceId,
             spanId = spanId,
             traceFlags = TraceFlagsImpl(isSampled = false, isRandom = false),
         )
+        assertNotNull(tp)
         assertEquals("00-$traceId-$spanId-00", tp.encode())
     }
 
     @Test
     fun `encode renders flags 02 when only random bit set`() {
-        val tp = TraceParent(
+        val tp = TraceParent.create(
             version = "00",
             traceId = traceId,
             spanId = spanId,
             traceFlags = TraceFlagsImpl(isSampled = false, isRandom = true),
         )
+        assertNotNull(tp)
         assertEquals("00-$traceId-$spanId-02", tp.encode())
     }
 
     @Test
     fun `encode renders flags 03 when sampled and random bits set`() {
-        val tp = TraceParent(
+        val tp = TraceParent.create(
             version = "00",
             traceId = traceId,
             spanId = spanId,
             traceFlags = TraceFlagsImpl(isSampled = true, isRandom = true),
         )
+        assertNotNull(tp)
         assertEquals("00-$traceId-$spanId-03", tp.encode())
     }
 
     @Test
     fun `encoded flags are always two lowercase hex characters`() {
-        val tp = TraceParent(
+        val tp = TraceParent.create(
             version = "00",
             traceId = traceId,
             spanId = spanId,
             traceFlags = TraceFlagsImpl(isSampled = false, isRandom = false),
         )
+        assertNotNull(tp)
         val flags = tp.encode().substringAfterLast('-')
         assertEquals(2, flags.length)
         assertTrue(flags.all { it in '0'..'9' || it in 'a'..'f' })
@@ -232,169 +238,49 @@ internal class TraceParentTest {
     }
 
     @Test
-    fun `constructor accepts canonical fields`() {
-        val tp = TraceParent(
+    fun `create returns a TraceParent for canonical inputs`() {
+        val tp = TraceParent.create(
             version = "00",
             traceId = traceId,
             spanId = spanId,
-            traceFlags = TraceFlagsImpl(isSampled = true, isRandom = false),
+            traceFlags = traceFlags,
         )
+        assertNotNull(tp)
         assertEquals(canonicalHeader, tp.encode())
     }
 
     @Test
-    fun `constructor rejects version of wrong length`() {
-        assertFailsWith<IllegalArgumentException> {
-            TraceParent(
-                version = "0",
-                traceId = traceId,
-                spanId = spanId,
-                traceFlags = TraceFlagsImpl(isSampled = true, isRandom = false),
-            )
-        }
+    fun `create returns null for version of wrong length`() {
+        assertNull(TraceParent.create("0", traceId, spanId, traceFlags))
     }
 
     @Test
-    fun `constructor rejects non-hex version`() {
-        assertFailsWith<IllegalArgumentException> {
-            TraceParent(
-                version = "0g",
-                traceId = traceId,
-                spanId = spanId,
-                traceFlags = TraceFlagsImpl(isSampled = true, isRandom = false),
-            )
-        }
+    fun `create returns null for non-hex version`() {
+        assertNull(TraceParent.create("pp", traceId, spanId, traceFlags))
     }
 
     @Test
-    fun `constructor rejects uppercase hex version`() {
-        assertFailsWith<IllegalArgumentException> {
-            TraceParent(
-                version = "0A",
-                traceId = traceId,
-                spanId = spanId,
-                traceFlags = TraceFlagsImpl(isSampled = true, isRandom = false),
-            )
-        }
+    fun `create returns null for forbidden version`() {
+        assertNull(TraceParent.create("ff", traceId, spanId, traceFlags))
     }
 
     @Test
-    fun `constructor rejects forbidden ff version`() {
-        assertFailsWith<IllegalArgumentException> {
-            TraceParent(
-                version = "ff",
-                traceId = traceId,
-                spanId = spanId,
-                traceFlags = TraceFlagsImpl(isSampled = true, isRandom = false),
-            )
-        }
+    fun `create returns null for trace id of wrong length`() {
+        assertNull(TraceParent.create("00", "1234", spanId, traceFlags))
     }
 
     @Test
-    fun `constructor rejects trace id of wrong length`() {
-        assertFailsWith<IllegalArgumentException> {
-            TraceParent(
-                version = "00",
-                traceId = "0".repeat(31),
-                spanId = spanId,
-                traceFlags = TraceFlagsImpl(isSampled = true, isRandom = false),
-            )
-        }
+    fun `create returns null for non-hex trace id`() {
+        assertNull(TraceParent.create("00", traceId.replaceFirst('a', 'g'), spanId, traceFlags))
     }
 
     @Test
-    fun `constructor rejects non-hex trace id`() {
-        assertFailsWith<IllegalArgumentException> {
-            TraceParent(
-                version = "00",
-                traceId = traceId.replaceFirst('a', 'g'),
-                spanId = spanId,
-                traceFlags = TraceFlagsImpl(isSampled = true, isRandom = false),
-            )
-        }
+    fun `create returns null for span id of wrong length`() {
+        assertNull(TraceParent.create("00", traceId, "1234", traceFlags))
     }
 
     @Test
-    fun `constructor rejects uppercase hex trace id`() {
-        assertFailsWith<IllegalArgumentException> {
-            TraceParent(
-                version = "00",
-                traceId = traceId.uppercase(),
-                spanId = spanId,
-                traceFlags = TraceFlagsImpl(isSampled = true, isRandom = false),
-            )
-        }
-    }
-
-    @Test
-    fun `constructor rejects span id of wrong length`() {
-        assertFailsWith<IllegalArgumentException> {
-            TraceParent(
-                version = "00",
-                traceId = traceId,
-                spanId = "0".repeat(15),
-                traceFlags = TraceFlagsImpl(isSampled = true, isRandom = false),
-            )
-        }
-    }
-
-    @Test
-    fun `constructor rejects non-hex span id`() {
-        assertFailsWith<IllegalArgumentException> {
-            TraceParent(
-                version = "00",
-                traceId = traceId,
-                spanId = spanId.replaceFirst('b', 'g'),
-                traceFlags = TraceFlagsImpl(isSampled = true, isRandom = false),
-            )
-        }
-    }
-
-    @Test
-    fun `constructor rejects uppercase hex span id`() {
-        assertFailsWith<IllegalArgumentException> {
-            TraceParent(
-                version = "00",
-                traceId = traceId,
-                spanId = spanId.uppercase(),
-                traceFlags = TraceFlagsImpl(isSampled = true, isRandom = false),
-            )
-        }
-    }
-
-    @Test
-    fun `constructor rejects empty version`() {
-        assertFailsWith<IllegalArgumentException> {
-            TraceParent(
-                version = "",
-                traceId = traceId,
-                spanId = spanId,
-                traceFlags = TraceFlagsImpl(isSampled = true, isRandom = false),
-            )
-        }
-    }
-
-    @Test
-    fun `constructor rejects empty trace id`() {
-        assertFailsWith<IllegalArgumentException> {
-            TraceParent(
-                version = "00",
-                traceId = "",
-                spanId = spanId,
-                traceFlags = TraceFlagsImpl(isSampled = true, isRandom = false),
-            )
-        }
-    }
-
-    @Test
-    fun `constructor rejects empty span id`() {
-        assertFailsWith<IllegalArgumentException> {
-            TraceParent(
-                version = "00",
-                traceId = traceId,
-                spanId = "",
-                traceFlags = TraceFlagsImpl(isSampled = true, isRandom = false),
-            )
-        }
+    fun `create returns null for non-hex span id`() {
+        assertNull(TraceParent.create("00", traceId, spanId.replaceFirst('b', 'g'), traceFlags))
     }
 }

--- a/sdk-api/src/commonMain/kotlin/io/opentelemetry/kotlin/factory/IdGenerator.kt
+++ b/sdk-api/src/commonMain/kotlin/io/opentelemetry/kotlin/factory/IdGenerator.kt
@@ -41,15 +41,17 @@ public fun ByteArray.toHexString(): String {
 
 /**
  * Encodes Span/Trace ID hex string as a ByteArray.
+ * A string that is not in the expected format return an empty [ByteArray]
  */
 @ExperimentalApi
-public fun String.hexToByteArray(): ByteArray {
-    require(length % 2 == 0)
-    val out = ByteArray(length / 2)
-    for (i in out.indices) {
-        val hi = this[i * 2].digitToInt(16)
-        val lo = this[i * 2 + 1].digitToInt(16)
-        out[i] = ((hi shl 4) or lo).toByte()
-    }
-    return out
-}
+public fun String.hexToByteArray(): ByteArray =
+    runCatching {
+        require(length % 2 == 0)
+        val out = ByteArray(length / 2)
+        for (i in out.indices) {
+            val hi = this[i * 2].digitToInt(16)
+            val lo = this[i * 2 + 1].digitToInt(16)
+            out[i] = ((hi shl 4) or lo).toByte()
+        }
+        out
+    }.getOrDefault(ByteArray(0))


### PR DESCRIPTION
Instead of throwing when invalid value are encountered, return no-op implementations. Use factory method when appropriate and make constructors private. Added some additional test coverage while I was at it.

Partially address #502