### PR TITLE
fix: make setter/getter optional arguments on TextMapPropagator

### DIFF
--- a/api/src/commonMain/kotlin/io/opentelemetry/kotlin/propagation/TextMapGetter.kt
+++ b/api/src/commonMain/kotlin/io/opentelemetry/kotlin/propagation/TextMapGetter.kt
@@ -21,7 +21,7 @@ public interface TextMapGetter<C> {
      * Returns the first value for [key] in [carrier], or null if absent.
      * Key lookup must be case-insensitive for HTTP carriers.
      */
-    public fun get(carrier: C, key: String): String?
+    public fun get(carrier: C?, key: String): String?
 
     /**
      * Returns all values associated with [key] in [carrier], in the order they appear,

--- a/api/src/commonMain/kotlin/io/opentelemetry/kotlin/propagation/TextMapSetter.kt
+++ b/api/src/commonMain/kotlin/io/opentelemetry/kotlin/propagation/TextMapSetter.kt
@@ -16,5 +16,5 @@ public fun interface TextMapSetter<C> {
      * Sets [key] to [value] on [carrier], replacing any existing value.
      * Values must consist only of US-ASCII characters valid for HTTP headers.
      */
-    public fun set(carrier: C, key: String, value: String)
+    public fun set(carrier: C?, key: String, value: String)
 }

