### PR TITLE
fix: span must not be exported if isSampled is false

### DIFF
--- a/api-ext/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/model/TraceFlagsExtTest.kt
+++ b/api-ext/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/model/TraceFlagsExtTest.kt
@@ -8,9 +8,9 @@ internal class TraceFlagsExtTest {
 
     @Test
     fun testEmptyString() {
-        assertEquals("00", FakeTraceFlags().hex)
-        assertEquals("01", FakeTraceFlags(isSampled = true).hex)
-        assertEquals("02", FakeTraceFlags(isRandom = true).hex)
-        assertEquals("03", FakeTraceFlags(isSampled = true, isRandom = true).hex)
+        assertEquals("00", FakeTraceFlags(isSampled = false).hex)
+        assertEquals("01", FakeTraceFlags().hex)
+        assertEquals("02", FakeTraceFlags(isSampled = false, isRandom = true).hex)
+        assertEquals("03", FakeTraceFlags(isRandom = true).hex)
     }
 }

--- a/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/BatchSpanProcessorImpl.kt
+++ b/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/BatchSpanProcessorImpl.kt
@@ -33,7 +33,12 @@ internal class BatchSpanProcessorImpl(
             exportAction = exporter::export
         )
 
-    override fun onEnd(span: ReadableSpan) = shutdownState.execute { processor.processTelemetry(span) }
+    override fun onEnd(span: ReadableSpan) {
+        if (!span.spanContext.traceFlags.isSampled) {
+            return
+        }
+        shutdownState.execute { processor.processTelemetry(span) }
+    }
 
     override fun isStartRequired(): Boolean = true
     override fun isEndRequired(): Boolean = true

