### PR TITLE
fix: Skip HTTP request in OTLP exporters when telemetry list is empty

### DIFF
--- a/exporters-otlp/src/commonMain/kotlin/io/opentelemetry/kotlin/export/TelemetryExporter.kt
+++ b/exporters-otlp/src/commonMain/kotlin/io/opentelemetry/kotlin/export/TelemetryExporter.kt
@@ -25,8 +25,10 @@ internal class TelemetryExporter<T>(
      */
     fun export(telemetry: List<T>): OperationResultCode =
         shutdownState.ifActive {
-            scope.launch {
-                exportTelemetry(telemetry)
+            if (telemetry.isNotEmpty()) {
+                scope.launch {
+                    exportTelemetry(telemetry)
+                }
             }
             Success
         }

--- a/exporters-otlp/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/export/OtlpHttpLogRecordExporterTest.kt
+++ b/exporters-otlp/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/export/OtlpHttpLogRecordExporterTest.kt
@@ -96,6 +96,13 @@ internal class OtlpHttpLogRecordExporterTest {
     }
 
     @Test
+    fun testExportNoOpOnEmpty() = runTest {
+        val code = exporter.export(emptyList())
+        assertEquals(OperationResultCode.Success, code)
+        assertTrue(server.requestHistory.isEmpty())
+    }
+
+    @Test
     fun testCustomHttpClientIsUsed() = runTest {
         val customServer = MockEngine {
             respond(content = ByteReadChannel(""), status = HttpStatusCode.OK)

--- a/exporters-otlp/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/export/OtlpHttpSpanExporterTest.kt
+++ b/exporters-otlp/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/export/OtlpHttpSpanExporterTest.kt
@@ -96,6 +96,13 @@ internal class OtlpHttpSpanExporterTest {
     }
 
     @Test
+    fun testExportNoOpOnEmpty() = runTest {
+        val code = exporter.export(emptyList())
+        assertEquals(OperationResultCode.Success, code)
+        assertTrue(server.requestHistory.isEmpty())
+    }
+
+    @Test
     fun testCustomHttpClientIsUsed() = runTest {
         val customServer = MockEngine {
             respond(content = ByteReadChannel(""), status = HttpStatusCode.OK)


### PR DESCRIPTION
Skip HTTP request in OTLP exporters when telemetry list is empty.

Fixes #555