### PR TITLE
`OtelJavaSpanBuilderAdapter.setStartTimestamp` should obey TimeUnit

### DIFF
--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/tracing/OtelJavaSpanBuilderAdapter.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/tracing/OtelJavaSpanBuilderAdapter.kt
@@ -90,7 +90,7 @@ internal class OtelJavaSpanBuilderAdapter(
     }
 
     override fun setStartTimestamp(startTimestamp: Long, unit: TimeUnit): OtelJavaSpanBuilder {
-        start = startTimestamp
+        start = unit.toNanos(startTimestamp)
         return this
     }
 

--- a/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/tracing/OtelJavaSpanExportTest.kt
+++ b/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/tracing/OtelJavaSpanExportTest.kt
@@ -74,6 +74,18 @@ internal class OtelJavaSpanExportTest {
     }
 
     @Test
+    fun `test start timestamp is converted to nanos from given unit`() = runTest {
+        val span = tracer.spanBuilder("start_timestamp_span")
+            .setStartTimestamp(5, TimeUnit.MILLISECONDS)
+            .startSpan()
+        span.end()
+
+        harness.assertSpans(1, null) { spans ->
+            assertEquals(TimeUnit.MILLISECONDS.toNanos(5), spans[0].startTimestamp)
+        }
+    }
+
+    @Test
     fun `test span attributes export`() = runTest {
         val spanName = "span_attrs"
         val span = tracer.spanBuilder(spanName).startSpan()


### PR DESCRIPTION
## Goal
`OtelJavaSpanBuilderAdapter.setStartTimestamp` should convert the given `TimeUnit` into nanoseconds instead of directly copying the `startTimestamp` with no conversion


## Testing
Updated a new unit test to `OtelJavaSpanExportTest` inline with the existing tests for the `OtelJavaSpanBuilderAdapter`