### PR TITLE
Implement LoggerConfigurator and LoggerConfig

### DIFF
--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/init/CompatLoggerProviderConfig.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/init/CompatLoggerProviderConfig.kt
@@ -2,18 +2,23 @@ package io.opentelemetry.kotlin.init
 
 import io.opentelemetry.kotlin.Clock
 import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.aliases.OtelJavaLoggerConfig
 import io.opentelemetry.kotlin.aliases.OtelJavaResource
+import io.opentelemetry.kotlin.aliases.OtelJavaScopeConfigurator
 import io.opentelemetry.kotlin.aliases.OtelJavaSdkLoggerProvider
 import io.opentelemetry.kotlin.aliases.OtelJavaSdkLoggerProviderBuilder
+import io.opentelemetry.kotlin.aliases.OtelJavaSdkLoggerProviderUtil
 import io.opentelemetry.kotlin.attributes.AttributesMutator
 import io.opentelemetry.kotlin.attributes.CompatAttributesModel
 import io.opentelemetry.kotlin.attributes.setAttributes
+import io.opentelemetry.kotlin.logging.LoggerConfigurator
 import io.opentelemetry.kotlin.logging.LoggerProvider
 import io.opentelemetry.kotlin.logging.LoggerProviderAdapter
 import io.opentelemetry.kotlin.logging.export.LogRecordProcessor
 import io.opentelemetry.kotlin.logging.export.OtelJavaLogRecordProcessorAdapter
 import io.opentelemetry.kotlin.resource.Resource
 import io.opentelemetry.kotlin.resource.ResourceAdapter
+import io.opentelemetry.kotlin.scope.toOtelKotlinInstrumentationScopeInfo
 import io.opentelemetry.kotlin.semconv.ServiceAttributes
 
 @ExperimentalApi
