### PR TITLE
Add klib consumer to min-versions test and document Kotlin floors per target

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -38,12 +38,6 @@ jobs:
       - name: Gradle Build
         run: ./gradlew build :benchmark-android:assemble :benchmark-android:compileReleaseAndroidTestKotlin :benchmark-jvm:assemble :examples:example-app-android:assembleRelease koverXmlReport -x :gradle-integration-test:test --stacktrace
 
-      - name: Publish snapshot to Maven local
-        run: ./gradlew publishToMavenLocal -PsnapshotPublish=true --stacktrace
-
-      - name: Gradle Integration Test
-        run: ./gradlew :gradle-integration-test:test --stacktrace
-
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
@@ -52,15 +46,44 @@ jobs:
           fail_ci_if_error: false
           files: build/reports/kover/reportRelease.xml
 
+  # Runs on macOS because the klib fixture consumes the library's iOS klibs, which KGP only
+  # publishes from a macOS host. The rest of the suite is host-independent, so it all runs here.
+  integration-test:
+    runs-on: macos-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout Branch
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+
+      - name: Setup Java
+        uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5.4.0
+        with:
+          distribution: 'adopt'
+          java-version: |
+            17
+            21
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
+
+      - name: Publish snapshot to Maven local
+        run: ./gradlew publishToMavenLocal -PsnapshotPublish=true --stacktrace
+
+      - name: Gradle Integration Test
+        run: ./gradlew :gradle-integration-test:test --stacktrace
+
   required-status-check:
     permissions:
       contents: read
       issues: write
     needs:
       - gradle-test
+      - integration-test
     runs-on: ubuntu-latest
     if: always()
     steps:
       - if: |
-          needs.gradle-test.result != 'success'
+          needs.gradle-test.result != 'success' || needs.integration-test.result != 'success'
         run: exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- Clarify the minimum supported Kotlin version per target family: 2.0.0 applies to JVM
