### PR TITLE
Implement MeterProvider and wire through OpenTelemetry entry points

### DIFF
--- a/api-ext/api/jvm/api-ext.api
+++ b/api-ext/api/jvm/api-ext.api
@@ -1,5 +1,6 @@
 public final class io/opentelemetry/kotlin/OpenTelemetryExtKt {
 	public static final fun getLogger (Lio/opentelemetry/kotlin/OpenTelemetry;Ljava/lang/String;)Lio/opentelemetry/kotlin/logging/Logger;
+	public static final fun getMeter (Lio/opentelemetry/kotlin/OpenTelemetry;Ljava/lang/String;)Lio/opentelemetry/kotlin/metrics/Meter;
 	public static final fun getTracer (Lio/opentelemetry/kotlin/OpenTelemetry;Ljava/lang/String;)Lio/opentelemetry/kotlin/tracing/Tracer;
 }
 

--- a/api-ext/src/commonMain/kotlin/io/opentelemetry/kotlin/OpenTelemetryExt.kt
+++ b/api-ext/src/commonMain/kotlin/io/opentelemetry/kotlin/OpenTelemetryExt.kt
@@ -1,6 +1,7 @@
 package io.opentelemetry.kotlin
 
 import io.opentelemetry.kotlin.logging.Logger
+import io.opentelemetry.kotlin.metrics.Meter
 import io.opentelemetry.kotlin.tracing.Tracer
 
 /**
@@ -21,4 +22,14 @@ public fun OpenTelemetry.getTracer(instrumentationScopeName: String): Tracer {
 @ThreadSafe
 public fun OpenTelemetry.getLogger(instrumentationScopeName: String): Logger {
     return loggerProvider.getLogger(name = instrumentationScopeName)
+}
+
+/**
+ * Returns a [Meter] for the given [instrumentationScopeName]. This is equivalent to calling
+ * [io.opentelemetry.kotlin.metrics.MeterProvider.getMeter].
+ */
+@ExperimentalApi
+@ThreadSafe
+public fun OpenTelemetry.getMeter(instrumentationScopeName: String): Meter {
+    return meterProvider.getMeter(name = instrumentationScopeName)
 }

--- a/api-ext/src/commonTest/kotlin/io/opentelemetry/kotlin/OpenTelemetryExtTest.kt
+++ b/api-ext/src/commonTest/kotlin/io/opentelemetry/kotlin/OpenTelemetryExtTest.kt
@@ -22,4 +22,13 @@ internal class OpenTelemetryExtTest {
         val observed = otel.getLogger(name)
         assertSame(expected, observed)
     }
+
+    @Test
+    fun testGetMeter() {
+        val otel = FakeOpenTelemetry()
+        val name = "my_meter"
+        val expected = otel.meterProvider.getMeter(name)
+        val observed = otel.getMeter(name)
+        assertSame(expected, observed)
+    }
 }

