### PR TITLE
Alter the default sampler used in Tracer

### DIFF
--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/TracerProviderConfigImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/TracerProviderConfigImpl.kt
@@ -9,6 +9,7 @@ import io.opentelemetry.kotlin.resource.Resource
 import io.opentelemetry.kotlin.tracing.export.SpanProcessor
 import io.opentelemetry.kotlin.tracing.sampling.Sampler
 import io.opentelemetry.kotlin.tracing.sampling.alwaysOn
+import io.opentelemetry.kotlin.tracing.sampling.parentBased
 
 internal class TracerProviderConfigImpl(
     private val clock: Clock,
@@ -17,7 +18,7 @@ internal class TracerProviderConfigImpl(
 
     private var processor: SpanProcessor? = null
     private var spanLimitsAction: SpanLimitsConfigDsl.() -> Unit = {}
-    private var samplerAction: SamplerConfigDsl.() -> Sampler = { alwaysOn() }
+    private var samplerAction: SamplerConfigDsl.() -> Sampler = { parentBased(root = alwaysOn()) }
 
     override fun spanLimits(action: SpanLimitsConfigDsl.() -> Unit) {
         spanLimitsAction = action

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/config/TracingConfig.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/config/TracingConfig.kt
@@ -4,7 +4,9 @@ import io.opentelemetry.kotlin.ThreadSafe
 import io.opentelemetry.kotlin.factory.SpanFactory
 import io.opentelemetry.kotlin.resource.Resource
 import io.opentelemetry.kotlin.tracing.export.SpanProcessor
+import io.opentelemetry.kotlin.tracing.sampling.AlwaysOffSampler
 import io.opentelemetry.kotlin.tracing.sampling.AlwaysOnSampler
+import io.opentelemetry.kotlin.tracing.sampling.ParentBasedSampler
 import io.opentelemetry.kotlin.tracing.sampling.Sampler
 
 /**
@@ -31,5 +33,13 @@ internal class TracingConfig(
     /**
      * Factory that produces the sampler to use when creating spans.
      */
-    val samplerFactory: (SpanFactory) -> Sampler = { _ -> AlwaysOnSampler() },
+    val samplerFactory: (SpanFactory) -> Sampler = { _ ->
+        ParentBasedSampler(
+            root = AlwaysOnSampler(),
+            remoteParentSampled = AlwaysOnSampler(),
+            remoteParentNotSampled = AlwaysOffSampler(),
+            localParentSampled = AlwaysOnSampler(),
+            localParentNotSampled = AlwaysOffSampler(),
+        )
+    },
 )

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/init/TracerProviderConfigImplTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/init/TracerProviderConfigImplTest.kt
@@ -1,19 +1,33 @@
 package io.opentelemetry.kotlin.init
 
 import io.opentelemetry.kotlin.assertHasSdkDefaultAttributes
+import io.opentelemetry.kotlin.attributes.AttributesModel
 import io.opentelemetry.kotlin.attributes.DEFAULT_ATTRIBUTE_LIMIT
 import io.opentelemetry.kotlin.clock.FakeClock
+import io.opentelemetry.kotlin.context.Context
+import io.opentelemetry.kotlin.factory.ContextFactoryImpl
 import io.opentelemetry.kotlin.factory.FakeSpanFactory
+import io.opentelemetry.kotlin.factory.IdGeneratorImpl
+import io.opentelemetry.kotlin.factory.SpanContextFactoryImpl
+import io.opentelemetry.kotlin.factory.SpanFactoryImpl
+import io.opentelemetry.kotlin.factory.TraceFlagsFactoryImpl
+import io.opentelemetry.kotlin.factory.TraceStateFactoryImpl
 import io.opentelemetry.kotlin.sdkDefaultAttributes
 import io.opentelemetry.kotlin.semconv.ServiceAttributes
 import io.opentelemetry.kotlin.semconv.TelemetryAttributes
+import io.opentelemetry.kotlin.tracing.NonRecordingSpan
+import io.opentelemetry.kotlin.tracing.SpanKind
+import io.opentelemetry.kotlin.tracing.TraceFlagsImpl
 import io.opentelemetry.kotlin.tracing.export.FakeSpanProcessor
 import io.opentelemetry.kotlin.tracing.export.SpanProcessor
 import io.opentelemetry.kotlin.tracing.export.compositeSpanProcessor
-import io.opentelemetry.kotlin.tracing.sampling.AlwaysOnSampler
 import io.opentelemetry.kotlin.tracing.sampling.FakeSampler
+import io.opentelemetry.kotlin.tracing.sampling.ParentBasedSampler
+import io.opentelemetry.kotlin.tracing.sampling.Sampler
+import io.opentelemetry.kotlin.tracing.sampling.SamplingResult.Decision
 import io.opentelemetry.kotlin.tracing.sampling.alwaysOn
 import kotlin.test.Test
+import kotlin.test.assertContains
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
 import kotlin.test.assertNotNull
@@ -26,10 +40,46 @@ internal class TracerProviderConfigImplTest {
     private val clock = FakeClock()
     private val base = sdkDefaultResource()
 
+    private val traceFlagsFactory = TraceFlagsFactoryImpl()
+    private val traceStateFactory = TraceStateFactoryImpl()
+    private val spanContextFactory =
+        SpanContextFactoryImpl(IdGeneratorImpl(), traceFlagsFactory, traceStateFactory)
+    private val contextFactory = ContextFactoryImpl(SpanFactoryImpl(spanContextFactory))
+
     @Test
-    fun testDefaultSamplerAlwaysOn() {
+    fun testDefaultSamplerParentBased() {
         val cfg = TracerProviderConfigImpl(clock).generateTracingConfig(base)
-        assertIs<AlwaysOnSampler>(cfg.samplerFactory(FakeSpanFactory()))
+        val sampler = assertIs<ParentBasedSampler>(cfg.samplerFactory(FakeSpanFactory()))
+        assertContains(sampler.description, "root:AlwaysOnSampler")
+    }
+
+    @Test
+    fun testDefaultSamplerRootSamples() {
+        assertEquals(Decision.RECORD_AND_SAMPLE, defaultSampler().decisionFor(contextFactory.root()))
+    }
+
+    @Test
+    fun testDefaultSamplerRemoteParentSampled() {
+        val context = contextWithParent(sampled = true, isRemote = true)
+        assertEquals(Decision.RECORD_AND_SAMPLE, defaultSampler().decisionFor(context))
+    }
+
+    @Test
+    fun testDefaultSamplerRemoteParentNotSampled() {
+        val context = contextWithParent(sampled = false, isRemote = true)
+        assertEquals(Decision.DROP, defaultSampler().decisionFor(context))
+    }
+
+    @Test
+    fun testDefaultSamplerLocalParentSampled() {
+        val context = contextWithParent(sampled = true, isRemote = false)
+        assertEquals(Decision.RECORD_AND_SAMPLE, defaultSampler().decisionFor(context))
+    }
+
+    @Test
+    fun testDefaultSamplerLocalParentNotSampled() {
+        val context = contextWithParent(sampled = false, isRemote = false)
+        assertEquals(Decision.DROP, defaultSampler().decisionFor(context))
     }
 
     @Test
@@ -199,4 +249,32 @@ internal class TracerProviderConfigImplTest {
         }.generateTracingConfig(base)
         assertEquals(value, cfg.resource.attributes[ServiceAttributes.SERVICE_NAME])
     }
+
+    private fun defaultSampler(): Sampler =
+        TracerProviderConfigImpl(clock).generateTracingConfig(base).samplerFactory(FakeSpanFactory())
+
+    private fun contextWithParent(sampled: Boolean, isRemote: Boolean): Context {
+        val traceFlags = when {
+            sampled -> traceFlagsFactory.default
+            else -> TraceFlagsImpl(isSampled = false, isRandom = false)
+        }
+        val parentSpanContext = spanContextFactory.create(
+            traceId = "12345678901234567890123456789012",
+            spanId = "1234567890123456",
+            traceFlags = traceFlags,
+            traceState = traceStateFactory.default,
+            isRemote = isRemote,
+        )
+        val parentSpan = NonRecordingSpan(spanContextFactory.invalid, parentSpanContext)
+        return contextFactory.root().storeSpan(parentSpan)
+    }
+
+    private fun Sampler.decisionFor(context: Context): Decision = shouldSample(
+        context = context,
+        traceId = "12345678901234567890123456789012",
+        name = "span",
+        spanKind = SpanKind.INTERNAL,
+        attributes = AttributesModel(),
+        links = emptyList(),
+    ).decision
 }


### PR DESCRIPTION
## Goal

Closes #669 by amending the default sampler used by Tracer to `ParentBased(alwaysOn)`.

## Testing

Added unit tests.
