### PR TITLE
Add test that enforces minimum supported versions

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -28,13 +28,18 @@ jobs:
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: 'adopt'
-          java-version: 21
+          java-version: |
+            17
+            21
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
 
       - name: Gradle Build
         run: ./gradlew build :benchmark-android:assemble :benchmark-android:compileReleaseAndroidTestKotlin :benchmark-jvm:assemble :examples:example-app-android:assembleRelease koverXmlReport --stacktrace
+
+      - name: Gradle Integration Test
+        run: ./gradlew :gradle-integration-test:test --stacktrace
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0

--- a/gradle-integration-test/build.gradle.kts
+++ b/gradle-integration-test/build.gradle.kts
@@ -1,0 +1,56 @@
+plugins {
+    kotlin("jvm")
+}
+
+ext["io.opentelemetry.kotlin.enableCodeCoverage"] = false
+
+kotlin {
+    jvmToolchain(17)
+}
+
+dependencies {
+    testImplementation(gradleTestKit())
+    testImplementation(libs.junit.jupiter.api)
+    testRuntimeOnly(libs.junit.jupiter.engine)
+    testRuntimeOnly(libs.junit.platform.launcher)
+}
+
+val minSupportedGradle = libs.versions.minSupportedGradle.get()
+val snapshotVersion = "${project.version}-SNAPSHOT"
+val catalogFile = rootProject.layout.projectDirectory.file("gradle/libs.versions.toml").asFile
+
+val publishSnapshotToMavenLocal = tasks.register<Exec>("publishSnapshotToMavenLocal") {
+    workingDir = rootProject.projectDir
+    val wrapper = when {
+        System.getProperty("os.name").lowercase().contains("windows") -> "gradlew.bat"
+        else -> "gradlew"
+    }
+    commandLine(
+        rootProject.projectDir.resolve(wrapper).absolutePath,
+        "publishToMavenLocal",
+        "-Pversion=$snapshotVersion",
+        "--no-daemon",
+        "--quiet",
+    )
+}
+
+tasks.test {
+    useJUnitPlatform()
+    dependsOn(publishSnapshotToMavenLocal)
+    systemProperty("otelKotlinVersion", snapshotVersion)
+    systemProperty("minSupportedGradle", minSupportedGradle)
+    systemProperty("catalogPath", catalogFile.absolutePath)
+    systemProperty("fixtureSrcDir", layout.projectDirectory.dir("src/test/resources/fixtures").asFile.absolutePath)
+
+    // if version catalog changes, invalidate the build so that the test case reruns
+    inputs.dir(layout.projectDirectory.dir("src/test/resources/fixtures"))
+        .withPropertyName("fixtures")
+        .withPathSensitivity(PathSensitivity.RELATIVE)
+    inputs.file(catalogFile)
+        .withPropertyName("catalog")
+        .withPathSensitivity(PathSensitivity.NONE)
+    testLogging {
+        showStandardStreams = true
+        showStackTraces = false
+    }
+}

--- a/gradle-integration-test/src/test/kotlin/io/opentelemetry/kotlin/integration/gradle/MinSupportedVersionsTest.kt
+++ b/gradle-integration-test/src/test/kotlin/io/opentelemetry/kotlin/integration/gradle/MinSupportedVersionsTest.kt
@@ -1,0 +1,52 @@
+package io.opentelemetry.kotlin.integration.gradle
+
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardCopyOption
+
+class MinSupportedVersionsTest {
+
+    @Test
+    fun `min supported versions can consume artifacts`(@TempDir tmp: Path) {
+        val fixtureSrc = File(systemProperty("fixtureSrcDir"), "min-versions-android-app").toPath()
+        copyRecursively(fixtureSrc, tmp)
+
+        val runner = GradleRunner.create()
+            .withProjectDir(tmp.toFile())
+            .withGradleVersion(systemProperty("minSupportedGradle"))
+            .withArguments(
+                "-PcatalogPath=${systemProperty("catalogPath")}",
+                "-PotelKotlinVersion=${systemProperty("otelKotlinVersion")}",
+                "-Pandroid.useAndroidX=true",
+                "-Pandroid.nonTransitiveRClass=true",
+                "assemble",
+                "--info",
+                "--stacktrace",
+                "--no-configuration-cache",
+            )
+            .forwardOutput()
+        runner.build()
+    }
+
+    private fun systemProperty(name: String): String =
+        requireNotNull(System.getProperty(name)) { "system property '$name' was not set by the Gradle test task" }
+
+    private fun copyRecursively(source: Path, target: Path) {
+        Files.walk(source).use { stream ->
+            stream.forEach { path ->
+                val rel = source.relativize(path)
+                val dest = target.resolve(rel.toString())
+                if (Files.isDirectory(path)) {
+                    Files.createDirectories(dest)
+                } else {
+                    Files.createDirectories(dest.parent)
+                    Files.copy(path, dest, StandardCopyOption.REPLACE_EXISTING)
+                }
+            }
+        }
+    }
+}

