### PR TITLE
fix: Remove service.version from default resource attributes

### DIFF
--- a/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/logging/LogExportTest.kt
+++ b/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/logging/LogExportTest.kt
@@ -70,7 +70,6 @@ internal class LogExportTest {
             schemaUrl = "https://example.com/some_schema.json"
             attributes = {
                 setStringAttribute("service.name", "test-service")
-                setStringAttribute("service.version", "1.0.0")
                 setStringAttribute("environment", "test")
             }
         }

--- a/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/logging/OtelJavaLogExportTest.kt
+++ b/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/logging/OtelJavaLogExportTest.kt
@@ -66,7 +66,6 @@ internal class OtelJavaLogExportTest {
             schemaUrl = "https://example.com/some_schema.json"
             attributes = {
                 setStringAttribute("service.name", "test-service")
-                setStringAttribute("service.version", "1.0.0")
                 setStringAttribute("environment", "test")
             }
         }

--- a/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/tracing/OtelJavaSpanExportTest.kt
+++ b/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/tracing/OtelJavaSpanExportTest.kt
@@ -287,7 +287,6 @@ internal class OtelJavaSpanExportTest {
             schemaUrl = "https://example.com/some_schema.json"
             attributes = {
                 setStringAttribute("service.name", "test-service")
-                setStringAttribute("service.version", "1.0.0")
                 setStringAttribute("environment", "test")
             }
         }

--- a/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/tracing/SpanExportTest.kt
+++ b/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/tracing/SpanExportTest.kt
@@ -346,7 +346,6 @@ internal class SpanExportTest {
             schemaUrl = "https://example.com/some_schema.json"
             attributes = {
                 setStringAttribute("service.name", "test-service")
-                setStringAttribute("service.version", "1.0.0")
                 setStringAttribute("environment", "test")
             }
         }

