### PR TITLE
fix: log warning for invalid instrumentation scope name

### DIFF
--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/LoggerProviderImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/LoggerProviderImpl.kt
@@ -12,6 +12,7 @@ import io.opentelemetry.kotlin.export.runWithTimeout
 import io.opentelemetry.kotlin.factory.ContextFactory
 import io.opentelemetry.kotlin.factory.SpanContextFactory
 import io.opentelemetry.kotlin.init.config.LoggingConfig
+import io.opentelemetry.kotlin.platformLog
 import io.opentelemetry.kotlin.provider.ApiProviderImpl
 
 internal class LoggerProviderImpl(
@@ -49,6 +50,9 @@ internal class LoggerProviderImpl(
         attributes: (AttributesMutator.() -> Unit)?
     ): Logger =
         shutdownState.ifActiveOrElse(noopLogger) {
+            if (name.isEmpty()) {
+                platformLog("Logger requested without instrumentation scope name")
+            }
             val key = apiProvider.createInstrumentationScopeInfo(name, version, schemaUrl, attributes)
             apiProvider.getOrCreate(key)
         }

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/MeterProviderImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/MeterProviderImpl.kt
@@ -9,6 +9,7 @@ import io.opentelemetry.kotlin.export.OperationResultCode
 import io.opentelemetry.kotlin.export.TelemetryCloseable
 import io.opentelemetry.kotlin.export.runWithTimeout
 import io.opentelemetry.kotlin.init.config.MetricsConfig
+import io.opentelemetry.kotlin.platformLog
 import io.opentelemetry.kotlin.provider.ApiProviderImpl
 
 internal class MeterProviderImpl(
@@ -35,6 +36,9 @@ internal class MeterProviderImpl(
         attributes: (AttributesMutator.() -> Unit)?,
     ): Meter =
         shutdownState.ifActiveOrElse(noopMeter) {
+            if (name.isEmpty()) {
+                platformLog("Meter requested without instrumentation scope name")
+            }
             val key = apiProvider.createInstrumentationScopeInfo(name, version, schemaUrl, attributes)
             apiProvider.getOrCreate(key)
         }

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/TracerProviderImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/TracerProviderImpl.kt
@@ -15,6 +15,7 @@ import io.opentelemetry.kotlin.factory.SpanContextFactory
 import io.opentelemetry.kotlin.factory.SpanFactory
 import io.opentelemetry.kotlin.factory.TraceFlagsFactory
 import io.opentelemetry.kotlin.init.config.TracingConfig
+import io.opentelemetry.kotlin.platformLog
 import io.opentelemetry.kotlin.provider.ApiProviderImpl
 
 internal class TracerProviderImpl(
@@ -58,6 +59,9 @@ internal class TracerProviderImpl(
         attributes: (AttributesMutator.() -> Unit)?
     ): Tracer =
         shutdownState.ifActiveOrElse(noopTracer) {
+            if (name.isEmpty()) {
+                platformLog("Tracer requested without instrumentation scope name")
+            }
             val key = apiProvider.createInstrumentationScopeInfo(
                 name = name,
                 version = version,


### PR DESCRIPTION
Log a warning when Tracer, Logger, or Meter is obtained with an empty name.

Fixes #543