--- a/api/api/jvm/api.api
+++ b/api/api/jvm/api.api
@@ -5,6 +5,7 @@ public abstract interface class io/opentelemetry/kotlin/OpenTelemetry {
 	public abstract fun getBaggage ()Lio/opentelemetry/kotlin/factory/BaggageFactory;
 	public abstract fun getContext ()Lio/opentelemetry/kotlin/factory/ContextFactory;
 	public abstract fun getLoggerProvider ()Lio/opentelemetry/kotlin/logging/LoggerProvider;
+	public abstract fun getMeterProvider ()Lio/opentelemetry/kotlin/metrics/MeterProvider;
 	public abstract fun getPropagator ()Lio/opentelemetry/kotlin/propagation/TextMapPropagator;
 	public abstract fun getSpan ()Lio/opentelemetry/kotlin/factory/SpanFactory;
 	public abstract fun getSpanContext ()Lio/opentelemetry/kotlin/factory/SpanContextFactory;

--- a/api/src/commonMain/kotlin/io/opentelemetry/kotlin/OpenTelemetry.kt
+++ b/api/src/commonMain/kotlin/io/opentelemetry/kotlin/OpenTelemetry.kt
@@ -8,6 +8,8 @@ import io.opentelemetry.kotlin.factory.TraceFlagsFactory
 import io.opentelemetry.kotlin.factory.TraceStateFactory
 import io.opentelemetry.kotlin.logging.Logger
 import io.opentelemetry.kotlin.logging.LoggerProvider
+import io.opentelemetry.kotlin.metrics.Meter
+import io.opentelemetry.kotlin.metrics.MeterProvider
 import io.opentelemetry.kotlin.propagation.TextMapPropagator
 import io.opentelemetry.kotlin.tracing.Tracer
 import io.opentelemetry.kotlin.tracing.TracerProvider
@@ -30,6 +32,11 @@ public interface OpenTelemetry {
      * The [LoggerProvider] for creating [Logger] instances.
      */
     public val loggerProvider: LoggerProvider
+
+    /**
+     * The [MeterProvider] for creating [Meter] instances.
+     */
+    public val meterProvider: MeterProvider
 
     /**
      * Factory that constructs SpanContext objects.

--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/CompatOpenTelemetryImpl.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/CompatOpenTelemetryImpl.kt
@@ -9,12 +9,14 @@ import io.opentelemetry.kotlin.factory.SpanFactory
 import io.opentelemetry.kotlin.factory.TraceFlagsFactory
 import io.opentelemetry.kotlin.factory.TraceStateFactory
 import io.opentelemetry.kotlin.logging.LoggerProvider
+import io.opentelemetry.kotlin.metrics.MeterProvider
 import io.opentelemetry.kotlin.propagation.TextMapPropagator
 import io.opentelemetry.kotlin.tracing.TracerProvider
 
 internal class CompatOpenTelemetryImpl(
     override val tracerProvider: TracerProvider,
     override val loggerProvider: LoggerProvider,
+    override val meterProvider: MeterProvider,
     override val clock: Clock,
     override val spanContext: SpanContextFactory,
     override val traceFlags: TraceFlagsFactory,

--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/OpenTelemetryCompatEntrypoint.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/OpenTelemetryCompatEntrypoint.kt
@@ -51,6 +51,7 @@ internal fun createCompatOpenTelemetryImpl(
     return CompatOpenTelemetryImpl(
         tracerProvider = cfg.tracerProviderConfig.build(clock, base, cfg.globalAttributeLimits),
         loggerProvider = cfg.loggerProviderConfig.build(clock, base, cfg.globalAttributeLimits),
+        meterProvider = cfg.meterProviderConfig.build(clock, base),
         clock = clock,
         spanContext = spanContext,
         traceFlags = traceFlags,

--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/OpenTelemetryCompatExt.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/OpenTelemetryCompatExt.kt
@@ -2,6 +2,7 @@ package io.opentelemetry.kotlin
 
 import io.opentelemetry.kotlin.aliases.OtelJavaOpenTelemetry
 import io.opentelemetry.kotlin.logging.OtelJavaLoggerProviderAdapter
+import io.opentelemetry.kotlin.metrics.OtelJavaMeterProviderAdapter
 import io.opentelemetry.kotlin.tracing.OtelJavaTracerProviderAdapter
 
 /**
@@ -18,6 +19,7 @@ public fun OpenTelemetry.toOtelJavaApi(): OtelJavaOpenTelemetry {
     }
     return OtelJavaOpenTelemetrySdk(
         OtelJavaTracerProviderAdapter(tracerProvider),
-        OtelJavaLoggerProviderAdapter(loggerProvider)
+        OtelJavaLoggerProviderAdapter(loggerProvider),
+        OtelJavaMeterProviderAdapter(meterProvider),
     )
 }

--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/OtelJavaOpenTelemetryExt.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/OtelJavaOpenTelemetryExt.kt
@@ -13,6 +13,7 @@ import io.opentelemetry.kotlin.factory.CompatTraceFlagsFactory
 import io.opentelemetry.kotlin.factory.CompatTraceStateFactory
 import io.opentelemetry.kotlin.init.CompatSpanLimitsConfig
 import io.opentelemetry.kotlin.logging.LoggerProviderAdapter
+import io.opentelemetry.kotlin.metrics.MeterProviderAdapter
 import io.opentelemetry.kotlin.propagation.TextMapPropagatorAdapter
 import io.opentelemetry.kotlin.tracing.TracerProviderAdapter
 
@@ -38,6 +39,7 @@ public fun OtelJavaOpenTelemetry.toOtelKotlinApi(): OpenTelemetry {
     return CompatOpenTelemetryImpl(
         tracerProvider = TracerProviderAdapter(tracerProvider, clock, CompatSpanLimitsConfig()),
         loggerProvider = LoggerProviderAdapter(logsBridge),
+        meterProvider = MeterProviderAdapter(meterProvider),
         clock = clock,
         spanContext = spanContext,
         traceFlags = traceFlags,

--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/OtelJavaOpenTelemetrySdk.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/OtelJavaOpenTelemetrySdk.kt
@@ -2,15 +2,18 @@ package io.opentelemetry.kotlin
 
 import io.opentelemetry.kotlin.aliases.OtelJavaContextPropagators
 import io.opentelemetry.kotlin.aliases.OtelJavaLoggerProvider
+import io.opentelemetry.kotlin.aliases.OtelJavaMeterProvider
 import io.opentelemetry.kotlin.aliases.OtelJavaOpenTelemetry
 import io.opentelemetry.kotlin.aliases.OtelJavaTracerProvider
 
 internal class OtelJavaOpenTelemetrySdk(
     private val tracerProvider: OtelJavaTracerProvider,
     private val loggerProvider: OtelJavaLoggerProvider,
+    private val meterProvider: OtelJavaMeterProvider,
 ) : OtelJavaOpenTelemetry {
 
     override fun getTracerProvider(): OtelJavaTracerProvider = tracerProvider
     override fun getLogsBridge(): OtelJavaLoggerProvider = loggerProvider
+    override fun getMeterProvider(): OtelJavaMeterProvider = meterProvider
     override fun getPropagators(): OtelJavaContextPropagators = OtelJavaContextPropagators.noop()
 }

--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/init/CompatOpenTelemetryConfig.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/init/CompatOpenTelemetryConfig.kt
@@ -21,6 +21,7 @@ internal class CompatOpenTelemetryConfig(
 
     internal val tracerProviderConfig = CompatTracerProviderConfig(clock, idGenerator)
     internal val loggerProviderConfig = CompatLoggerProviderConfig(clock)
+    internal val meterProviderConfig = CompatMeterProviderConfig(clock)
     internal val globalAttributeLimits = CompatAttributeLimitsConfig()
     internal val propagatorCfg = CompatPropagatorConfigImpl()
 
@@ -61,6 +62,10 @@ internal class CompatOpenTelemetryConfig(
 
     override fun loggerProvider(action: LoggerProviderConfigDsl.() -> Unit) {
         loggerProviderConfig.action()
+    }
+
+    override fun meterProvider(action: MeterProviderConfigDsl.() -> Unit) {
+        meterProviderConfig.action()
     }
 
     override fun propagator(action: PropagatorConfigDsl.() -> TextMapPropagator) {

--- a/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/OpenTelemetrySdkTest.kt
+++ b/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/OpenTelemetrySdkTest.kt
@@ -53,4 +53,17 @@ internal class OpenTelemetrySdkTest {
         assertNotSame(b, c)
         assertNotSame(c, d)
     }
+
+    @Test
+    fun `retrieve meter provider`() {
+        val sdk = createCompatOpenTelemetry()
+        val provider = sdk.meterProvider
+        val a = provider.getMeter("test")
+        val b = provider.getMeter("test")
+        val c = provider.getMeter("test", "1.0.0")
+        val d = provider.getMeter("another")
+        assertSame(a, b)
+        assertNotSame(b, c)
+        assertNotSame(c, d)
+    }
 }

--- a/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/OtelJavaOpenTelemetrySdkTest.kt
+++ b/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/OtelJavaOpenTelemetrySdkTest.kt
@@ -3,6 +3,8 @@ package io.opentelemetry.kotlin
 import io.opentelemetry.kotlin.aliases.OtelJavaContextPropagators
 import io.opentelemetry.kotlin.logging.FakeLoggerProvider
 import io.opentelemetry.kotlin.logging.OtelJavaLoggerProviderAdapter
+import io.opentelemetry.kotlin.metrics.FakeMeterProvider
+import io.opentelemetry.kotlin.metrics.OtelJavaMeterProviderAdapter
 import io.opentelemetry.kotlin.tracing.FakeTracerProvider
 import io.opentelemetry.kotlin.tracing.OtelJavaTracerProviderAdapter
 import org.junit.Test
@@ -14,10 +16,12 @@ internal class OtelJavaOpenTelemetrySdkTest {
     fun `test entrypoint`() {
         val tracerProvider = OtelJavaTracerProviderAdapter(FakeTracerProvider())
         val loggerProvider = OtelJavaLoggerProviderAdapter(FakeLoggerProvider())
+        val meterProvider = OtelJavaMeterProviderAdapter(FakeMeterProvider())
 
-        val otel = OtelJavaOpenTelemetrySdk(tracerProvider, loggerProvider)
+        val otel = OtelJavaOpenTelemetrySdk(tracerProvider, loggerProvider, meterProvider)
         assertSame(tracerProvider, otel.tracerProvider)
         assertSame(loggerProvider, otel.logsBridge)
+        assertSame(meterProvider, otel.meterProvider)
         assertSame(otel.propagators, OtelJavaContextPropagators.noop())
     }
 }

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/OpenTelemetryImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/OpenTelemetryImpl.kt
@@ -14,6 +14,7 @@ import io.opentelemetry.kotlin.factory.SpanFactory
 import io.opentelemetry.kotlin.factory.TraceFlagsFactory
 import io.opentelemetry.kotlin.factory.TraceStateFactory
 import io.opentelemetry.kotlin.logging.LoggerProvider
+import io.opentelemetry.kotlin.metrics.MeterProvider
 import io.opentelemetry.kotlin.propagation.TextMapPropagator
 import io.opentelemetry.kotlin.tracing.TracerProvider
 import kotlinx.coroutines.withTimeout
@@ -21,6 +22,7 @@ import kotlinx.coroutines.withTimeout
 internal class OpenTelemetryImpl(
     override val tracerProvider: TracerProvider,
     override val loggerProvider: LoggerProvider,
+    override val meterProvider: MeterProvider,
     override val clock: Clock,
     override val spanContext: SpanContextFactory,
     override val traceFlags: TraceFlagsFactory,
@@ -45,7 +47,11 @@ internal class OpenTelemetryImpl(
             is TelemetryCloseable -> loggerProvider.forceFlush()
             else -> Success
         }
-        combineResults(tracerResult, loggerResult)
+        val meterResult = when (meterProvider) {
+            is TelemetryCloseable -> meterProvider.forceFlush()
+            else -> Success
+        }
+        combineResults(tracerResult, loggerResult, meterResult)
     }
 
     override suspend fun shutdown(): OperationResultCode =
@@ -59,7 +65,11 @@ internal class OpenTelemetryImpl(
                     is TelemetryCloseable -> loggerProvider.shutdown()
                     else -> Success
                 }
-                combineResults(tracerResult, loggerResult)
+                val meterResult = when (meterProvider) {
+                    is TelemetryCloseable -> meterProvider.shutdown()
+                    else -> Success
+                }
+                combineResults(tracerResult, loggerResult, meterResult)
             }
         }
 

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/OpenTelemetryImplEntrypoint.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/OpenTelemetryImplEntrypoint.kt
@@ -12,6 +12,7 @@ import io.opentelemetry.kotlin.factory.TraceStateFactoryImpl
 import io.opentelemetry.kotlin.init.OpenTelemetryConfigDsl
 import io.opentelemetry.kotlin.init.OpenTelemetryConfigImpl
 import io.opentelemetry.kotlin.logging.LoggerProviderImpl
+import io.opentelemetry.kotlin.metrics.MeterProviderImpl
 import io.opentelemetry.kotlin.tracing.TracerProviderImpl
 
 /**
@@ -60,6 +61,7 @@ internal fun createOpenTelemetryImpl(
 
     val tracingConfig = cfg.generateTracingConfig()
     val loggingConfig = cfg.generateLoggingConfig()
+    val metricsConfig = cfg.generateMetricsConfig()
     return OpenTelemetryImpl(
         tracerProvider = TracerProviderImpl(
             clock = clock,
@@ -75,6 +77,9 @@ internal fun createOpenTelemetryImpl(
             loggingConfig = loggingConfig,
             contextFactory = contextFactory,
             spanContextFactory = spanContext,
+        ),
+        meterProvider = MeterProviderImpl(
+            metricsConfig = metricsConfig,
         ),
         clock = clock,
         spanContext = spanContext,

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/OpenTelemetryConfigImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/OpenTelemetryConfigImpl.kt
@@ -10,6 +10,7 @@ internal class OpenTelemetryConfigImpl(
 
     internal val tracingConfig: TracerProviderConfigImpl = TracerProviderConfigImpl(clock)
     internal val loggingConfig: LoggerProviderConfigImpl = LoggerProviderConfigImpl(clock)
+    internal val metricsConfig: MeterProviderConfigImpl = MeterProviderConfigImpl()
     internal val contextConfig: ContextConfigImpl = ContextConfigImpl()
     internal val propagatorCfg: PropagatorConfigImpl = PropagatorConfigImpl()
     private val globalAttributeLimits = AttributeLimitsConfigImpl()
@@ -24,6 +25,10 @@ internal class OpenTelemetryConfigImpl(
 
     override fun loggerProvider(action: LoggerProviderConfigDsl.() -> Unit) {
         loggingConfig.action()
+    }
+
+    override fun meterProvider(action: MeterProviderConfigDsl.() -> Unit) {
+        metricsConfig.action()
     }
 
     override fun context(action: ContextConfigDsl.() -> Unit) {
@@ -41,4 +46,7 @@ internal class OpenTelemetryConfigImpl(
 
     internal fun generateLoggingConfig() =
         loggingConfig.generateLoggingConfig(defaultResource.merge(globalResourceConfig.generateResource()), globalAttributeLimits)
+
+    internal fun generateMetricsConfig() =
+        metricsConfig.generateMetricsConfig(defaultResource.merge(globalResourceConfig.generateResource()))
 }

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/MeterImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/MeterImpl.kt
@@ -1,0 +1,9 @@
+package io.opentelemetry.kotlin.metrics
+
+import io.opentelemetry.kotlin.InstrumentationScopeInfo
+import io.opentelemetry.kotlin.resource.Resource
+
+internal class MeterImpl(
+    val instrumentationScopeInfo: InstrumentationScopeInfo,
+    val resource: Resource,
+) : Meter

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/MeterProviderImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/MeterProviderImpl.kt
@@ -1,0 +1,47 @@
+package io.opentelemetry.kotlin.metrics
+
+import io.opentelemetry.kotlin.NoopOpenTelemetry
+import io.opentelemetry.kotlin.attributes.AttributesMutator
+import io.opentelemetry.kotlin.export.BatchTelemetryDefaults
+import io.opentelemetry.kotlin.export.CompositeTelemetryCloseable
+import io.opentelemetry.kotlin.export.MutableShutdownState
+import io.opentelemetry.kotlin.export.OperationResultCode
+import io.opentelemetry.kotlin.export.TelemetryCloseable
+import io.opentelemetry.kotlin.export.runWithTimeout
+import io.opentelemetry.kotlin.init.config.MetricsConfig
+import io.opentelemetry.kotlin.provider.ApiProviderImpl
+
+internal class MeterProviderImpl(
+    metricsConfig: MetricsConfig,
+) : MeterProvider, TelemetryCloseable {
+
+    private val shutdownState: MutableShutdownState = MutableShutdownState()
+    private val closeable: TelemetryCloseable = CompositeTelemetryCloseable(emptyList())
+    private val noopMeter = NoopOpenTelemetry.meterProvider.getMeter("")
+
+    private val apiProvider by lazy {
+        ApiProviderImpl<Meter> { key ->
+            MeterImpl(
+                instrumentationScopeInfo = key,
+                resource = metricsConfig.resource,
+            )
+        }
+    }
+
+    override fun getMeter(
+        name: String,
+        version: String?,
+        schemaUrl: String?,
+        attributes: (AttributesMutator.() -> Unit)?,
+    ): Meter =
+        shutdownState.ifActiveOrElse(noopMeter) {
+            val key = apiProvider.createInstrumentationScopeInfo(name, version, schemaUrl, attributes)
+            apiProvider.getOrCreate(key)
+        }
+
+    override suspend fun forceFlush(): OperationResultCode =
+        runWithTimeout(BatchTelemetryDefaults.FORCE_FLUSH_TIMEOUT_MS, closeable::forceFlush)
+
+    override suspend fun shutdown(): OperationResultCode =
+        shutdownState.shutdown(BatchTelemetryDefaults.SHUTDOWN_TIMEOUT_MS, closeable::shutdown)
+}

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/OpenTelemetryImplTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/OpenTelemetryImplTest.kt
@@ -16,6 +16,7 @@ import io.opentelemetry.kotlin.factory.FakeTraceFlagsFactory
 import io.opentelemetry.kotlin.factory.FakeTraceStateFactory
 import io.opentelemetry.kotlin.logging.FakeLoggerProvider
 import io.opentelemetry.kotlin.logging.LoggerProvider
+import io.opentelemetry.kotlin.metrics.FakeMeterProvider
 import io.opentelemetry.kotlin.tracing.FakeTracerProvider
 import io.opentelemetry.kotlin.tracing.TracerProvider
 import kotlinx.coroutines.delay
@@ -199,6 +200,7 @@ internal class OpenTelemetryImplTest {
     ): TelemetryCloseable = OpenTelemetryImpl(
         tracerProvider = tracerProvider,
         loggerProvider = loggerProvider,
+        meterProvider = FakeMeterProvider(),
         clock = FakeClock(),
         spanContext = FakeSpanContextFactory(),
         traceFlags = FakeTraceFlagsFactory(),

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/metrics/MeterProviderImplTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/metrics/MeterProviderImplTest.kt
@@ -1,0 +1,66 @@
+package io.opentelemetry.kotlin.metrics
+
+import io.opentelemetry.kotlin.NoopOpenTelemetry
+import io.opentelemetry.kotlin.attributes.AttributesModel
+import io.opentelemetry.kotlin.export.OperationResultCode
+import io.opentelemetry.kotlin.init.config.MetricsConfig
+import io.opentelemetry.kotlin.resource.ResourceImpl
+import kotlinx.coroutines.test.runTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertSame
+
+internal class MeterProviderImplTest {
+
+    private val metricsConfig = MetricsConfig(
+        resource = ResourceImpl(AttributesModel(), null),
+    )
+    private lateinit var impl: MeterProviderImpl
+
+    @BeforeTest
+    fun setup() {
+        impl = MeterProviderImpl(metricsConfig)
+    }
+
+    @Test
+    fun testMinimalMeterProvider() {
+        assertNotNull(impl.getMeter(name = ""))
+    }
+
+    @Test
+    fun testDupeMeterProviderName() {
+        val first = impl.getMeter(name = "name")
+        val second = impl.getMeter(name = "name")
+        val third = impl.getMeter(name = "other")
+        assertSame(first, second)
+        assertNotEquals(first, third)
+    }
+
+    @Test
+    fun testDupeMeterProviderVersion() {
+        val first = impl.getMeter(name = "name", version = "0.1.0")
+        val second = impl.getMeter(name = "name", version = "0.1.0")
+        val third = impl.getMeter(name = "name", version = "0.2.0")
+        assertSame(first, second)
+        assertNotEquals(first, third)
+    }
+
+    @Test
+    fun testForceFlushNoReaders() = runTest {
+        assertEquals(OperationResultCode.Success, impl.forceFlush())
+    }
+
+    @Test
+    fun testShutdownNoReaders() = runTest {
+        assertEquals(OperationResultCode.Success, impl.shutdown())
+    }
+
+    @Test
+    fun testGetMeterAfterShutdownReturnsNoopMeter() = runTest {
+        impl.shutdown()
+        assertSame(NoopOpenTelemetry.meterProvider.getMeter(""), impl.getMeter("test"))
+    }
+}

--- a/noop/src/commonMain/kotlin/io/opentelemetry/kotlin/NoopOpenTelemetryImpl.kt
+++ b/noop/src/commonMain/kotlin/io/opentelemetry/kotlin/NoopOpenTelemetryImpl.kt
@@ -18,6 +18,8 @@ import io.opentelemetry.kotlin.factory.TraceFlagsFactory
 import io.opentelemetry.kotlin.factory.TraceStateFactory
 import io.opentelemetry.kotlin.logging.LoggerProvider
 import io.opentelemetry.kotlin.logging.NoopLoggerProvider
+import io.opentelemetry.kotlin.metrics.MeterProvider
+import io.opentelemetry.kotlin.metrics.NoopMeterProvider
 import io.opentelemetry.kotlin.propagation.NoopTextMapPropagator
 import io.opentelemetry.kotlin.propagation.TextMapPropagator
 import io.opentelemetry.kotlin.tracing.NoopTracerProvider
@@ -27,6 +29,7 @@ import io.opentelemetry.kotlin.tracing.TracerProvider
 internal object NoopOpenTelemetryImpl : OpenTelemetrySdk {
     override val tracerProvider: TracerProvider = NoopTracerProvider
     override val loggerProvider: LoggerProvider = NoopLoggerProvider
+    override val meterProvider: MeterProvider = NoopMeterProvider
     override val clock: Clock = NoopClock
     override val spanContext: SpanContextFactory = NoopSpanContextFactory
     override val traceFlags: TraceFlagsFactory = NoopTraceFlagsFactory

--- a/sdk-api/api/jvm/sdk-api.api
+++ b/sdk-api/api/jvm/sdk-api.api
@@ -126,6 +126,7 @@ public abstract interface class io/opentelemetry/kotlin/init/OpenTelemetryConfig
 	public abstract fun attributeLimits (Lkotlin/jvm/functions/Function1;)V
 	public abstract fun context (Lkotlin/jvm/functions/Function1;)V
 	public abstract fun loggerProvider (Lkotlin/jvm/functions/Function1;)V
+	public abstract fun meterProvider (Lkotlin/jvm/functions/Function1;)V
 	public abstract fun propagator (Lkotlin/jvm/functions/Function1;)V
 	public abstract fun tracerProvider (Lkotlin/jvm/functions/Function1;)V
 }

--- a/sdk-api/src/commonMain/kotlin/io/opentelemetry/kotlin/init/OpenTelemetryConfigDsl.kt
+++ b/sdk-api/src/commonMain/kotlin/io/opentelemetry/kotlin/init/OpenTelemetryConfigDsl.kt
@@ -27,6 +27,11 @@ public interface OpenTelemetryConfigDsl : ResourceConfigDsl {
     public fun loggerProvider(action: LoggerProviderConfigDsl.() -> Unit)
 
     /**
+     * Defines configuration for the [io.opentelemetry.kotlin.metrics.MeterProvider].
+     */
+    public fun meterProvider(action: MeterProviderConfigDsl.() -> Unit)
+
+    /**
      * Defines configuration for how Context behaves.
      */
     public fun context(action: ContextConfigDsl.() -> Unit)

--- a/test-fakes/src/commonMain/kotlin/io/opentelemetry/kotlin/FakeOpenTelemetry.kt
+++ b/test-fakes/src/commonMain/kotlin/io/opentelemetry/kotlin/FakeOpenTelemetry.kt
@@ -19,6 +19,8 @@ import io.opentelemetry.kotlin.factory.TraceFlagsFactory
 import io.opentelemetry.kotlin.factory.TraceStateFactory
 import io.opentelemetry.kotlin.logging.FakeLoggerProvider
 import io.opentelemetry.kotlin.logging.LoggerProvider
+import io.opentelemetry.kotlin.metrics.FakeMeterProvider
+import io.opentelemetry.kotlin.metrics.MeterProvider
 import io.opentelemetry.kotlin.propagation.FakeTextMapPropagator
 import io.opentelemetry.kotlin.propagation.TextMapPropagator
 import io.opentelemetry.kotlin.tracing.FakeTracerProvider
@@ -27,6 +29,7 @@ import io.opentelemetry.kotlin.tracing.TracerProvider
 class FakeOpenTelemetry : OpenTelemetrySdk {
     override val tracerProvider: TracerProvider = FakeTracerProvider()
     override val loggerProvider: LoggerProvider = FakeLoggerProvider()
+    override val meterProvider: MeterProvider = FakeMeterProvider()
     override val clock: Clock = FakeClock()
     override val spanContext: SpanContextFactory = FakeSpanContextFactory()
     override val traceFlags: TraceFlagsFactory = FakeTraceFlagsFactory()

--- a/test-fakes/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/FakeMeter.kt
+++ b/test-fakes/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/FakeMeter.kt
@@ -1,0 +1,5 @@
+package io.opentelemetry.kotlin.metrics
+
+class FakeMeter(
+    val name: String
+) : Meter

--- a/test-fakes/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/FakeMeterProvider.kt
+++ b/test-fakes/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/FakeMeterProvider.kt
@@ -1,0 +1,17 @@
+package io.opentelemetry.kotlin.metrics
+
+import io.opentelemetry.kotlin.attributes.AttributesMutator
+
+class FakeMeterProvider : MeterProvider {
+
+    val map = mutableMapOf<String, FakeMeter>()
+
+    override fun getMeter(
+        name: String,
+        version: String?,
+        schemaUrl: String?,
+        attributes: (AttributesMutator.() -> Unit)?
+    ): Meter = map.getOrPut(name) {
+        FakeMeter(name)
+    }
+}


### PR DESCRIPTION
## Goal

Closes #376 by providing a minimal MeterProvider implementation and wiring it through the Otel entry points for kotlin-impl, compat, and noop.

Entry-point wiring, metric readers, views, and the aggregation pipeline are intentionally deferred to a subsequent PR.

## Testing

  - Added entry points and MeterProvider unit tests
  - Verified ./gradlew build, ./gradlew assembleAndroidTest, and ./gradlew apiDump
