### PR TITLE
Fix build for min version test

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -36,7 +36,10 @@ jobs:
         uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
 
       - name: Gradle Build
-        run: ./gradlew build :benchmark-android:assemble :benchmark-android:compileReleaseAndroidTestKotlin :benchmark-jvm:assemble :examples:example-app-android:assembleRelease koverXmlReport --stacktrace
+        run: ./gradlew build :benchmark-android:assemble :benchmark-android:compileReleaseAndroidTestKotlin :benchmark-jvm:assemble :examples:example-app-android:assembleRelease koverXmlReport -x :gradle-integration-test:test --stacktrace
+
+      - name: Publish snapshot to Maven local
+        run: ./gradlew publishToMavenLocal -PsnapshotPublish=true --stacktrace
 
       - name: Gradle Integration Test
         run: ./gradlew :gradle-integration-test:test --stacktrace

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,6 +22,12 @@ plugins.withType<YarnPlugin> {
 group = "io.opentelemetry.kotlin"
 version = project.version
 
+if (project.hasProperty("snapshotPublish")) {
+    allprojects {
+        version = "${version}-SNAPSHOT"
+    }
+}
+
 kover {
     merge {
         subprojects { project ->

--- a/gradle-integration-test/build.gradle.kts
+++ b/gradle-integration-test/build.gradle.kts
@@ -19,24 +19,12 @@ val minSupportedGradle = libs.versions.minSupportedGradle.get()
 val snapshotVersion = "${project.version}-SNAPSHOT"
 val catalogFile = rootProject.layout.projectDirectory.file("gradle/libs.versions.toml").asFile
 
-val publishSnapshotToMavenLocal = tasks.register<Exec>("publishSnapshotToMavenLocal") {
-    workingDir = rootProject.projectDir
-    val wrapper = when {
-        System.getProperty("os.name").lowercase().contains("windows") -> "gradlew.bat"
-        else -> "gradlew"
-    }
-    commandLine(
-        rootProject.projectDir.resolve(wrapper).absolutePath,
-        "publishToMavenLocal",
-        "-Pversion=$snapshotVersion",
-        "--no-daemon",
-        "--quiet",
-    )
-}
+// snapshot artifacts consumed by the test must already be installed in mavenLocal
+// In CI this is wired as two steps as running via Gradle's Exec from inside this build caused
+// Kotlin/Native klib writes to race against the outer build's `build/` directories.
 
 tasks.test {
     useJUnitPlatform()
-    dependsOn(publishSnapshotToMavenLocal)
     systemProperty("otelKotlinVersion", snapshotVersion)
     systemProperty("minSupportedGradle", minSupportedGradle)
     systemProperty("catalogPath", catalogFile.absolutePath)


### PR DESCRIPTION
## Goal

Attempts to fix the build on CI by separating out publishing a snapshot from running the min supported version test added in #521. Building within the same project caused [compilation errors](https://github.com/open-telemetry/opentelemetry-kotlin/actions/runs/26207693230/job/77111047421) around klibs/missing artifacts.
