### PR TITLE
Alter dupe span link behavior

### DIFF
--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/model/SpanCreationCollector.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/model/SpanCreationCollector.kt
@@ -31,13 +31,8 @@ internal class SpanCreationCollector(
         spanContext: SpanContext,
         attributes: (AttributesMutator.() -> Unit)?,
     ) {
-        if (linksList.size < spanLimitConfig.linkCountLimit && !hasSpanContext(spanContext)) {
+        if (linksList.size < spanLimitConfig.linkCountLimit) {
             linksList.add(buildSpanLink(spanContext, attributes, spanLimitConfig))
         }
     }
-
-    private fun hasSpanContext(spanContext: SpanContext): Boolean =
-        linksList.any {
-            it.spanContext.traceId == spanContext.traceId && it.spanContext.spanId == spanContext.spanId
-        }
 }

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/model/SpanModel.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/model/SpanModel.kt
@@ -125,16 +125,10 @@ internal class SpanModel(
         attributes: (AttributesMutator.() -> Unit)?
     ) {
         lock.write {
-            if (isRecording() && linksList.size < spanLimitConfig.linkCountLimit && !hasSpanContext(spanContext)) {
+            if (isRecording() && linksList.size < spanLimitConfig.linkCountLimit) {
                 val link = buildSpanLink(spanContext, attributes, spanLimitConfig)
                 linksList.add(link)
             }
-        }
-    }
-
-    private fun hasSpanContext(spanContext: SpanContext): Boolean {
-        return linksList.any {
-            it.spanContext.traceId == spanContext.traceId && it.spanContext.spanId == spanContext.spanId
         }
     }
 

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/SpanLinkTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/SpanLinkTest.kt
@@ -70,14 +70,48 @@ internal class SpanLinkTest {
     }
 
     @Test
-    fun testTwoSpanLinksWithSameKey() {
+    fun testDuplicateSpanContextsAppended() {
         tracer.startSpan("test").apply {
             addLink(fakeSpanContext)
             addLink(fakeSpanContext)
             end()
         }
-        val links = retrieveLinks(1)
+        val links = retrieveLinks(2)
         assertLinkData(links[0], fakeSpanContext, emptyMap())
+        assertLinkData(links[1], fakeSpanContext, emptyMap())
+    }
+
+    @Test
+    fun testDuplicateSpanContextsKeepDistinctAttributes() {
+        tracer.startSpan("test").apply {
+            addLink(fakeSpanContext) {
+                setStringAttribute("foo", "first")
+            }
+            addLink(fakeSpanContext) {
+                setStringAttribute("foo", "second")
+            }
+            end()
+        }
+        val links = retrieveLinks(2)
+        assertLinkData(links[0], fakeSpanContext, mapOf("foo" to "first"))
+        assertLinkData(links[1], fakeSpanContext, mapOf("foo" to "second"))
+    }
+
+    @Test
+    fun testDuplicateSpanContextsAppendedDuringCreation() {
+        tracer.startSpan("test", action = {
+            addLink(fakeSpanContext) {
+                setStringAttribute("foo", "first")
+            }
+            addLink(fakeSpanContext) {
+                setStringAttribute("foo", "second")
+            }
+        }).apply {
+            end()
+        }
+        val links = retrieveLinks(2)
+        assertLinkData(links[0], fakeSpanContext, mapOf("foo" to "first"))
+        assertLinkData(links[1], fakeSpanContext, mapOf("foo" to "second"))
     }
 
     @Test

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/TracerSamplerTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/TracerSamplerTest.kt
@@ -172,14 +172,14 @@ internal class TracerSamplerTest {
     }
 
     @Test
-    fun testSamplerReceivesDedupedLinks() {
+    fun testSamplerReceivesDuplicateLinks() {
         val sampler = FakeSampler()
         val tracer = buildTracer(sampler)
         tracer.startSpan("test") {
             addLink(FakeSpanContext.VALID)
             addLink(FakeSpanContext.VALID)
         }
-        assertEquals(1, sampler.lastLinks.size)
+        assertEquals(2, sampler.lastLinks.size)
     }
 
     @Test


### PR DESCRIPTION
## Goal

Closes #547 by allowing span links to be added as long as the link limit is not exceeded. The existing approach is overly restrictive and there's not anything in the specification that prevents duplicate links being added.