### PR TITLE
fix: links supplied to sampler are an empty list

### DIFF
--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/TracerImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/TracerImpl.kt
@@ -3,7 +3,6 @@ package io.opentelemetry.kotlin.tracing
 import io.opentelemetry.kotlin.Clock
 import io.opentelemetry.kotlin.InstrumentationScopeInfo
 import io.opentelemetry.kotlin.NoopOpenTelemetry
-import io.opentelemetry.kotlin.attributes.AttributesModel
 import io.opentelemetry.kotlin.attributes.setAttributes
 import io.opentelemetry.kotlin.context.Context
 import io.opentelemetry.kotlin.export.ShutdownState
@@ -17,6 +16,7 @@ import io.opentelemetry.kotlin.resource.Resource
 import io.opentelemetry.kotlin.tracing.export.SpanProcessor
 import io.opentelemetry.kotlin.tracing.model.CreatedSpan
 import io.opentelemetry.kotlin.tracing.model.ReadWriteSpanImpl
+import io.opentelemetry.kotlin.tracing.model.SpanCreationCollector
 import io.opentelemetry.kotlin.tracing.model.SpanModel
 import io.opentelemetry.kotlin.tracing.sampling.AlwaysOnSampler
 import io.opentelemetry.kotlin.tracing.sampling.Sampler
@@ -61,13 +61,16 @@ internal class TracerImpl(
             }
             val spanIdBytes = idGenerator.generateSpanIdBytes()
 
+            val collector = SpanCreationCollector(spanLimitConfig)
+            action?.invoke(collector)
+
             val result = sampler.shouldSample(
                 context = ctx,
                 traceId = traceIdBytes.toHexString(),
                 name = name,
                 spanKind = spanKind,
-                attributes = AttributesModel(),
-                links = emptyList(),
+                attributes = collector.attributes,
+                links = collector.links
             )
 
             val sampled = result.decision == SamplingResult.Decision.RECORD_AND_SAMPLE
@@ -87,12 +90,11 @@ internal class TracerImpl(
                 resource = resource,
                 parent = parentSpanContext,
                 spanContext = spanContext,
-                spanLimitConfig = spanLimitConfig
+                spanLimitConfig = spanLimitConfig,
+                initialLinks = collector.links
             )
             spanModel.setAttributes(result.attributes)
-            if (action != null) {
-                action(spanModel)
-            }
+            spanModel.setAttributes(collector.attributes)
             processor?.onStart(ReadWriteSpanImpl(spanModel), ctx)
             CreatedSpan(spanModel)
         }

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/model/BuildSpanLink.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/model/BuildSpanLink.kt
@@ -21,8 +21,6 @@ internal fun buildSpanLink(
         attributeLimit = spanLimitConfig.attributeCountPerLinkLimit,
         attributeValueLengthLimit = spanLimitConfig.attributeValueLengthLimit
     )
-    if (attributes != null) {
-        attributes(container)
-    }
+    attributes?.invoke(container)
     return SpanLinkImpl(spanContext, container)
 }

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/model/BuildSpanLink.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/model/BuildSpanLink.kt
@@ -1,0 +1,22 @@
+package io.opentelemetry.kotlin.tracing.model
+
+import io.opentelemetry.kotlin.attributes.AttributesModel
+import io.opentelemetry.kotlin.attributes.AttributesMutator
+import io.opentelemetry.kotlin.init.config.SpanLimitConfig
+import io.opentelemetry.kotlin.tracing.SpanContext
+import io.opentelemetry.kotlin.tracing.SpanLinkImpl
+
+internal fun buildSpanLink(
+    spanContext: SpanContext,
+    attributes: (AttributesMutator.() -> Unit)?,
+    spanLimitConfig: SpanLimitConfig
+): SpanLink {
+    val container = AttributesModel(
+        attributeLimit = spanLimitConfig.attributeCountPerLinkLimit,
+        attributeValueLengthLimit = spanLimitConfig.attributeValueLengthLimit
+    )
+    if (attributes != null) {
+        attributes(container)
+    }
+    return SpanLinkImpl(spanContext, container)
+}

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/model/BuildSpanLink.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/model/BuildSpanLink.kt
@@ -6,6 +6,12 @@ import io.opentelemetry.kotlin.init.config.SpanLimitConfig
 import io.opentelemetry.kotlin.tracing.SpanContext
 import io.opentelemetry.kotlin.tracing.SpanLinkImpl
 
