### PR TITLE
feat: adding the implementation of AlwaysRecordSampler

### DIFF
--- a/compat/api/jvm/compat.api
+++ b/compat/api/jvm/compat.api
@@ -62,6 +62,7 @@ public final class io/opentelemetry/kotlin/tracing/ext/SpanLinkDataExtKt {
 public final class io/opentelemetry/kotlin/tracing/sampling/CompatBuiltInSamplerApiKt {
 	public static final fun alwaysOff (Lio/opentelemetry/kotlin/init/SamplerConfigDsl;)Lio/opentelemetry/kotlin/tracing/sampling/Sampler;
 	public static final fun alwaysOn (Lio/opentelemetry/kotlin/init/SamplerConfigDsl;)Lio/opentelemetry/kotlin/tracing/sampling/Sampler;
+	public static final fun alwaysRecord (Lio/opentelemetry/kotlin/init/SamplerConfigDsl;Lio/opentelemetry/kotlin/tracing/sampling/Sampler;)Lio/opentelemetry/kotlin/tracing/sampling/Sampler;
 	public static final fun parentBased (Lio/opentelemetry/kotlin/init/SamplerConfigDsl;Lio/opentelemetry/kotlin/tracing/sampling/Sampler;Lio/opentelemetry/kotlin/tracing/sampling/Sampler;Lio/opentelemetry/kotlin/tracing/sampling/Sampler;Lio/opentelemetry/kotlin/tracing/sampling/Sampler;Lio/opentelemetry/kotlin/tracing/sampling/Sampler;)Lio/opentelemetry/kotlin/tracing/sampling/Sampler;
 	public static synthetic fun parentBased$default (Lio/opentelemetry/kotlin/init/SamplerConfigDsl;Lio/opentelemetry/kotlin/tracing/sampling/Sampler;Lio/opentelemetry/kotlin/tracing/sampling/Sampler;Lio/opentelemetry/kotlin/tracing/sampling/Sampler;Lio/opentelemetry/kotlin/tracing/sampling/Sampler;Lio/opentelemetry/kotlin/tracing/sampling/Sampler;ILjava/lang/Object;)Lio/opentelemetry/kotlin/tracing/sampling/Sampler;
 }

--- a/compat/build.gradle.kts
+++ b/compat/build.gradle.kts
@@ -17,8 +17,10 @@ kotlin {
                 implementation(project(":model"))
                 implementation(project(":java-typealiases"))
                 implementation(project.dependencies.platform(libs.opentelemetry.bom))
+                implementation(project.dependencies.platform(libs.opentelemetry.bom.alpha))
                 implementation(libs.opentelemetry.api)
                 implementation(libs.opentelemetry.sdk)
+                implementation(libs.opentelemetry.sdk.extension.incubator)
             }
         }
         val jvmTest by getting {

--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/tracing/sampling/CompatBuiltInSamplerApi.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/tracing/sampling/CompatBuiltInSamplerApi.kt
@@ -1,6 +1,7 @@
 package io.opentelemetry.kotlin.tracing.sampling
 
 import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.aliases.OtelJavaAlwaysRecordSampler
 import io.opentelemetry.kotlin.aliases.OtelJavaSampler
 import io.opentelemetry.kotlin.init.SamplerConfigDsl
 
@@ -19,6 +20,16 @@ public fun SamplerConfigDsl.alwaysOn(): Sampler = SamplerAdapter(OtelJavaSampler
  */
 @ExperimentalApi
 public fun SamplerConfigDsl.alwaysOff(): Sampler = SamplerAdapter(OtelJavaSampler.alwaysOff())
+
+/**
+ * Configures sampling so that spans are always recorded, even if the delegate sampler
+ * would otherwise drop them.
+ *
+ * https://opentelemetry.io/docs/specs/otel/trace/sdk/#alwaysrecord
+ */
+@ExperimentalApi
+public fun SamplerConfigDsl.alwaysRecord(root: Sampler): Sampler =
+    SamplerAdapter(OtelJavaAlwaysRecordSampler.create(root.toOtelJavaSampler()))
 
 /**
  * Configures sampling based on the parent span's sampling decision.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,6 +15,7 @@ kotlinxCoroutines = "1.10.2"
 ktor = "3.5.0"
 okio = "3.17.0"
 otel = "1.63.0"
+otel-alpha = "1.63.0-alpha"
 kotlinSerialization = "1.11.0"
 mavenPublish = "0.36.0"
 nexus = "2.0.0"
@@ -56,8 +57,10 @@ ktor-client-cio = { module = "io.ktor:ktor-client-cio", version.ref = "ktor" }
 ktor-client-mock = { module = "io.ktor:ktor-client-mock", version.ref = "ktor" }
 okio-fakefilesystem = { module = "com.squareup.okio:okio-fakefilesystem", version.ref = "okio" }
 opentelemetry-bom = { group = "io.opentelemetry", name = "opentelemetry-bom", version.ref = "otel" }
+opentelemetry-bom-alpha = { group = "io.opentelemetry", name = "opentelemetry-bom-alpha", version.ref = "otel-alpha" }
 opentelemetry-api = { group = "io.opentelemetry", name = "opentelemetry-api"}
 opentelemetry-sdk = { group = "io.opentelemetry", name = "opentelemetry-sdk"}
+opentelemetry-sdk-extension-incubator = { group = "io.opentelemetry", name = "opentelemetry-sdk-extension-incubator"}
 kotlin-serialization = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinSerialization" }
 mavenPublish = { module = "com.vanniktech.maven.publish:com.vanniktech.maven.publish.gradle.plugin", version.ref = "mavenPublish" }
 junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "junit" }

--- a/implementation/api/jvm/implementation.api
+++ b/implementation/api/jvm/implementation.api
@@ -6,6 +6,7 @@ public final class io/opentelemetry/kotlin/OpenTelemetryImplEntrypointKt {
 public final class io/opentelemetry/kotlin/tracing/sampling/BuiltInSamplerApiKt {
 	public static final fun alwaysOff (Lio/opentelemetry/kotlin/init/SamplerConfigDsl;)Lio/opentelemetry/kotlin/tracing/sampling/Sampler;
 	public static final fun alwaysOn (Lio/opentelemetry/kotlin/init/SamplerConfigDsl;)Lio/opentelemetry/kotlin/tracing/sampling/Sampler;
+	public static final fun alwaysRecord (Lio/opentelemetry/kotlin/init/SamplerConfigDsl;Lio/opentelemetry/kotlin/tracing/sampling/Sampler;)Lio/opentelemetry/kotlin/tracing/sampling/Sampler;
 	public static final fun parentBased (Lio/opentelemetry/kotlin/init/SamplerConfigDsl;Lio/opentelemetry/kotlin/tracing/sampling/Sampler;Lio/opentelemetry/kotlin/tracing/sampling/Sampler;Lio/opentelemetry/kotlin/tracing/sampling/Sampler;Lio/opentelemetry/kotlin/tracing/sampling/Sampler;Lio/opentelemetry/kotlin/tracing/sampling/Sampler;)Lio/opentelemetry/kotlin/tracing/sampling/Sampler;
 	public static synthetic fun parentBased$default (Lio/opentelemetry/kotlin/init/SamplerConfigDsl;Lio/opentelemetry/kotlin/tracing/sampling/Sampler;Lio/opentelemetry/kotlin/tracing/sampling/Sampler;Lio/opentelemetry/kotlin/tracing/sampling/Sampler;Lio/opentelemetry/kotlin/tracing/sampling/Sampler;Lio/opentelemetry/kotlin/tracing/sampling/Sampler;ILjava/lang/Object;)Lio/opentelemetry/kotlin/tracing/sampling/Sampler;
 }

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/sampling/AlwaysRecordSampler.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/sampling/AlwaysRecordSampler.kt
@@ -1,0 +1,34 @@
+package io.opentelemetry.kotlin.tracing.sampling
+
+import io.opentelemetry.kotlin.attributes.AttributeContainer
+import io.opentelemetry.kotlin.context.Context
+import io.opentelemetry.kotlin.tracing.SpanKind
+import io.opentelemetry.kotlin.tracing.model.SpanLink
+import io.opentelemetry.kotlin.tracing.sampling.SamplingResult.Decision.DROP
+import io.opentelemetry.kotlin.tracing.sampling.SamplingResult.Decision.RECORD_ONLY
+
+internal class AlwaysRecordSampler(
+    private val root: Sampler,
+) : Sampler {
+
+    override val description: String = "AlwaysRecordSampler{${root.description}}"
+
+    override fun shouldSample(
+        context: Context,
+        traceId: String,
+        name: String,
+        spanKind: SpanKind,
+        attributes: AttributeContainer,
+        links: List<SpanLink>,
+    ): SamplingResult {
+        val delegate = root.shouldSample(context, traceId, name, spanKind, attributes, links)
+        if (delegate.decision == DROP) {
+            return SamplingResultImpl(
+                decision = RECORD_ONLY,
+                attributes = delegate.attributes,
+                traceState = delegate.traceState,
+            )
+        }
+        return delegate
+    }
+}

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/sampling/BuiltInSamplerApi.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/sampling/BuiltInSamplerApi.kt
@@ -20,6 +20,15 @@ public fun SamplerConfigDsl.alwaysOn(): Sampler = AlwaysOnSampler()
 public fun SamplerConfigDsl.alwaysOff(): Sampler = AlwaysOffSampler()
 
 /**
+ * Configures sampling so that spans are always recorded, even if the delegate sampler
+ * would otherwise drop them.
+ *
+ * https://opentelemetry.io/docs/specs/otel/trace/sdk/#alwaysrecord
+ */
+@ExperimentalApi
+public fun SamplerConfigDsl.alwaysRecord(root: Sampler): Sampler = AlwaysRecordSampler(root)
+
+/**
  * Configures sampling based on the parent span's sampling decision.
  *
  * https://opentelemetry.io/docs/specs/otel/trace/sdk/#parentbased

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/sampling/BuiltInSamplersTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/sampling/BuiltInSamplersTest.kt
@@ -2,6 +2,7 @@ package io.opentelemetry.kotlin.tracing.sampling
 
 import io.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.kotlin.InstrumentationScopeInfoImpl
+import io.opentelemetry.kotlin.attributes.AttributesModel
 import io.opentelemetry.kotlin.clock.FakeClock
 import io.opentelemetry.kotlin.context.Context
 import io.opentelemetry.kotlin.export.MutableShutdownState
@@ -13,7 +14,9 @@ import io.opentelemetry.kotlin.factory.TraceFlagsFactoryImpl
 import io.opentelemetry.kotlin.factory.TraceStateFactoryImpl
 import io.opentelemetry.kotlin.init.SamplerConfigDsl
 import io.opentelemetry.kotlin.resource.FakeResource
+import io.opentelemetry.kotlin.tracing.FakeTraceState
 import io.opentelemetry.kotlin.tracing.NonRecordingSpan
+import io.opentelemetry.kotlin.tracing.SpanKind
 import io.opentelemetry.kotlin.tracing.TraceFlagsImpl
 import io.opentelemetry.kotlin.tracing.TracerImpl
 import io.opentelemetry.kotlin.tracing.export.FakeSpanProcessor
@@ -132,5 +135,74 @@ internal class BuiltInSamplersTest {
         val span = tracer.startSpan("child", parentContext = contextWithParent(sampled = false, isRemote = false))
         assertFalse(span.isRecording())
         assertFalse(span.spanContext.traceFlags.isSampled)
+    }
+
+    @Test
+    fun testAlwaysRecordSamplerDescription() {
+        val sampler = samplerDsl.alwaysRecord(root = FakeSampler())
+        assertEquals("AlwaysRecordSampler{FakeSampler}", sampler.description)
+    }
+
+    @Test
+    fun testAlwaysRecordSamplerDrop() {
+        val fakeSampler = FakeSampler(SamplingResult.Decision.DROP)
+        val result = samplerDsl.alwaysRecord(root = fakeSampler).shouldSample(
+            context = contextFactory.root(),
+            traceId = "000000000000000000ffffffffffffff",
+            name = "span",
+            spanKind = SpanKind.INTERNAL,
+            attributes = AttributesModel(),
+            links = emptyList(),
+        )
+        assertEquals(SamplingResult.Decision.RECORD_ONLY, result.decision)
+    }
+
+    @Test
+    fun testAlwaysRecordSamplerRecordOnly() {
+        val fakeSampler = FakeSampler(SamplingResult.Decision.RECORD_ONLY)
+        val result = samplerDsl.alwaysRecord(root = fakeSampler).shouldSample(
+            context = contextFactory.root(),
+            traceId = "000000000000000000ffffffffffffff",
+            name = "span",
+            spanKind = SpanKind.INTERNAL,
+            attributes = AttributesModel(),
+            links = emptyList(),
+        )
+        assertEquals(SamplingResult.Decision.RECORD_ONLY, result.decision)
+    }
+
+    @Test
+    fun testAlwaysRecordSamplerRecordAndSample() {
+        val fakeSampler = FakeSampler(SamplingResult.Decision.RECORD_AND_SAMPLE)
+        val result = samplerDsl.alwaysRecord(root = fakeSampler).shouldSample(
+            context = contextFactory.root(),
+            traceId = "000000000000000000ffffffffffffff",
+            name = "span",
+            spanKind = SpanKind.INTERNAL,
+            attributes = AttributesModel(),
+            links = emptyList(),
+        )
+        assertEquals(SamplingResult.Decision.RECORD_AND_SAMPLE, result.decision)
+    }
+
+    @Test
+    fun testAlwaysRecordSamplerDropPreservesAttributesAndTraceState() {
+        val traceState = FakeTraceState(mapOf("vendor" to "data"))
+        val fakeSampler = FakeSampler(
+            decision = SamplingResult.Decision.DROP,
+            samplerAttributes = mapOf("key" to "value"),
+            samplerTraceState = traceState,
+        )
+        val result = samplerDsl.alwaysRecord(root = fakeSampler).shouldSample(
+            context = contextFactory.root(),
+            traceId = "000000000000000000ffffffffffffff",
+            name = "span",
+            spanKind = SpanKind.INTERNAL,
+            attributes = AttributesModel(),
+            links = emptyList(),
+        )
+        assertEquals(SamplingResult.Decision.RECORD_ONLY, result.decision)
+        assertEquals("value", result.attributes.attributes["key"])
+        assertEquals("data", result.traceState.get("vendor"))
     }
 }

--- a/java-typealiases/build.gradle.kts
+++ b/java-typealiases/build.gradle.kts
@@ -11,8 +11,10 @@ kotlin {
         val jvmAndAndroidMain by getting {
             dependencies {
                 implementation(project.dependencies.platform(libs.opentelemetry.bom))
+                implementation(project.dependencies.platform(libs.opentelemetry.bom.alpha))
                 implementation(libs.opentelemetry.api)
                 implementation(libs.opentelemetry.sdk)
+                implementation(libs.opentelemetry.sdk.extension.incubator)
             }
         }
     }

--- a/java-typealiases/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/aliases/Aliases.kt
+++ b/java-typealiases/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/aliases/Aliases.kt
@@ -45,6 +45,7 @@ import io.opentelemetry.sdk.common.Clock
 import io.opentelemetry.sdk.common.CompletableResultCode
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo
 import io.opentelemetry.sdk.common.InstrumentationScopeInfo
+import io.opentelemetry.sdk.extension.incubator.trace.samplers.AlwaysRecordSampler
 import io.opentelemetry.sdk.logs.LogLimits
 import io.opentelemetry.sdk.logs.LogRecordProcessor
 import io.opentelemetry.sdk.logs.ReadWriteLogRecord
@@ -143,3 +144,4 @@ typealias OtelJavaLogLimits = LogLimits
 typealias OtelJavaSampler = Sampler
 typealias OtelJavaSamplingResult = SamplingResult
 typealias OtelJavaSamplingDecision = SamplingDecision
+typealias OtelJavaAlwaysRecordSampler = AlwaysRecordSampler


### PR DESCRIPTION
## Goal

<!-- Describe what this change seeks to address -->

Implement the AlwaysRecord built-in sampler and add it to the built-in sampler APIs.

Closes https://github.com/open-telemetry/opentelemetry-kotlin/issues/549

## Changes

- Added `AlwaysRecordSampler` based on the OpenTelemetry specification:
  https://opentelemetry.io/docs/specs/otel/trace/sdk/#alwaysrecord
- Added `AlwaysRecordSampler` to `BuiltInSamplerApi`.
- Added `AlwaysRecordSampler` to `CompatBuiltInSamplerApi`.
- Added `opentelemetry-sdk-extension-incubator` as a dependency to access the Java implementation required by `CompatBuiltInSamplerApi`.
- Added tests covering:
  - Conversion of `DROP` decisions to `RECORD_ONLY`
  - Description format (`AlwaysRecordSampler{${root.description}}`)
  - Preservation of attributes and trace state from the wrapped sampler

## Testing

- Added unit tests for `AlwaysRecordSampler`.
- Verified that sampling decisions, descriptions, attributes, and trace state behave according to the specification.