### PR TITLE
fix: TraceFlags.isRandom as true

### DIFF
--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/factory/TraceFlagsFactoryImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/factory/TraceFlagsFactoryImpl.kt
@@ -6,7 +6,7 @@ import io.opentelemetry.kotlin.tracing.TraceFlagsImpl
 
 @ExperimentalApi
 internal class TraceFlagsFactoryImpl : TraceFlagsFactory {
-    override val default: TraceFlags by lazy { TraceFlagsImpl(isSampled = true, isRandom = false) }
+    override val default: TraceFlags by lazy { TraceFlagsImpl(isSampled = true, isRandom = true) }
 
     override fun fromHex(hex: String): TraceFlags {
         if (!hex.isValid()) {

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/TracerImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/TracerImpl.kt
@@ -108,7 +108,7 @@ internal class TracerImpl(
             spanIdBytes = spanIdBytes,
             traceFlags = when {
                 sampled -> traceFlagsDefault
-                else -> TraceFlagsImpl(isSampled = false, isRandom = false)
+                else -> TraceFlagsImpl(isSampled = false, isRandom = true)
             },
             isValid = true,
             isRemote = false,

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/TracerSamplerTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/TracerSamplerTest.kt
@@ -99,6 +99,7 @@ internal class TracerSamplerTest {
         val span = tracer.startSpan("test")
         assertTrue(span.isRecording())
         assertFalse(span.spanContext.traceFlags.isSampled)
+        assertTrue(span.spanContext.traceFlags.isRandom)
     }
 
     @Test

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/TracerSpanContextTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/TracerSpanContextTest.kt
@@ -123,6 +123,6 @@ internal class TracerSpanContextTest {
         assertNotEquals(idGenerator.invalidTraceId.toHexString(), spanContext.traceId)
         assertNotEquals(idGenerator.invalidSpanId.toHexString(), spanContext.spanId)
         assertEquals(emptyMap(), spanContext.traceState.asMap())
-        assertEquals("01", spanContext.traceFlags.hex)
+        assertEquals("03", spanContext.traceFlags.hex)
     }
 }


### PR DESCRIPTION
## Goal

<!-- Describe what this change seeks to address -->

To conform to the random trace flag OpenTelemetry Specification.
This is because the traceIdBytes is generated from `kotlin.random.Random`.

https://github.com/open-telemetry/opentelemetry-kotlin/issues/552

## Testing

<!-- Describe how this change has been tested -->

I updated `TracerSpanContextTest.kt` as the spanContext.traceFlags.hex expects "03".
I followed the W3C trace flags specification https://www.w3.org/TR/trace-context-2/#trace-flags .

- "00" → not Sampled & not Random
- "01" → Sampled & not Random
- "02" → not Sampled & Random
- "03" → Sampled & Random