+/**
+ * Builds a single [SpanLink] with per-link attribute limits applied.
+ *
+ * Extracted as a shared helper so that [SpanModel] and [SpanCreationCollector]
+ * apply the same limits without duplicating the logic.
+ */
 internal fun buildSpanLink(
     spanContext: SpanContext,
     attributes: (AttributesMutator.() -> Unit)?,

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/model/SpanCreationCollector.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/model/SpanCreationCollector.kt
@@ -1,0 +1,43 @@
+package io.opentelemetry.kotlin.tracing.model
+
+import io.opentelemetry.kotlin.attributes.AttributeContainer
+import io.opentelemetry.kotlin.attributes.AttributesModel
+import io.opentelemetry.kotlin.attributes.AttributesMutator
+import io.opentelemetry.kotlin.init.config.SpanLimitConfig
+import io.opentelemetry.kotlin.tracing.SpanContext
+import io.opentelemetry.kotlin.tracing.SpanCreationAction
+
+/**
+ * Collects user-provided attributes and links from the [SpanCreationAction] lambda
+ * before the sampling decision is made.
+ *
+ * Passing the collected state to [Sampler.shouldSample] allows samplers to use
+ * user attributes and links as input for their decision, as required by the
+ * OpenTelemetry specification. The span is not yet created at this point,
+ * so [isRecording] checks are unnecessary.
+ */
+internal class SpanCreationCollector(
+    private val spanLimitConfig: SpanLimitConfig,
+    private val attrs: AttributesModel = AttributesModel(
+        attributeLimit = spanLimitConfig.attributeCountLimit,
+        attributeValueLengthLimit = spanLimitConfig.attributeValueLengthLimit
+    )
+) : SpanCreationAction, AttributesMutator by attrs {
+    private val linksList = mutableListOf<SpanLink>()
+    val attributes: AttributeContainer get() = attrs
+    val links: List<SpanLink> get() = linksList.toList()
+
+    override fun addLink(
+        spanContext: SpanContext,
+        attributes: (AttributesMutator.() -> Unit)?,
+    ) {
+        if (linksList.size < spanLimitConfig.linkCountLimit && !hasSpanContext(spanContext)) {
+            linksList.add(buildSpanLink(spanContext, attributes, spanLimitConfig))
+        }
+    }
+
+    private fun hasSpanContext(spanContext: SpanContext): Boolean =
+        linksList.any {
+            it.spanContext.traceId == spanContext.traceId && it.spanContext.spanId == spanContext.spanId
+        }
+}

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/model/SpanModel.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/model/SpanModel.kt
@@ -33,7 +33,8 @@ internal class SpanModel(
     override val resource: Resource,
     override val parent: SpanContext,
     spanContext: SpanContext,
-    private val spanLimitConfig: SpanLimitConfig
+    private val spanLimitConfig: SpanLimitConfig,
+    initialLinks: List<SpanLink>
 ) : ReadWriteSpan, SpanCreationAction {
 
     private enum class State {
@@ -112,7 +113,7 @@ internal class SpanModel(
             eventsList.toList()
         }
 
-    private val linksList = mutableListOf<SpanLinkData>()
+    private val linksList = initialLinks.toMutableList<SpanLinkData>()
 
     override val links: List<SpanLinkData>
         get() = lock.read {

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/model/SpanModel.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/model/SpanModel.kt
@@ -13,7 +13,6 @@ import io.opentelemetry.kotlin.tracing.SpanCreationAction
 import io.opentelemetry.kotlin.tracing.SpanDataImpl
 import io.opentelemetry.kotlin.tracing.SpanEventImpl
 import io.opentelemetry.kotlin.tracing.SpanKind
-import io.opentelemetry.kotlin.tracing.SpanLinkImpl
 import io.opentelemetry.kotlin.tracing.StatusData
 import io.opentelemetry.kotlin.tracing.data.SpanData
 import io.opentelemetry.kotlin.tracing.data.SpanEventData
@@ -126,14 +125,7 @@ internal class SpanModel(
     ) {
         lock.write {
             if (isRecording() && linksList.size < spanLimitConfig.linkCountLimit && !hasSpanContext(spanContext)) {
-                val container = AttributesModel(
-                    attributeLimit = spanLimitConfig.attributeCountPerLinkLimit,
-                    attributeValueLengthLimit = spanLimitConfig.attributeValueLengthLimit
-                )
-                if (attributes != null) {
-                    attributes(container)
-                }
-                val link = SpanLinkImpl(spanContext, container)
+                val link = buildSpanLink(spanContext, attributes, spanLimitConfig)
                 linksList.add(link)
             }
         }

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/integration/test/tracing/model/SpanModelTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/integration/test/tracing/model/SpanModelTest.kt
@@ -32,7 +32,8 @@ internal class SpanModelTest {
                 eventCountLimit = 100,
                 attributeCountPerEventLimit = 100,
                 attributeCountPerLinkLimit = 100
-            )
+            ),
+            initialLinks = emptyList(),
         )
         assertTrue(span.isRecording())
         span.end()

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/TracerSamplerTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/TracerSamplerTest.kt
@@ -159,4 +159,70 @@ internal class TracerSamplerTest {
         val span = tracer.startSpan("test")
         assertEquals(2, span.toReadableSpan().attributes.size)
     }
+
+    @Test
+    fun testSamplerReceiverUserAttributes() {
+        val sampler = FakeSampler()
+        val tracer = buildTracer(sampler)
+        tracer.startSpan("test") {
+            setStringAttribute("user.key", "user.value")
+        }
+
+        assertEquals("user.value", sampler.lastAttributes["user.key"])
+    }
+
+    @Test
+    fun testSamplerReceivesDedupedLinks() {
+        val sampler = FakeSampler()
+        val tracer = buildTracer(sampler)
+        tracer.startSpan("test") {
+            addLink(FakeSpanContext.VALID)
+            addLink(FakeSpanContext.VALID)
+        }
+        assertEquals(1, sampler.lastLinks.size)
+    }
+
+    @Test
+    fun testSamplerReceiversUserLinks() {
+        val sampler = FakeSampler()
+        val tracer = buildTracer(sampler)
+
+        val ctxA = FakeSpanContext.INVALID
+        val ctxB = FakeSpanContext.VALID
+
+        tracer.startSpan("test") {
+            addLink(ctxA)
+            addLink(ctxB)
+        }
+
+        assertEquals(2, sampler.lastLinks.size)
+        assertEquals(ctxA.spanId, sampler.lastLinks[0].spanContext.spanId)
+        assertEquals(ctxB.spanId, sampler.lastLinks[1].spanContext.spanId)
+    }
+
+    @Test
+    fun testSamplerReceiverCappedLinks() {
+        val sampler = FakeSampler()
+
+        val cfg = SpanLimitConfig(
+            attributeCountLimit = fakeSpanLimitsConfig.attributeCountLimit,
+            attributeValueLengthLimit = fakeSpanLimitsConfig.attributeValueLengthLimit,
+            linkCountLimit = 1,
+            eventCountLimit = fakeSpanLimitsConfig.eventCountLimit,
+            attributeCountPerEventLimit = fakeSpanLimitsConfig.attributeCountPerEventLimit,
+            attributeCountPerLinkLimit = fakeSpanLimitsConfig.attributeCountPerLinkLimit,
+        )
+
+        val tracer = buildTracer(sampler, cfg)
+        val ctxA = FakeSpanContext.INVALID
+        val ctxB = FakeSpanContext.VALID
+
+        tracer.startSpan("test") {
+            addLink(ctxA)
+            addLink(ctxB)
+        }
+
+        assertEquals(1, sampler.lastLinks.size)
+        assertEquals(ctxA.spanId, sampler.lastLinks[0].spanContext.spanId)
+    }
 }

--- a/test-fakes/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/sampling/FakeSampler.kt
+++ b/test-fakes/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/sampling/FakeSampler.kt
@@ -16,6 +16,12 @@ class FakeSampler(
     var callCount = 0
         private set
 
+    var lastAttributes: Map<String, Any> = emptyMap()
+        private set
+
+    var lastLinks: List<SpanLink> = emptyList()
+        private set
+
     override fun shouldSample(
         context: Context,
         traceId: String,
@@ -25,6 +31,8 @@ class FakeSampler(
         links: List<SpanLink>,
     ): SamplingResult {
         callCount++
+        lastAttributes = attributes.attributes
+        lastLinks = links
         return FakeSamplingResult(decision, FakeAttributeContainer(samplerAttributes), samplerTraceState)
     }
 


### PR DESCRIPTION
## Goal

<!-- Describe what this change seeks to address -->

Previously, `shouldSample` was called with empty attributes and links, so samplers had no way to use user-provided span attributes or links when making sampling decisions. This did not comply with the OpenTelemetry specification.

To fix this, `SpanCreationCollector` was introduced to collect user-provided attributes and links from the `action` lambda before sampling. The following changes were made:

- Introduce `SpanCreationCollector` and execute the `action` lambda before calling `shouldSample`
- Pass the collected attributes and links to `shouldSample` to inform the sampling decision
- Seed `SpanModel` with the collected links via a new `initialLinks` constructor parameter

Closes #546

## Testing

<!-- Describe how this change has been tested -->

The following tests were added to `TracerSamplerTest` to verify that the sampler receives user-provided attributes and links:

- `testSamplerReceiverUserAttributes` — verifies that user attributes set in the `action` lambda are passed to `shouldSample`
- `testSamplerReceiversUserLinks` — verifies that user links added in the `action` lambda are passed to `shouldSample` in the correct order
- `testSamplerReceivesCappedLinks` — verifies that links are capped before being passed to `shouldSample`
- `testSamplerReceivesDedupedLinks` — verifies that duplicate links are deduplicated before being passed to `shouldSample`

Existing tests in `TracerSamplerTest` and `SpanLinkTest` were confirmed to remain green, ensuring no regression in sampler attribute application order or link handling behavior.