### PR TITLE
Alter OtlpClient to handle partial success response

### DIFF
--- a/exporters-otlp/src/commonMain/kotlin/io/opentelemetry/kotlin/export/OtlpClient.kt
+++ b/exporters-otlp/src/commonMain/kotlin/io/opentelemetry/kotlin/export/OtlpClient.kt
@@ -14,15 +14,16 @@ import io.ktor.http.contentType
 import io.ktor.utils.io.readRemaining
 import io.opentelemetry.kotlin.export.OtlpClient.Companion.MAX_ERROR_BODY_BYTES
 import io.opentelemetry.kotlin.export.OtlpResponse.ClientError
+import io.opentelemetry.kotlin.export.OtlpResponse.PartialSuccess
 import io.opentelemetry.kotlin.export.OtlpResponse.RetryableError
 import io.opentelemetry.kotlin.export.OtlpResponse.ServerError
 import io.opentelemetry.kotlin.export.OtlpResponse.Success
 import io.opentelemetry.kotlin.export.OtlpResponse.Unknown
-import io.opentelemetry.kotlin.logging.export.deserializeLogRecordErrorMessage
+import io.opentelemetry.kotlin.logging.export.deserializeLogRecordPartialSuccess
 import io.opentelemetry.kotlin.logging.export.toProtobufByteArray
 import io.opentelemetry.kotlin.logging.model.ReadableLogRecord
 import io.opentelemetry.kotlin.tracing.data.SpanData
-import io.opentelemetry.kotlin.tracing.export.deserializeTraceRecordErrorMessage
+import io.opentelemetry.kotlin.tracing.export.deserializeTraceRecordPartialSuccess
 import io.opentelemetry.kotlin.tracing.export.toProtobufByteArray
 import kotlinx.io.readByteArray
 
