### PR TITLE
chore: remove @ExperimentalApi from Attributes

### DIFF
--- a/api-ext/src/commonMain/kotlin/io/opentelemetry/kotlin/attributes/AttributesMutatorExt.kt
+++ b/api-ext/src/commonMain/kotlin/io/opentelemetry/kotlin/attributes/AttributesMutatorExt.kt
@@ -1,6 +1,5 @@
 package io.opentelemetry.kotlin.attributes
 
-import io.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.kotlin.ThreadSafe
 
 /**
@@ -10,7 +9,6 @@ import io.opentelemetry.kotlin.ThreadSafe
  *
  * https://opentelemetry.io/docs/specs/otel/common/#attribute
  */
-@ExperimentalApi
 @ThreadSafe
 public fun AttributesMutator.setAttributes(attributes: Map<String, Any>) {
     attributes.forEach {

--- a/api/README.md
+++ b/api/README.md
@@ -27,7 +27,7 @@ Any component marked stable here should NOT have api surface marked with `@Exper
 
 | component   | development | stable |
 |-------------|-------------|--------|
-| attributes  | ⚠️          |        |
+| attributes  |             | ⚠️     |
 | baggage     | ⚠️          | ️      |
 | context     | ⚠️          | ️      |
 | factory     | ⚠️          | ️      |

--- a/api/README.md
+++ b/api/README.md
@@ -27,7 +27,7 @@ Any component marked stable here should NOT have api surface marked with `@Exper
 
 | component   | development | stable |
 |-------------|-------------|--------|
-| attributes  |             | ⚠️     |
+| attributes  |             | ✅     |
 | baggage     | ⚠️          | ️      |
 | context     | ⚠️          | ️      |
 | factory     | ⚠️          | ️      |

--- a/api/src/commonMain/kotlin/io/opentelemetry/kotlin/attributes/AnyValue.kt
+++ b/api/src/commonMain/kotlin/io/opentelemetry/kotlin/attributes/AnyValue.kt
@@ -1,13 +1,10 @@
 package io.opentelemetry.kotlin.attributes
 
-import io.opentelemetry.kotlin.ExperimentalApi
-
 /**
  * Represents an attribute value as defined by the OpenTelemetry specification.
  *
  * https://opentelemetry.io/docs/specs/otel/common/#anyvalue
  */
-@ExperimentalApi
 public sealed class AnyValue {
 
     public object NullValue : AnyValue() {

--- a/api/src/commonMain/kotlin/io/opentelemetry/kotlin/attributes/AttributesMutator.kt
+++ b/api/src/commonMain/kotlin/io/opentelemetry/kotlin/attributes/AttributesMutator.kt
@@ -1,6 +1,5 @@
 package io.opentelemetry.kotlin.attributes
 
-import io.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.kotlin.ThreadSafe
 
 /**
@@ -8,7 +7,6 @@ import io.opentelemetry.kotlin.ThreadSafe
  *
  * https://opentelemetry.io/docs/specs/otel/common/#attribute
  */
-@ExperimentalApi
 @ThreadSafe
 public interface AttributesMutator {
 

--- a/sdk-api/src/commonMain/kotlin/io/opentelemetry/kotlin/attributes/AttributeContainer.kt
+++ b/sdk-api/src/commonMain/kotlin/io/opentelemetry/kotlin/attributes/AttributeContainer.kt
@@ -1,6 +1,5 @@
 package io.opentelemetry.kotlin.attributes
 
-import io.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.kotlin.ThreadSafe
 
 /**
@@ -8,7 +7,6 @@ import io.opentelemetry.kotlin.ThreadSafe
  *
  * https://opentelemetry.io/docs/specs/otel/common/#attribute
  */
-@ExperimentalApi
 @ThreadSafe
 public interface AttributeContainer {
 


### PR DESCRIPTION
## Goal

<!-- Describe what this change seeks to address -->

Remove `@ExperimentalApi` from Attributes to make it stable.

Close https://github.com/open-telemetry/opentelemetry-kotlin/issues/596

## Testing

<!-- Describe how this change has been tested -->

There are no addtional tests because I just removed `@ExperimentalApi` annotions from attributes.