--- a/gradle-integration-test/src/test/resources/fixtures/min-versions-android-app/build.gradle.kts
+++ b/gradle-integration-test/src/test/resources/fixtures/min-versions-android-app/build.gradle.kts
@@ -1,0 +1,53 @@
+import org.gradle.api.JavaVersion
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
+
+plugins {
+    alias(libs.plugins.test.kotlin.multiplatform)
+    alias(libs.plugins.test.android.library)
+}
+
+val otelKotlinVersion: String = providers.gradleProperty("otelKotlinVersion").get()
+val fixtureKotlinLang = KotlinVersion.fromVersion(libs.versions.minSupportedKotlinLang.get())
+
+android {
+    namespace = "io.opentelemetry.kotlin.minversion"
+    compileSdk = libs.versions.android.minCompileSdk.get().toInt()
+    defaultConfig {
+        minSdk = libs.versions.android.minSdk.get().toInt()
+    }
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
+    }
+}
+
+kotlin {
+    androidTarget {
+        compilerOptions {
+            jvmTarget.set(JvmTarget.JVM_11)
+        }
+    }
+    jvm {
+        compilerOptions {
+            jvmTarget.set(JvmTarget.JVM_11)
+        }
+    }
+
+    compilerOptions {
+        apiVersion.set(fixtureKotlinLang)
+        languageVersion.set(fixtureKotlinLang)
+    }
+
+    sourceSets {
+        val commonMain by getting {
+            dependencies {
+                implementation("io.opentelemetry.kotlin:api:$otelKotlinVersion")
+                implementation("io.opentelemetry.kotlin:sdk-api:$otelKotlinVersion")
+                implementation("io.opentelemetry.kotlin:core:$otelKotlinVersion")
+                implementation("io.opentelemetry.kotlin:implementation:$otelKotlinVersion")
+                implementation("io.opentelemetry.kotlin:exporters-core:$otelKotlinVersion")
+            }
+        }
+    }
+}

--- a/gradle-integration-test/src/test/resources/fixtures/min-versions-android-app/settings.gradle.kts
+++ b/gradle-integration-test/src/test/resources/fixtures/min-versions-android-app/settings.gradle.kts
@@ -1,0 +1,24 @@
+pluginManagement {
+    repositories {
+        mavenLocal()
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        mavenLocal()
+        google()
+        mavenCentral()
+    }
+    versionCatalogs {
+        create("libs") {
+            from(files(providers.gradleProperty("catalogPath").get()))
+        }
+    }
+}
+
+rootProject.name = "min-versions-android-app"

--- a/gradle-integration-test/src/test/resources/fixtures/min-versions-android-app/src/commonMain/kotlin/io/opentelemetry/kotlin/minversion/Consumer.kt
+++ b/gradle-integration-test/src/test/resources/fixtures/min-versions-android-app/src/commonMain/kotlin/io/opentelemetry/kotlin/minversion/Consumer.kt
@@ -1,0 +1,11 @@
+@file:OptIn(io.opentelemetry.kotlin.ExperimentalApi::class)
+
+package io.opentelemetry.kotlin.minversion
+
+import io.opentelemetry.kotlin.OpenTelemetry
+import io.opentelemetry.kotlin.OpenTelemetrySdk
+
+internal class Consumer {
+    val api: OpenTelemetry? = null
+    val sdk: OpenTelemetrySdk? = null
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,10 @@ kotlin = "2.3.21"
 android-minSdk = "21"
 android-compileSdk = "36"
 android-minCompileSdk = "34"
-android-minAgpVersion = "7.1.3"
+android-minAgpVersion = "8.0.0"
+minSupportedKotlinLang = "2.0"
+minSupportedKotlinPlugin = "2.0.0"
+minSupportedGradle = "8.0"
 detekt = "1.23.8"
 binaryCompatibilityValidator = "0.18.1"
 kotlinxBenchmarkRuntime = "0.4.17"
@@ -87,6 +90,8 @@ wire = { id = "com.squareup.wire", version.ref = "wire" }
 buildKonfig = { id = "com.codingfeline.buildkonfig", version.ref = "buildKonfig" }
 compose-multiplatform = { id = "org.jetbrains.compose", version.ref = "composeMultiplatform" }
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
+test-kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "minSupportedKotlinPlugin" }
+test-android-library = { id = "com.android.library", version.ref = "android-minAgpVersion" }
 
 [bundles]
 junit = ["junit-jupiter-api", "junit-jupiter-engine", "junit-vintage-engine"]

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -43,6 +43,7 @@ include(
     "examples:example-app",
     "examples:example-app-android",
     ":smoke-test",
+    ":gradle-integration-test",
 )
 
 includeFromDir("instrumentation")


### PR DESCRIPTION
## Goal

Adds a test fixture that is built using [Gradle TestKit](https://docs.gradle.org/current/userguide/test_kit.html) that compiles against our min supported versions. The test runs on CI and should therefore break compilation if a regression is introduced via transitive dependencies. I've tested this out by bumping the coroutines dependency to the latest and confirmed that the build failed.

Closes #515 