--- a/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/SimpleSpanProcessor.kt
+++ b/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/SimpleSpanProcessor.kt
@@ -34,6 +34,9 @@ internal class SimpleSpanProcessor(
     }
 
     override fun onEnd(span: ReadableSpan) {
+        if (!span.spanContext.traceFlags.isSampled) {
+            return
+        }
         shutdownState.execute {
             scope.launch {
                 lock.write {

--- a/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/export/BatchSpanProcessorImplTest.kt
+++ b/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/export/BatchSpanProcessorImplTest.kt
@@ -3,6 +3,8 @@ package io.opentelemetry.kotlin.tracing.export
 import io.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.kotlin.export.OperationResultCode
 import io.opentelemetry.kotlin.tracing.FakeReadWriteSpan
+import io.opentelemetry.kotlin.tracing.FakeSpanContext
+import io.opentelemetry.kotlin.tracing.FakeTraceFlags
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
@@ -52,5 +54,19 @@ internal class BatchSpanProcessorImplTest {
         processor.shutdown()
         advanceUntilIdle()
         assertEquals(OperationResultCode.Success, processor.forceFlush())
+    }
+
+    @Test
+    fun testOnEndSkipsUnsampledSpan() = runTest {
+        val span = FakeReadWriteSpan(
+            spanContext = FakeSpanContext(traceFlags = FakeTraceFlags(isSampled = false))
+        )
+
+        processor.onEnd(span)
+        processor.forceFlush()
+        processor.shutdown()
+        advanceUntilIdle()
+
+        assertTrue(exporter.exports.isEmpty())
     }
 }

--- a/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/export/SimpleSpanProcessorTest.kt
+++ b/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/export/SimpleSpanProcessorTest.kt
@@ -4,6 +4,8 @@ import io.opentelemetry.kotlin.context.FakeContext
 import io.opentelemetry.kotlin.export.FakeTraceExportConfig
 import io.opentelemetry.kotlin.export.OperationResultCode
 import io.opentelemetry.kotlin.tracing.FakeReadWriteSpan
+import io.opentelemetry.kotlin.tracing.FakeSpanContext
+import io.opentelemetry.kotlin.tracing.FakeTraceFlags
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -35,6 +37,21 @@ internal class SimpleSpanProcessorTest {
 
         val export = exporter.exports.single()
         assertEquals(span.name, export.name)
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun testSpanProcessorSkipsUnsampledSpan() = runTest {
+        val exporter = FakeSpanExporter()
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val processor = SimpleSpanProcessor(exporter, scope)
+        val span = FakeReadWriteSpan(
+            spanContext = FakeSpanContext(traceFlags = FakeTraceFlags(isSampled = false))
+        )
+
+        processor.onEnd(span)
+
+        assertTrue(exporter.exports.isEmpty())
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)

--- a/implementation/src/commonTest/resources/log_emit_override.json
+++ b/implementation/src/commonTest/resources/log_emit_override.json
@@ -21,7 +21,7 @@
     "spanContext": {
       "traceId": "12345678901234567890123456789012",
       "spanId": "1234567890123456",
-      "traceFlags": "00",
+      "traceFlags": "01",
       "traceState": {
         "foo": "bar"
       }

--- a/implementation/src/commonTest/resources/span_attempted_override.json
+++ b/implementation/src/commonTest/resources/span_attempted_override.json
@@ -35,7 +35,7 @@
         "spanContext": {
           "traceId": "00000000000000000000000000000000",
           "spanId": "0000000000000000",
-          "traceFlags": "00",
+          "traceFlags": "01",
           "traceState": {
             "foo": "bar"
           }

--- a/implementation/src/commonTest/resources/span_override_on_ending.json
+++ b/implementation/src/commonTest/resources/span_override_on_ending.json
@@ -44,7 +44,7 @@
         "spanContext": {
           "traceId": "00000000000000000000000000000000",
           "spanId": "0000000000000000",
-          "traceFlags": "00",
+          "traceFlags": "01",
           "traceState": {
             "foo": "bar"
           }
@@ -58,7 +58,7 @@
         "spanContext": {
           "traceId": "12345678901234567890123456789012",
           "spanId": "1234567890123456",
-          "traceFlags": "00",
+          "traceFlags": "01",
           "traceState": {
             "foo": "bar"
           }

--- a/implementation/src/commonTest/resources/span_override_on_start.json
+++ b/implementation/src/commonTest/resources/span_override_on_start.json
@@ -38,7 +38,7 @@
         "spanContext": {
           "traceId": "00000000000000000000000000000000",
           "spanId": "0000000000000000",
-          "traceFlags": "00",
+          "traceFlags": "01",
           "traceState": {
             "foo": "bar"
           }
@@ -50,7 +50,7 @@
         "spanContext": {
           "traceId": "12345678901234567890123456789012",
           "spanId": "1234567890123456",
-          "traceFlags": "00",
+          "traceFlags": "01",
           "traceState": {
             "foo": "bar"
           }

--- a/implementation/src/commonTest/resources/span_read_on_end.json
+++ b/implementation/src/commonTest/resources/span_read_on_end.json
@@ -35,7 +35,7 @@
         "spanContext": {
           "traceId": "00000000000000000000000000000000",
           "spanId": "0000000000000000",
-          "traceFlags": "00",
+          "traceFlags": "01",
           "traceState": {
             "foo": "bar"
           }

--- a/integration-test/src/commonMain/kotlin/io/opentelemetry/kotlin/framework/InMemorySpanProcessor.kt
+++ b/integration-test/src/commonMain/kotlin/io/opentelemetry/kotlin/framework/InMemorySpanProcessor.kt
@@ -20,6 +20,9 @@ internal class InMemorySpanProcessor(
     }
 
     override fun onEnd(span: ReadableSpan) {
+        if (!span.spanContext.traceFlags.isSampled) {
+            return
+        }
         scope.launch {
             exporter.export(listOf(span.toSpanData()))
         }

--- a/test-fakes/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/FakeTraceFlags.kt
+++ b/test-fakes/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/FakeTraceFlags.kt
@@ -1,6 +1,6 @@
 package io.opentelemetry.kotlin.tracing
 
 class FakeTraceFlags(
-    override val isSampled: Boolean = false,
+    override val isSampled: Boolean = true,
     override val isRandom: Boolean = false,
 ) : TraceFlags

--- a/testing/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/testing/common/InMemorySpanProcessor.kt
+++ b/testing/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/testing/common/InMemorySpanProcessor.kt
@@ -12,6 +12,9 @@ internal class InMemorySpanProcessor(private val exporter: InMemorySpanExporter)
     override fun isStartRequired(): Boolean = true
 
     override fun onEnd(span: OtelJavaReadableSpan) {
+        if (!span.spanContext.traceFlags.isSampled) {
+            return
+        }
         exporter.export(mutableListOf(span.toSpanData()))
     }
 


### PR DESCRIPTION
## Goal

Close https://github.com/open-telemetry/opentelemetry-kotlin/issues/550

Previously, when the `Sampler` returned `RECORD_ONLY` (i.e. `SpanContext.traceFlags.isSampled == false`), the span was still forwarded to `SpanExporter`s. This violates the OpenTelemetry [Built-in span processors](https://opentelemetry.io/docs/specs/otel/trace/sdk/#built-in-span-processors) specification.

This change makes every `SpanProcessor.onEnd` short-circuit when the span is not sampled, so unsampled spans are no longer passed to the exporter.

### Changes

- Added an `isSampled` early-return at the top of `onEnd` in the following `SpanProcessor` implementations:
  - `SimpleSpanProcessor`
  - `BatchSpanProcessorImpl`
  - `PersistingSpanProcessor`
  - `InMemorySpanProcessor` (both in the `integration-test` and `testing` modules)
- Changed the default of `FakeTraceFlags.isSampled` to `true`. Existing tests assumed `isSampled == true`, but the previous non-compliant implementation also exported unsampled spans, so the tests happened to pass with `isSampled = false` as well. Once the spec-compliant behavior is in place, the test fake needs this default to keep the existing test intent.
- Adjusted the expected hex values in `TraceFlagsExtTest` and the `traceFlags` field in the JSON test resources from `"00"` to `"01"` to match the new default.

## Testing

- Added unit tests to `SimpleSpanProcessorTest` and `BatchSpanProcessorImplTest` that pass a span with `isSampled == false` to `onEnd` and assert that `FakeSpanExporter.exports` remains empty.
- Verified locally with `./gradlew build` (existing tests, new tests, and Detekt all pass).

