### PR TITLE
fix: Use TraceService response model for OTLP trace response

### DIFF
--- a/exporters-protobuf/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/ExportTracesResponseDeserializer.kt
+++ b/exporters-protobuf/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/ExportTracesResponseDeserializer.kt
@@ -1,6 +1,6 @@
 package io.opentelemetry.kotlin.tracing.export
 
-import io.opentelemetry.proto.collector.logs.v1.ExportLogsServiceResponse
+import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceResponse
 
 fun ByteArray.deserializeTraceRecordErrorMessage() =
-    ExportLogsServiceResponse.ADAPTER.decode(this).partial_success?.error_message
+    ExportTraceServiceResponse.ADAPTER.decode(this).partial_success?.error_message


### PR DESCRIPTION
Use the correct ExportTraceServiceResponse model in ExportTracesResponseDeserializer instead of　ExportLogsServiceResponse.

Fixes #557