### PR TITLE
Allow supplying custom IdGenerator

### DIFF
--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/OpenTelemetryCompatEntrypoint.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/OpenTelemetryCompatEntrypoint.kt
@@ -3,13 +3,11 @@ package io.opentelemetry.kotlin
 import io.opentelemetry.kotlin.clock.ClockAdapter
 import io.opentelemetry.kotlin.factory.CompatBaggageFactory
 import io.opentelemetry.kotlin.factory.CompatContextFactory
-import io.opentelemetry.kotlin.factory.CompatIdGenerator
 import io.opentelemetry.kotlin.factory.CompatResourceFactory
 import io.opentelemetry.kotlin.factory.CompatSpanContextFactory
 import io.opentelemetry.kotlin.factory.CompatSpanFactory
 import io.opentelemetry.kotlin.factory.CompatTraceFlagsFactory
 import io.opentelemetry.kotlin.factory.CompatTraceStateFactory
-import io.opentelemetry.kotlin.factory.IdGenerator
 import io.opentelemetry.kotlin.init.CompatOpenTelemetryConfig
 import io.opentelemetry.kotlin.init.OpenTelemetryConfigDsl
 
@@ -27,29 +25,17 @@ public fun createCompatOpenTelemetry(
     clock: Clock = ClockAdapter(io.opentelemetry.sdk.common.Clock.getDefault()),
     config: OpenTelemetryConfigDsl.() -> Unit = {}
 ): OpenTelemetry {
-    return createCompatOpenTelemetryImpl(clock, config)
-}
-
-/**
- * Internal implementation of [createCompatOpenTelemetry]. This is not publicly visible as
- * we don't want to allow users to supply a custom [IdGenerator].
- */
-@ExperimentalApi
-internal fun createCompatOpenTelemetryImpl(
-    clock: Clock,
-    config: OpenTelemetryConfigDsl.() -> Unit,
-    idGenerator: IdGenerator = CompatIdGenerator(),
-): OpenTelemetry {
     val traceFlags = CompatTraceFlagsFactory()
     val traceState = CompatTraceStateFactory()
     val spanContext = CompatSpanContextFactory()
     val contextFactory = CompatContextFactory()
     val span = CompatSpanFactory(spanContext)
 
-    val cfg = CompatOpenTelemetryConfig(clock, idGenerator).apply(config)
+    val cfg = CompatOpenTelemetryConfig(clock).apply(config)
+    val resolvedIdGenerator = cfg.resolveIdGenerator()
     val base = cfg.buildGlobalResource()
     return CompatOpenTelemetryImpl(
-        tracerProvider = cfg.tracerProviderConfig.build(clock, base, cfg.globalAttributeLimits),
+        tracerProvider = cfg.tracerProviderConfig.build(clock, resolvedIdGenerator, base, cfg.globalAttributeLimits),
         loggerProvider = cfg.loggerProviderConfig.build(clock, base, cfg.globalAttributeLimits),
         meterProvider = cfg.meterProviderConfig.build(clock, base),
         clock = clock,
@@ -59,7 +45,7 @@ internal fun createCompatOpenTelemetryImpl(
         context = contextFactory,
         span = span,
         baggage = CompatBaggageFactory(),
-        idGenerator = idGenerator,
+        idGenerator = resolvedIdGenerator,
         resource = CompatResourceFactory,
         propagator = cfg.propagatorCfg.buildPropagator(),
     )

--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/factory/OtelJavaIdGeneratorAdapter.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/factory/OtelJavaIdGeneratorAdapter.kt
@@ -1,0 +1,14 @@
+package io.opentelemetry.kotlin.factory
+
+import io.opentelemetry.kotlin.aliases.OtelJavaIdGenerator
+
+/**
+ * Wraps a Kotlin [IdGenerator] so it can be supplied to the underlying opentelemetry-java
+ * [OtelJavaIdGenerator].
+ */
+internal class OtelJavaIdGeneratorAdapter(
+    private val impl: IdGenerator,
+) : OtelJavaIdGenerator {
+    override fun generateSpanId(): String = impl.generateSpanIdBytes().toHexString()
+    override fun generateTraceId(): String = impl.generateTraceIdBytes().toHexString()
+}

--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/init/CompatOpenTelemetryConfig.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/init/CompatOpenTelemetryConfig.kt
@@ -6,6 +6,7 @@ import io.opentelemetry.kotlin.aliases.OtelJavaResource
 import io.opentelemetry.kotlin.attributes.AttributesMutator
 import io.opentelemetry.kotlin.attributes.CompatAttributesModel
 import io.opentelemetry.kotlin.attributes.setAttributes
+import io.opentelemetry.kotlin.factory.CompatIdGenerator
 import io.opentelemetry.kotlin.factory.IdGenerator
 import io.opentelemetry.kotlin.propagation.CompatPropagatorConfigImpl
 import io.opentelemetry.kotlin.propagation.TextMapPropagator
@@ -16,14 +17,15 @@ import io.opentelemetry.kotlin.semconv.ServiceAttributes
 @ExperimentalApi
 internal class CompatOpenTelemetryConfig(
     clock: Clock,
-    idGenerator: IdGenerator,
 ) : OpenTelemetryConfigDsl {
 
-    internal val tracerProviderConfig = CompatTracerProviderConfig(clock, idGenerator)
+    internal val tracerProviderConfig = CompatTracerProviderConfig(clock)
     internal val loggerProviderConfig = CompatLoggerProviderConfig(clock)
     internal val meterProviderConfig = CompatMeterProviderConfig(clock)
     internal val globalAttributeLimits = CompatAttributeLimitsConfig()
     internal val propagatorCfg = CompatPropagatorConfigImpl()
+
+    private var customIdGenerator: (() -> IdGenerator)? = null
 
     override fun attributeLimits(action: AttributeLimitsConfigDsl.() -> Unit) {
         globalAttributeLimits.action()
@@ -71,4 +73,10 @@ internal class CompatOpenTelemetryConfig(
     override fun propagator(action: PropagatorConfigDsl.() -> TextMapPropagator) {
         propagatorCfg.action()
     }
+
+    override fun idGenerator(action: () -> IdGenerator) {
+        customIdGenerator = action
+    }
+
+    internal fun resolveIdGenerator(): IdGenerator = customIdGenerator?.invoke() ?: CompatIdGenerator()
 }

--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/init/CompatTracerProviderConfig.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/init/CompatTracerProviderConfig.kt
@@ -12,6 +12,7 @@ import io.opentelemetry.kotlin.attributes.setAttributes
 import io.opentelemetry.kotlin.factory.CompatSpanContextFactory
 import io.opentelemetry.kotlin.factory.CompatSpanFactory
 import io.opentelemetry.kotlin.factory.IdGenerator
+import io.opentelemetry.kotlin.factory.OtelJavaIdGeneratorAdapter
 import io.opentelemetry.kotlin.resource.Resource
 import io.opentelemetry.kotlin.resource.ResourceAdapter
 import io.opentelemetry.kotlin.semconv.ServiceAttributes
@@ -26,7 +27,6 @@ import io.opentelemetry.kotlin.tracing.sampling.SamplerAdapter
 @ExperimentalApi
 internal class CompatTracerProviderConfig(
     private val clock: Clock,
-    idGenerator: IdGenerator,
 ) : TracerProviderConfigDsl {
 
     private val builder: OtelJavaSdkTracerProviderBuilder = OtelJavaSdkTracerProvider.builder()
@@ -36,12 +36,6 @@ internal class CompatTracerProviderConfig(
 
     private val resourceAttrs = CompatAttributesModel()
     private var resourceSchemaUrl: String? = null
-
-    init {
-        if (idGenerator is OtelJavaIdGenerator) {
-            builder.setIdGenerator(idGenerator)
-        }
-    }
 
     override var serviceName: String
         get() = serviceNameOverride ?: "unknown_service"
@@ -82,9 +76,16 @@ internal class CompatTracerProviderConfig(
 
     fun build(
         clock: Clock,
+        idGenerator: IdGenerator,
         baseResource: Resource = ResourceAdapter(OtelJavaResource.builder().build()),
         globalLimits: CompatAttributeLimitsConfig? = null,
     ): TracerProvider {
+        builder.setIdGenerator(
+            when (idGenerator) {
+                is OtelJavaIdGenerator -> idGenerator
+                else -> OtelJavaIdGeneratorAdapter(idGenerator)
+            }
+        )
         if (globalLimits?.attributeCountLimitSet == true) {
             spanLimitsConfig.attributeCountLimit = globalLimits.attributeCountLimit
         }

--- a/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/factory/CompatCustomIdGeneratorTest.kt
+++ b/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/factory/CompatCustomIdGeneratorTest.kt
@@ -1,0 +1,31 @@
+package io.opentelemetry.kotlin.factory
+
+import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.createCompatOpenTelemetry
+import org.junit.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalApi::class)
+internal class CompatCustomIdGeneratorTest {
+
+    private val traceId = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    private val spanId = "bbbbbbbbbbbbbbbb"
+
+    /** A plain Kotlin [IdGenerator] that does NOT implement [OtelJavaIdGenerator]. */
+    private val custom = object : IdGenerator {
+        override fun generateSpanIdBytes(): ByteArray = spanId.hexToByteArray()
+        override fun generateTraceIdBytes(): ByteArray = traceId.hexToByteArray()
+        override val invalidTraceId: ByteArray = "00000000000000000000000000000000".hexToByteArray()
+        override val invalidSpanId: ByteArray = "0000000000000000".hexToByteArray()
+    }
+
+    @Test
+    fun `custom kotlin id generator is honored via the java adapter`() {
+        val sdk = createCompatOpenTelemetry {
+            idGenerator { custom }
+        }
+        val span = sdk.tracerProvider.getTracer("test").startSpan("span")
+        assertEquals(traceId, span.spanContext.traceId)
+        assertEquals(spanId, span.spanContext.spanId)
+    }
+}

--- a/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/framework/OtelKotlinHarness.kt
+++ b/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/framework/OtelKotlinHarness.kt
@@ -2,7 +2,7 @@ package io.opentelemetry.kotlin.framework
 
 import io.opentelemetry.kotlin.OpenTelemetry
 import io.opentelemetry.kotlin.aliases.OtelJavaIdGenerator
-import io.opentelemetry.kotlin.createCompatOpenTelemetryImpl
+import io.opentelemetry.kotlin.createCompatOpenTelemetry
 import io.opentelemetry.kotlin.factory.CompatIdGenerator
 import io.opentelemetry.kotlin.factory.IdGenerator
 import io.opentelemetry.kotlin.toOtelJavaApi
@@ -13,13 +13,13 @@ internal class OtelKotlinHarness(scheduler: TestCoroutineScheduler) :
     OtelKotlinTestRule(scheduler) {
 
     override val kotlinApi: OpenTelemetry by lazy {
-        createCompatOpenTelemetryImpl(
+        createCompatOpenTelemetry(
             clock = fakeClock,
             config = {
+                idGenerator { FakeIdGenerator() }
                 tracerProvider { tracerProviderConfig() }
                 loggerProvider { loggerProviderConfig() }
             },
-            idGenerator = FakeIdGenerator()
         )
     }
 

--- a/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/init/CompatTracerProviderSamplerTest.kt
+++ b/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/init/CompatTracerProviderSamplerTest.kt
@@ -19,11 +19,13 @@ import org.junit.Test
 @OptIn(ExperimentalApi::class)
 internal class CompatTracerProviderSamplerTest {
 
+    private val idGenerator = CompatIdGenerator()
+
     @Test
     fun `default sampler records and samples spans`() {
         val clock = FakeClock()
-        val config = CompatTracerProviderConfig(clock, CompatIdGenerator())
-        val provider = config.build(clock)
+        val config = CompatTracerProviderConfig(clock)
+        val provider = config.build(clock, idGenerator)
         val span = provider.getTracer("test").startSpan("span")
         assertTrue(span.isRecording())
         assertTrue(span.spanContext.traceFlags.isSampled)
@@ -32,10 +34,10 @@ internal class CompatTracerProviderSamplerTest {
     @Test
     fun `builtin ALWAYS_ON sampler records and samples spans`() {
         val clock = FakeClock()
-        val config = CompatTracerProviderConfig(clock, CompatIdGenerator()).apply {
+        val config = CompatTracerProviderConfig(clock).apply {
             sampler { alwaysOn() }
         }
-        val span = config.build(clock).getTracer("test").startSpan("span")
+        val span = config.build(clock, idGenerator).getTracer("test").startSpan("span")
         assertTrue(span.isRecording())
         assertTrue(span.spanContext.traceFlags.isSampled)
     }
@@ -43,20 +45,20 @@ internal class CompatTracerProviderSamplerTest {
     @Test
     fun `custom sampler DROP produces non-recording span`() {
         val clock = FakeClock()
-        val config = CompatTracerProviderConfig(clock, CompatIdGenerator()).apply {
+        val config = CompatTracerProviderConfig(clock).apply {
             sampler { FakeSampler(SamplingResult.Decision.DROP) }
         }
-        val span = config.build(clock).getTracer("test").startSpan("span")
+        val span = config.build(clock, idGenerator).getTracer("test").startSpan("span")
         assertFalse(span.isRecording())
     }
 
     @Test
     fun `custom sampler RECORD_AND_SAMPLE produces recording and sampled span`() {
         val clock = FakeClock()
-        val config = CompatTracerProviderConfig(clock, CompatIdGenerator()).apply {
+        val config = CompatTracerProviderConfig(clock).apply {
             sampler { FakeSampler(SamplingResult.Decision.RECORD_AND_SAMPLE) }
         }
-        val span = config.build(clock).getTracer("test").startSpan("span")
+        val span = config.build(clock, idGenerator).getTracer("test").startSpan("span")
         assertTrue(span.isRecording())
         assertTrue(span.spanContext.traceFlags.isSampled)
     }
@@ -64,10 +66,10 @@ internal class CompatTracerProviderSamplerTest {
     @Test
     fun `builtin ALWAYS_OFF sampler drops spans`() {
         val clock = FakeClock()
-        val config = CompatTracerProviderConfig(clock, CompatIdGenerator()).apply {
+        val config = CompatTracerProviderConfig(clock).apply {
             sampler { alwaysOff() }
         }
-        val span = config.build(clock).getTracer("test").startSpan("span")
+        val span = config.build(clock, idGenerator).getTracer("test").startSpan("span")
         assertFalse(span.isRecording())
         assertFalse(span.spanContext.traceFlags.isSampled)
     }
@@ -88,10 +90,10 @@ internal class CompatTracerProviderSamplerTest {
     @Test
     fun `parentBased samples root spans with alwaysOn`() {
         val clock = FakeClock()
-        val config = CompatTracerProviderConfig(clock, CompatIdGenerator()).apply {
+        val config = CompatTracerProviderConfig(clock).apply {
             sampler { parentBased(root = alwaysOn()) }
         }
-        val span = config.build(clock).getTracer("test").startSpan("span")
+        val span = config.build(clock, idGenerator).getTracer("test").startSpan("span")
         assertTrue(span.isRecording())
         assertTrue(span.spanContext.traceFlags.isSampled)
     }
@@ -99,10 +101,10 @@ internal class CompatTracerProviderSamplerTest {
     @Test
     fun `parentBased drops root spans with alwaysOff`() {
         val clock = FakeClock()
-        val config = CompatTracerProviderConfig(clock, CompatIdGenerator()).apply {
+        val config = CompatTracerProviderConfig(clock).apply {
             sampler { parentBased(root = alwaysOff()) }
         }
-        val span = config.build(clock).getTracer("test").startSpan("span")
+        val span = config.build(clock, idGenerator).getTracer("test").startSpan("span")
         assertFalse(span.isRecording())
         assertFalse(span.spanContext.traceFlags.isSampled)
     }

--- a/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/init/GlobalAttributeLimitsConfigTest.kt
+++ b/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/init/GlobalAttributeLimitsConfigTest.kt
@@ -10,6 +10,7 @@ import kotlin.test.assertTrue
 internal class GlobalAttributeLimitsConfigTest {
 
     private val clock = FakeClock()
+    private val idGenerator = CompatIdGenerator()
 
     @Test
     fun `CompatAttributeLimitsConfig default state`() {
@@ -35,8 +36,8 @@ internal class GlobalAttributeLimitsConfigTest {
     fun `global only - applies to spans and logs`() {
         val globalLimits = CompatAttributeLimitsConfig().apply { attributeCountLimit = 64 }
 
-        val tracerConfig = CompatTracerProviderConfig(clock, CompatIdGenerator())
-        tracerConfig.build(clock, globalLimits = globalLimits)
+        val tracerConfig = CompatTracerProviderConfig(clock)
+        tracerConfig.build(clock, idGenerator, globalLimits = globalLimits)
         assertEquals(64, tracerConfig.spanLimitsConfig.attributeCountLimit)
 
         val loggerConfig = CompatLoggerProviderConfig(clock)
@@ -48,10 +49,10 @@ internal class GlobalAttributeLimitsConfigTest {
     fun `signal-specific overrides global`() {
         val globalLimits = CompatAttributeLimitsConfig().apply { attributeCountLimit = 64 }
 
-        val tracerConfig = CompatTracerProviderConfig(clock, CompatIdGenerator()).apply {
+        val tracerConfig = CompatTracerProviderConfig(clock).apply {
             spanLimits { attributeCountLimit = 32 }
         }
-        tracerConfig.build(clock, globalLimits = globalLimits)
+        tracerConfig.build(clock, idGenerator, globalLimits = globalLimits)
         assertEquals(32, tracerConfig.spanLimitsConfig.attributeCountLimit)
 
         val loggerConfig = CompatLoggerProviderConfig(clock)
@@ -63,18 +64,18 @@ internal class GlobalAttributeLimitsConfigTest {
     fun `partial signal override - other global properties still apply`() {
         val globalLimits = CompatAttributeLimitsConfig().apply { attributeCountLimit = 64 }
 
-        val tracerConfig = CompatTracerProviderConfig(clock, CompatIdGenerator()).apply {
+        val tracerConfig = CompatTracerProviderConfig(clock).apply {
             spanLimits { attributeValueLengthLimit = 256 }
         }
-        tracerConfig.build(clock, globalLimits = globalLimits)
+        tracerConfig.build(clock, idGenerator, globalLimits = globalLimits)
         assertEquals(64, tracerConfig.spanLimitsConfig.attributeCountLimit)
         assertEquals(256, tracerConfig.spanLimitsConfig.attributeValueLengthLimit)
     }
 
     @Test
     fun `no global - defaults are zero (Java SDK uses its own defaults)`() {
-        val tracerConfig = CompatTracerProviderConfig(clock, CompatIdGenerator())
-        tracerConfig.build(clock)
+        val tracerConfig = CompatTracerProviderConfig(clock)
+        tracerConfig.build(clock, idGenerator)
         assertEquals(DEFAULT_ATTR_LIMIT, tracerConfig.spanLimitsConfig.attributeCountLimit)
         assertEquals(DEFAULT_ATTR_VALUE_LENGTH_LIMIT, tracerConfig.spanLimitsConfig.attributeValueLengthLimit)
 

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/OpenTelemetryImplEntrypoint.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/OpenTelemetryImplEntrypoint.kt
@@ -2,8 +2,6 @@ package io.opentelemetry.kotlin
 
 import io.opentelemetry.kotlin.factory.BaggageFactoryImpl
 import io.opentelemetry.kotlin.factory.ContextFactoryImpl
-import io.opentelemetry.kotlin.factory.IdGenerator
-import io.opentelemetry.kotlin.factory.IdGeneratorImpl
 import io.opentelemetry.kotlin.factory.ResourceFactoryImpl
 import io.opentelemetry.kotlin.factory.SpanContextFactoryImpl
 import io.opentelemetry.kotlin.factory.SpanFactoryImpl
@@ -31,25 +29,14 @@ public fun createOpenTelemetry(
      */
     config: OpenTelemetryConfigDsl.() -> Unit = {}
 ): OpenTelemetry {
-    return createOpenTelemetryImpl(clock, config)
-}
+    val cfg = OpenTelemetryConfigImpl(clock).apply(config)
+    val idGenerator = cfg.resolveIdGenerator()
 
-/**
- * Internal implementation of [createOpenTelemetry]. This is not publicly visible as
- * we don't want to allow users to supply a custom [IdGenerator].
- */
-@ExperimentalApi
-internal fun createOpenTelemetryImpl(
-    clock: Clock,
-    config: OpenTelemetryConfigDsl.() -> Unit,
-    idGenerator: IdGenerator = IdGeneratorImpl(),
-): OpenTelemetry {
     val resourceFactory = ResourceFactoryImpl()
     val traceFlags = TraceFlagsFactoryImpl()
     val traceState = TraceStateFactoryImpl()
     val spanContext = SpanContextFactoryImpl(idGenerator, traceFlags, traceState)
 
-    val cfg = OpenTelemetryConfigImpl(clock).apply(config)
     val span = SpanFactoryImpl(spanContext)
     val contextFactory = ContextFactoryImpl(span, cfg.contextConfig::generateStorage)
     cfg.propagatorCfg.installFactories(

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/OpenTelemetryConfigImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/OpenTelemetryConfigImpl.kt
@@ -1,6 +1,8 @@
 package io.opentelemetry.kotlin.init
 
 import io.opentelemetry.kotlin.Clock
+import io.opentelemetry.kotlin.factory.IdGenerator
+import io.opentelemetry.kotlin.factory.IdGeneratorImpl
 import io.opentelemetry.kotlin.propagation.TextMapPropagator
 
 internal class OpenTelemetryConfigImpl(
@@ -14,6 +16,8 @@ internal class OpenTelemetryConfigImpl(
     internal val contextConfig: ContextConfigImpl = ContextConfigImpl()
     internal val propagatorCfg: PropagatorConfigImpl = PropagatorConfigImpl()
     private val globalAttributeLimits = AttributeLimitsConfigImpl()
+
+    private var customIdGenerator: (() -> IdGenerator)? = null
 
     override fun attributeLimits(action: AttributeLimitsConfigDsl.() -> Unit) {
         globalAttributeLimits.action()
@@ -38,6 +42,12 @@ internal class OpenTelemetryConfigImpl(
     override fun propagator(action: PropagatorConfigDsl.() -> TextMapPropagator) {
         propagatorCfg.action()
     }
+
+    override fun idGenerator(action: () -> IdGenerator) {
+        customIdGenerator = action
+    }
+
+    internal fun resolveIdGenerator(): IdGenerator = customIdGenerator?.invoke() ?: IdGeneratorImpl()
 
     private val defaultResource by lazy(::sdkDefaultResource)
 

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/CreateOpenTelemetryIdGeneratorTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/CreateOpenTelemetryIdGeneratorTest.kt
@@ -1,0 +1,33 @@
+package io.opentelemetry.kotlin
+
+import io.opentelemetry.kotlin.factory.FakeIdGenerator
+import io.opentelemetry.kotlin.factory.IdGeneratorImpl
+import io.opentelemetry.kotlin.factory.toHexString
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertSame
+
+@OptIn(ExperimentalApi::class)
+internal class CreateOpenTelemetryIdGeneratorTest {
+
+    @Test
+    fun `default id generator is used when none is configured`() {
+        val api = createOpenTelemetry() as OpenTelemetrySdk
+        assertIs<IdGeneratorImpl>(api.idGenerator)
+    }
+
+    @Test
+    fun `custom id generator supplied via the DSL is used for spans`() {
+        val custom = FakeIdGenerator()
+        val api = createOpenTelemetry {
+            idGenerator { custom }
+        } as OpenTelemetrySdk
+
+        assertSame(custom, api.idGenerator)
+
+        val span = api.tracerProvider.getTracer("test").startSpan("span")
+        assertEquals(custom.generateTraceIdBytes().toHexString(), span.spanContext.traceId)
+        assertEquals(custom.generateSpanIdBytes().toHexString(), span.spanContext.spanId)
+    }
+}

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/init/OpenTelemetryConfigImplTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/init/OpenTelemetryConfigImplTest.kt
@@ -8,6 +8,7 @@ import io.opentelemetry.kotlin.context.DefaultImplicitContextStorage
 import io.opentelemetry.kotlin.context.FakeContext
 import io.opentelemetry.kotlin.context.FakeImplicitContextStorage
 import io.opentelemetry.kotlin.context.ImplicitContextStorageMode
+import io.opentelemetry.kotlin.factory.FakeIdGenerator
 import io.opentelemetry.kotlin.logging.export.FakeLogRecordProcessor
 import io.opentelemetry.kotlin.propagation.CompositeTextMapPropagator
 import io.opentelemetry.kotlin.propagation.W3CBaggagePropagator
@@ -65,6 +66,21 @@ internal class OpenTelemetryConfigImplTest {
         }
         assertNotNull(cfg.generateTracingConfig().processor)
         assertNotNull(cfg.generateLoggingConfig().processor)
+    }
+
+    @Test
+    fun testIdGeneratorDefault() {
+        val cfg = OpenTelemetryConfigImpl(clock)
+        assertNotNull(cfg.resolveIdGenerator())
+    }
+
+    @Test
+    fun testIdGeneratorOverride() {
+        val custom = FakeIdGenerator()
+        val cfg = OpenTelemetryConfigImpl(clock).apply {
+            idGenerator { custom }
+        }
+        assertSame(custom, cfg.resolveIdGenerator())
     }
 
     @Test

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/integration/test/IntegrationTestHarness.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/integration/test/IntegrationTestHarness.kt
@@ -1,7 +1,7 @@
 package io.opentelemetry.kotlin.integration.test
 
 import io.opentelemetry.kotlin.OpenTelemetry
-import io.opentelemetry.kotlin.createOpenTelemetryImpl
+import io.opentelemetry.kotlin.createOpenTelemetry
 import io.opentelemetry.kotlin.factory.IdGeneratorImpl
 import io.opentelemetry.kotlin.framework.OtelKotlinTestRule
 import kotlinx.coroutines.test.TestCoroutineScheduler
@@ -13,13 +13,13 @@ import kotlin.random.Random
  */
 internal class IntegrationTestHarness(scheduler: TestCoroutineScheduler) : OtelKotlinTestRule(scheduler) {
     override val kotlinApi: OpenTelemetry by lazy {
-        createOpenTelemetryImpl(
+        createOpenTelemetry(
             clock = fakeClock,
             config = {
+                idGenerator { IdGeneratorImpl(Random(0)) }
                 tracerProvider { tracerProviderConfig() }
                 loggerProvider { loggerProviderConfig() }
             },
-            idGenerator = IdGeneratorImpl(Random(0))
         )
     }
 }

--- a/sdk-api/api/jvm/sdk-api.api
+++ b/sdk-api/api/jvm/sdk-api.api
@@ -125,6 +125,7 @@ public abstract interface class io/opentelemetry/kotlin/init/MeterProviderConfig
 public abstract interface class io/opentelemetry/kotlin/init/OpenTelemetryConfigDsl : io/opentelemetry/kotlin/init/ResourceConfigDsl {
 	public abstract fun attributeLimits (Lkotlin/jvm/functions/Function1;)V
 	public abstract fun context (Lkotlin/jvm/functions/Function1;)V
+	public abstract fun idGenerator (Lkotlin/jvm/functions/Function0;)V
 	public abstract fun loggerProvider (Lkotlin/jvm/functions/Function1;)V
 	public abstract fun meterProvider (Lkotlin/jvm/functions/Function1;)V
 	public abstract fun propagator (Lkotlin/jvm/functions/Function1;)V

--- a/sdk-api/src/commonMain/kotlin/io/opentelemetry/kotlin/init/OpenTelemetryConfigDsl.kt
+++ b/sdk-api/src/commonMain/kotlin/io/opentelemetry/kotlin/init/OpenTelemetryConfigDsl.kt
@@ -1,6 +1,7 @@
 package io.opentelemetry.kotlin.init
 
 import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.factory.IdGenerator
 import io.opentelemetry.kotlin.propagation.TextMapPropagator
 
 /**
@@ -41,4 +42,11 @@ public interface OpenTelemetryConfigDsl : ResourceConfigDsl {
      * https://opentelemetry.io/docs/specs/otel/context/api-propagators/
      */
     public fun propagator(action: PropagatorConfigDsl.() -> TextMapPropagator)
+
+    /**
+     * Configures a custom [IdGenerator] that is used to generate trace and span IDs. If this is
+     * not set the SDK will provide its own default implementation.
+     * https://opentelemetry.io/docs/specs/otel/trace/sdk/#id-generators
+     */
+    public fun idGenerator(action: () -> IdGenerator)
 }


### PR DESCRIPTION
## Goal

Closes #670 by allowing a custom `IdGenerator` to be supplied as mandated by the spec.

## Testing

Added unit tests.
