### PR TITLE
SpanProcessor.onEnding should be forwarded by OtelJavaSpanProcessorAdapter

### DIFF
--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/tracing/export/OtelJavaSpanProcessorAdapter.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/tracing/export/OtelJavaSpanProcessorAdapter.kt
@@ -1,16 +1,18 @@
 package io.opentelemetry.kotlin.tracing.export
 
 import io.opentelemetry.kotlin.aliases.OtelJavaContext
+import io.opentelemetry.kotlin.aliases.OtelJavaExtendedSpanProcessor
 import io.opentelemetry.kotlin.aliases.OtelJavaReadWriteSpan
 import io.opentelemetry.kotlin.aliases.OtelJavaReadableSpan
 import io.opentelemetry.kotlin.aliases.OtelJavaSpanProcessor
 import io.opentelemetry.kotlin.context.toOtelKotlinContext
 import io.opentelemetry.kotlin.tracing.model.ReadWriteSpanAdapter
 import io.opentelemetry.kotlin.tracing.model.ReadableSpanAdapter
+import io.opentelemetry.sdk.trace.ReadWriteSpan
 
 internal class OtelJavaSpanProcessorAdapter(
     private val impl: SpanProcessor
-) : OtelJavaSpanProcessor {
+) : OtelJavaSpanProcessor, OtelJavaExtendedSpanProcessor {
 
     override fun onStart(parentContext: OtelJavaContext, span: OtelJavaReadWriteSpan) {
         impl.onStart(ReadWriteSpanAdapter(span), parentContext.toOtelKotlinContext())
@@ -20,6 +22,11 @@ internal class OtelJavaSpanProcessorAdapter(
         impl.onEnd(ReadableSpanAdapter(span))
     }
 
+    override fun onEnding(span: ReadWriteSpan) {
+        impl.onEnding(ReadWriteSpanAdapter(span))
+    }
+
     override fun isStartRequired(): Boolean = impl.isStartRequired()
     override fun isEndRequired(): Boolean = impl.isEndRequired()
+    override fun isOnEndingRequired(): Boolean = impl.isOnEndingRequired()
 }

--- a/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/tracing/export/OtelJavaSpanProcessorAdapterTest.kt
+++ b/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/tracing/export/OtelJavaSpanProcessorAdapterTest.kt
@@ -7,6 +7,7 @@ import io.opentelemetry.kotlin.context.Context
 import io.opentelemetry.kotlin.context.toOtelJavaContext
 import io.opentelemetry.kotlin.context.toOtelKotlinContext
 import io.opentelemetry.kotlin.framework.OtelKotlinHarness
+import io.opentelemetry.kotlin.tracing.Span
 import io.opentelemetry.kotlin.tracing.SpanContext
 import io.opentelemetry.kotlin.tracing.SpanKind
 import io.opentelemetry.kotlin.tracing.ext.storeInContext
@@ -31,6 +32,29 @@ internal class OtelJavaSpanProcessorAdapterTest {
     fun `span propagated correctly`() {
         with(harness) {
             val fakeTime = 5_000_000L
+            var startCalled = false
+            var endingCalled = false
+            var endCalled = false
+            config.spanProcessors.add(
+                FakeSpanProcessor(
+                    startAction = { span, context ->
+                        startCalled = true
+                        assertInputForSpan(
+                            expectedName = "test",
+                            expectedParentSpanContextSupplier = { OtelJavaSpan.getInvalid().spanContext.toOtelKotlinSpanContext() },
+                        )(span, context)
+                    },
+                    endAction = {
+                        endCalled = true
+                        assertReadableSpan(expectedName = "test")(it)
+                    },
+                    endingAction = {
+                        endingCalled = true
+                        assertReadWriteSpan(expectedName = "test")(it)
+                    }
+                )
+            )
+
             val span = tracer.startSpan(
                 name = "test",
                 spanKind = SpanKind.CLIENT,
@@ -46,39 +70,66 @@ internal class OtelJavaSpanProcessorAdapterTest {
                     setStringAttribute("eventAttr", "value")
                 }
             }
-            config.spanProcessors.add(
-                FakeSpanProcessor(
-                    startAction = assertInputForSpan(
-                        expectedName = "test",
-                        expectedParentSpanContextSupplier = { OtelJavaSpan.getInvalid().spanContext.toOtelKotlinSpanContext() },
-                    ),
-                    endAction = assertReadableSpan(expectedName = "test"),
-                    endingAction = assertReadableSpan(expectedName = "test")
-                )
-            )
             span.end()
+
+            assertEquals(true, startCalled)
+            assertEquals(true, endingCalled)
+            assertEquals(true, endCalled)
         }
+    }
+
+    @Test
+    fun `onEnding invoked when required`() {
+        with(harness) {
+            val processor = FakeSpanProcessor(onEndingRequired = true)
+            config.spanProcessors.add(processor)
+
+            tracer.startSpan("test").end()
+
+            assertEquals(1, processor.endingCalls.size)
+            assertEquals("test", processor.endingCalls.single().name)
+        }
+    }
+
+    @Test
+    fun `isOnEndingRequired delegates to impl`() {
+        assertEquals(
+            true,
+            OtelJavaSpanProcessorAdapter(FakeSpanProcessor(onEndingRequired = true)).isOnEndingRequired()
+        )
+        assertEquals(
+            false,
+            OtelJavaSpanProcessorAdapter(FakeSpanProcessor(onEndingRequired = false)).isOnEndingRequired()
+        )
     }
 
     @Test
     fun `parent context propagated correctly`() {
         with(harness) {
-            val parentSpan = tracer.startSpan("parent")
+            lateinit var parentSpan: Span
+            var startCalled = false
+
+            config.spanProcessors.add(
+                FakeSpanProcessor(
+                    startAction = { span, context ->
+                        startCalled = true
+                        assertInputForSpan(
+                            expectedName = "name",
+                            expectedParentSpanContextSupplier = { parentSpan.spanContext },
+                        )(span, context)
+                    },
+                    endAction = assertReadableSpan(expectedName = "name")
+                )
+            )
+
+            parentSpan = tracer.startSpan("parent")
             val childSpan = tracer.startSpan(
                 name = "name",
                 parentContext = parentSpan.storeInContext(rootContext)
             )
-
-            config.spanProcessors.add(
-                FakeSpanProcessor(
-                    startAction = assertInputForSpan(
-                        expectedName = "name",
-                        expectedParentSpanContextSupplier = { parentSpan.spanContext },
-                    ),
-                    endAction = assertReadableSpan(expectedName = "name")
-                )
-            )
             childSpan.end()
+
+            assertEquals(true, startCalled)
         }
     }
 
@@ -108,6 +159,17 @@ internal class OtelJavaSpanProcessorAdapterTest {
         return fun(span: ReadableSpan) {
             if (span.name == expectedName) {
                 assertEquals(expectedName, span.name)
+            }
+        }
+    }
+
+    private fun assertReadWriteSpan(
+        expectedName: String,
+    ): (span: ReadWriteSpan) -> Unit {
+        return fun(span: ReadWriteSpan) {
+            if (span.name == expectedName) {
+                assertEquals(expectedName, span.name)
+                assertEquals("value", span.attributes["key"])
             }
         }
     }

--- a/java-typealiases/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/aliases/Aliases.kt
+++ b/java-typealiases/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/aliases/Aliases.kt
@@ -70,6 +70,7 @@ import io.opentelemetry.sdk.trace.data.LinkData
 import io.opentelemetry.sdk.trace.data.SpanData
 import io.opentelemetry.sdk.trace.data.StatusData
 import io.opentelemetry.sdk.trace.export.SpanExporter
+import io.opentelemetry.sdk.trace.internal.ExtendedSpanProcessor
 import io.opentelemetry.sdk.trace.samplers.Sampler
 import io.opentelemetry.sdk.trace.samplers.SamplingDecision
 import io.opentelemetry.sdk.trace.samplers.SamplingResult
@@ -112,6 +113,7 @@ typealias OtelJavaSpanExporter = SpanExporter
 typealias OtelJavaReadWriteSpan = ReadWriteSpan
 typealias OtelJavaReadableSpan = ReadableSpan
 typealias OtelJavaSpanProcessor = SpanProcessor
+typealias OtelJavaExtendedSpanProcessor = ExtendedSpanProcessor
 typealias OtelJavaOpenTelemetrySdk = OpenTelemetrySdk
 typealias OtelJavaSdkLoggerProvider = SdkLoggerProvider
 typealias OtelJavaSdkLoggerProviderBuilder = SdkLoggerProviderBuilder

--- a/sdk-api/api/jvm/sdk-api.api
+++ b/sdk-api/api/jvm/sdk-api.api
@@ -263,10 +263,15 @@ public abstract interface class io/opentelemetry/kotlin/tracing/export/SpanExpor
 
 public abstract interface class io/opentelemetry/kotlin/tracing/export/SpanProcessor : io/opentelemetry/kotlin/export/TelemetryCloseable {
 	public abstract fun isEndRequired ()Z
+	public abstract fun isOnEndingRequired ()Z
 	public abstract fun isStartRequired ()Z
 	public abstract fun onEnd (Lio/opentelemetry/kotlin/tracing/model/ReadableSpan;)V
 	public abstract fun onEnding (Lio/opentelemetry/kotlin/tracing/model/ReadWriteSpan;)V
 	public abstract fun onStart (Lio/opentelemetry/kotlin/tracing/model/ReadWriteSpan;Lio/opentelemetry/kotlin/context/Context;)V
+}
+
+public final class io/opentelemetry/kotlin/tracing/export/SpanProcessor$DefaultImpls {
+	public static fun isOnEndingRequired (Lio/opentelemetry/kotlin/tracing/export/SpanProcessor;)Z
 }
 
 public abstract interface class io/opentelemetry/kotlin/tracing/model/ReadWriteSpan : io/opentelemetry/kotlin/tracing/Span, io/opentelemetry/kotlin/tracing/model/ReadableSpan {

--- a/sdk-api/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/SpanProcessor.kt
+++ b/sdk-api/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/SpanProcessor.kt
@@ -39,4 +39,9 @@ public interface SpanProcessor : TelemetryCloseable {
      * Determines whether this span processor is required when a span ends.
      */
     public fun isEndRequired(): Boolean
+
+    /**
+     * Determines whether this span processor is required when a span is ending.
+     */
+    public fun isOnEndingRequired(): Boolean = true
 }

--- a/test-fakes/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/FakeSpanProcessor.kt
+++ b/test-fakes/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/FakeSpanProcessor.kt
@@ -8,6 +8,7 @@ import io.opentelemetry.kotlin.tracing.model.ReadableSpan
 class FakeSpanProcessor(
     var startRequired: Boolean = true,
     var endRequired: Boolean = true,
+    var onEndingRequired: Boolean = true,
     var flushCode: () -> OperationResultCode = { OperationResultCode.Success },
     var shutdownCode: () -> OperationResultCode = { OperationResultCode.Success },
     var startAction: (ReadWriteSpan, Context) -> Unit = { _, _ -> },
@@ -39,6 +40,7 @@ class FakeSpanProcessor(
 
     override fun isStartRequired(): Boolean = startRequired
     override fun isEndRequired(): Boolean = endRequired
+    override fun isOnEndingRequired(): Boolean = onEndingRequired
     override suspend fun forceFlush(): OperationResultCode = flushCode()
     override suspend fun shutdown(): OperationResultCode = shutdownCode()
 }


### PR DESCRIPTION
## Goal
Address https://github.com/open-telemetry/opentelemetry-kotlin/issues/636 and forward `onEnding` and `isOnEndingRequired` for adapted `SpanProcessor`s.

## Testing
Added new tests to `OtelJavaSpanProcessorAdapterTest`. This PR also adjusts the ordering in the `OtelJavaSpanProcessorAdapterTest` so that the callbacks are actually triggered (the `OtelKotlinTestRule.tracerProviderConfig` snapshots the tracers).