### PR TITLE
Tweak default schedule delay

### DIFF
--- a/exporters-core/api/android/exporters-core.api
+++ b/exporters-core/api/android/exporters-core.api
@@ -1,9 +1,10 @@
 public final class io/opentelemetry/kotlin/export/BatchTelemetryDefaults {
 	public static final field EXPORT_TIMEOUT_MS J
 	public static final field INSTANCE Lio/opentelemetry/kotlin/export/BatchTelemetryDefaults;
+	public static final field LOG_SCHEDULE_DELAY_MS J
 	public static final field MAX_EXPORT_BATCH_SIZE I
 	public static final field MAX_QUEUE_SIZE I
-	public static final field SCHEDULE_DELAY_MS J
+	public static final field SPAN_SCHEDULE_DELAY_MS J
 }
 
 public final class io/opentelemetry/kotlin/logging/export/CoreLogRecordExporterApiKt {

--- a/exporters-core/api/jvm/exporters-core.api
+++ b/exporters-core/api/jvm/exporters-core.api
@@ -2,10 +2,11 @@ public final class io/opentelemetry/kotlin/export/BatchTelemetryDefaults {
 	public static final field EXPORT_TIMEOUT_MS J
 	public static final field FORCE_FLUSH_TIMEOUT_MS J
 	public static final field INSTANCE Lio/opentelemetry/kotlin/export/BatchTelemetryDefaults;
+	public static final field LOG_SCHEDULE_DELAY_MS J
 	public static final field MAX_EXPORT_BATCH_SIZE I
 	public static final field MAX_QUEUE_SIZE I
-	public static final field SCHEDULE_DELAY_MS J
 	public static final field SHUTDOWN_TIMEOUT_MS J
+	public static final field SPAN_SCHEDULE_DELAY_MS J
 }
 
 public final class io/opentelemetry/kotlin/logging/export/CoreLogRecordExporterApiKt {

--- a/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/export/BatchTelemetryConfig.kt
+++ b/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/export/BatchTelemetryConfig.kt
@@ -6,7 +6,7 @@ import io.opentelemetry.kotlin.error.SdkErrorHandler
 
 internal class BatchTelemetryConfig(
     maxQueueSize: Int = BatchTelemetryDefaults.MAX_QUEUE_SIZE,
-    scheduleDelayMs: Long = BatchTelemetryDefaults.SCHEDULE_DELAY_MS,
+    scheduleDelayMs: Long = BatchTelemetryDefaults.SPAN_SCHEDULE_DELAY_MS,
     exportTimeoutMs: Long = BatchTelemetryDefaults.EXPORT_TIMEOUT_MS,
     maxExportBatchSize: Int = BatchTelemetryDefaults.MAX_EXPORT_BATCH_SIZE,
     forceFlushTimeoutMs: Long = BatchTelemetryDefaults.FORCE_FLUSH_TIMEOUT_MS,
@@ -31,7 +31,7 @@ internal class BatchTelemetryConfig(
         api = API,
         configParameterName = "scheduleDelayMs",
         value = scheduleDelayMs,
-        default = BatchTelemetryDefaults.SCHEDULE_DELAY_MS,
+        default = BatchTelemetryDefaults.SPAN_SCHEDULE_DELAY_MS,
     ) { it > 0 }
 
     /**

--- a/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/export/BatchTelemetryDefaults.kt
+++ b/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/export/BatchTelemetryDefaults.kt
@@ -14,9 +14,16 @@ public object BatchTelemetryDefaults {
     public const val MAX_QUEUE_SIZE: Int = 2048
 
     /**
-     * Delay in ms before a flush is triggered
+     * Delay in ms before a flush is triggered for spans.
+     * See https://opentelemetry.io/docs/specs/otel/trace/sdk/#batching-processor
      */
-    public const val SCHEDULE_DELAY_MS: Long = 5000
+    public const val SPAN_SCHEDULE_DELAY_MS: Long = 5000
+
+    /**
+     * Delay in ms before a flush is triggered for log records.
+     * See https://opentelemetry.io/docs/specs/otel/logs/sdk/#batching-processor
+     */
+    public const val LOG_SCHEDULE_DELAY_MS: Long = 1000
 
     /**
      * Timeout in ms for exporting telemetry

--- a/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/CoreLogRecordExporterApi.kt
+++ b/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/CoreLogRecordExporterApi.kt
@@ -56,7 +56,7 @@ public fun LogExportConfigDsl.compositeLogRecordExporter(vararg exporters: LogRe
 public fun LogExportConfigDsl.batchLogRecordProcessor(
     exporter: LogRecordExporter,
     maxQueueSize: Int = BatchTelemetryDefaults.MAX_QUEUE_SIZE,
-    scheduleDelayMs: Long = BatchTelemetryDefaults.SCHEDULE_DELAY_MS,
+    scheduleDelayMs: Long = BatchTelemetryDefaults.LOG_SCHEDULE_DELAY_MS,
     exportTimeoutMs: Long = BatchTelemetryDefaults.EXPORT_TIMEOUT_MS,
     maxExportBatchSize: Int = BatchTelemetryDefaults.MAX_EXPORT_BATCH_SIZE,
     dispatcher: CoroutineDispatcher = Dispatchers.Default,

--- a/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/CoreSpanExporterApi.kt
+++ b/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/CoreSpanExporterApi.kt
@@ -49,13 +49,13 @@ public fun TraceExportConfigDsl.compositeSpanExporter(vararg exporters: SpanExpo
 
 /**
  * Creates a batching processor that sends telemetry in batches.
- * See https://opentelemetry.io/docs/specs/otel/logs/sdk/#batching-processor
+ * See https://opentelemetry.io/docs/specs/otel/trace/sdk/#batching-processor
  */
 @ExperimentalApi
 public fun TraceExportConfigDsl.batchSpanProcessor(
     exporter: SpanExporter,
     maxQueueSize: Int = BatchTelemetryDefaults.MAX_QUEUE_SIZE,
-    scheduleDelayMs: Long = BatchTelemetryDefaults.SCHEDULE_DELAY_MS,
+    scheduleDelayMs: Long = BatchTelemetryDefaults.SPAN_SCHEDULE_DELAY_MS,
     exportTimeoutMs: Long = BatchTelemetryDefaults.EXPORT_TIMEOUT_MS,
     maxExportBatchSize: Int = BatchTelemetryDefaults.MAX_EXPORT_BATCH_SIZE,
     dispatcher: CoroutineDispatcher = Dispatchers.Default,

--- a/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/export/BatchTelemetryConfigTest.kt
+++ b/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/export/BatchTelemetryConfigTest.kt
@@ -10,7 +10,7 @@ internal class BatchTelemetryConfigTest {
     fun testDefaults() {
         val cfg = BatchTelemetryConfig()
         assertEquals(BatchTelemetryDefaults.MAX_QUEUE_SIZE, cfg.maxQueueSize)
-        assertEquals(BatchTelemetryDefaults.SCHEDULE_DELAY_MS, cfg.scheduleDelayMs)
+        assertEquals(BatchTelemetryDefaults.SPAN_SCHEDULE_DELAY_MS, cfg.scheduleDelayMs)
         assertEquals(BatchTelemetryDefaults.EXPORT_TIMEOUT_MS, cfg.exportTimeoutMs)
         assertEquals(BatchTelemetryDefaults.MAX_EXPORT_BATCH_SIZE, cfg.maxExportBatchSize)
         assertEquals(BatchTelemetryDefaults.FORCE_FLUSH_TIMEOUT_MS, cfg.forceFlushTimeoutMs)

--- a/exporters-persistence/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/PersistingLogRecordProcessorApi.kt
+++ b/exporters-persistence/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/PersistingLogRecordProcessorApi.kt
@@ -33,7 +33,7 @@ public fun LogExportConfigDsl.persistingLogRecordProcessor(
     exporter: LogRecordExporter,
     cacheDirectory: Path,
     maxQueueSize: Int = BatchTelemetryDefaults.MAX_QUEUE_SIZE,
-    scheduleDelayMs: Long = BatchTelemetryDefaults.SCHEDULE_DELAY_MS,
+    scheduleDelayMs: Long = BatchTelemetryDefaults.LOG_SCHEDULE_DELAY_MS,
     exportTimeoutMs: Long = BatchTelemetryDefaults.EXPORT_TIMEOUT_MS,
     maxExportBatchSize: Int = BatchTelemetryDefaults.MAX_EXPORT_BATCH_SIZE,
 ): LogRecordProcessor {
@@ -54,7 +54,7 @@ internal fun LogExportConfigDsl.persistingLogRecordProcessorImpl(
     exporter: LogRecordExporter,
     fileSystem: TelemetryFileSystem,
     maxQueueSize: Int = BatchTelemetryDefaults.MAX_QUEUE_SIZE,
-    scheduleDelayMs: Long = BatchTelemetryDefaults.SCHEDULE_DELAY_MS,
+    scheduleDelayMs: Long = BatchTelemetryDefaults.LOG_SCHEDULE_DELAY_MS,
     exportTimeoutMs: Long = BatchTelemetryDefaults.EXPORT_TIMEOUT_MS,
     maxExportBatchSize: Int = BatchTelemetryDefaults.MAX_EXPORT_BATCH_SIZE,
     sdkErrorHandler: SdkErrorHandler = NoopSdkErrorHandler,

--- a/exporters-persistence/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/PersistingSpanProcessorApi.kt
+++ b/exporters-persistence/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/PersistingSpanProcessorApi.kt
@@ -33,7 +33,7 @@ public fun TraceExportConfigDsl.persistingSpanProcessor(
     exporter: SpanExporter,
     cacheDirectory: Path,
     maxQueueSize: Int = BatchTelemetryDefaults.MAX_QUEUE_SIZE,
-    scheduleDelayMs: Long = BatchTelemetryDefaults.SCHEDULE_DELAY_MS,
+    scheduleDelayMs: Long = BatchTelemetryDefaults.SPAN_SCHEDULE_DELAY_MS,
     exportTimeoutMs: Long = BatchTelemetryDefaults.EXPORT_TIMEOUT_MS,
     maxExportBatchSize: Int = BatchTelemetryDefaults.MAX_EXPORT_BATCH_SIZE,
 ): SpanProcessor {
@@ -54,7 +54,7 @@ internal fun TraceExportConfigDsl.persistingSpanProcessorImpl(
     exporter: SpanExporter,
     fileSystem: TelemetryFileSystem,
     maxQueueSize: Int = BatchTelemetryDefaults.MAX_QUEUE_SIZE,
-    scheduleDelayMs: Long = BatchTelemetryDefaults.SCHEDULE_DELAY_MS,
+    scheduleDelayMs: Long = BatchTelemetryDefaults.SPAN_SCHEDULE_DELAY_MS,
     exportTimeoutMs: Long = BatchTelemetryDefaults.EXPORT_TIMEOUT_MS,
     maxExportBatchSize: Int = BatchTelemetryDefaults.MAX_EXPORT_BATCH_SIZE,
     sdkErrorHandler: SdkErrorHandler = NoopSdkErrorHandler,


### PR DESCRIPTION
## Goal

Closes #674 by using the correct default scheduling delay for batch log record processors.