--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/propagation/TextMapGetterAdapter.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/propagation/TextMapGetterAdapter.kt
@@ -8,7 +8,7 @@ internal class TextMapGetterAdapter<C : Any>(
 
     override fun keys(carrier: C): Collection<String> = delegate.keys(carrier).toList()
 
-    override fun get(carrier: C, key: String): String? = delegate.get(carrier, key)
+    override fun get(carrier: C?, key: String): String? = delegate.get(carrier, key)
 
     override fun getAll(carrier: C, key: String): List<String> =
         get(carrier, key)?.let { listOf(it) } ?: emptyList()

--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/propagation/TextMapSetterAdapter.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/propagation/TextMapSetterAdapter.kt
@@ -6,7 +6,7 @@ internal class TextMapSetterAdapter<C : Any>(
     private val delegate: OtelJavaTextMapSetter<C>,
 ) : TextMapSetter<C> {
 
-    override fun set(carrier: C, key: String, value: String) {
+    override fun set(carrier: C?, key: String, value: String) {
         delegate.set(carrier, key, value)
     }
 }

--- a/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/propagation/CompatPropagatorApiTest.kt
+++ b/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/propagation/CompatPropagatorApiTest.kt
@@ -168,14 +168,14 @@ private class ContextWritingPropagator(
 @OptIn(ExperimentalApi::class)
 private object MapTextMapGetter : TextMapGetter<Map<String, String>> {
     override fun keys(carrier: Map<String, String>): Collection<String> = carrier.keys
-    override fun get(carrier: Map<String, String>, key: String): String? = carrier[key]
+    override fun get(carrier: Map<String, String>?, key: String): String? = carrier?.get(key)
     override fun getAll(carrier: Map<String, String>, key: String): List<String> =
         carrier[key]?.let { listOf(it) } ?: emptyList()
 }
 
 @OptIn(ExperimentalApi::class)
 private object MapTextMapSetter : TextMapSetter<MutableMap<String, String>> {
-    override fun set(carrier: MutableMap<String, String>, key: String, value: String) {
-        carrier[key] = value
+    override fun set(carrier: MutableMap<String, String>?, key: String, value: String) {
+        carrier?.set(key, value)
     }
 }

--- a/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/propagation/TextMapPropagatorAdapterTest.kt
+++ b/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/propagation/TextMapPropagatorAdapterTest.kt
@@ -94,7 +94,7 @@ internal class TextMapPropagatorAdapterTest {
             val errMsg = "getter must not be invoked when context is not a ContextAdapter"
 
             override fun keys(carrier: Map<String, String>): Collection<String> = error(errMsg)
-            override fun get(carrier: Map<String, String>, key: String): String = error(errMsg)
+            override fun get(carrier: Map<String, String>?, key: String): String = error(errMsg)
             override fun getAll(carrier: Map<String, String>, key: String): List<String> = error(errMsg)
         }
 
@@ -146,7 +146,7 @@ internal class TextMapPropagatorAdapterTest {
                 error(errMsg)
             }
 
-            override fun get(carrier: Map<String, String>, key: String): String {
+            override fun get(carrier: Map<String, String>?, key: String): String {
                 error(errMsg)
             }
 
@@ -160,14 +160,14 @@ internal class TextMapPropagatorAdapterTest {
     }
 
     private object MapSetter : TextMapSetter<MutableMap<String, String>> {
-        override fun set(carrier: MutableMap<String, String>, key: String, value: String) {
-            carrier[key] = value
+        override fun set(carrier: MutableMap<String, String>?, key: String, value: String) {
+            carrier?.set(key, value)
         }
     }
 
     private object MapGetter : TextMapGetter<Map<String, String>> {
         override fun keys(carrier: Map<String, String>): Collection<String> = carrier.keys
-        override fun get(carrier: Map<String, String>, key: String): String? = carrier[key]
+        override fun get(carrier: Map<String, String>?, key: String): String? = carrier?.get(key)
         override fun getAll(carrier: Map<String, String>, key: String): List<String> =
             carrier[key]?.let { listOf(it) } ?: emptyList()
     }

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/propagation/MapCarrierFixtures.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/propagation/MapCarrierFixtures.kt
@@ -5,14 +5,14 @@ import io.opentelemetry.kotlin.ExperimentalApi
 @OptIn(ExperimentalApi::class)
 internal object MapTextMapGetter : TextMapGetter<Map<String, String>> {
     override fun keys(carrier: Map<String, String>): Collection<String> = carrier.keys
-    override fun get(carrier: Map<String, String>, key: String): String? = carrier[key]
+    override fun get(carrier: Map<String, String>?, key: String): String? = carrier?.get(key)
     override fun getAll(carrier: Map<String, String>, key: String): List<String> =
         carrier[key]?.let { listOf(it) } ?: emptyList()
 }
 
 @OptIn(ExperimentalApi::class)
 internal object MapTextMapSetter : TextMapSetter<MutableMap<String, String>> {
-    override fun set(carrier: MutableMap<String, String>, key: String, value: String) {
-        carrier[key] = value
+    override fun set(carrier: MutableMap<String, String>?, key: String, value: String) {
+        carrier?.set(key, value)
     }
 }

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/propagation/W3CBaggagePropagatorTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/propagation/W3CBaggagePropagatorTest.kt
@@ -307,8 +307,8 @@ internal class W3CBaggagePropagatorTest {
 
     private object MultiValueMapTextMapGetter : TextMapGetter<Map<String, List<String>>> {
         override fun keys(carrier: Map<String, List<String>>): Collection<String> = carrier.keys
-        override fun get(carrier: Map<String, List<String>>, key: String): String? =
-            carrier[key]?.firstOrNull()
+        override fun get(carrier: Map<String, List<String>>?, key: String): String? =
+            carrier?.get(key)?.firstOrNull()
         override fun getAll(carrier: Map<String, List<String>>, key: String): List<String> =
             carrier[key].orEmpty()
     }

--- a/noop/src/commonTest/kotlin/io/opentelemetry/kotlin/NoopTests.kt
+++ b/noop/src/commonTest/kotlin/io/opentelemetry/kotlin/NoopTests.kt
@@ -239,7 +239,7 @@ internal class NoopTests {
         // extract returns the original context unchanged
         val getter = object : TextMapGetter<MutableMap<String, String>> {
             override fun keys(carrier: MutableMap<String, String>) = carrier.keys
-            override fun get(carrier: MutableMap<String, String>, key: String) = carrier[key]
+            override fun get(carrier: MutableMap<String, String>?, key: String) = carrier?.get(key)
             override fun getAll(carrier: MutableMap<String, String>, key: String): List<String> =
                 carrier[key]?.let { listOf(it) } ?: emptyList()
         }

--- a/smoke-test/src/jvmTest/kotlin/io/opentelemetry/kotlin/smoketest/PropagationCrossCheckTest.kt
+++ b/smoke-test/src/jvmTest/kotlin/io/opentelemetry/kotlin/smoketest/PropagationCrossCheckTest.kt
@@ -99,14 +99,14 @@ private class OtelRefs(
 @OptIn(ExperimentalApi::class)
 private object MapTextMapGetter : TextMapGetter<Map<String, String>> {
     override fun keys(carrier: Map<String, String>): Collection<String> = carrier.keys
-    override fun get(carrier: Map<String, String>, key: String): String? = carrier[key]
+    override fun get(carrier: Map<String, String>?, key: String): String? = carrier?.get(key)
     override fun getAll(carrier: Map<String, String>, key: String): List<String> =
         carrier[key]?.let { listOf(it) } ?: emptyList()
 }
 
 @OptIn(ExperimentalApi::class)
 private object MapTextMapSetter : TextMapSetter<MutableMap<String, String>> {
-    override fun set(carrier: MutableMap<String, String>, key: String, value: String) {
-        carrier[key] = value
+    override fun set(carrier: MutableMap<String, String>?, key: String, value: String) {
+        carrier?.set(key, value)
     }
 }


### PR DESCRIPTION
## Goal

The [Propagator API spec](https://opentelemetry.io/docs/specs/otel/context/api-propagators/#overview) defines the carrier argument on `TextMapSetter` and `TextMapGetter` as optional (i.e. nullable). However, the current interface signatures make the carrier non-nullable, which is not compliant with the spec.

This PR updates `TextMapSetter.set` and `TextMapGetter.get` so that the carrier parameter is nullable (`C?`), aligning the API with the OpenTelemetry specification.

Close https://github.com/open-telemetry/opentelemetry-kotlin/issues/542

## Testing

All existing propagation tests continue to pass after the change. Implementations that previously assumed a non-null carrier (e.g. `MapTextMapGetter`, `MapTextMapSetter` in tests and compat adapters) have been updated to use safe-call operators (`?.`) on the nullable carrier, ensuring correct null-handling behaviour at call sites.
