### PR TITLE
fix: Retry OTLP HTTP requests on retryable status codes

### DIFF
--- a/exporters-otlp/src/commonMain/kotlin/io/opentelemetry/kotlin/export/OtlpClient.kt
+++ b/exporters-otlp/src/commonMain/kotlin/io/opentelemetry/kotlin/export/OtlpClient.kt
@@ -14,6 +14,7 @@ import io.ktor.http.contentType
 import io.ktor.utils.io.readRemaining
 import io.opentelemetry.kotlin.export.OtlpClient.Companion.MAX_ERROR_BODY_BYTES
 import io.opentelemetry.kotlin.export.OtlpResponse.ClientError
+import io.opentelemetry.kotlin.export.OtlpResponse.RetryableError
 import io.opentelemetry.kotlin.export.OtlpResponse.ServerError
 import io.opentelemetry.kotlin.export.OtlpResponse.Success
 import io.opentelemetry.kotlin.export.OtlpResponse.Unknown
@@ -60,6 +61,11 @@ internal class OtlpClient(
             }
             when (val code = response.status.value) {
                 200 -> Success
+                429, 502, 503, 504 -> RetryableError(
+                    code,
+                    response.parseRetryAfterMs(),
+                    onError(response.boundedBodyBytes()),
+                )
                 in 400..499 -> ClientError(code, onError(response.boundedBodyBytes()))
                 in 500..599 -> ServerError(code, onError(response.boundedBodyBytes()))
                 else -> Unknown
@@ -74,6 +80,14 @@ internal class OtlpClient(
      */
     private suspend fun HttpResponse.boundedBodyBytes(): ByteArray =
         bodyAsChannel().readRemaining(MAX_ERROR_BODY_BYTES).readByteArray()
+
+    /**
+     * Parses the Retry-After header (in seconds) as milliseconds.
+     */
+    private fun HttpResponse.parseRetryAfterMs(): Long? {
+        val header = headers[HttpHeaders.RetryAfter] ?: return null
+        return header.toLongOrNull()?.takeIf { it >= 0 }?.let { it * 1000L }
+    }
 
     private companion object {
         const val MAX_ERROR_BODY_BYTES: Long = 4 * 1024 * 1024

--- a/exporters-otlp/src/commonMain/kotlin/io/opentelemetry/kotlin/export/OtlpResponse.kt
+++ b/exporters-otlp/src/commonMain/kotlin/io/opentelemetry/kotlin/export/OtlpResponse.kt
@@ -20,6 +20,16 @@ internal sealed class OtlpResponse(val statusCode: Int) {
         }
     }
 
+    class RetryableError(
+        statusCode: Int,
+        val retryAfterMs: Long?,
+        val errorMessage: String?,
+    ) : OtlpResponse(statusCode) {
+        override fun toString(): String {
+            return "RetryableError(errorMessage=$errorMessage, retryAfterMs=$retryAfterMs, statusCode=$statusCode)"
+        }
+    }
+
     object Unknown : OtlpResponse(-1) {
         override fun toString(): String {
             return "Unknown(statusCode=$statusCode)"

--- a/exporters-otlp/src/commonMain/kotlin/io/opentelemetry/kotlin/export/TelemetryExporter.kt
+++ b/exporters-otlp/src/commonMain/kotlin/io/opentelemetry/kotlin/export/TelemetryExporter.kt
@@ -34,13 +34,18 @@ internal class TelemetryExporter<T>(
     private suspend fun exportTelemetry(telemetry: List<T>) {
         var delayMs = initialDelayMs
         repeat(maxAttempts) {
-            when (exportAction(telemetry)) {
+            when (val response = exportAction(telemetry)) {
                 is OtlpResponse.Success -> {
                     return
                 }
 
                 is OtlpResponse.ClientError -> {
                     return
+                }
+
+                is OtlpResponse.RetryableError -> {
+                    delay(response.retryAfterMs ?: delayMs)
+                    delayMs = (delayMs * 2).coerceAtMost(maxAttemptIntervalMs)
                 }
 
                 is OtlpResponse.ServerError, is OtlpResponse.Unknown -> {

--- a/exporters-otlp/src/commonTest/kotlin/io/opentelemetry/kotlin/export/OtlpClientTest.kt
+++ b/exporters-otlp/src/commonTest/kotlin/io/opentelemetry/kotlin/export/OtlpClientTest.kt
@@ -4,8 +4,11 @@ import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
 import io.ktor.client.engine.mock.toByteReadPacket
 import io.ktor.client.plugins.HttpTimeoutConfig.Companion.INFINITE_TIMEOUT_MS
+import io.ktor.http.Headers
+import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpMethod
 import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
 import io.ktor.util.toMap
 import io.ktor.utils.io.ByteReadChannel
 import io.opentelemetry.kotlin.logging.export.toProtobufByteArray
@@ -21,6 +24,8 @@ import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNull
 
 internal class OtlpClientTest {
 
@@ -33,6 +38,7 @@ internal class OtlpClientTest {
     private lateinit var client: OtlpClient
     private lateinit var server: MockEngine
     private lateinit var mockResponseStatus: HttpStatusCode
+    private var mockResponseHeaders: Headers = Headers.Empty
     private var serverDelayMs: Long = 0
 
     @BeforeTest
@@ -43,7 +49,8 @@ internal class OtlpClientTest {
             }
             respond(
                 content = ByteReadChannel(""),
-                status = mockResponseStatus
+                status = mockResponseStatus,
+                headers = mockResponseHeaders,
             )
         }
         val httpClient = createDefaultHttpClient(INFINITE_TIMEOUT_MS, server)
@@ -170,6 +177,42 @@ internal class OtlpClientTest {
         val headers = request.headers.toMap().mapValues { it.value.joinToString() }
         val userAgent = headers["User-Agent"]
         assertEquals(expectedUserAgent, userAgent)
+    }
+
+    @Test
+    fun testExportLogRetryableError() = runTest {
+        mockResponseStatus = HttpStatusCode.TooManyRequests
+        val response = client.exportLogs(logRecords)
+        assertIs<OtlpResponse.RetryableError>(response)
+        assertEquals(429, response.statusCode)
+        assertNull(response.retryAfterMs)
+    }
+
+    @Test
+    fun testExportTraceRetryableError() = runTest {
+        mockResponseStatus = HttpStatusCode.TooManyRequests
+        val response = client.exportTraces(spans)
+        assertIs<OtlpResponse.RetryableError>(response)
+        assertEquals(429, response.statusCode)
+        assertNull(response.retryAfterMs)
+    }
+
+    @Test
+    fun testExportLogRetryableErrorHonoursRetryAfter() = runTest {
+        mockResponseStatus = HttpStatusCode.TooManyRequests
+        mockResponseHeaders = headersOf(HttpHeaders.RetryAfter, "5")
+        val response = client.exportLogs(logRecords)
+        assertIs<OtlpResponse.RetryableError>(response)
+        assertEquals(5000L, response.retryAfterMs)
+    }
+
+    @Test
+    fun testExportTraceRetryableErrorHonoursRetryAfter() = runTest {
+        mockResponseStatus = HttpStatusCode.ServiceUnavailable
+        mockResponseHeaders = headersOf(HttpHeaders.RetryAfter, "12")
+        val response = client.exportTraces(spans)
+        assertIs<OtlpResponse.RetryableError>(response)
+        assertEquals(12_000L, response.retryAfterMs)
     }
 
     private suspend fun sendAndAssertLogRequest(

--- a/exporters-otlp/src/commonTest/kotlin/io/opentelemetry/kotlin/export/OtlpResponseTest.kt
+++ b/exporters-otlp/src/commonTest/kotlin/io/opentelemetry/kotlin/export/OtlpResponseTest.kt
@@ -28,6 +28,18 @@ internal class OtlpResponseTest {
     }
 
     @Test
+    fun testRetryableError() {
+        val retryable = OtlpResponse.RetryableError(429, 1500L, "slow down")
+        assertEquals(429, retryable.statusCode)
+        assertEquals(1500L, retryable.retryAfterMs)
+        assertEquals("slow down", retryable.errorMessage)
+        assertEquals(
+            "RetryableError(errorMessage=slow down, retryAfterMs=1500, statusCode=429)",
+            retryable.toString()
+        )
+    }
+
+    @Test
     fun testUnknownCode() {
         assertEquals(-1, OtlpResponse.Unknown.statusCode)
     }


### PR DESCRIPTION
Retry OTLP HTTP requests on retryable status codes (429, 502, 503, 504) and honour the Retry-After header.

Fixes #559