### PR TITLE
Create initial interfaces for declarative config

### DIFF
--- a/api/api/jvm/api.api
+++ b/api/api/jvm/api.api
@@ -119,6 +119,24 @@ public abstract interface class io/opentelemetry/kotlin/baggage/BaggageEntryMeta
 	public abstract fun getValue ()Ljava/lang/String;
 }
 
+public abstract interface class io/opentelemetry/kotlin/config/ConfigProperties {
+	public abstract fun getBoolean (Ljava/lang/String;)Ljava/lang/Boolean;
+	public abstract fun getBooleanList (Ljava/lang/String;)Ljava/util/List;
+	public abstract fun getDouble (Ljava/lang/String;)Ljava/lang/Double;
+	public abstract fun getDoubleList (Ljava/lang/String;)Ljava/util/List;
+	public abstract fun getLong (Ljava/lang/String;)Ljava/lang/Long;
+	public abstract fun getLongList (Ljava/lang/String;)Ljava/util/List;
+	public abstract fun getPropertyKeys ()Ljava/util/Set;
+	public abstract fun getString (Ljava/lang/String;)Ljava/lang/String;
+	public abstract fun getStringList (Ljava/lang/String;)Ljava/util/List;
+	public abstract fun getStructured (Ljava/lang/String;)Lio/opentelemetry/kotlin/config/ConfigProperties;
+	public abstract fun getStructuredList (Ljava/lang/String;)Ljava/util/List;
+}
+
+public abstract interface class io/opentelemetry/kotlin/config/ConfigProvider {
+	public abstract fun getInstrumentationConfig ()Lio/opentelemetry/kotlin/config/ConfigProperties;
+}
+
 public abstract interface class io/opentelemetry/kotlin/context/Context {
 	public abstract fun attach ()Lio/opentelemetry/kotlin/context/Scope;
 	public abstract fun clearBaggage ()Lio/opentelemetry/kotlin/context/Context;

--- a/api/src/commonMain/kotlin/io/opentelemetry/kotlin/config/ConfigProperties.kt
+++ b/api/src/commonMain/kotlin/io/opentelemetry/kotlin/config/ConfigProperties.kt
@@ -1,0 +1,72 @@
+package io.opentelemetry.kotlin.config
+
+import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.ThreadSafe
+
+/**
+ * Represents a node in the declarative configuration tree.
+ *
+ * Accessors return `null` when the named property is absent or its value cannot be converted
+ * to the requested type.
+ *
+ * https://opentelemetry.io/docs/specs/otel/configuration/#declarative-configuration
+ */
+@ExperimentalApi
+@ThreadSafe
+public interface ConfigProperties {
+
+    /**
+     * Returns a string value for [name] or null if it doesn't exist.
+     */
+    public fun getString(name: String): String?
+
+    /**
+     * Returns a boolean value for [name] or null if it doesn't exist.
+     */
+    public fun getBoolean(name: String): Boolean?
+
+    /**
+     * Returns a long value for [name] or null if it doesn't exist.
+     */
+    public fun getLong(name: String): Long?
+
+    /**
+     * Returns a double value for [name] or null if it doesn't exist.
+     */
+    public fun getDouble(name: String): Double?
+
+    /**
+     * Returns a string list value for [name] or null if it doesn't exist.
+     */
+    public fun getStringList(name: String): List<String>?
+
+    /**
+     * Returns a boolean list value for [name] or null if it doesn't exist.
+     */
+    public fun getBooleanList(name: String): List<Boolean>?
+
+    /**
+     * Returns a long list value for [name] or null if it doesn't exist.
+     */
+    public fun getLongList(name: String): List<Long>?
+
+    /**
+     * Returns a double list value for [name] or null if it doesn't exist.
+     */
+    public fun getDoubleList(name: String): List<Double>?
+
+    /**
+     * Returns the child mapping node identified by [name], or `null` if absent.
+     */
+    public fun getStructured(name: String): ConfigProperties?
+
+    /**
+     * Returns the list of child mapping nodes identified by [name], or `null` if absent.
+     */
+    public fun getStructuredList(name: String): List<ConfigProperties>?
+
+    /**
+     * The names of all properties present in this mapping node.
+     */
+    public val propertyKeys: Set<String>
+}

--- a/api/src/commonMain/kotlin/io/opentelemetry/kotlin/config/ConfigProvider.kt
+++ b/api/src/commonMain/kotlin/io/opentelemetry/kotlin/config/ConfigProvider.kt
@@ -1,0 +1,20 @@
+package io.opentelemetry.kotlin.config
+
+import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.ThreadSafe
+
+/**
+ * Provides access to declarative configuration consumed at runtime by instrumentation libraries.
+ *
+ * https://opentelemetry.io/docs/specs/otel/configuration/#declarative-configuration
+ */
+@ExperimentalApi
+@ThreadSafe
+public interface ConfigProvider {
+
+    /**
+     * Returns the `instrumentation` section of the declarative configuration, or an empty
+     * [ConfigProperties] if none is set.
+     */
+    public val instrumentationConfig: ConfigProperties
+}

--- a/noop/src/commonMain/kotlin/io/opentelemetry/kotlin/config/NoopConfigProperties.kt
+++ b/noop/src/commonMain/kotlin/io/opentelemetry/kotlin/config/NoopConfigProperties.kt
@@ -1,0 +1,18 @@
+package io.opentelemetry.kotlin.config
+
+import io.opentelemetry.kotlin.ExperimentalApi
+
+@ExperimentalApi
+internal object NoopConfigProperties : ConfigProperties {
+    override fun getString(name: String): String? = null
+    override fun getBoolean(name: String): Boolean? = null
+    override fun getLong(name: String): Long? = null
+    override fun getDouble(name: String): Double? = null
+    override fun getStringList(name: String): List<String>? = null
+    override fun getBooleanList(name: String): List<Boolean>? = null
+    override fun getLongList(name: String): List<Long>? = null
+    override fun getDoubleList(name: String): List<Double>? = null
+    override fun getStructured(name: String): ConfigProperties? = null
+    override fun getStructuredList(name: String): List<ConfigProperties>? = null
+    override val propertyKeys: Set<String> = emptySet()
+}

--- a/noop/src/commonMain/kotlin/io/opentelemetry/kotlin/config/NoopConfigProvider.kt
+++ b/noop/src/commonMain/kotlin/io/opentelemetry/kotlin/config/NoopConfigProvider.kt
@@ -1,0 +1,8 @@
+package io.opentelemetry.kotlin.config
+
+import io.opentelemetry.kotlin.ExperimentalApi
+
+@ExperimentalApi
+internal object NoopConfigProvider : ConfigProvider {
+    override val instrumentationConfig: ConfigProperties = NoopConfigProperties
+}

--- a/noop/src/commonTest/kotlin/io/opentelemetry/kotlin/NoopTests.kt
+++ b/noop/src/commonTest/kotlin/io/opentelemetry/kotlin/NoopTests.kt
@@ -1,6 +1,8 @@
 package io.opentelemetry.kotlin
 
 import io.opentelemetry.kotlin.baggage.NoopBaggage
+import io.opentelemetry.kotlin.config.NoopConfigProperties
+import io.opentelemetry.kotlin.config.NoopConfigProvider
 import io.opentelemetry.kotlin.context.NoopContext
 import io.opentelemetry.kotlin.context.NoopContextKey
 import io.opentelemetry.kotlin.factory.NoopBaggageFactory
@@ -259,6 +261,23 @@ internal class NoopTests {
     fun testNoopOpenTelemetryBaggage() {
         assertSame(NoopBaggageFactory, NoopOpenTelemetry.baggage)
         assertSame(NoopBaggage, NoopOpenTelemetry.baggage.create { put("k", "v") })
+    }
+
+    @Test
+    fun testNoopConfigProvider() {
+        assertSame(NoopConfigProperties, NoopConfigProvider.instrumentationConfig)
+
+        assertNull(NoopConfigProperties.getString(""))
+        assertNull(NoopConfigProperties.getBoolean(""))
+        assertNull(NoopConfigProperties.getLong(""))
+        assertNull(NoopConfigProperties.getDouble(""))
+        assertNull(NoopConfigProperties.getStringList(""))
+        assertNull(NoopConfigProperties.getBooleanList(""))
+        assertNull(NoopConfigProperties.getLongList(""))
+        assertNull(NoopConfigProperties.getDoubleList(""))
+        assertNull(NoopConfigProperties.getStructured(""))
+        assertNull(NoopConfigProperties.getStructuredList(""))
+        assertSame(emptySet(), NoopConfigProperties.propertyKeys)
     }
 
     private fun verifySpanOperationsAreNoop(span: NoopSpan) {


### PR DESCRIPTION
## Goal

Creates the initial interfaces and no-op implementations for declarative config: https://opentelemetry.io/docs/specs/otel/configuration/api/#overview
