### PR TITLE
Setup yaml parser

### DIFF
--- a/config/build.gradle.kts
+++ b/config/build.gradle.kts
@@ -12,6 +12,19 @@ kotlin {
         val commonMain by getting {
             dependencies {
                 implementation(project(":sdk-api"))
+                implementation(libs.yamlkt)
+                implementation(libs.okio)
+            }
+        }
+        val commonTest by getting {
+            dependencies {
+                implementation(libs.kotlin.test)
+                implementation(libs.okio.fakefilesystem)
+            }
+        }
+        val jvmTest by getting {
+            dependencies {
+                implementation(libs.kotlin.test)
             }
         }
     }

--- a/config/src/commonMain/kotlin/io/opentelemetry/kotlin/config/ConfigModule.kt
+++ b/config/src/commonMain/kotlin/io/opentelemetry/kotlin/config/ConfigModule.kt
@@ -1,6 +1,0 @@
-package io.opentelemetry.kotlin.config
-
-/**
- * Placeholder declaration so KMP artifacts are published.
- */
-internal object ConfigModule

--- a/config/src/commonMain/kotlin/io/opentelemetry/kotlin/config/YamlConfigParser.kt
+++ b/config/src/commonMain/kotlin/io/opentelemetry/kotlin/config/YamlConfigParser.kt
@@ -1,0 +1,34 @@
+package io.opentelemetry.kotlin.config
+
+import io.opentelemetry.kotlin.ExperimentalApi
+import net.mamoe.yamlkt.Yaml
+import okio.FileSystem
+import okio.Path
+
+/**
+ * Parses declarative-configuration YAML into a raw parsed value.
+ *
+ * Returned values follow yamlkt's representation (`Map<String, Any?>`, `List<*>`, or
+ * scalars), or `null` for an empty document.
+ */
+@ExperimentalApi
+class YamlConfigParser {
+
+    /**
+     * Parses a single YAML document from [yaml], returning the raw parsed value or `null` if
+     * the document is empty.
+     */
+    fun parse(yaml: String): Any? {
+        if (yaml.isBlank()) {
+            return null
+        }
+        return Yaml.decodeAnyFromString(yaml)
+    }
+
+    /**
+     * Reads the file at [path] from [fileSystem] and parses it as a single YAML document,
+     * returning the raw parsed value or `null` if the document is empty.
+     */
+    fun parse(fileSystem: FileSystem, path: Path): Any? =
+        parse(fileSystem.read(path) { readUtf8() })
+}

--- a/config/src/commonTest/kotlin/io/opentelemetry/kotlin/config/YamlConfigParserTest.kt
+++ b/config/src/commonTest/kotlin/io/opentelemetry/kotlin/config/YamlConfigParserTest.kt
@@ -1,0 +1,54 @@
+package io.opentelemetry.kotlin.config
+
+import okio.Path.Companion.toPath
+import okio.fakefilesystem.FakeFileSystem
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+internal class YamlConfigParserTest {
+
+    private val parser = YamlConfigParser()
+
+    @Test
+    fun emptyStringReturnsNull() {
+        assertNull(parser.parse(""))
+    }
+
+    @Test
+    fun parsesScalarMapping() {
+        val result = parser.parse("key: value")
+        assertEquals(mapOf("key" to "value"), result)
+    }
+
+    @Test
+    fun parsesNestedMapping() {
+        val yaml =
+            """
+            parent:
+              child: value
+            """.trimIndent()
+        val result = parser.parse(yaml)
+        assertEquals(mapOf("parent" to mapOf("child" to "value")), result)
+    }
+
+    @Test
+    fun emptyFileReturnsNull() {
+        val fileSystem = FakeFileSystem()
+        val path = "config.yaml".toPath()
+        fileSystem.write(path) { }
+
+        assertNull(parser.parse(fileSystem, path))
+    }
+
+    @Test
+    fun parsesFileContents() {
+        val fileSystem = FakeFileSystem()
+        val path = "config.yaml".toPath()
+        fileSystem.write(path) {
+            writeUtf8("key: value")
+        }
+
+        assertEquals(mapOf("key" to "value"), parser.parse(fileSystem, path))
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -34,6 +34,7 @@ buildKonfig = "0.22.0"
 composeMultiplatform = "1.11.1"
 androidxActivityCompose = "1.13.0"
 kotest = "6.2.2"
+yamlkt = "0.13.0"
 
 [libraries]
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
@@ -55,7 +56,9 @@ ktor-client-encoding = { module = "io.ktor:ktor-client-encoding", version.ref = 
 ktor-client-okhttp = { module = "io.ktor:ktor-client-okhttp", version.ref = "ktor" }
 ktor-client-cio = { module = "io.ktor:ktor-client-cio", version.ref = "ktor" }
 ktor-client-mock = { module = "io.ktor:ktor-client-mock", version.ref = "ktor" }
+okio = { module = "com.squareup.okio:okio", version.ref = "okio" }
 okio-fakefilesystem = { module = "com.squareup.okio:okio-fakefilesystem", version.ref = "okio" }
+yamlkt = { module = "net.mamoe.yamlkt:yamlkt", version.ref = "yamlkt" }
 opentelemetry-bom = { group = "io.opentelemetry", name = "opentelemetry-bom", version.ref = "otel" }
 opentelemetry-bom-alpha = { group = "io.opentelemetry", name = "opentelemetry-bom-alpha", version.ref = "otel-alpha" }
 opentelemetry-api = { group = "io.opentelemetry", name = "opentelemetry-api"}

--- a/implementation/build.gradle.kts
+++ b/implementation/build.gradle.kts
@@ -24,7 +24,6 @@ kotlin {
             dependencies {
                 implementation(project(":sdk-api"))
                 implementation(project(":sdk-common"))
-                implementation(project(":config"))
                 implementation(project(":api-ext"))
                 implementation(project(":sdk-api"))
                 implementation(project(":model"))


### PR DESCRIPTION
## Goal

Closes #535 by setting up a YAML parser that can be used for declarative configuration. https://github.com/him188/yamlkt seems to be the best choice for KMP YAML parsers as it's used by Ktor.

## Testing

Added a unit test.