+  and Android consumers only, while iOS and JS consumers need at least the Kotlin version
+  this library is built with (currently 2.4.0) — a klib toolchain constraint shared by
+  all KMP libraries. Both floors are now enforced by integration tests.
+  ([#633](https://github.com/open-telemetry/opentelemetry-kotlin/pull/633))
 - Raise the minimum supported AGP version to 8.0.2. Through no fault of
   opentelemetry-kotlin, AGP 8.0.0 bundles an R8 that fails to dex Kotlin 2.0
   `@Metadata`, so projects on that version can't build against these artifacts

--- a/gradle-integration-test/src/test/kotlin/io/opentelemetry/kotlin/integration/gradle/MinSupportedVersionsTest.kt
+++ b/gradle-integration-test/src/test/kotlin/io/opentelemetry/kotlin/integration/gradle/MinSupportedVersionsTest.kt
@@ -11,18 +11,39 @@ import java.nio.file.StandardCopyOption
 class MinSupportedVersionsTest {
 
     @Test
-    fun `min supported versions can consume artifacts`(@TempDir tmp: Path) {
-        val fixtureSrc = File(systemProperty("fixtureSrcDir"), "min-versions-android-app").toPath()
+    fun `min supported versions can consume jvm and android artifacts`(@TempDir tmp: Path) {
+        assembleFixture(
+            fixtureName = "min-versions-android-app",
+            gradleVersion = systemProperty("minSupportedGradle"),
+            tmp = tmp,
+        )
+    }
+
+    // Klib (iOS/JS) consumers need at least the Kotlin version this library is built with,
+    // so the fixture builds with exactly that version. iOS coverage requires a macOS host.
+    @Test
+    fun `min supported versions can consume klib artifacts`(@TempDir tmp: Path) {
+        assembleFixture(
+            fixtureName = "min-versions-kmp-app",
+            gradleVersion = systemProperty("minSupportedGradle"),
+            tmp = tmp,
+        )
+    }
+
+    private fun assembleFixture(
+        fixtureName: String,
+        gradleVersion: String,
+        tmp: Path,
+    ) {
+        val fixtureSrc = File(systemProperty("fixtureSrcDir"), fixtureName).toPath()
         copyRecursively(fixtureSrc, tmp)
 
         val runner = GradleRunner.create()
             .withProjectDir(tmp.toFile())
-            .withGradleVersion(systemProperty("minSupportedGradle"))
+            .withGradleVersion(gradleVersion)
             .withArguments(
                 "-PcatalogPath=${systemProperty("catalogPath")}",
                 "-PotelKotlinVersion=${systemProperty("otelKotlinVersion")}",
-                "-Pandroid.useAndroidX=true",
-                "-Pandroid.nonTransitiveRClass=true",
                 "assemble",
                 "--info",
                 "--stacktrace",

--- a/gradle-integration-test/src/test/resources/fixtures/min-versions-android-app/build.gradle.kts
+++ b/gradle-integration-test/src/test/resources/fixtures/min-versions-android-app/build.gradle.kts
@@ -3,7 +3,7 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 
 plugins {
-    alias(libs.plugins.test.kotlin.multiplatform)
+    alias(libs.plugins.test.kotlin.multiplatform.jvm)
     alias(libs.plugins.test.android.library)
 }
 

--- a/gradle-integration-test/src/test/resources/fixtures/min-versions-android-app/gradle.properties
+++ b/gradle-integration-test/src/test/resources/fixtures/min-versions-android-app/gradle.properties
@@ -1,0 +1,2 @@
+android.useAndroidX=true
+android.nonTransitiveRClass=true

--- a/gradle-integration-test/src/test/resources/fixtures/min-versions-kmp-app/build.gradle.kts
+++ b/gradle-integration-test/src/test/resources/fixtures/min-versions-kmp-app/build.gradle.kts
@@ -1,0 +1,26 @@
+plugins {
+    alias(libs.plugins.test.kotlin.multiplatform.klib)
+}
+
+val otelKotlinVersion: String = providers.gradleProperty("otelKotlinVersion").get()
+
+kotlin {
+    js {
+        nodejs()
+        binaries.library()
+    }
+    iosArm64()
+    iosSimulatorArm64()
+
+    sourceSets {
+        val commonMain by getting {
+            dependencies {
+                implementation("io.opentelemetry.kotlin:api:$otelKotlinVersion")
+                implementation("io.opentelemetry.kotlin:sdk-api:$otelKotlinVersion")
+                implementation("io.opentelemetry.kotlin:core:$otelKotlinVersion")
+                implementation("io.opentelemetry.kotlin:implementation:$otelKotlinVersion")
+                implementation("io.opentelemetry.kotlin:exporters-core:$otelKotlinVersion")
+            }
+        }
+    }
+}

--- a/gradle-integration-test/src/test/resources/fixtures/min-versions-kmp-app/gradle.properties
+++ b/gradle-integration-test/src/test/resources/fixtures/min-versions-kmp-app/gradle.properties
@@ -1,0 +1,2 @@
+# The Kotlin/Native compiler runs inside the Gradle daemon, whose TestKit defaults are too small.
+org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=1g

--- a/gradle-integration-test/src/test/resources/fixtures/min-versions-kmp-app/settings.gradle.kts
+++ b/gradle-integration-test/src/test/resources/fixtures/min-versions-kmp-app/settings.gradle.kts
@@ -1,0 +1,24 @@
+pluginManagement {
+    repositories {
+        mavenLocal()
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        mavenLocal()
+        google()
+        mavenCentral()
+    }
+    versionCatalogs {
+        create("libs") {
+            from(files(providers.gradleProperty("catalogPath").get()))
+        }
+    }
+}
+
+rootProject.name = "min-versions-kmp-app"

--- a/gradle-integration-test/src/test/resources/fixtures/min-versions-kmp-app/src/commonMain/kotlin/io/opentelemetry/kotlin/minversion/Consumer.kt
+++ b/gradle-integration-test/src/test/resources/fixtures/min-versions-kmp-app/src/commonMain/kotlin/io/opentelemetry/kotlin/minversion/Consumer.kt
@@ -1,0 +1,11 @@
+@file:OptIn(io.opentelemetry.kotlin.ExperimentalApi::class)
+
+package io.opentelemetry.kotlin.minversion
+
+import io.opentelemetry.kotlin.OpenTelemetry
+import io.opentelemetry.kotlin.OpenTelemetrySdk
+
+internal class Consumer {
+    val api: OpenTelemetry? = null
+    val sdk: OpenTelemetrySdk? = null
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -93,7 +93,8 @@ wire = { id = "com.squareup.wire", version.ref = "wire" }
 buildKonfig = { id = "com.codingfeline.buildkonfig", version.ref = "buildKonfig" }
 compose-multiplatform = { id = "org.jetbrains.compose", version.ref = "composeMultiplatform" }
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
-test-kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "minSupportedKotlinPlugin" }
+test-kotlin-multiplatform-jvm = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "minSupportedKotlinPlugin" }
+test-kotlin-multiplatform-klib = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 test-android-library = { id = "com.android.library", version.ref = "android-minAgpVersion" }
 
 [bundles]


### PR DESCRIPTION
## Summary
- Add a `min-versions-kmp-app` fixture that consumes the published iOS/JS klibs, enforcing the Kotlin floor for klib consumers.
- Document the per-target Kotlin floors in the changelog: **2.0.0 for JVM/Android** consumers, while **iOS/JS consumers need at least the Kotlin version this library is built with**.
- Consolidate the integration tests into a macOS CI job.

## Why klib consumers have a higher floor
Klibs are stamped with `abi_version` = the build Kotlin's version, and older compilers reject them outright. This is a klib toolchain constraint shared by all KMP libraries — not something this library can lower.

https://youtrack.jetbrains.com/issue/KT-76131

## CI changes
Integration tests now run in a single `integration-test` job on `macos-latest`, because only a macOS host can publish (and therefore consume) the Apple klibs.

## Testing
Ran the exact CI sequence locally on macOS (`publishToMavenLocal` + `:gradle-integration-test:test`): both fixtures pass — the JVM/Android one at Gradle/AGP 8.0.2 and Kotlin 2.0.0, the klib one at Kotlin 2.4.0 with iOS + JS targets.
