### PR TITLE
fix: TraceFlags.isRandom as true

### DIFF
--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/tracing/ext/TraceFlagsExt.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/tracing/ext/TraceFlagsExt.kt
@@ -4,18 +4,11 @@ import io.opentelemetry.kotlin.aliases.OtelJavaTraceFlags
 import io.opentelemetry.kotlin.tracing.TraceFlags
 
 internal fun TraceFlags.toOtelJavaTraceFlags(): OtelJavaTraceFlags {
-    val sb = StringBuilder()
-    sb.append(
-        when {
-            isRandom -> "1"
-            else -> "0"
-        }
-    )
-    sb.append(
-        when {
-            isSampled -> "1"
-            else -> "0"
-        }
-    )
-    return OtelJavaTraceFlags.fromHex(sb.toString(), 0)
+    val traceFlagsHex = when {
+        isRandom && isSampled -> "03"
+        isRandom && !isSampled -> "02"
+        !isRandom && isSampled -> "01"
+        else -> "00"
+    }
+    return OtelJavaTraceFlags.fromHex(traceFlagsHex, 0)
 }

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/factory/TraceFlagsFactoryImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/factory/TraceFlagsFactoryImpl.kt
@@ -6,7 +6,7 @@ import io.opentelemetry.kotlin.tracing.TraceFlagsImpl
 
 @ExperimentalApi
 internal class TraceFlagsFactoryImpl : TraceFlagsFactory {
-    override val default: TraceFlags by lazy { TraceFlagsImpl(isSampled = true, isRandom = false) }
+    override val default: TraceFlags by lazy { TraceFlagsImpl(isSampled = true, isRandom = true) }
 
     override fun fromHex(hex: String): TraceFlags {
         if (!hex.isValid()) {

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/TracerImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/TracerImpl.kt
@@ -118,7 +118,7 @@ internal class TracerImpl(
             spanIdBytes = spanIdBytes,
             traceFlags = when {
                 sampled -> traceFlagsDefault
-                else -> TraceFlagsImpl(isSampled = false, isRandom = false)
+                else -> TraceFlagsImpl(isSampled = false, isRandom = true)
             },
             isValid = true,
             isRemote = false,

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/factory/TraceFlagsFactoryImplTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/factory/TraceFlagsFactoryImplTest.kt
@@ -13,7 +13,7 @@ internal class TraceFlagsFactoryImplTest {
         val flags = factory.default
 
         assertTrue(flags.isSampled)
-        assertFalse(flags.isRandom)
+        assertTrue(flags.isRandom)
     }
 
     @Test

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/integration/test/logging/LogProcessorOnEmitTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/integration/test/logging/LogProcessorOnEmitTest.kt
@@ -82,7 +82,7 @@ internal class LogProcessorOnEmitTest {
             assertEquals("bar", resource.attributes["resource.foo"])
             assertEquals("2cc2b48c50aefe53b3974ed91e6b4ea9", spanContext.traceId)
             assertEquals("e77bcc2f537f0b02", spanContext.spanId)
-            assertEquals("01", spanContext.traceFlags.hex)
+            assertEquals("03", spanContext.traceFlags.hex)
             assertEquals(emptyMap(), spanContext.traceState.asMap())
             assertTrue(spanContext.isValid)
         }

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/TracerSpanContextTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/TracerSpanContextTest.kt
@@ -123,6 +123,6 @@ internal class TracerSpanContextTest {
         assertNotEquals(idGenerator.invalidTraceId.toHexString(), spanContext.traceId)
         assertNotEquals(idGenerator.invalidSpanId.toHexString(), spanContext.spanId)
         assertEquals(emptyMap(), spanContext.traceState.asMap())
-        assertEquals("01", spanContext.traceFlags.hex)
+        assertEquals("03", spanContext.traceFlags.hex)
     }
 }

--- a/implementation/src/commonTest/resources/event.json
+++ b/implementation/src/commonTest/resources/event.json
@@ -20,7 +20,7 @@
     "spanContext": {
       "traceId": "00000000000000000000000000000000",
       "spanId": "0000000000000000",
-      "traceFlags": "01",
+      "traceFlags": "03",
       "traceState": {}
     },
     "severity": "WARN4",

--- a/implementation/src/commonTest/resources/log_attrs.json
+++ b/implementation/src/commonTest/resources/log_attrs.json
@@ -20,7 +20,7 @@
     "spanContext": {
       "traceId": "00000000000000000000000000000000",
       "spanId": "0000000000000000",
-      "traceFlags": "01",
+      "traceFlags": "03",
       "traceState": {}
     },
     "severity": "UNKNOWN",

--- a/implementation/src/commonTest/resources/log_basic_props.json
+++ b/implementation/src/commonTest/resources/log_basic_props.json
@@ -20,7 +20,7 @@
     "spanContext": {
       "traceId": "00000000000000000000000000000000",
       "spanId": "0000000000000000",
-      "traceFlags": "01",
+      "traceFlags": "03",
       "traceState": {}
     },
     "severity": "WARN2",

--- a/implementation/src/commonTest/resources/log_emit_override.json
+++ b/implementation/src/commonTest/resources/log_emit_override.json
@@ -22,9 +22,7 @@
       "traceId": "12345678901234567890123456789012",
       "spanId": "1234567890123456",
       "traceFlags": "01",
-      "traceState": {
-        "foo": "bar"
-      }
+      "traceState": { "foo": "bar" }
     },
     "severity": "INFO",
     "severityText": "info",

--- a/implementation/src/commonTest/resources/log_java_api.json
+++ b/implementation/src/commonTest/resources/log_java_api.json
@@ -20,7 +20,7 @@
     "spanContext": {
       "traceId": "00000000000000000000000000000000",
       "spanId": "0000000000000000",
-      "traceFlags": "01",
+      "traceFlags": "03",
       "traceState": {}
     },
     "severity": "DEBUG2",

--- a/implementation/src/commonTest/resources/log_minimal.json
+++ b/implementation/src/commonTest/resources/log_minimal.json
@@ -20,7 +20,7 @@
     "spanContext": {
       "traceId": "00000000000000000000000000000000",
       "spanId": "0000000000000000",
-      "traceFlags": "01",
+      "traceFlags": "03",
       "traceState": {}
     },
     "severity": "UNKNOWN",

--- a/implementation/src/commonTest/resources/log_naughty_export.json
+++ b/implementation/src/commonTest/resources/log_naughty_export.json
@@ -21,7 +21,7 @@
     "spanContext": {
       "traceId": "2cc2b48c50aefe53b3974ed91e6b4ea9",
       "spanId": "e77bcc2f537f0b02",
-      "traceFlags": "01",
+      "traceFlags": "03",
       "traceState": {}
     },
     "severity": "WARN2",

--- a/implementation/src/commonTest/resources/log_resource_scope.json
+++ b/implementation/src/commonTest/resources/log_resource_scope.json
@@ -23,7 +23,7 @@
     "spanContext": {
       "traceId": "00000000000000000000000000000000",
       "spanId": "0000000000000000",
-      "traceFlags": "01",
+      "traceFlags": "03",
       "traceState": {}
     },
     "severity": "UNKNOWN",

--- a/implementation/src/commonTest/resources/log_root_context.json
+++ b/implementation/src/commonTest/resources/log_root_context.json
@@ -20,7 +20,7 @@
     "spanContext": {
       "traceId": "00000000000000000000000000000000",
       "spanId": "0000000000000000",
-      "traceFlags": "01",
+      "traceFlags": "03",
       "traceState": {}
     },
     "severity": "UNKNOWN",

--- a/implementation/src/commonTest/resources/log_span_context.json
+++ b/implementation/src/commonTest/resources/log_span_context.json
@@ -20,7 +20,7 @@
     "spanContext": {
       "traceId": "2cc2b48c50aefe53b3974ed91e6b4ea9",
       "spanId": "e77bcc2f537f0b02",
-      "traceFlags": "01",
+      "traceFlags": "03",
       "traceState": {}
     },
     "severity": "UNKNOWN",

--- a/implementation/src/commonTest/resources/span_ancestry.json
+++ b/implementation/src/commonTest/resources/span_ancestry.json
@@ -9,13 +9,13 @@
     "spanContext": {
       "traceId": "2cc2b48c50aefe53b3974ed91e6b4ea9",
       "spanId": "e77bcc2f537f0b02",
-      "traceFlags": "01",
+      "traceFlags": "03",
       "traceState": {}
     },
     "parentSpanContext": {
       "traceId": "00000000000000000000000000000000",
       "spanId": "0000000000000000",
-      "traceFlags": "01",
+      "traceFlags": "03",
       "traceState": {}
     },
     "startTimestamp": 0,
@@ -53,13 +53,13 @@
     "spanContext": {
       "traceId": "2cc2b48c50aefe53b3974ed91e6b4ea9",
       "spanId": "ac2c315346a8f5dc",
-      "traceFlags": "01",
+      "traceFlags": "03",
       "traceState": {}
     },
     "parentSpanContext": {
       "traceId": "2cc2b48c50aefe53b3974ed91e6b4ea9",
       "spanId": "e77bcc2f537f0b02",
-      "traceFlags": "01",
+      "traceFlags": "03",
       "traceState": {}
     },
     "startTimestamp": 0,

--- a/implementation/src/commonTest/resources/span_attempted_override.json
+++ b/implementation/src/commonTest/resources/span_attempted_override.json
@@ -9,13 +9,13 @@
     "spanContext": {
       "traceId": "2cc2b48c50aefe53b3974ed91e6b4ea9",
       "spanId": "e77bcc2f537f0b02",
-      "traceFlags": "01",
+      "traceFlags": "03",
       "traceState": {}
     },
     "parentSpanContext": {
       "traceId": "00000000000000000000000000000000",
       "spanId": "0000000000000000",
-      "traceFlags": "01",
+      "traceFlags": "03",
       "traceState": {}
     },
     "startTimestamp": 0,

--- a/implementation/src/commonTest/resources/span_attrs.json
+++ b/implementation/src/commonTest/resources/span_attrs.json
@@ -9,13 +9,13 @@
     "spanContext": {
       "traceId": "2cc2b48c50aefe53b3974ed91e6b4ea9",
       "spanId": "e77bcc2f537f0b02",
-      "traceFlags": "01",
+      "traceFlags": "03",
       "traceState": {}
     },
     "parentSpanContext": {
       "traceId": "00000000000000000000000000000000",
       "spanId": "0000000000000000",
-      "traceFlags": "01",
+      "traceFlags": "03",
       "traceState": {}
     },
     "startTimestamp": 0,

--- a/implementation/src/commonTest/resources/span_basic_props.json
+++ b/implementation/src/commonTest/resources/span_basic_props.json
@@ -9,13 +9,13 @@
     "spanContext": {
       "traceId": "2cc2b48c50aefe53b3974ed91e6b4ea9",
       "spanId": "e77bcc2f537f0b02",
-      "traceFlags": "01",
+      "traceFlags": "03",
       "traceState": {}
     },
     "parentSpanContext": {
       "traceId": "00000000000000000000000000000000",
       "spanId": "0000000000000000",
-      "traceFlags": "01",
+      "traceFlags": "03",
       "traceState": {}
     },
     "startTimestamp": 500,

--- a/implementation/src/commonTest/resources/span_complex_java_api.json
+++ b/implementation/src/commonTest/resources/span_complex_java_api.json
@@ -120,7 +120,7 @@
         "spanContext": {
           "traceId": "2cc2b48c50aefe53b3974ed91e6b4ea9",
           "spanId": "e77bcc2f537f0b02",
-          "traceFlags": "01",
+          "traceFlags": "03",
           "traceState": {}
         },
         "attributes": {},
@@ -130,7 +130,7 @@
         "spanContext": {
           "traceId": "ac2c315346a8f5dcc0a79602f9a51310",
           "spanId": "9d46ef3bafda11b1",
-          "traceFlags": "01",
+          "traceFlags": "03",
           "traceState": {}
         },
         "attributes": {},

--- a/implementation/src/commonTest/resources/span_complex_java_api.json
+++ b/implementation/src/commonTest/resources/span_complex_java_api.json
@@ -9,7 +9,7 @@
     "spanContext": {
       "traceId": "2cc2b48c50aefe53b3974ed91e6b4ea9",
       "spanId": "e77bcc2f537f0b02",
-      "traceFlags": "01",
+      "traceFlags": "03",
       "traceState": {}
     },
     "parentSpanContext": {
@@ -53,7 +53,7 @@
     "spanContext": {
       "traceId": "ac2c315346a8f5dcc0a79602f9a51310",
       "spanId": "9d46ef3bafda11b1",
-      "traceFlags": "01",
+      "traceFlags": "03",
       "traceState": {}
     },
     "parentSpanContext": {
@@ -97,7 +97,7 @@
     "spanContext": {
       "traceId": "64f6c8f22faf620c7229690068c4b09c",
       "spanId": "17765490bce89c73",
-      "traceFlags": "01",
+      "traceFlags": "03",
       "traceState": {}
     },
     "parentSpanContext": {

--- a/implementation/src/commonTest/resources/span_event.json
+++ b/implementation/src/commonTest/resources/span_event.json
@@ -9,13 +9,13 @@
     "spanContext": {
       "traceId": "2cc2b48c50aefe53b3974ed91e6b4ea9",
       "spanId": "e77bcc2f537f0b02",
-      "traceFlags": "01",
+      "traceFlags": "03",
       "traceState": {}
     },
     "parentSpanContext": {
       "traceId": "00000000000000000000000000000000",
       "spanId": "0000000000000000",
-      "traceFlags": "01",
+      "traceFlags": "03",
       "traceState": {}
     },
     "startTimestamp": 0,

--- a/implementation/src/commonTest/resources/span_java_api.json
+++ b/implementation/src/commonTest/resources/span_java_api.json
@@ -9,7 +9,7 @@
     "spanContext": {
       "traceId": "2cc2b48c50aefe53b3974ed91e6b4ea9",
       "spanId": "e77bcc2f537f0b02",
-      "traceFlags": "01",
+      "traceFlags": "03",
       "traceState": {}
     },
     "parentSpanContext": {

--- a/implementation/src/commonTest/resources/span_links.json
+++ b/implementation/src/commonTest/resources/span_links.json
@@ -9,13 +9,13 @@
     "spanContext": {
       "traceId": "2cc2b48c50aefe53b3974ed91e6b4ea9",
       "spanId": "e77bcc2f537f0b02",
-      "traceFlags": "01",
+      "traceFlags": "03",
       "traceState": {}
     },
     "parentSpanContext": {
       "traceId": "00000000000000000000000000000000",
       "spanId": "0000000000000000",
-      "traceFlags": "01",
+      "traceFlags": "03",
       "traceState": {}
     },
     "startTimestamp": 0,
@@ -53,13 +53,13 @@
     "spanContext": {
       "traceId": "ac2c315346a8f5dcc0a79602f9a51310",
       "spanId": "9d46ef3bafda11b1",
-      "traceFlags": "01",
+      "traceFlags": "03",
       "traceState": {}
     },
     "parentSpanContext": {
       "traceId": "00000000000000000000000000000000",
       "spanId": "0000000000000000",
-      "traceFlags": "01",
+      "traceFlags": "03",
       "traceState": {}
     },
     "startTimestamp": 0,
@@ -70,7 +70,7 @@
         "spanContext": {
           "traceId": "2cc2b48c50aefe53b3974ed91e6b4ea9",
           "spanId": "e77bcc2f537f0b02",
-          "traceFlags": "01",
+          "traceFlags": "03",
           "traceState": {}
         },
         "attributes": {

--- a/implementation/src/commonTest/resources/span_minimal.json
+++ b/implementation/src/commonTest/resources/span_minimal.json
@@ -9,13 +9,13 @@
     "spanContext": {
       "traceId": "2cc2b48c50aefe53b3974ed91e6b4ea9",
       "spanId": "e77bcc2f537f0b02",
-      "traceFlags": "01",
+      "traceFlags": "03",
       "traceState": {}
     },
     "parentSpanContext": {
       "traceId": "00000000000000000000000000000000",
       "spanId": "0000000000000000",
-      "traceFlags": "01",
+      "traceFlags": "03",
       "traceState": {}
     },
     "startTimestamp": 0,

--- a/implementation/src/commonTest/resources/span_override_on_ending.json
+++ b/implementation/src/commonTest/resources/span_override_on_ending.json
@@ -9,13 +9,13 @@
     "spanContext": {
       "traceId": "2cc2b48c50aefe53b3974ed91e6b4ea9",
       "spanId": "e77bcc2f537f0b02",
-      "traceFlags": "01",
+      "traceFlags": "03",
       "traceState": {}
     },
     "parentSpanContext": {
       "traceId": "00000000000000000000000000000000",
       "spanId": "0000000000000000",
-      "traceFlags": "01",
+      "traceFlags": "03",
       "traceState": {}
     },
     "startTimestamp": 0,

--- a/implementation/src/commonTest/resources/span_override_on_start.json
+++ b/implementation/src/commonTest/resources/span_override_on_start.json
@@ -9,13 +9,13 @@
     "spanContext": {
       "traceId": "2cc2b48c50aefe53b3974ed91e6b4ea9",
       "spanId": "e77bcc2f537f0b02",
-      "traceFlags": "01",
+      "traceFlags": "03",
       "traceState": {}
     },
     "parentSpanContext": {
       "traceId": "00000000000000000000000000000000",
       "spanId": "0000000000000000",
-      "traceFlags": "01",
+      "traceFlags": "03",
       "traceState": {}
     },
     "startTimestamp": 0,

--- a/implementation/src/commonTest/resources/span_read_on_end.json
+++ b/implementation/src/commonTest/resources/span_read_on_end.json
@@ -9,13 +9,13 @@
     "spanContext": {
       "traceId": "2cc2b48c50aefe53b3974ed91e6b4ea9",
       "spanId": "e77bcc2f537f0b02",
-      "traceFlags": "01",
+      "traceFlags": "03",
       "traceState": {}
     },
     "parentSpanContext": {
       "traceId": "00000000000000000000000000000000",
       "spanId": "0000000000000000",
-      "traceFlags": "01",
+      "traceFlags": "03",
       "traceState": {}
     },
     "startTimestamp": 0,


### PR DESCRIPTION
## Goal

<!-- Describe what this change seeks to address -->

To conform to the random trace flag OpenTelemetry Specification.
This is because the traceIdBytes is generated from `kotlin.random.Random`.

Close https://github.com/open-telemetry/opentelemetry-kotlin/issues/552

## Testing

<!-- Describe how this change has been tested -->

I updated some tests as the spanContext.traceFlags.hex expects "03".
I followed the W3C trace flags specification https://www.w3.org/TR/trace-context-2/#trace-flags .

- "00" → not Sampled & not Random
- "01" → Sampled & not Random
- "02" → not Sampled & Random
- "03" → Sampled & Random