### PR TITLE
Pin the klib consumer Kotlin floor at 2.4.0

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -18,7 +18,7 @@
       "description": "Never bump the minimum-supported version pins in the version catalog. sharedVariableName is the version.ref of the catalog entry, with '-'/'_' normalized to '.'",
       "matchManagers": ["gradle"],
       "matchJsonata": [
-        "sharedVariableName in ['android.minSdk', 'android.minCompileSdk', 'android.minAgpVersion', 'minSupportedKotlinLang', 'minSupportedKotlinPlugin', 'minSupportedGradle']"
+        "sharedVariableName in ['android.minSdk', 'android.minCompileSdk', 'android.minAgpVersion', 'minSupportedKotlinLang', 'minSupportedKotlinPlugin', 'minSupportedKotlinKlib', 'minSupportedGradle']"
       ],
       "enabled": false
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- Pin the minimum supported Kotlin version for iOS and JS (klib) consumers at 2.4.0 in the
+  version catalog, instead of implicitly tracking the Kotlin version this library is built
+  with. A Kotlin update that would raise this floor now fails the min-versions integration
+  test, so raising it becomes a deliberate, documented decision.
+  ([#647](https://github.com/open-telemetry/opentelemetry-kotlin/pull/647))
 - Clarify the minimum supported Kotlin version per target family: 2.0.0 applies to JVM
   and Android consumers only, while iOS and JS consumers need at least the Kotlin version
   this library is built with (currently 2.4.0) — a klib toolchain constraint shared by

--- a/gradle-integration-test/src/test/kotlin/io/opentelemetry/kotlin/integration/gradle/MinSupportedVersionsTest.kt
+++ b/gradle-integration-test/src/test/kotlin/io/opentelemetry/kotlin/integration/gradle/MinSupportedVersionsTest.kt
@@ -19,8 +19,10 @@ class MinSupportedVersionsTest {
         )
     }
 
-    // Klib (iOS/JS) consumers need at least the Kotlin version this library is built with,
-    // so the fixture builds with exactly that version. iOS coverage requires a macOS host.
+    // Klib (iOS/JS) consumers need at least the Kotlin version this library is built with, so the
+    // fixture builds with the declared klib floor (minSupportedKotlinKlib). A Kotlin bump that
+    // outgrows that pin fails here — raising the floor must be a deliberate decision, not a side
+    // effect of a dependency update. iOS coverage requires a macOS host.
     @Test
     fun `min supported versions can consume klib artifacts`(@TempDir tmp: Path) {
         assembleFixture(

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,6 +7,7 @@ android-minCompileSdk = "34"
 android-minAgpVersion = "8.0.2"
 minSupportedKotlinLang = "2.0"
 minSupportedKotlinPlugin = "2.0.0"
+minSupportedKotlinKlib = "2.4.0"
 minSupportedGradle = "8.0.2"
 detekt = "1.23.8"
 binaryCompatibilityValidator = "0.18.1"
@@ -94,7 +95,7 @@ buildKonfig = { id = "com.codingfeline.buildkonfig", version.ref = "buildKonfig"
 compose-multiplatform = { id = "org.jetbrains.compose", version.ref = "composeMultiplatform" }
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 test-kotlin-multiplatform-jvm = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "minSupportedKotlinPlugin" }
-test-kotlin-multiplatform-klib = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
+test-kotlin-multiplatform-klib = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "minSupportedKotlinKlib" }
 test-android-library = { id = "com.android.library", version.ref = "android-minAgpVersion" }
 
 [bundles]


### PR DESCRIPTION
## Goal

The min-versions klib fixture consumed the published iOS/JS artifacts with whatever Kotlin this library is currently built with (the `test-kotlin-multiplatform-klib` alias tracked the `kotlin` catalog version), so every Kotlin bump would silently raise the floor for klib consumers.

Pin the floor in the version catalog instead (`minSupportedKotlinKlib = 2.4.0`). A Kotlin update that outgrows the pin now fails the min-versions integration test, making a floor raise a deliberate, documented decision rather than a side effect of a dependency update.

The new pin is also added to Renovate's never-bump list (#645), matching the other minimum-supported version pins.

## Testing

Ran `publishToMavenLocal -PsnapshotPublish=true` followed by `:gradle-integration-test:test` locally (macOS): both fixtures pass, with the klib fixture resolving KGP 2.4.0 through the new pin.