@@ -37,19 +38,19 @@ internal class OtlpClient(
     suspend fun exportLogs(telemetry: List<ReadableLogRecord>): OtlpResponse = exportTelemetry(
         OtlpEndpoint.Logs,
         telemetry::toProtobufByteArray,
-        ByteArray::deserializeLogRecordErrorMessage
+        ByteArray::deserializeLogRecordPartialSuccess
     )
 
     suspend fun exportTraces(telemetry: List<SpanData>): OtlpResponse = exportTelemetry(
         OtlpEndpoint.Traces,
         telemetry::toProtobufByteArray,
-        ByteArray::deserializeTraceRecordErrorMessage
+        ByteArray::deserializeTraceRecordPartialSuccess
     )
 
     private suspend fun exportTelemetry(
         endpoint: OtlpEndpoint,
         requestSerializer: () -> ByteArray,
-        onError: (body: ByteArray) -> String?,
+        parsePartialSuccess: (body: ByteArray) -> OtlpPartialSuccess?,
     ): OtlpResponse {
         return try {
             val url = "$baseUrl/${endpoint.path}"
@@ -59,15 +60,21 @@ internal class OtlpClient(
                 header(HttpHeaders.UserAgent, userAgent)
                 setBody(requestSerializer())
             }
+            // A 200 can still be a partial success and error responses can carry an error message,
+            // so the body is always parsed rather than relying on the status code alone (see #558).
+            val body = parsePartialSuccess(response.boundedBodyBytes())
             when (val code = response.status.value) {
-                200 -> Success
+                200 -> when (body) {
+                    null -> Success
+                    else -> PartialSuccess(body.rejectedCount, body.errorMessage)
+                }
                 429, 502, 503, 504 -> RetryableError(
                     code,
                     response.parseRetryAfterMs(),
-                    onError(response.boundedBodyBytes()),
+                    body?.errorMessage,
                 )
-                in 400..499 -> ClientError(code, onError(response.boundedBodyBytes()))
-                in 500..599 -> ServerError(code, onError(response.boundedBodyBytes()))
+                in 400..499 -> ClientError(code, body?.errorMessage)
+                in 500..599 -> ServerError(code, body?.errorMessage)
                 else -> Unknown
             }
         } catch (ignored: HttpRequestTimeoutException) {

--- a/exporters-otlp/src/commonMain/kotlin/io/opentelemetry/kotlin/export/OtlpResponse.kt
+++ b/exporters-otlp/src/commonMain/kotlin/io/opentelemetry/kotlin/export/OtlpResponse.kt
@@ -8,6 +8,15 @@ internal sealed class OtlpResponse(val statusCode: Int) {
         }
     }
 
+    class PartialSuccess(
+        val rejectedCount: Long,
+        val errorMessage: String?,
+    ) : OtlpResponse(200) {
+        override fun toString(): String {
+            return "PartialSuccess(rejectedCount=$rejectedCount, errorMessage=$errorMessage, statusCode=$statusCode)"
+        }
+    }
+
     class ClientError(statusCode: Int, val errorMessage: String?) : OtlpResponse(statusCode) {
         override fun toString(): String {
             return "ClientError(errorMessage=$errorMessage, statusCode=$statusCode)"

--- a/exporters-otlp/src/commonMain/kotlin/io/opentelemetry/kotlin/export/TelemetryExporter.kt
+++ b/exporters-otlp/src/commonMain/kotlin/io/opentelemetry/kotlin/export/TelemetryExporter.kt
@@ -41,6 +41,12 @@ internal class TelemetryExporter<T>(
                     return
                 }
 
+                // The server accepted the request; retrying would only re-send the rejected
+                // portion, so treat a partial success as terminal.
+                is OtlpResponse.PartialSuccess -> {
+                    return
+                }
+
                 is OtlpResponse.ClientError -> {
                     return
                 }

--- a/exporters-otlp/src/commonTest/kotlin/io/opentelemetry/kotlin/export/OtlpClientTest.kt
+++ b/exporters-otlp/src/commonTest/kotlin/io/opentelemetry/kotlin/export/OtlpClientTest.kt
@@ -17,6 +17,10 @@ import io.opentelemetry.kotlin.logging.model.ReadableLogRecord
 import io.opentelemetry.kotlin.tracing.data.FakeSpanData
 import io.opentelemetry.kotlin.tracing.data.SpanData
 import io.opentelemetry.kotlin.tracing.export.toProtobufByteArray
+import io.opentelemetry.proto.collector.logs.v1.ExportLogsPartialSuccess
+import io.opentelemetry.proto.collector.logs.v1.ExportLogsServiceResponse
+import io.opentelemetry.proto.collector.trace.v1.ExportTracePartialSuccess
+import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceResponse
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.test.runTest
 import kotlinx.io.readByteArray
@@ -24,8 +28,10 @@ import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertIs
 import kotlin.test.assertNull
+import kotlin.time.Duration.Companion.milliseconds
 
 internal class OtlpClientTest {
 
@@ -39,16 +45,17 @@ internal class OtlpClientTest {
     private lateinit var server: MockEngine
     private lateinit var mockResponseStatus: HttpStatusCode
     private var mockResponseHeaders: Headers = Headers.Empty
+    private var mockResponseBody: ByteArray = ByteArray(0)
     private var serverDelayMs: Long = 0
 
     @BeforeTest
     fun setUp() {
         server = MockEngine {
             if (serverDelayMs > 0) {
-                delay(serverDelayMs)
+                delay(serverDelayMs.milliseconds)
             }
             respond(
-                content = ByteReadChannel(""),
+                content = ByteReadChannel(mockResponseBody),
                 status = mockResponseStatus,
                 headers = mockResponseHeaders,
             )
@@ -214,6 +221,91 @@ internal class OtlpClientTest {
         assertIs<OtlpResponse.RetryableError>(response)
         assertEquals(12_000L, response.retryAfterMs)
     }
+
+    @Test
+    fun testExportLog4xxDeserialization() = runTest {
+        mockResponseStatus = HttpStatusCode.BadRequest
+        mockResponseBody = logResponseBody(rejected = 0L, msg = "bad request")
+        val response = client.exportLogs(logRecords)
+        assertIs<OtlpResponse.ClientError>(response)
+        assertEquals("bad request", response.errorMessage)
+    }
+
+    @Test
+    fun testExportLog5xxDeserialization() = runTest {
+        mockResponseStatus = HttpStatusCode.InternalServerError
+        mockResponseBody = logResponseBody(rejected = 0L, msg = "internal error")
+        val response = client.exportLogs(logRecords)
+        assertIs<OtlpResponse.ServerError>(response)
+        assertEquals("internal error", response.errorMessage)
+    }
+
+    @Test
+    fun testExportTrace4xxDeserialization() = runTest {
+        mockResponseStatus = HttpStatusCode.BadRequest
+        mockResponseBody = traceResponseBody(rejected = 0L, msg = "bad request")
+        val response = client.exportTraces(spans)
+        assertIs<OtlpResponse.ClientError>(response)
+        assertEquals("bad request", response.errorMessage)
+    }
+
+    @Test
+    fun testExportTrace5xxDeserialization() = runTest {
+        mockResponseStatus = HttpStatusCode.InternalServerError
+        mockResponseBody = traceResponseBody(rejected = 0L, msg = "internal error")
+        val response = client.exportTraces(spans)
+        assertIs<OtlpResponse.ServerError>(response)
+        assertEquals("internal error", response.errorMessage)
+    }
+
+    @Test
+    fun testExportLogPartialSuccess() = runTest {
+        mockResponseStatus = HttpStatusCode.OK
+        mockResponseBody = logResponseBody(rejected = 2L, msg = "2 log records rejected")
+        val response = client.exportLogs(logRecords)
+        assertFalse(response is OtlpResponse.Success)
+    }
+
+    @Test
+    fun testExportTracePartialSuccess() = runTest {
+        mockResponseStatus = HttpStatusCode.OK
+        mockResponseBody = traceResponseBody(rejected = 3L, msg = "3 spans rejected")
+        val response = client.exportTraces(spans)
+        assertFalse(response is OtlpResponse.Success)
+    }
+
+    @Test
+    fun testExportLog200EmptyBodyIsSuccess() = runTest {
+        mockResponseStatus = HttpStatusCode.OK
+        mockResponseBody = ByteArray(0)
+        assertEquals(OtlpResponse.Success, client.exportLogs(logRecords))
+    }
+
+    @Test
+    fun testExportLogMalformedErrorBody() = runTest {
+        mockResponseStatus = HttpStatusCode.BadRequest
+        mockResponseBody = byteArrayOf(0xFF.toByte(), 0xFE.toByte(), 0x00, 0x42)
+        val response = client.exportLogs(logRecords)
+        assertEquals(400, response.statusCode)
+    }
+
+    @Test
+    fun testExportTraceMalformedErrorBody() = runTest {
+        mockResponseStatus = HttpStatusCode.BadRequest
+        mockResponseBody = byteArrayOf(0xFF.toByte(), 0xFE.toByte(), 0x00, 0x42)
+        val response = client.exportTraces(spans)
+        assertEquals(400, response.statusCode)
+    }
+
+    private fun logResponseBody(rejected: Long, msg: String): ByteArray =
+        ExportLogsServiceResponse.ADAPTER.encode(
+            ExportLogsServiceResponse(partial_success = ExportLogsPartialSuccess(rejected, msg))
+        )
+
+    private fun traceResponseBody(rejected: Long, msg: String): ByteArray =
+        ExportTraceServiceResponse.ADAPTER.encode(
+            ExportTraceServiceResponse(partial_success = ExportTracePartialSuccess(rejected, msg))
+        )
 
     private suspend fun sendAndAssertLogRequest(
         telemetry: List<ReadableLogRecord>,

--- a/exporters-protobuf/src/commonMain/kotlin/io/opentelemetry/kotlin/export/OtlpPartialSuccess.kt
+++ b/exporters-protobuf/src/commonMain/kotlin/io/opentelemetry/kotlin/export/OtlpPartialSuccess.kt
@@ -1,0 +1,13 @@
+package io.opentelemetry.kotlin.export
+
+/**
+ * The parsed `partial_success` field of an OTLP export response.
+ *
+ * Per the OTLP spec a `partial_success` message with an empty value (rejected count of `0` and an
+ * empty `error_message`) is equivalent to it being absent, so this type is only produced when the
+ * server actually rejected some telemetry or supplied a warning message.
+ */
+public data class OtlpPartialSuccess(
+    val rejectedCount: Long,
+    val errorMessage: String,
+)

--- a/exporters-protobuf/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/ExportLogsResponseDeserializer.kt
+++ b/exporters-protobuf/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/ExportLogsResponseDeserializer.kt
@@ -1,6 +1,17 @@
 package io.opentelemetry.kotlin.logging.export
 
+import io.opentelemetry.kotlin.export.OtlpPartialSuccess
 import io.opentelemetry.proto.collector.logs.v1.ExportLogsServiceResponse
 
-fun ByteArray.deserializeLogRecordErrorMessage() : String? =
-    ExportLogsServiceResponse.ADAPTER.decode(this).partial_success?.error_message
+/**
+ * Parses the `partial_success` field of a log export response, returning null when it is absent,
+ * empty (equivalent to absent per the OTLP spec), or the body cannot be decoded.
+ */
+fun ByteArray.deserializeLogRecordPartialSuccess(): OtlpPartialSuccess? =
+    runCatching { ExportLogsServiceResponse.ADAPTER.decode(this).partial_success }
+        .getOrNull()
+        ?.takeIf { it.rejected_log_records > 0L || it.error_message.isNotEmpty() }
+        ?.let { OtlpPartialSuccess(it.rejected_log_records, it.error_message) }
+
+fun ByteArray.deserializeLogRecordErrorMessage(): String? =
+    deserializeLogRecordPartialSuccess()?.errorMessage

--- a/exporters-protobuf/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/ExportTracesResponseDeserializer.kt
+++ b/exporters-protobuf/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/ExportTracesResponseDeserializer.kt
@@ -1,6 +1,17 @@
 package io.opentelemetry.kotlin.tracing.export
 
+import io.opentelemetry.kotlin.export.OtlpPartialSuccess
 import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceResponse
 
-fun ByteArray.deserializeTraceRecordErrorMessage() =
-    ExportTraceServiceResponse.ADAPTER.decode(this).partial_success?.error_message
+/**
+ * Parses the `partial_success` field of a trace export response, returning null when it is absent,
+ * empty (equivalent to absent per the OTLP spec), or the body cannot be decoded.
+ */
+fun ByteArray.deserializeTraceRecordPartialSuccess(): OtlpPartialSuccess? =
+    runCatching { ExportTraceServiceResponse.ADAPTER.decode(this).partial_success }
+        .getOrNull()
+        ?.takeIf { it.rejected_spans > 0L || it.error_message.isNotEmpty() }
+        ?.let { OtlpPartialSuccess(it.rejected_spans, it.error_message) }
+
+fun ByteArray.deserializeTraceRecordErrorMessage(): String? =
+    deserializeTraceRecordPartialSuccess()?.errorMessage


### PR DESCRIPTION
## Goal

Alters `OtlpClient` so that it handles a partial success response even when the status code is 200. I've additionally hardened the client so that it doesn't crash when a malformed body is returned.

Closes #558

## Testing

Added test cases.
