### PR TITLE
fix: ReadWriteLogRecord.SpanContext as variable

### DIFF
--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/logging/export/ReadWriteLogRecordAdapter.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/logging/export/ReadWriteLogRecordAdapter.kt
@@ -44,6 +44,11 @@ internal class ReadWriteLogRecordAdapter(
         set(value) {
         }
 
+    override var spanContext: SpanContext
+        get() = SpanContextAdapter(impl.spanContext)
+        set(value) {
+        }
+
     override var eventName: String?
         get() = impl.eventName
         set(value) {
@@ -91,9 +96,6 @@ internal class ReadWriteLogRecordAdapter(
 
     override val attributes: Map<String, Any>
         get() = impl.attributes.convertToMap()
-
-    override val spanContext: SpanContext
-        get() = SpanContextAdapter(impl.spanContext)
 
     override val resource: Resource
         get() = ResourceAdapter(impl.toLogRecordData().resource)

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/model/LogRecordModel.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/model/LogRecordModel.kt
@@ -22,7 +22,7 @@ internal class LogRecordModel(
     eventName: String?,
     severityText: String?,
     severityNumber: SeverityNumber?,
-    override val spanContext: SpanContext,
+    spanContext: SpanContext,
     logLimitConfig: LogLimitConfig,
 ) : ReadWriteLogRecord {
 
@@ -71,6 +71,16 @@ internal class LogRecordModel(
         }
 
     override var body: Any? = body
+        get() = lock.read {
+            field
+        }
+        set(value) {
+            lock.write {
+                field = value
+            }
+        }
+
+    override var spanContext: SpanContext = spanContext
         get() = lock.read {
             field
         }

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/integration/test/logging/LogProcessorOnEmitTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/integration/test/logging/LogProcessorOnEmitTest.kt
@@ -6,6 +6,8 @@ import io.opentelemetry.kotlin.integration.test.IntegrationTestHarness
 import io.opentelemetry.kotlin.logging.SeverityNumber
 import io.opentelemetry.kotlin.logging.export.LogRecordProcessor
 import io.opentelemetry.kotlin.logging.model.ReadWriteLogRecord
+import io.opentelemetry.kotlin.tracing.FakeSpanContext
+import io.opentelemetry.kotlin.tracing.model.hex
 import kotlinx.coroutines.test.runTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -78,6 +80,10 @@ internal class LogProcessorOnEmitTest {
             assertEquals(true, attributes["experiment_enabled"])
             assertEquals("test_logger", instrumentationScopeInfo.name)
             assertEquals("bar", resource.attributes["resource.foo"])
+            assertEquals("2cc2b48c50aefe53b3974ed91e6b4ea9", spanContext.traceId)
+            assertEquals("e77bcc2f537f0b02", spanContext.spanId)
+            assertEquals("01", spanContext.traceFlags.hex)
+            assertEquals(emptyMap(), spanContext.traceState.asMap())
             assertTrue(spanContext.isValid)
         }
 
@@ -89,6 +95,7 @@ internal class LogProcessorOnEmitTest {
             severityNumber = SeverityNumber.INFO
             severityText = "info"
             setStringAttribute("key", "value")
+            spanContext = FakeSpanContext.VALID
         }
 
         override suspend fun forceFlush(): OperationResultCode = OperationResultCode.Success

--- a/implementation/src/commonTest/resources/log_emit_override.json
+++ b/implementation/src/commonTest/resources/log_emit_override.json
@@ -19,10 +19,12 @@
     "timestampEpochNanos": 123,
     "observedTimestampEpochNanos": 456,
     "spanContext": {
-      "traceId": "2cc2b48c50aefe53b3974ed91e6b4ea9",
-      "spanId": "e77bcc2f537f0b02",
-      "traceFlags": "01",
-      "traceState": {}
+      "traceId": "12345678901234567890123456789012",
+      "spanId": "1234567890123456",
+      "traceFlags": "00",
+      "traceState": {
+        "foo": "bar"
+      }
     },
     "severity": "INFO",
     "severityText": "info",

--- a/sdk-api/api/jvm/sdk-api.api
+++ b/sdk-api/api/jvm/sdk-api.api
@@ -192,12 +192,14 @@ public abstract interface class io/opentelemetry/kotlin/logging/model/ReadWriteL
 	public abstract fun getObservedTimestamp ()Ljava/lang/Long;
 	public abstract fun getSeverityNumber ()Lio/opentelemetry/kotlin/logging/SeverityNumber;
 	public abstract fun getSeverityText ()Ljava/lang/String;
+	public abstract fun getSpanContext ()Lio/opentelemetry/kotlin/tracing/SpanContext;
 	public abstract fun getTimestamp ()Ljava/lang/Long;
 	public abstract fun setBody (Ljava/lang/Object;)V
 	public abstract fun setEventName (Ljava/lang/String;)V
 	public abstract fun setObservedTimestamp (Ljava/lang/Long;)V
 	public abstract fun setSeverityNumber (Lio/opentelemetry/kotlin/logging/SeverityNumber;)V
 	public abstract fun setSeverityText (Ljava/lang/String;)V
+	public abstract fun setSpanContext (Lio/opentelemetry/kotlin/tracing/SpanContext;)V
 	public abstract fun setTimestamp (Ljava/lang/Long;)V
 }
 

--- a/sdk-api/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/model/ReadWriteLogRecord.kt
+++ b/sdk-api/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/model/ReadWriteLogRecord.kt
@@ -4,6 +4,7 @@ import io.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.kotlin.attributes.AttributeContainer
 import io.opentelemetry.kotlin.attributes.AttributesMutator
 import io.opentelemetry.kotlin.logging.SeverityNumber
+import io.opentelemetry.kotlin.tracing.SpanContext
 
 /**
  * A read-write representation of a log record.
@@ -44,4 +45,9 @@ public interface ReadWriteLogRecord : ReadableLogRecord, AttributesMutator, Attr
      * Contains the event name if this is an event, otherwise null
      */
     public override var eventName: String?
+
+    /**
+     * The span context associated with the log record
+     */
+    public override var spanContext: SpanContext
 }


### PR DESCRIPTION
## Goal

Closes #553

Makes `spanContext` mutable on `ReadWriteLogRecord` so that `LogRecordProcessor` implementations can override it during `onEmit`, consistent with how other log record fields (`body`, `timestamp`, `severityNumber`, etc.) are already handled.

## Changes

- **`sdk-api`**: Declares `spanContext` as `var` in the `ReadWriteLogRecord` interface
- **`implementation`**: Updates `LogRecordModel` to store `spanContext` as a thread-safe `var` backed by a read-write lock, consistent with other mutable fields
- **`compat`**: Updates `ReadWriteLogRecordAdapter` to expose `spanContext` as `var`
- **`sdk-api` API dump**: Adds `getSpanContext` / `setSpanContext` to the public API surface

## Testing

- Extended `LogProcessorOnEmitTest.testOverridePropertiesInProcessor` to:
  - Assert the original `spanContext` (traceId, spanId, traceFlags, traceState) before the override
  - Override `spanContext` with `FakeSpanContext.VALID` in the processor
  - Verify the exported record reflects the new span context via golden file (`log_emit_override.json`)
- `./gradlew build` passes

## Known limitations

The `spanContext` setter in `ReadWriteLogRecordAdapter` (compat module) is a no-op, consistent with all other property setters in the same class. This is a limitation of the Java SDK interop layer — `OtelJavaReadWriteLogRecord` does not expose setters for these fields. Mutations in `LogRecordProcessor.onEmit` will have no effect when using the compat backend.