@@ -24,6 +29,7 @@ internal class CompatLoggerProviderConfig(
     private val builder: OtelJavaSdkLoggerProviderBuilder = OtelJavaSdkLoggerProvider.builder()
     internal val logLimitsConfig = CompatLogLimitsConfig()
     private var logLimitsAction: (LogLimitsConfigDsl.() -> Unit)? = null
+    private var loggerConfigurator: LoggerConfigurator? = null
     private var serviceNameOverride: String? = null
 
     override var serviceName: String
@@ -54,6 +60,21 @@ internal class CompatLoggerProviderConfig(
         logLimitsAction = action
     }
 
+    override fun loggerConfigurator(configurator: LoggerConfigurator) {
+        loggerConfigurator = configurator
+    }
+
+    private fun applyLoggerConfigurator(configurator: LoggerConfigurator) {
+        val scopeConfigurator = OtelJavaScopeConfigurator<OtelJavaLoggerConfig> { javaScope ->
+            val scope = javaScope.toOtelKotlinInstrumentationScopeInfo()
+            when (configurator.loggerConfig(scope).enabled) {
+                true -> OtelJavaLoggerConfig.enabled()
+                false -> OtelJavaLoggerConfig.disabled()
+            }
+        }
+        OtelJavaSdkLoggerProviderUtil.setLoggerConfigurator(builder, scopeConfigurator)
+    }
+
     fun build(
         clock: Clock,
         baseResource: Resource = ResourceAdapter(OtelJavaResource.builder().build()),
@@ -67,6 +88,7 @@ internal class CompatLoggerProviderConfig(
         }
         logLimitsAction?.invoke(logLimitsConfig)
         builder.setLogLimits(logLimitsConfig::build)
+        loggerConfigurator?.let(::applyLoggerConfigurator)
         val resource = ResourceAdapter(
             OtelJavaResource.create(resourceAttrs.otelJavaAttributes(), resourceSchemaUrl)
         )

--- a/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/logging/LoggerConfigTest.kt
+++ b/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/logging/LoggerConfigTest.kt
@@ -1,0 +1,36 @@
+package io.opentelemetry.kotlin.logging
+
+import io.opentelemetry.kotlin.framework.OtelKotlinHarness
+import kotlinx.coroutines.test.runTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+internal class LoggerConfigTest {
+
+    private lateinit var harness: OtelKotlinHarness
+
+    @BeforeTest
+    fun setUp() = runTest {
+        harness = OtelKotlinHarness(testScheduler)
+    }
+
+    @Test
+    fun `loggerConfigurator disables matching scope`() = runTest {
+        harness.config.loggerProvider = {
+            loggerConfigurator { scope ->
+                object : LoggerConfig {
+                    override val enabled = scope.name != "disabled"
+                }
+            }
+        }
+
+        val loggerProvider = harness.kotlinApi.loggerProvider
+        loggerProvider.getLogger("disabled").emit("dropped")
+        loggerProvider.getLogger("enabled").emit("kept")
+
+        harness.assertLogRecords(expectedCount = 1) { logs ->
+            assertEquals("kept", logs.single().body)
+        }
+    }
+}

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/LoggerProviderConfigImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/LoggerProviderConfigImpl.kt
@@ -3,6 +3,8 @@ package io.opentelemetry.kotlin.init
 import io.opentelemetry.kotlin.Clock
 import io.opentelemetry.kotlin.init.config.LogLimitConfig
 import io.opentelemetry.kotlin.init.config.LoggingConfig
+import io.opentelemetry.kotlin.logging.LoggerConfigImpl
+import io.opentelemetry.kotlin.logging.LoggerConfigurator
 import io.opentelemetry.kotlin.logging.export.LogRecordProcessor
 import io.opentelemetry.kotlin.platformLog
 import io.opentelemetry.kotlin.resource.Resource
@@ -14,6 +16,10 @@ internal class LoggerProviderConfigImpl(
 
     private var processor: LogRecordProcessor? = null
     private var logLimitsAction: LogLimitsConfigDsl.() -> Unit = {}
+    private val defaultLoggerConfig = LoggerConfigImpl(true)
+    private var loggerConfigurator: LoggerConfigurator = LoggerConfigurator {
+        defaultLoggerConfig
+    }
 
     override fun export(action: LogExportConfigDsl.() -> LogRecordProcessor) {
         if (processor != null) {
@@ -27,10 +33,18 @@ internal class LoggerProviderConfigImpl(
         logLimitsAction = action
     }
 
-    fun generateLoggingConfig(base: Resource, globalLimits: AttributeLimitsConfigImpl? = null): LoggingConfig = LoggingConfig(
+    override fun loggerConfigurator(configurator: LoggerConfigurator) {
+        loggerConfigurator = configurator
+    }
+
+    fun generateLoggingConfig(
+        base: Resource,
+        globalLimits: AttributeLimitsConfigImpl? = null
+    ): LoggingConfig = LoggingConfig(
         processor = processor,
         logLimits = generateLogLimitsConfig(globalLimits),
         resource = base.merge(resourceConfigImpl.generateResource()),
+        loggerConfigurator = loggerConfigurator,
     )
 
     private fun generateLogLimitsConfig(globalLimits: AttributeLimitsConfigImpl?): LogLimitConfig {

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/config/LoggingConfig.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/config/LoggingConfig.kt
@@ -1,6 +1,7 @@
 package io.opentelemetry.kotlin.init.config
 
 import io.opentelemetry.kotlin.ThreadSafe
+import io.opentelemetry.kotlin.logging.LoggerConfigurator
 import io.opentelemetry.kotlin.logging.export.LogRecordProcessor
 import io.opentelemetry.kotlin.resource.Resource
 
@@ -23,5 +24,10 @@ internal class LoggingConfig(
     /**
      * A resource to append to spans.
      */
-    val resource: Resource
+    val resource: Resource,
+
+    /**
+     * Computes the per-logger config
+     */
+    val loggerConfigurator: LoggerConfigurator
 )

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/LoggerConfigImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/LoggerConfigImpl.kt
@@ -1,0 +1,6 @@
+package io.opentelemetry.kotlin.logging
+
+/**
+ * Internal implementation of [LoggerConfig].
+ */
+internal class LoggerConfigImpl(override val enabled: Boolean) : LoggerConfig

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/LoggerProviderImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/LoggerProviderImpl.kt
@@ -29,17 +29,22 @@ internal class LoggerProviderImpl(
     private val noopLogger = NoopOpenTelemetry.loggerProvider.getLogger("")
 
     private val apiProvider by lazy {
-        ApiProviderImpl<Logger> { key ->
-            LoggerImpl(
-                clock,
-                loggingConfig.processor,
-                contextFactory,
-                spanContextFactory,
-                key,
-                loggingConfig.resource,
-                loggingConfig.logLimits,
-                shutdownState,
-            )
+        ApiProviderImpl { key ->
+            val loggerConfig = loggingConfig.loggerConfigurator.loggerConfig(key)
+            if (!loggerConfig.enabled) {
+                noopLogger
+            } else {
+                LoggerImpl(
+                    clock,
+                    loggingConfig.processor,
+                    contextFactory,
+                    spanContextFactory,
+                    key,
+                    loggingConfig.resource,
+                    loggingConfig.logLimits,
+                    shutdownState,
+                )
+            }
         }
     }
 

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/integration/test/logging/LoggerConfigTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/integration/test/logging/LoggerConfigTest.kt
@@ -1,0 +1,46 @@
+package io.opentelemetry.kotlin.integration.test.logging
+
+import io.opentelemetry.kotlin.integration.test.IntegrationTestHarness
+import io.opentelemetry.kotlin.logging.LoggerConfigImpl
+import kotlinx.coroutines.test.runTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+internal class LoggerConfigTest {
+
+    private lateinit var harness: IntegrationTestHarness
+
+    @BeforeTest
+    fun setUp() = runTest {
+        harness = IntegrationTestHarness(testScheduler)
+    }
+
+    @Test
+    fun testLoggerConfiguratorDisablesMatchingScope() = runTest {
+        harness.config.loggerProvider = {
+            loggerConfigurator { scope ->
+                when (scope.name) {
+                    "disabled" -> LoggerConfigImpl(false)
+                    else -> LoggerConfigImpl(true)
+                }
+            }
+        }
+
+        val loggerProvider = harness.loggerProvider
+        val disabled = loggerProvider.getLogger("disabled")
+        val enabled = loggerProvider.getLogger("enabled")
+
+        assertFalse(disabled.enabled())
+        assertTrue(enabled.enabled())
+
+        disabled.emit("dropped")
+        enabled.emit("kept")
+
+        harness.assertLogRecords(expectedCount = 1) { logs ->
+            assertEquals(logs.single().body, "kept")
+        }
+    }
+}

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/LoggerProviderImplTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/LoggerProviderImplTest.kt
@@ -22,10 +22,12 @@ import kotlin.test.assertSame
 internal class LoggerProviderImplTest {
 
     private val clock = FakeClock()
+    private val loggerConfigurator = LoggerConfigurator { LoggerConfigImpl(true) }
     private val loggingConfig = LoggingConfig(
         null,
         LogLimitConfig(100, 100),
-        ResourceImpl(AttributesModel(), null)
+        ResourceImpl(AttributesModel(), null),
+        loggerConfigurator,
     )
     private val contextFactory = FakeContextFactory()
     private val spanContextFactory = FakeSpanContextFactory()
@@ -120,6 +122,7 @@ internal class LoggerProviderImplTest {
             processor,
             LogLimitConfig(100, 100),
             FakeResource(),
+            loggerConfigurator,
         )
         impl = LoggerProviderImpl(clock, config, contextFactory, spanContextFactory)
         impl.getLogger(name = "test")
@@ -142,6 +145,7 @@ internal class LoggerProviderImplTest {
             processor,
             LogLimitConfig(100, 100),
             FakeResource(),
+            loggerConfigurator,
         )
         impl = LoggerProviderImpl(clock, config, contextFactory, spanContextFactory)
         impl.getLogger(name = "test")
@@ -165,6 +169,7 @@ internal class LoggerProviderImplTest {
             processor,
             LogLimitConfig(100, 100),
             FakeResource(),
+            loggerConfigurator,
         )
         impl = LoggerProviderImpl(clock, config, contextFactory, spanContextFactory)
         val logger = impl.getLogger(name = "test")

--- a/integration-test/src/commonMain/kotlin/io/opentelemetry/kotlin/framework/OtelKotlinTestRule.kt
+++ b/integration-test/src/commonMain/kotlin/io/opentelemetry/kotlin/framework/OtelKotlinTestRule.kt
@@ -61,6 +61,7 @@ abstract class OtelKotlinTestRule(context: TestCoroutineScheduler) {
             )
         }
         logLimits(config.logLimits)
+        config.loggerProvider(this)
     }
 
     /**

--- a/integration-test/src/commonMain/kotlin/io/opentelemetry/kotlin/framework/TestHarnessConfig.kt
+++ b/integration-test/src/commonMain/kotlin/io/opentelemetry/kotlin/framework/TestHarnessConfig.kt
@@ -2,6 +2,7 @@ package io.opentelemetry.kotlin.framework
 
 import io.opentelemetry.kotlin.attributes.AttributesMutator
 import io.opentelemetry.kotlin.init.LogLimitsConfigDsl
+import io.opentelemetry.kotlin.init.LoggerProviderConfigDsl
 import io.opentelemetry.kotlin.init.SpanLimitsConfigDsl
 import io.opentelemetry.kotlin.logging.export.LogRecordProcessor
 import io.opentelemetry.kotlin.tracing.export.SpanProcessor
@@ -13,4 +14,5 @@ data class TestHarnessConfig(
     val logRecordProcessors: MutableList<LogRecordProcessor> = mutableListOf(),
     var spanLimits: SpanLimitsConfigDsl.() -> Unit = {},
     var logLimits: LogLimitsConfigDsl.() -> Unit = {},
+    var loggerProvider: LoggerProviderConfigDsl.() -> Unit = {},
 )

--- a/java-typealiases/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/aliases/Aliases.kt
+++ b/java-typealiases/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/aliases/Aliases.kt
@@ -45,6 +45,7 @@ import io.opentelemetry.sdk.common.Clock
 import io.opentelemetry.sdk.common.CompletableResultCode
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo
 import io.opentelemetry.sdk.common.InstrumentationScopeInfo
+import io.opentelemetry.sdk.common.internal.ScopeConfigurator
 import io.opentelemetry.sdk.extension.incubator.trace.samplers.AlwaysRecordSampler
 import io.opentelemetry.sdk.logs.LogLimits
 import io.opentelemetry.sdk.logs.LogRecordProcessor
@@ -54,6 +55,8 @@ import io.opentelemetry.sdk.logs.SdkLoggerProviderBuilder
 import io.opentelemetry.sdk.logs.data.Body
 import io.opentelemetry.sdk.logs.data.LogRecordData
 import io.opentelemetry.sdk.logs.export.LogRecordExporter
+import io.opentelemetry.sdk.logs.internal.LoggerConfig
+import io.opentelemetry.sdk.logs.internal.SdkLoggerProviderUtil
 import io.opentelemetry.sdk.metrics.SdkMeterProvider
 import io.opentelemetry.sdk.metrics.SdkMeterProviderBuilder
 import io.opentelemetry.sdk.resources.Resource
@@ -117,6 +120,9 @@ typealias OtelJavaExtendedSpanProcessor = ExtendedSpanProcessor
 typealias OtelJavaOpenTelemetrySdk = OpenTelemetrySdk
 typealias OtelJavaSdkLoggerProvider = SdkLoggerProvider
 typealias OtelJavaSdkLoggerProviderBuilder = SdkLoggerProviderBuilder
+typealias OtelJavaSdkLoggerProviderUtil = SdkLoggerProviderUtil
+typealias OtelJavaLoggerConfig = LoggerConfig
+typealias OtelJavaScopeConfigurator<T> = ScopeConfigurator<T>
 typealias OtelJavaMeterProvider = MeterProvider
 typealias OtelJavaMeterBuilder = MeterBuilder
 typealias OtelJavaMeter = Meter

--- a/sdk-api/api/jvm/sdk-api.api
+++ b/sdk-api/api/jvm/sdk-api.api
@@ -117,6 +117,7 @@ public abstract interface class io/opentelemetry/kotlin/init/LogLimitsConfigDsl 
 public abstract interface class io/opentelemetry/kotlin/init/LoggerProviderConfigDsl : io/opentelemetry/kotlin/init/ResourceConfigDsl {
 	public abstract fun export (Lkotlin/jvm/functions/Function1;)V
 	public abstract fun logLimits (Lkotlin/jvm/functions/Function1;)V
+	public abstract fun loggerConfigurator (Lio/opentelemetry/kotlin/logging/LoggerConfigurator;)V
 }
 
 public abstract interface class io/opentelemetry/kotlin/init/MeterProviderConfigDsl : io/opentelemetry/kotlin/init/ResourceConfigDsl {
@@ -172,6 +173,14 @@ public abstract interface class io/opentelemetry/kotlin/init/TracerProviderConfi
 	public abstract fun export (Lkotlin/jvm/functions/Function1;)V
 	public abstract fun sampler (Lkotlin/jvm/functions/Function1;)V
 	public abstract fun spanLimits (Lkotlin/jvm/functions/Function1;)V
+}
+
+public abstract interface class io/opentelemetry/kotlin/logging/LoggerConfig {
+	public abstract fun getEnabled ()Z
+}
+
+public abstract interface class io/opentelemetry/kotlin/logging/LoggerConfigurator {
+	public abstract fun loggerConfig (Lio/opentelemetry/kotlin/InstrumentationScopeInfo;)Lio/opentelemetry/kotlin/logging/LoggerConfig;
 }
 
 public abstract interface class io/opentelemetry/kotlin/logging/export/LogRecordExporter : io/opentelemetry/kotlin/export/TelemetryCloseable {

--- a/sdk-api/src/commonMain/kotlin/io/opentelemetry/kotlin/init/LoggerProviderConfigDsl.kt
+++ b/sdk-api/src/commonMain/kotlin/io/opentelemetry/kotlin/init/LoggerProviderConfigDsl.kt
@@ -1,6 +1,7 @@
 package io.opentelemetry.kotlin.init
 
 import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.logging.LoggerConfigurator
 import io.opentelemetry.kotlin.logging.export.LogRecordProcessor
 
 /**
@@ -19,4 +20,9 @@ public interface LoggerProviderConfigDsl : ResourceConfigDsl {
      * Configures how log records should be processed and exported.
      */
     public fun export(action: LogExportConfigDsl.() -> LogRecordProcessor)
+
+    /**
+     * Configures behavior of the logger.
+     */
+    public fun loggerConfigurator(configurator: LoggerConfigurator)
 }

--- a/sdk-api/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/LoggerConfig.kt
+++ b/sdk-api/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/LoggerConfig.kt
@@ -1,0 +1,15 @@
+package io.opentelemetry.kotlin.logging
+
+import io.opentelemetry.kotlin.ExperimentalApi
+
+/**
+ * Immutable model of how a [Logger] should behave.
+ */
+@ExperimentalApi
+public interface LoggerConfig {
+
+    /**
+     * Whether the logger is enabled.
+     */
+    public val enabled: Boolean
+}

--- a/sdk-api/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/LoggerConfigurator.kt
+++ b/sdk-api/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/LoggerConfigurator.kt
@@ -1,0 +1,19 @@
+package io.opentelemetry.kotlin.logging
+
+import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.InstrumentationScopeInfo
+
+/**
+ * Dynamically controls how a [Logger] should behave by constructing a [LoggerConfig].
+ * Implementations must return quickly as this code may be invoked frequently.
+ *
+ * https://opentelemetry.io/docs/specs/otel/logs/sdk/#loggerconfigurator
+ */
+@ExperimentalApi
+public fun interface LoggerConfigurator {
+
+    /**
+     * Returns the [LoggerConfig] for the given [scope].
+     */
+    public fun loggerConfig(scope: InstrumentationScopeInfo): LoggerConfig
+}


### PR DESCRIPTION
## Goal

Partially addresses #673 by adding `LoggerConfigurator` and `LoggerConfig` interfaces. The `LoggerConfig` interface only implements `enabled` for now, other properties described in the spec will be added in a future PR: https://opentelemetry.io/docs/specs/otel/logs/sdk/#loggerconfig

## Testing

Added unit tests.