--- a/compat/src/jvmTest/resources/log_resource.json
+++ b/compat/src/jvmTest/resources/log_resource.json
@@ -4,8 +4,7 @@
       "schemaUrl": "https://example.com/some_schema.json",
       "attributes": {
         "environment": "test",
-        "service.name": "test-service",
-        "service.version": "UNKNOWN"
+        "service.name": "test-service"
       }
     },
     "instrumentationScopeInfo": {

--- a/compat/src/jvmTest/resources/span_resource.json
+++ b/compat/src/jvmTest/resources/span_resource.json
@@ -31,8 +31,7 @@
       "schemaUrl": "https://example.com/some_schema.json",
       "attributes": {
         "environment": "test",
-        "service.name": "test-service",
-        "service.version": "UNKNOWN"
+        "service.name": "test-service"
       }
     },
     "instrumentationScopeInfo": {

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/ResourceConfigImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/ResourceConfigImpl.kt
@@ -15,7 +15,6 @@ internal fun sdkDefaultResource(): Resource = ResourceImpl(
         attributeLimit = NO_ATTRIBUTE_LIMIT,
         attrs = mutableMapOf(
             ServiceAttributes.SERVICE_NAME to "unknown_service",
-            ServiceAttributes.SERVICE_VERSION to BuildKonfig.SDK_VERSION,
             TelemetryAttributes.TELEMETRY_SDK_NAME to "opentelemetry",
             TelemetryAttributes.TELEMETRY_SDK_LANGUAGE to "kotlin",
             TelemetryAttributes.TELEMETRY_SDK_VERSION to BuildKonfig.SDK_VERSION,

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/SdkDefaultAttributes.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/SdkDefaultAttributes.kt
@@ -7,7 +7,6 @@ import kotlin.test.assertTrue
 
 internal val sdkDefaultAttributes: Map<String, Any> = mapOf(
     ServiceAttributes.SERVICE_NAME to "unknown_service",
-    ServiceAttributes.SERVICE_VERSION to BuildKonfig.SDK_VERSION,
     TelemetryAttributes.TELEMETRY_SDK_NAME to "opentelemetry",
     TelemetryAttributes.TELEMETRY_SDK_LANGUAGE to "kotlin",
     TelemetryAttributes.TELEMETRY_SDK_VERSION to BuildKonfig.SDK_VERSION,
@@ -15,7 +14,6 @@ internal val sdkDefaultAttributes: Map<String, Any> = mapOf(
 
 internal fun assertHasSdkDefaultAttributes(attributes: Map<String, Any>) {
     assertEquals("unknown_service", attributes[ServiceAttributes.SERVICE_NAME])
-    assertTrue(attributes.containsKey(ServiceAttributes.SERVICE_VERSION))
     assertEquals("opentelemetry", attributes[TelemetryAttributes.TELEMETRY_SDK_NAME])
     assertEquals("kotlin", attributes[TelemetryAttributes.TELEMETRY_SDK_LANGUAGE])
     assertTrue(attributes.containsKey(TelemetryAttributes.TELEMETRY_SDK_VERSION))

--- a/implementation/src/commonTest/resources/event.json
+++ b/implementation/src/commonTest/resources/event.json
@@ -4,7 +4,6 @@
       "schemaUrl": "null",
       "attributes": {
         "service.name": "unknown_service",
-        "service.version": "UNKNOWN",
         "telemetry.sdk.name": "opentelemetry",
         "telemetry.sdk.language": "kotlin",
         "telemetry.sdk.version": "UNKNOWN"

--- a/implementation/src/commonTest/resources/log_attrs.json
+++ b/implementation/src/commonTest/resources/log_attrs.json
@@ -4,7 +4,6 @@
       "schemaUrl": "null",
       "attributes": {
         "service.name": "unknown_service",
-        "service.version": "UNKNOWN",
         "telemetry.sdk.name": "opentelemetry",
         "telemetry.sdk.language": "kotlin",
         "telemetry.sdk.version": "UNKNOWN"

--- a/implementation/src/commonTest/resources/log_basic_props.json
+++ b/implementation/src/commonTest/resources/log_basic_props.json
@@ -4,7 +4,6 @@
       "schemaUrl": "null",
       "attributes": {
         "service.name": "unknown_service",
-        "service.version": "UNKNOWN",
         "telemetry.sdk.name": "opentelemetry",
         "telemetry.sdk.language": "kotlin",
         "telemetry.sdk.version": "UNKNOWN"

--- a/implementation/src/commonTest/resources/log_emit_override.json
+++ b/implementation/src/commonTest/resources/log_emit_override.json
@@ -4,7 +4,6 @@
       "schemaUrl": "https://example.com/foo",
       "attributes": {
         "service.name": "unknown_service",
-        "service.version": "UNKNOWN",
         "telemetry.sdk.name": "opentelemetry",
         "telemetry.sdk.language": "kotlin",
         "telemetry.sdk.version": "UNKNOWN",

--- a/implementation/src/commonTest/resources/log_java_api.json
+++ b/implementation/src/commonTest/resources/log_java_api.json
@@ -4,7 +4,6 @@
       "schemaUrl": "null",
       "attributes": {
         "service.name": "unknown_service",
-        "service.version": "UNKNOWN",
         "telemetry.sdk.name": "opentelemetry",
         "telemetry.sdk.language": "kotlin",
         "telemetry.sdk.version": "UNKNOWN"

--- a/implementation/src/commonTest/resources/log_minimal.json
+++ b/implementation/src/commonTest/resources/log_minimal.json
@@ -4,7 +4,6 @@
       "schemaUrl": "null",
       "attributes": {
         "service.name": "unknown_service",
-        "service.version": "UNKNOWN",
         "telemetry.sdk.name": "opentelemetry",
         "telemetry.sdk.language": "kotlin",
         "telemetry.sdk.version": "UNKNOWN"

--- a/implementation/src/commonTest/resources/log_naughty_export.json
+++ b/implementation/src/commonTest/resources/log_naughty_export.json
@@ -4,7 +4,6 @@
       "schemaUrl": "https://example.com/foo",
       "attributes": {
         "service.name": "unknown_service",
-        "service.version": "UNKNOWN",
         "telemetry.sdk.name": "opentelemetry",
         "telemetry.sdk.language": "kotlin",
         "telemetry.sdk.version": "UNKNOWN",

--- a/implementation/src/commonTest/resources/log_resource_scope.json
+++ b/implementation/src/commonTest/resources/log_resource_scope.json
@@ -4,7 +4,6 @@
       "schemaUrl": "https://example.com/foo",
       "attributes": {
         "service.name": "unknown_service",
-        "service.version": "UNKNOWN",
         "telemetry.sdk.name": "opentelemetry",
         "telemetry.sdk.language": "kotlin",
         "telemetry.sdk.version": "UNKNOWN",

--- a/implementation/src/commonTest/resources/log_root_context.json
+++ b/implementation/src/commonTest/resources/log_root_context.json
@@ -4,7 +4,6 @@
       "schemaUrl": "null",
       "attributes": {
         "service.name": "unknown_service",
-        "service.version": "UNKNOWN",
         "telemetry.sdk.name": "opentelemetry",
         "telemetry.sdk.language": "kotlin",
         "telemetry.sdk.version": "UNKNOWN"

--- a/implementation/src/commonTest/resources/log_span_context.json
+++ b/implementation/src/commonTest/resources/log_span_context.json
@@ -4,7 +4,6 @@
       "schemaUrl": "null",
       "attributes": {
         "service.name": "unknown_service",
-        "service.version": "UNKNOWN",
         "telemetry.sdk.name": "opentelemetry",
         "telemetry.sdk.language": "kotlin",
         "telemetry.sdk.version": "UNKNOWN"

--- a/implementation/src/commonTest/resources/span_ancestry.json
+++ b/implementation/src/commonTest/resources/span_ancestry.json
@@ -31,7 +31,6 @@
       "schemaUrl": "null",
       "attributes": {
         "service.name": "unknown_service",
-        "service.version": "UNKNOWN",
         "telemetry.sdk.name": "opentelemetry",
         "telemetry.sdk.language": "kotlin",
         "telemetry.sdk.version": "UNKNOWN"
@@ -76,7 +75,6 @@
       "schemaUrl": "null",
       "attributes": {
         "service.name": "unknown_service",
-        "service.version": "UNKNOWN",
         "telemetry.sdk.name": "opentelemetry",
         "telemetry.sdk.language": "kotlin",
         "telemetry.sdk.version": "UNKNOWN"

--- a/implementation/src/commonTest/resources/span_attempted_override.json
+++ b/implementation/src/commonTest/resources/span_attempted_override.json
@@ -53,7 +53,6 @@
       "schemaUrl": "null",
       "attributes": {
         "service.name": "unknown_service",
-        "service.version": "UNKNOWN",
         "telemetry.sdk.name": "opentelemetry",
         "telemetry.sdk.language": "kotlin",
         "telemetry.sdk.version": "UNKNOWN"

--- a/implementation/src/commonTest/resources/span_attrs.json
+++ b/implementation/src/commonTest/resources/span_attrs.json
@@ -34,7 +34,6 @@
       "schemaUrl": "null",
       "attributes": {
         "service.name": "unknown_service",
-        "service.version": "UNKNOWN",
         "telemetry.sdk.name": "opentelemetry",
         "telemetry.sdk.language": "kotlin",
         "telemetry.sdk.version": "UNKNOWN"

--- a/implementation/src/commonTest/resources/span_basic_props.json
+++ b/implementation/src/commonTest/resources/span_basic_props.json
@@ -31,7 +31,6 @@
       "schemaUrl": "null",
       "attributes": {
         "service.name": "unknown_service",
-        "service.version": "UNKNOWN",
         "telemetry.sdk.name": "opentelemetry",
         "telemetry.sdk.language": "kotlin",
         "telemetry.sdk.version": "UNKNOWN"

--- a/implementation/src/commonTest/resources/span_complex_java_api.json
+++ b/implementation/src/commonTest/resources/span_complex_java_api.json
@@ -31,7 +31,6 @@
       "schemaUrl": "null",
       "attributes": {
         "service.name": "unknown_service",
-        "service.version": "UNKNOWN",
         "telemetry.sdk.name": "opentelemetry",
         "telemetry.sdk.language": "kotlin",
         "telemetry.sdk.version": "UNKNOWN"
@@ -76,7 +75,6 @@
       "schemaUrl": "null",
       "attributes": {
         "service.name": "unknown_service",
-        "service.version": "UNKNOWN",
         "telemetry.sdk.name": "opentelemetry",
         "telemetry.sdk.language": "kotlin",
         "telemetry.sdk.version": "UNKNOWN"
@@ -148,7 +146,6 @@
       "schemaUrl": "null",
       "attributes": {
         "service.name": "unknown_service",
-        "service.version": "UNKNOWN",
         "telemetry.sdk.name": "opentelemetry",
         "telemetry.sdk.language": "kotlin",
         "telemetry.sdk.version": "UNKNOWN"

--- a/implementation/src/commonTest/resources/span_event.json
+++ b/implementation/src/commonTest/resources/span_event.json
@@ -40,7 +40,6 @@
       "schemaUrl": "null",
       "attributes": {
         "service.name": "unknown_service",
-        "service.version": "UNKNOWN",
         "telemetry.sdk.name": "opentelemetry",
         "telemetry.sdk.language": "kotlin",
         "telemetry.sdk.version": "UNKNOWN"

--- a/implementation/src/commonTest/resources/span_java_api.json
+++ b/implementation/src/commonTest/resources/span_java_api.json
@@ -40,7 +40,6 @@
       "schemaUrl": "null",
       "attributes": {
         "service.name": "unknown_service",
-        "service.version": "UNKNOWN",
         "telemetry.sdk.name": "opentelemetry",
         "telemetry.sdk.language": "kotlin",
         "telemetry.sdk.version": "UNKNOWN"

--- a/implementation/src/commonTest/resources/span_links.json
+++ b/implementation/src/commonTest/resources/span_links.json
@@ -31,7 +31,6 @@
       "schemaUrl": "null",
       "attributes": {
         "service.name": "unknown_service",
-        "service.version": "UNKNOWN",
         "telemetry.sdk.name": "opentelemetry",
         "telemetry.sdk.language": "kotlin",
         "telemetry.sdk.version": "UNKNOWN"
@@ -89,7 +88,6 @@
       "schemaUrl": "null",
       "attributes": {
         "service.name": "unknown_service",
-        "service.version": "UNKNOWN",
         "telemetry.sdk.name": "opentelemetry",
         "telemetry.sdk.language": "kotlin",
         "telemetry.sdk.version": "UNKNOWN"

--- a/implementation/src/commonTest/resources/span_minimal.json
+++ b/implementation/src/commonTest/resources/span_minimal.json
@@ -33,7 +33,6 @@
       "schemaUrl": "null",
       "attributes": {
         "service.name": "unknown_service",
-        "service.version": "UNKNOWN",
         "telemetry.sdk.name": "opentelemetry",
         "telemetry.sdk.language": "kotlin",
         "telemetry.sdk.version": "UNKNOWN"

--- a/implementation/src/commonTest/resources/span_override_on_ending.json
+++ b/implementation/src/commonTest/resources/span_override_on_ending.json
@@ -78,7 +78,6 @@
       "schemaUrl": "null",
       "attributes": {
         "service.name": "unknown_service",
-        "service.version": "UNKNOWN",
         "telemetry.sdk.name": "opentelemetry",
         "telemetry.sdk.language": "kotlin",
         "telemetry.sdk.version": "UNKNOWN"

--- a/implementation/src/commonTest/resources/span_override_on_start.json
+++ b/implementation/src/commonTest/resources/span_override_on_start.json
@@ -70,7 +70,6 @@
       "schemaUrl": "null",
       "attributes": {
         "service.name": "unknown_service",
-        "service.version": "UNKNOWN",
         "telemetry.sdk.name": "opentelemetry",
         "telemetry.sdk.language": "kotlin",
         "telemetry.sdk.version": "UNKNOWN"

--- a/implementation/src/commonTest/resources/span_read_on_end.json
+++ b/implementation/src/commonTest/resources/span_read_on_end.json
@@ -55,7 +55,6 @@
       "schemaUrl": "null",
       "attributes": {
         "service.name": "unknown_service",
-        "service.version": "UNKNOWN",
         "telemetry.sdk.name": "opentelemetry",
         "telemetry.sdk.language": "kotlin",
         "telemetry.sdk.version": "UNKNOWN"

--- a/integration-test/src/commonMain/kotlin/io/opentelemetry/kotlin/framework/serialization/conversion/SerializableResource.kt
+++ b/integration-test/src/commonMain/kotlin/io/opentelemetry/kotlin/framework/serialization/conversion/SerializableResource.kt
@@ -2,7 +2,6 @@ package io.opentelemetry.kotlin.framework.serialization.conversion
 
 import io.opentelemetry.kotlin.framework.serialization.SerializableResource
 import io.opentelemetry.kotlin.resource.Resource
-import io.opentelemetry.kotlin.semconv.ServiceAttributes
 import io.opentelemetry.kotlin.semconv.TelemetryAttributes
 
 fun Resource.toSerializable() =
@@ -10,7 +9,6 @@ fun Resource.toSerializable() =
         schemaUrl = schemaUrl.toString(),
         attributes = attributes.mapValues {
             when (it.key) {
-                ServiceAttributes.SERVICE_VERSION -> "UNKNOWN"
                 TelemetryAttributes.TELEMETRY_SDK_VERSION -> "UNKNOWN"
                 else -> it.value
             }


### PR DESCRIPTION
Remove service.version from the SDK default resource attributes since it's not mandated by the spec and conflicts with telemetry.sdk.version.

Fixes #554