### PR TITLE
fix: scheduledDelayMillis 1000 to 5000

### DIFF
--- a/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/export/BatchTelemetryDefaults.kt
+++ b/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/export/BatchTelemetryDefaults.kt
@@ -16,7 +16,7 @@ public object BatchTelemetryDefaults {
     /**
      * Delay in ms before a flush is triggered
      */
-    public const val SCHEDULE_DELAY_MS: Long = 1000
+    public const val SCHEDULE_DELAY_MS: Long = 5000
 
     /**
      * Timeout in ms for exporting telemetry


### PR DESCRIPTION
## Goal

<!-- Describe what this change seeks to address -->

Modify scheduledDelayMillis to conform to the OTel specification.

https://opentelemetry.io/docs/specs/otel/trace/sdk/#batching-processor:~:text=scheduledDelayMillis%20%2D%20the%20maximum%20delay%20interval%20in%20milliseconds%20between%20two%20consecutive%20exports.%20The%20default%20value%20is%205000.

- https://github.com/open-telemetry/opentelemetry-kotlin/issues/548

## Testing

<!-- Describe how this change has been tested -->

No testing was required.
