### PR TITLE
Download opentelemetry-configuration schema

### DIFF
--- a/.github/workflows/update-config.yml
+++ b/.github/workflows/update-config.yml
@@ -1,0 +1,82 @@
+name: Update declarative configuration schema
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  update-config:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Check for new opentelemetry-configuration version
+        run: |
+          latest=$(gh api repos/open-telemetry/opentelemetry-configuration/releases/latest --jq '.tag_name' | sed 's/^v//')
+          current=$(grep 'val openTelemetryConfigurationVersion' config/build.gradle.kts | sed 's/.*"\(.*\)".*/\1/')
+
+          echo "Latest opentelemetry-configuration version: $latest"
+          echo "Current opentelemetry-configuration version: $current"
+
+          if [[ "$latest" == "$current" ]]; then
+            echo "Already up to date, nothing to do."
+            echo "UP_TO_DATE=true" >> $GITHUB_ENV
+          else
+            echo "New version available: $latest"
+            echo "UP_TO_DATE=false" >> $GITHUB_ENV
+            echo "LATEST=$latest" >> $GITHUB_ENV
+            echo "CURRENT=$current" >> $GITHUB_ENV
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Java
+        if: env.UP_TO_DATE == 'false'
+        uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5.5.0
+        with:
+          distribution: 'adopt'
+          java-version: 21
+
+      - name: Setup Gradle
+        if: env.UP_TO_DATE == 'false'
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
+
+      - name: Update opentelemetry-configuration version in build file
+        if: env.UP_TO_DATE == 'false'
+        run: |
+          sed -Ei "s/(val openTelemetryConfigurationVersion = \").*\"/\1${LATEST}\"/" config/build.gradle.kts
+
+      - name: Regenerate declarative configuration classes
+        if: env.UP_TO_DATE == 'false'
+        run: ./gradlew :config:generateOpenTelemetryConfiguration
+
+      - name: Use CLA approved github bot
+        if: env.UP_TO_DATE == 'false'
+        run: .github/scripts/use-cla-approved-github-bot.sh
+
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        if: env.UP_TO_DATE == 'false'
+        id: otelbot-token
+        with:
+          client-id: ${{ vars.OTELBOT_CLIENT_ID }}
+          private-key: ${{ secrets.OTELBOT_PRIVATE_KEY }}
+
+      - name: Create pull request
+        if: env.UP_TO_DATE == 'false'
+        env:
+          GH_TOKEN: ${{ steps.otelbot-token.outputs.token }}
+        run: |
+          message="Update opentelemetry-configuration to v${LATEST}"
+          branch="otelbot/update-config-to-${LATEST}"
+
+          git checkout -b $branch
+          git add config/build.gradle.kts config/src/
+          git commit -m "$message"
+          git push --set-upstream origin $branch
+          gh pr create --title "$message" \
+                       --body "Updates opentelemetry-configuration from \`${CURRENT}\` to \`v${LATEST}\`." \
+                       --base main

--- a/config/build.gradle.kts
+++ b/config/build.gradle.kts
@@ -1,3 +1,5 @@
+import de.undercouch.gradle.tasks.download.Download
+
 plugins {
     kotlin("multiplatform")
     id("com.android.kotlin.multiplatform.library")
@@ -5,7 +7,13 @@ plugins {
     id("signing")
     id("com.vanniktech.maven.publish")
     id("org.jetbrains.kotlinx.kover")
+    alias(libs.plugins.download)
 }
+
+// release version of https://github.com/open-telemetry/opentelemetry-configuration
+val openTelemetryConfigurationVersion = "1.1.0"
+val openTelemetryConfigurationRepoZip =
+    "https://github.com/open-telemetry/opentelemetry-configuration/archive/v${openTelemetryConfigurationVersion}.zip"
 
 kotlin {
     sourceSets {
@@ -14,5 +22,41 @@ kotlin {
                 implementation(project(":sdk-api"))
             }
         }
+    }
+}
+
+val downloadOpenTelemetryConfiguration by tasks.registering(Download::class) {
+    src(openTelemetryConfigurationRepoZip)
+    dest(
+        layout.buildDirectory.file(
+            "opentelemetry-configuration-${openTelemetryConfigurationVersion}/opentelemetry-configuration.zip"
+        )
+    )
+    overwrite(false)
+}
+
+val refreshOpenTelemetryConfiguration by tasks.registering(Copy::class) {
+    dependsOn(downloadOpenTelemetryConfiguration)
+
+    from(zipTree(downloadOpenTelemetryConfiguration.get().dest))
+    eachFile(closureOf<FileCopyDetails> {
+        // remove top level folder (opentelemetry-configuration-<version>/)
+        val pathParts = path.split("/")
+        path = pathParts.subList(1, pathParts.size).joinToString("/")
+    })
+    into(layout.buildDirectory.dir("opentelemetry-configuration-${openTelemetryConfigurationVersion}/"))
+}
+
+// This task will generate Kotlin data-model classes from the downloaded opentelemetry-configuration
+// JSON schema. It's currently a no-op.
+tasks.register("generateOpenTelemetryConfiguration") {
+    dependsOn(refreshOpenTelemetryConfiguration)
+    val schemaDir =
+        layout.buildDirectory.dir("opentelemetry-configuration-${openTelemetryConfigurationVersion}")
+    doLast {
+        logger.lifecycle(
+            "generateOpenTelemetryConfiguration is a no-op placeholder; " +
+                    "schema available at ${schemaDir.get().asFile}"
+        )
     }
 }


### PR DESCRIPTION
## Goal

Partially addresses #533 by writing gradle tasks that download the schema from the opentelemetry-configuration repository. This uses a similar approach to the semantic convention generation and adds a new GH workflow that creates a PR with the necessary changes.

## Testing

Ran the task locally and inspected the build directory.