### PR TITLE
fix: remove println from OTLP exporters

### DIFF
--- a/exporters-otlp/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/OtlpHttpLogRecordExporter.kt
+++ b/exporters-otlp/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/OtlpHttpLogRecordExporter.kt
@@ -13,9 +13,7 @@ internal class OtlpHttpLogRecordExporter(
 ) : LogRecordExporter {
 
     private val exporter = TelemetryExporter(initialDelayMs, maxAttemptIntervalMs, maxAttempts) {
-        otlpClient.exportLogs(it).also { response ->
-            println("OTLP exported log: $response")
-        }
+        otlpClient.exportLogs(it)
     }
 
     override suspend fun export(telemetry: List<ReadableLogRecord>): OperationResultCode {

--- a/exporters-otlp/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/OtlpHttpSpanExporter.kt
+++ b/exporters-otlp/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/OtlpHttpSpanExporter.kt
@@ -13,9 +13,7 @@ internal class OtlpHttpSpanExporter(
 ) : SpanExporter {
 
     private val exporter = TelemetryExporter(initialDelayMs, maxAttemptIntervalMs, maxAttempts) {
-        otlpClient.exportTraces(it).also { response ->
-            println("OTLP exported trace: $response")
-        }
+        otlpClient.exportTraces(it)
     }
 
     override suspend fun export(telemetry: List<SpanData>): OperationResultCode {


### PR DESCRIPTION
Remove debug println statements from OtlpHttpSpanExporter and OtlpHttpLogRecordExporter.

Fixes #556