### PR TITLE
Prevent Renovate from bumping minimum-supported version pins

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -13,6 +13,14 @@
     {
       "matchUpdateTypes": ["minor", "major"],
       "schedule": ["before 8am on Monday"]
+    },
+    {
+      "description": "Never bump the minimum-supported version pins in the version catalog. sharedVariableName is the version.ref of the catalog entry, with '-'/'_' normalized to '.'",
+      "matchManagers": ["gradle"],
+      "matchJsonata": [
+        "sharedVariableName in ['android.minSdk', 'android.minCompileSdk', 'android.minAgpVersion', 'minSupportedKotlinLang', 'minSupportedKotlinPlugin', 'minSupportedGradle']"
+      ],
+      "enabled": false
     }
   ],
   "labels": [


### PR DESCRIPTION
## Goal

The version catalog pins minimum-supported toolchain versions (`android-minSdk`, `android-minCompileSdk`, `android-minAgpVersion`, `minSupportedKotlinLang`, `minSupportedKotlinPlugin`, `minSupportedGradle`) so CI can test against the oldest supported versions. Renovate sees the catalog entries that reference these pins as outdated dependencies and keeps proposing bumps (#619, #594, #567), and closing those PRs only ignores that one update, so they come back.

This adds a package rule that disables Renovate updates for any dependency whose version comes from one of the min pins. Renovate has no dedicated matcher for version catalog refs, but its gradle manager records each catalog entry's `version.ref` as `sharedVariableName` (normalized `-`/`_` → `.`), which `matchJsonata` can match on. Once merged, Renovate should autoclose #619.
