### PR TITLE
Supply root context to ImplicitContextStorage

### DIFF
--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/ContextConfigImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/ContextConfigImpl.kt
@@ -9,14 +9,14 @@ import io.opentelemetry.kotlin.context.threadLocalImplicitContextStorage
 internal class ContextConfigImpl : ContextConfigDsl {
     override var storageMode: ImplicitContextStorageMode = ImplicitContextStorageMode.GLOBAL
 
-    private var customStorage: (() -> ImplicitContextStorage)? = null
+    private var customStorage: ((() -> Context) -> ImplicitContextStorage)? = null
 
-    override fun storage(action: () -> ImplicitContextStorage) {
+    override fun storage(action: (rootSupplier: () -> Context) -> ImplicitContextStorage) {
         customStorage = action
     }
 
     internal fun generateStorage(rootSupplier: () -> Context): ImplicitContextStorage {
-        customStorage?.let { return it() }
+        customStorage?.let { return it(rootSupplier) }
         return when (storageMode) {
             ImplicitContextStorageMode.GLOBAL -> DefaultImplicitContextStorage(rootSupplier)
             ImplicitContextStorageMode.THREAD_LOCAL -> threadLocalImplicitContextStorage(rootSupplier)

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/init/OpenTelemetryConfigImplTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/init/OpenTelemetryConfigImplTest.kt
@@ -4,6 +4,7 @@ import io.opentelemetry.kotlin.NoopOpenTelemetry
 import io.opentelemetry.kotlin.attributes.DEFAULT_ATTRIBUTE_LIMIT
 import io.opentelemetry.kotlin.attributes.DEFAULT_ATTRIBUTE_VALUE_LENGTH_LIMIT
 import io.opentelemetry.kotlin.clock.FakeClock
+import io.opentelemetry.kotlin.context.Context
 import io.opentelemetry.kotlin.context.DefaultImplicitContextStorage
 import io.opentelemetry.kotlin.context.FakeContext
 import io.opentelemetry.kotlin.context.FakeImplicitContextStorage
@@ -156,6 +157,23 @@ internal class OpenTelemetryConfigImplTest {
             }
         }
         assertSame(custom, cfg.contextConfig.generateStorage(::FakeContext))
+    }
+
+    @Test
+    fun testCustomStorageReceivesRootSupplier() {
+        val root = FakeContext()
+        var captured: (() -> Context)? = null
+        val cfg = OpenTelemetryConfigImpl(clock).apply {
+            context {
+                storage { rootSupplier ->
+                    captured = rootSupplier
+                    DefaultImplicitContextStorage(rootSupplier)
+                }
+            }
+        }
+        val storage = cfg.contextConfig.generateStorage { root }
+        assertSame(root, captured?.invoke())
+        assertSame(root, storage.implicitContext())
     }
 
     @Test

--- a/sdk-api/api/jvm/sdk-api.api
+++ b/sdk-api/api/jvm/sdk-api.api
@@ -104,7 +104,7 @@ public abstract interface annotation class io/opentelemetry/kotlin/init/ConfigDs
 public abstract interface class io/opentelemetry/kotlin/init/ContextConfigDsl {
 	public abstract fun getStorageMode ()Lio/opentelemetry/kotlin/context/ImplicitContextStorageMode;
 	public abstract fun setStorageMode (Lio/opentelemetry/kotlin/context/ImplicitContextStorageMode;)V
-	public abstract fun storage (Lkotlin/jvm/functions/Function0;)V
+	public abstract fun storage (Lkotlin/jvm/functions/Function1;)V
 }
 
 public abstract interface class io/opentelemetry/kotlin/init/LogExportConfigDsl {

--- a/sdk-api/src/commonMain/kotlin/io/opentelemetry/kotlin/init/ContextConfigDsl.kt
+++ b/sdk-api/src/commonMain/kotlin/io/opentelemetry/kotlin/init/ContextConfigDsl.kt
@@ -1,6 +1,7 @@
 package io.opentelemetry.kotlin.init
 
 import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.context.Context
 import io.opentelemetry.kotlin.context.ImplicitContextStorage
 import io.opentelemetry.kotlin.context.ImplicitContextStorageMode
 
@@ -20,6 +21,9 @@ public interface ContextConfigDsl {
     /**
      * Plugs in a custom [ImplicitContextStorage] implementation. When set, this takes precedence
      * over [storageMode]. May only be called once.
+     *
+     * The [action] receives a `rootSupplier` that provides the root [Context], allowing the
+     * custom implementation to fall back to the root context when none is set.
      */
-    public fun storage(action: () -> ImplicitContextStorage)
+    public fun storage(action: (rootSupplier: () -> Context) -> ImplicitContextStorage)
 }


### PR DESCRIPTION
## Goal

Alters the API so that if a custom `ImplicitContextStorage` is specified, a root context supplier is available. This is important as custom storage will always want to start with root context as the default, but currently it's not possible to access this until after the SDK has initialized.