### PR TITLE
Inject SdkErrorHandler instance

### DIFF
--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/OpenTelemetryCompatEntrypoint.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/OpenTelemetryCompatEntrypoint.kt
@@ -1,6 +1,8 @@
 package io.opentelemetry.kotlin
 
 import io.opentelemetry.kotlin.clock.ClockAdapter
+import io.opentelemetry.kotlin.error.NoopSdkErrorHandler
+import io.opentelemetry.kotlin.error.SdkErrorHandler
 import io.opentelemetry.kotlin.factory.CompatBaggageFactory
 import io.opentelemetry.kotlin.factory.CompatContextFactory
 import io.opentelemetry.kotlin.factory.CompatResourceFactory
@@ -31,7 +33,8 @@ public fun createCompatOpenTelemetry(
     val contextFactory = CompatContextFactory()
     val span = CompatSpanFactory(spanContext)
 
-    val cfg = CompatOpenTelemetryConfig(clock).apply(config)
+    val sdkErrorHandler: SdkErrorHandler = NoopSdkErrorHandler
+    val cfg = CompatOpenTelemetryConfig(clock, sdkErrorHandler).apply(config)
     val resolvedIdGenerator = cfg.resolveIdGenerator()
     val base = cfg.buildGlobalResource()
     return CompatOpenTelemetryImpl(

--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/init/CompatLoggerProviderConfig.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/init/CompatLoggerProviderConfig.kt
@@ -8,6 +8,7 @@ import io.opentelemetry.kotlin.aliases.OtelJavaSdkLoggerProviderBuilder
 import io.opentelemetry.kotlin.attributes.AttributesMutator
 import io.opentelemetry.kotlin.attributes.CompatAttributesModel
 import io.opentelemetry.kotlin.attributes.setAttributes
+import io.opentelemetry.kotlin.error.SdkErrorHandler
 import io.opentelemetry.kotlin.logging.LoggerProvider
 import io.opentelemetry.kotlin.logging.LoggerProviderAdapter
 import io.opentelemetry.kotlin.logging.export.LogRecordProcessor
@@ -19,6 +20,7 @@ import io.opentelemetry.kotlin.semconv.ServiceAttributes
 @ExperimentalApi
 internal class CompatLoggerProviderConfig(
     private val clock: Clock,
+    private val sdkErrorHandler: SdkErrorHandler,
 ) : LoggerProviderConfigDsl {
 
     private val builder: OtelJavaSdkLoggerProviderBuilder = OtelJavaSdkLoggerProvider.builder()
@@ -46,7 +48,7 @@ internal class CompatLoggerProviderConfig(
     }
 
     override fun export(action: LogExportConfigDsl.() -> LogRecordProcessor) {
-        val processor = LogExportConfigCompat(clock).action()
+        val processor = LogExportConfigCompat(clock, sdkErrorHandler).action()
         builder.addLogRecordProcessor(OtelJavaLogRecordProcessorAdapter(processor))
     }
 
@@ -79,5 +81,8 @@ internal class CompatLoggerProviderConfig(
         return LoggerProviderAdapter(builder.build())
     }
 
-    private class LogExportConfigCompat(override val clock: Clock) : LogExportConfigDsl
+    private class LogExportConfigCompat(
+        override val clock: Clock,
+        override val sdkErrorHandler: SdkErrorHandler,
+    ) : LogExportConfigDsl
 }

--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/init/CompatOpenTelemetryConfig.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/init/CompatOpenTelemetryConfig.kt
@@ -6,6 +6,7 @@ import io.opentelemetry.kotlin.aliases.OtelJavaResource
 import io.opentelemetry.kotlin.attributes.AttributesMutator
 import io.opentelemetry.kotlin.attributes.CompatAttributesModel
 import io.opentelemetry.kotlin.attributes.setAttributes
+import io.opentelemetry.kotlin.error.SdkErrorHandler
 import io.opentelemetry.kotlin.factory.CompatIdGenerator
 import io.opentelemetry.kotlin.factory.IdGenerator
 import io.opentelemetry.kotlin.propagation.CompatPropagatorConfigImpl
@@ -17,10 +18,11 @@ import io.opentelemetry.kotlin.semconv.ServiceAttributes
 @ExperimentalApi
 internal class CompatOpenTelemetryConfig(
     clock: Clock,
+    sdkErrorHandler: SdkErrorHandler,
 ) : OpenTelemetryConfigDsl {
 
-    internal val tracerProviderConfig = CompatTracerProviderConfig(clock)
-    internal val loggerProviderConfig = CompatLoggerProviderConfig(clock)
+    internal val tracerProviderConfig = CompatTracerProviderConfig(clock, sdkErrorHandler)
+    internal val loggerProviderConfig = CompatLoggerProviderConfig(clock, sdkErrorHandler)
     internal val meterProviderConfig = CompatMeterProviderConfig(clock)
     internal val globalAttributeLimits = CompatAttributeLimitsConfig()
     internal val propagatorCfg = CompatPropagatorConfigImpl()

--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/init/CompatTracerProviderConfig.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/init/CompatTracerProviderConfig.kt
@@ -9,6 +9,7 @@ import io.opentelemetry.kotlin.aliases.OtelJavaSdkTracerProviderBuilder
 import io.opentelemetry.kotlin.attributes.AttributesMutator
 import io.opentelemetry.kotlin.attributes.CompatAttributesModel
 import io.opentelemetry.kotlin.attributes.setAttributes
+import io.opentelemetry.kotlin.error.SdkErrorHandler
 import io.opentelemetry.kotlin.factory.CompatSpanContextFactory
 import io.opentelemetry.kotlin.factory.CompatSpanFactory
 import io.opentelemetry.kotlin.factory.IdGenerator
@@ -27,6 +28,7 @@ import io.opentelemetry.kotlin.tracing.sampling.SamplerAdapter
 @ExperimentalApi
 internal class CompatTracerProviderConfig(
     private val clock: Clock,
+    private val sdkErrorHandler: SdkErrorHandler,
 ) : TracerProviderConfigDsl {
 
     private val builder: OtelJavaSdkTracerProviderBuilder = OtelJavaSdkTracerProvider.builder()
@@ -58,7 +60,7 @@ internal class CompatTracerProviderConfig(
     }
 
     override fun export(action: TraceExportConfigDsl.() -> SpanProcessor) {
-        val processor = TraceExportConfigCompat(clock).action()
+        val processor = TraceExportConfigCompat(clock, sdkErrorHandler).action()
         builder.addSpanProcessor(OtelJavaSpanProcessorAdapter(processor))
     }
 
@@ -106,5 +108,8 @@ internal class CompatTracerProviderConfig(
         return TracerProviderAdapter(builder.build(), clock, spanLimitsConfig)
     }
 
-    private class TraceExportConfigCompat(override val clock: Clock) : TraceExportConfigDsl
+    private class TraceExportConfigCompat(
+        override val clock: Clock,
+        override val sdkErrorHandler: SdkErrorHandler,
+    ) : TraceExportConfigDsl
 }

--- a/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/init/CompatTracerProviderSamplerTest.kt
+++ b/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/init/CompatTracerProviderSamplerTest.kt
@@ -3,6 +3,7 @@ package io.opentelemetry.kotlin.init
 import io.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.kotlin.clock.FakeClock
 import io.opentelemetry.kotlin.createCompatOpenTelemetry
+import io.opentelemetry.kotlin.error.NoopSdkErrorHandler
 import io.opentelemetry.kotlin.factory.CompatIdGenerator
 import io.opentelemetry.kotlin.tracing.export.FakeSpanProcessor
 import io.opentelemetry.kotlin.tracing.export.compositeSpanProcessor
@@ -24,7 +25,7 @@ internal class CompatTracerProviderSamplerTest {
     @Test
     fun `default sampler records and samples spans`() {
         val clock = FakeClock()
-        val config = CompatTracerProviderConfig(clock)
+        val config = CompatTracerProviderConfig(clock, NoopSdkErrorHandler)
         val provider = config.build(clock, idGenerator)
         val span = provider.getTracer("test").startSpan("span")
         assertTrue(span.isRecording())
@@ -34,7 +35,7 @@ internal class CompatTracerProviderSamplerTest {
     @Test
     fun `builtin ALWAYS_ON sampler records and samples spans`() {
         val clock = FakeClock()
-        val config = CompatTracerProviderConfig(clock).apply {
+        val config = CompatTracerProviderConfig(clock, NoopSdkErrorHandler).apply {
             sampler { alwaysOn() }
         }
         val span = config.build(clock, idGenerator).getTracer("test").startSpan("span")
@@ -45,7 +46,7 @@ internal class CompatTracerProviderSamplerTest {
     @Test
     fun `custom sampler DROP produces non-recording span`() {
         val clock = FakeClock()
-        val config = CompatTracerProviderConfig(clock).apply {
+        val config = CompatTracerProviderConfig(clock, NoopSdkErrorHandler).apply {
             sampler { FakeSampler(SamplingResult.Decision.DROP) }
         }
         val span = config.build(clock, idGenerator).getTracer("test").startSpan("span")
@@ -55,7 +56,7 @@ internal class CompatTracerProviderSamplerTest {
     @Test
     fun `custom sampler RECORD_AND_SAMPLE produces recording and sampled span`() {
         val clock = FakeClock()
-        val config = CompatTracerProviderConfig(clock).apply {
+        val config = CompatTracerProviderConfig(clock, NoopSdkErrorHandler).apply {
             sampler { FakeSampler(SamplingResult.Decision.RECORD_AND_SAMPLE) }
         }
         val span = config.build(clock, idGenerator).getTracer("test").startSpan("span")
@@ -66,7 +67,7 @@ internal class CompatTracerProviderSamplerTest {
     @Test
     fun `builtin ALWAYS_OFF sampler drops spans`() {
         val clock = FakeClock()
-        val config = CompatTracerProviderConfig(clock).apply {
+        val config = CompatTracerProviderConfig(clock, NoopSdkErrorHandler).apply {
             sampler { alwaysOff() }
         }
         val span = config.build(clock, idGenerator).getTracer("test").startSpan("span")
@@ -90,7 +91,7 @@ internal class CompatTracerProviderSamplerTest {
     @Test
     fun `parentBased samples root spans with alwaysOn`() {
         val clock = FakeClock()
-        val config = CompatTracerProviderConfig(clock).apply {
+        val config = CompatTracerProviderConfig(clock, NoopSdkErrorHandler).apply {
             sampler { parentBased(root = alwaysOn()) }
         }
         val span = config.build(clock, idGenerator).getTracer("test").startSpan("span")
@@ -101,7 +102,7 @@ internal class CompatTracerProviderSamplerTest {
     @Test
     fun `parentBased drops root spans with alwaysOff`() {
         val clock = FakeClock()
-        val config = CompatTracerProviderConfig(clock).apply {
+        val config = CompatTracerProviderConfig(clock, NoopSdkErrorHandler).apply {
             sampler { parentBased(root = alwaysOff()) }
         }
         val span = config.build(clock, idGenerator).getTracer("test").startSpan("span")

--- a/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/init/GlobalAttributeLimitsConfigTest.kt
+++ b/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/init/GlobalAttributeLimitsConfigTest.kt
@@ -1,6 +1,7 @@
 package io.opentelemetry.kotlin.init
 
 import io.opentelemetry.kotlin.clock.FakeClock
+import io.opentelemetry.kotlin.error.NoopSdkErrorHandler
 import io.opentelemetry.kotlin.factory.CompatIdGenerator
 import org.junit.Test
 import kotlin.test.assertEquals
@@ -36,11 +37,11 @@ internal class GlobalAttributeLimitsConfigTest {
     fun `global only - applies to spans and logs`() {
         val globalLimits = CompatAttributeLimitsConfig().apply { attributeCountLimit = 64 }
 
-        val tracerConfig = CompatTracerProviderConfig(clock)
+        val tracerConfig = CompatTracerProviderConfig(clock, NoopSdkErrorHandler)
         tracerConfig.build(clock, idGenerator, globalLimits = globalLimits)
         assertEquals(64, tracerConfig.spanLimitsConfig.attributeCountLimit)
 
-        val loggerConfig = CompatLoggerProviderConfig(clock)
+        val loggerConfig = CompatLoggerProviderConfig(clock, NoopSdkErrorHandler)
         loggerConfig.build(clock, globalLimits = globalLimits)
         assertEquals(64, loggerConfig.logLimitsConfig.attributeCountLimit)
     }
@@ -49,13 +50,13 @@ internal class GlobalAttributeLimitsConfigTest {
     fun `signal-specific overrides global`() {
         val globalLimits = CompatAttributeLimitsConfig().apply { attributeCountLimit = 64 }
 
-        val tracerConfig = CompatTracerProviderConfig(clock).apply {
+        val tracerConfig = CompatTracerProviderConfig(clock, NoopSdkErrorHandler).apply {
             spanLimits { attributeCountLimit = 32 }
         }
         tracerConfig.build(clock, idGenerator, globalLimits = globalLimits)
         assertEquals(32, tracerConfig.spanLimitsConfig.attributeCountLimit)
 
-        val loggerConfig = CompatLoggerProviderConfig(clock)
+        val loggerConfig = CompatLoggerProviderConfig(clock, NoopSdkErrorHandler)
         loggerConfig.build(clock, globalLimits = globalLimits)
         assertEquals(64, loggerConfig.logLimitsConfig.attributeCountLimit)
     }
@@ -64,7 +65,7 @@ internal class GlobalAttributeLimitsConfigTest {
     fun `partial signal override - other global properties still apply`() {
         val globalLimits = CompatAttributeLimitsConfig().apply { attributeCountLimit = 64 }
 
-        val tracerConfig = CompatTracerProviderConfig(clock).apply {
+        val tracerConfig = CompatTracerProviderConfig(clock, NoopSdkErrorHandler).apply {
             spanLimits { attributeValueLengthLimit = 256 }
         }
         tracerConfig.build(clock, idGenerator, globalLimits = globalLimits)
@@ -74,12 +75,12 @@ internal class GlobalAttributeLimitsConfigTest {
 
     @Test
     fun `no global - defaults are zero (Java SDK uses its own defaults)`() {
-        val tracerConfig = CompatTracerProviderConfig(clock)
+        val tracerConfig = CompatTracerProviderConfig(clock, NoopSdkErrorHandler)
         tracerConfig.build(clock, idGenerator)
         assertEquals(DEFAULT_ATTR_LIMIT, tracerConfig.spanLimitsConfig.attributeCountLimit)
         assertEquals(DEFAULT_ATTR_VALUE_LENGTH_LIMIT, tracerConfig.spanLimitsConfig.attributeValueLengthLimit)
 
-        val loggerConfig = CompatLoggerProviderConfig(clock)
+        val loggerConfig = CompatLoggerProviderConfig(clock, NoopSdkErrorHandler)
         loggerConfig.build(clock)
         assertEquals(DEFAULT_ATTR_LIMIT, loggerConfig.logLimitsConfig.attributeCountLimit)
         assertEquals(DEFAULT_ATTR_VALUE_LENGTH_LIMIT, loggerConfig.logLimitsConfig.attributeValueLengthLimit)

--- a/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/export/BatchTelemetryConfig.kt
+++ b/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/export/BatchTelemetryConfig.kt
@@ -1,7 +1,6 @@
 package io.opentelemetry.kotlin.export
 
 import io.opentelemetry.kotlin.config.validateOrUseDefault
-import io.opentelemetry.kotlin.error.NoopSdkErrorHandler
 import io.opentelemetry.kotlin.error.SdkErrorHandler
 
 internal class BatchTelemetryConfig(
@@ -10,7 +9,7 @@ internal class BatchTelemetryConfig(
     exportTimeoutMs: Long = BatchTelemetryDefaults.EXPORT_TIMEOUT_MS,
     maxExportBatchSize: Int = BatchTelemetryDefaults.MAX_EXPORT_BATCH_SIZE,
     forceFlushTimeoutMs: Long = BatchTelemetryDefaults.FORCE_FLUSH_TIMEOUT_MS,
-    sdkErrorHandler: SdkErrorHandler = NoopSdkErrorHandler,
+    sdkErrorHandler: SdkErrorHandler,
 ) {
     /**
      * Maximum number of telemetry items the queue can hold before items are dropped.

--- a/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/export/BatchTelemetryProcessor.kt
+++ b/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/export/BatchTelemetryProcessor.kt
@@ -12,7 +12,7 @@ import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withTimeout
 
 internal class BatchTelemetryProcessor<T>(
-    private val config: BatchTelemetryConfig = BatchTelemetryConfig(),
+    private val config: BatchTelemetryConfig,
     dispatcher: CoroutineDispatcher = Dispatchers.Default,
     private val exportAction: suspend (telemetry: List<T>) -> OperationResultCode,
 ) : TelemetryCloseable {

--- a/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/BatchLogRecordProcessorImpl.kt
+++ b/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/BatchLogRecordProcessorImpl.kt
@@ -2,6 +2,7 @@ package io.opentelemetry.kotlin.logging.export
 
 import io.opentelemetry.kotlin.InstrumentationScopeInfo
 import io.opentelemetry.kotlin.context.Context
+import io.opentelemetry.kotlin.error.SdkErrorHandler
 import io.opentelemetry.kotlin.export.BatchTelemetryConfig
 import io.opentelemetry.kotlin.export.BatchTelemetryDefaults
 import io.opentelemetry.kotlin.export.BatchTelemetryProcessor
@@ -18,6 +19,7 @@ internal class BatchLogRecordProcessorImpl(
     scheduleDelayMs: Long,
     exportTimeoutMs: Long,
     maxExportBatchSize: Int,
+    sdkErrorHandler: SdkErrorHandler,
     dispatcher: CoroutineDispatcher = Dispatchers.Default,
 ) : LogRecordProcessor {
 
@@ -29,6 +31,7 @@ internal class BatchLogRecordProcessorImpl(
                 scheduleDelayMs = scheduleDelayMs,
                 exportTimeoutMs = exportTimeoutMs,
                 maxExportBatchSize = maxExportBatchSize,
+                sdkErrorHandler = sdkErrorHandler,
             ),
             dispatcher = dispatcher,
             exportAction = exporter::export

--- a/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/CoreLogRecordExporterApi.kt
+++ b/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/CoreLogRecordExporterApi.kt
@@ -2,7 +2,6 @@
 package io.opentelemetry.kotlin.logging.export
 
 import io.opentelemetry.kotlin.ExperimentalApi
-import io.opentelemetry.kotlin.error.NoopSdkErrorHandler
 import io.opentelemetry.kotlin.export.BatchTelemetryDefaults
 import io.opentelemetry.kotlin.export.telemetryExceptionHandler
 import io.opentelemetry.kotlin.init.LogExportConfigDsl
@@ -21,7 +20,7 @@ public fun LogExportConfigDsl.compositeLogRecordProcessor(vararg processors: Log
         platformLog("At least one processor must be provided")
         return NoopLogRecordProcessor
     }
-    return CompositeLogRecordProcessor(processors.toList(), NoopSdkErrorHandler)
+    return CompositeLogRecordProcessor(processors.toList(), sdkErrorHandler)
 }
 
 /**
@@ -45,7 +44,7 @@ public fun LogExportConfigDsl.compositeLogRecordExporter(vararg exporters: LogRe
         platformLog("At least one exporter must be provided")
         return NoopLogRecordExporter
     }
-    return CompositeLogRecordExporter(exporters.toList(), NoopSdkErrorHandler)
+    return CompositeLogRecordExporter(exporters.toList(), sdkErrorHandler)
 }
 
 /**
@@ -66,6 +65,7 @@ public fun LogExportConfigDsl.batchLogRecordProcessor(
     scheduleDelayMs,
     exportTimeoutMs,
     maxExportBatchSize,
+    sdkErrorHandler,
     dispatcher,
 )
 

--- a/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/BatchSpanProcessorImpl.kt
+++ b/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/BatchSpanProcessorImpl.kt
@@ -1,6 +1,7 @@
 package io.opentelemetry.kotlin.tracing.export
 
 import io.opentelemetry.kotlin.context.Context
+import io.opentelemetry.kotlin.error.SdkErrorHandler
 import io.opentelemetry.kotlin.export.BatchTelemetryConfig
 import io.opentelemetry.kotlin.export.BatchTelemetryDefaults
 import io.opentelemetry.kotlin.export.BatchTelemetryProcessor
@@ -17,6 +18,7 @@ internal class BatchSpanProcessorImpl(
     scheduleDelayMs: Long,
     exportTimeoutMs: Long,
     maxExportBatchSize: Int,
+    sdkErrorHandler: SdkErrorHandler,
     dispatcher: CoroutineDispatcher = Dispatchers.Default,
 ) : SpanProcessor {
 
@@ -28,6 +30,7 @@ internal class BatchSpanProcessorImpl(
                 scheduleDelayMs = scheduleDelayMs,
                 exportTimeoutMs = exportTimeoutMs,
                 maxExportBatchSize = maxExportBatchSize,
+                sdkErrorHandler = sdkErrorHandler,
             ),
             dispatcher = dispatcher,
             exportAction = exporter::export

--- a/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/CoreSpanExporterApi.kt
+++ b/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/CoreSpanExporterApi.kt
@@ -1,7 +1,6 @@
 package io.opentelemetry.kotlin.tracing.export
 
 import io.opentelemetry.kotlin.ExperimentalApi
-import io.opentelemetry.kotlin.error.NoopSdkErrorHandler
 import io.opentelemetry.kotlin.export.BatchTelemetryDefaults
 import io.opentelemetry.kotlin.export.telemetryExceptionHandler
 import io.opentelemetry.kotlin.init.TraceExportConfigDsl
@@ -20,7 +19,7 @@ public fun TraceExportConfigDsl.compositeSpanProcessor(vararg processors: SpanPr
         platformLog("At least one processor must be provided")
         return NoopSpanProcessor
     }
-    return CompositeSpanProcessor(processors.toList(), NoopSdkErrorHandler)
+    return CompositeSpanProcessor(processors.toList(), sdkErrorHandler)
 }
 
 /**
@@ -44,7 +43,7 @@ public fun TraceExportConfigDsl.compositeSpanExporter(vararg exporters: SpanExpo
         platformLog("At least one exporter must be provided")
         return NoopSpanExporter
     }
-    return CompositeSpanExporter(exporters.toList(), NoopSdkErrorHandler)
+    return CompositeSpanExporter(exporters.toList(), sdkErrorHandler)
 }
 
 /**
@@ -65,6 +64,7 @@ public fun TraceExportConfigDsl.batchSpanProcessor(
     scheduleDelayMs,
     exportTimeoutMs,
     maxExportBatchSize,
+    sdkErrorHandler,
     dispatcher,
 )
 

--- a/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/export/BatchTelemetryConfigTest.kt
+++ b/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/export/BatchTelemetryConfigTest.kt
@@ -1,6 +1,7 @@
 package io.opentelemetry.kotlin.export
 
 import io.opentelemetry.kotlin.error.FakeSdkErrorHandler
+import io.opentelemetry.kotlin.error.NoopSdkErrorHandler
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -8,7 +9,7 @@ internal class BatchTelemetryConfigTest {
 
     @Test
     fun testDefaults() {
-        val cfg = BatchTelemetryConfig()
+        val cfg = BatchTelemetryConfig(sdkErrorHandler = NoopSdkErrorHandler)
         assertEquals(BatchTelemetryDefaults.MAX_QUEUE_SIZE, cfg.maxQueueSize)
         assertEquals(BatchTelemetryDefaults.SPAN_SCHEDULE_DELAY_MS, cfg.scheduleDelayMs)
         assertEquals(BatchTelemetryDefaults.EXPORT_TIMEOUT_MS, cfg.exportTimeoutMs)
@@ -28,7 +29,7 @@ internal class BatchTelemetryConfigTest {
             sdkErrorHandler = handler,
         )
         assertEquals(5, handler.apiMisuses.size)
-        val default = BatchTelemetryConfig()
+        val default = BatchTelemetryConfig(sdkErrorHandler = NoopSdkErrorHandler)
         assertEquals(default.maxQueueSize, cfg.maxQueueSize)
         assertEquals(default.scheduleDelayMs, cfg.scheduleDelayMs)
         assertEquals(default.exportTimeoutMs, cfg.exportTimeoutMs)

--- a/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/export/BatchTelemetryProcessorTest.kt
+++ b/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/export/BatchTelemetryProcessorTest.kt
@@ -1,6 +1,7 @@
 package io.opentelemetry.kotlin.export
 
 import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.error.NoopSdkErrorHandler
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -52,6 +53,7 @@ internal class BatchTelemetryProcessorTest {
                 maxExportBatchSize = 1,
                 scheduleDelayMs = 1,
                 exportTimeoutMs = 1000,
+                sdkErrorHandler = NoopSdkErrorHandler,
             ),
             dispatcher = dispatcher,
             exportAction = {
@@ -79,6 +81,7 @@ internal class BatchTelemetryProcessorTest {
                 maxExportBatchSize = 1,
                 scheduleDelayMs = 1,
                 exportTimeoutMs = 1000,
+                sdkErrorHandler = NoopSdkErrorHandler,
             ),
             dispatcher = dispatcher,
             exportAction = { OperationResultCode.Success }
@@ -96,6 +99,7 @@ internal class BatchTelemetryProcessorTest {
                 maxExportBatchSize = 1,
                 scheduleDelayMs = 1,
                 exportTimeoutMs = 1000,
+                sdkErrorHandler = NoopSdkErrorHandler,
             ),
             dispatcher = dispatcher,
             exportAction = { OperationResultCode.Success }
@@ -159,6 +163,7 @@ internal class BatchTelemetryProcessorTest {
                 maxExportBatchSize = batchSize,
                 scheduleDelayMs = 1,
                 exportTimeoutMs = exportTimeoutMs,
+                sdkErrorHandler = NoopSdkErrorHandler,
             ),
             dispatcher = dispatcher,
             exportAction = {

--- a/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/export/FakeLogExportConfig.kt
+++ b/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/export/FakeLogExportConfig.kt
@@ -2,8 +2,11 @@ package io.opentelemetry.kotlin.export
 
 import io.opentelemetry.kotlin.Clock
 import io.opentelemetry.kotlin.clock.FakeClock
+import io.opentelemetry.kotlin.error.NoopSdkErrorHandler
+import io.opentelemetry.kotlin.error.SdkErrorHandler
 import io.opentelemetry.kotlin.init.LogExportConfigDsl
 
 internal class FakeLogExportConfig(
-    override val clock: Clock = FakeClock()
+    override val clock: Clock = FakeClock(),
+    override val sdkErrorHandler: SdkErrorHandler = NoopSdkErrorHandler,
 ) : LogExportConfigDsl

--- a/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/export/FakeTraceExportConfig.kt
+++ b/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/export/FakeTraceExportConfig.kt
@@ -2,8 +2,11 @@ package io.opentelemetry.kotlin.export
 
 import io.opentelemetry.kotlin.Clock
 import io.opentelemetry.kotlin.clock.FakeClock
+import io.opentelemetry.kotlin.error.NoopSdkErrorHandler
+import io.opentelemetry.kotlin.error.SdkErrorHandler
 import io.opentelemetry.kotlin.init.TraceExportConfigDsl
 
 internal class FakeTraceExportConfig(
-    override val clock: Clock = FakeClock()
+    override val clock: Clock = FakeClock(),
+    override val sdkErrorHandler: SdkErrorHandler = NoopSdkErrorHandler,
 ) : TraceExportConfigDsl

--- a/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/export/BatchLogRecordProcessorImplTest.kt
+++ b/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/export/BatchLogRecordProcessorImplTest.kt
@@ -3,6 +3,7 @@ package io.opentelemetry.kotlin.logging.export
 import io.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.kotlin.FakeInstrumentationScopeInfo
 import io.opentelemetry.kotlin.context.FakeContext
+import io.opentelemetry.kotlin.error.NoopSdkErrorHandler
 import io.opentelemetry.kotlin.export.OperationResultCode
 import io.opentelemetry.kotlin.logging.model.FakeReadWriteLogRecord
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -29,6 +30,7 @@ internal class BatchLogRecordProcessorImplTest {
             scheduleDelayMs = 1,
             exportTimeoutMs = 1000,
             maxExportBatchSize = 10,
+            sdkErrorHandler = NoopSdkErrorHandler,
         )
     }
 

--- a/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/export/BatchSpanProcessorImplTest.kt
+++ b/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/export/BatchSpanProcessorImplTest.kt
@@ -1,6 +1,7 @@
 package io.opentelemetry.kotlin.tracing.export
 
 import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.error.NoopSdkErrorHandler
 import io.opentelemetry.kotlin.export.OperationResultCode
 import io.opentelemetry.kotlin.tracing.FakeReadWriteSpan
 import io.opentelemetry.kotlin.tracing.FakeSpanContext
@@ -28,6 +29,7 @@ internal class BatchSpanProcessorImplTest {
             scheduleDelayMs = 1,
             exportTimeoutMs = 1000,
             maxExportBatchSize = 10,
+            sdkErrorHandler = NoopSdkErrorHandler,
         )
     }
 

--- a/exporters-otlp/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/export/OtlpHttpLogRecordExporterTest.kt
+++ b/exporters-otlp/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/export/OtlpHttpLogRecordExporterTest.kt
@@ -12,6 +12,7 @@ import io.ktor.util.toMap
 import io.ktor.utils.io.ByteReadChannel
 import io.opentelemetry.kotlin.Clock
 import io.opentelemetry.kotlin.clock.FakeClock
+import io.opentelemetry.kotlin.error.NoopSdkErrorHandler
 import io.opentelemetry.kotlin.export.OperationResultCode
 import io.opentelemetry.kotlin.export.OtlpClient
 import io.opentelemetry.kotlin.export.createDefaultHttpClient
@@ -112,6 +113,7 @@ internal class OtlpHttpLogRecordExporterTest {
         }
         val fakeConfig = object : LogExportConfigDsl {
             override val clock: Clock = FakeClock()
+            override val sdkErrorHandler = NoopSdkErrorHandler
         }
         val customExporter = fakeConfig.otlpHttpLogRecordExporter(baseUrl, customClient)
         customExporter.export(logRecords)

--- a/exporters-otlp/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/export/OtlpHttpSpanExporterTest.kt
+++ b/exporters-otlp/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/export/OtlpHttpSpanExporterTest.kt
@@ -12,6 +12,7 @@ import io.ktor.util.toMap
 import io.ktor.utils.io.ByteReadChannel
 import io.opentelemetry.kotlin.Clock
 import io.opentelemetry.kotlin.clock.FakeClock
+import io.opentelemetry.kotlin.error.NoopSdkErrorHandler
 import io.opentelemetry.kotlin.export.OperationResultCode
 import io.opentelemetry.kotlin.export.OtlpClient
 import io.opentelemetry.kotlin.export.createDefaultHttpClient
@@ -112,6 +113,7 @@ internal class OtlpHttpSpanExporterTest {
         }
         val fakeConfig = object : TraceExportConfigDsl {
             override val clock: Clock = FakeClock()
+            override val sdkErrorHandler = NoopSdkErrorHandler
         }
         val customExporter = fakeConfig.otlpHttpSpanExporter(baseUrl, customClient)
         customExporter.export(spans)

--- a/exporters-persistence/src/commonMain/kotlin/io/opentelemetry/kotlin/export/PersistedTelemetryConfig.kt
+++ b/exporters-persistence/src/commonMain/kotlin/io/opentelemetry/kotlin/export/PersistedTelemetryConfig.kt
@@ -1,13 +1,12 @@
 package io.opentelemetry.kotlin.export
 
 import io.opentelemetry.kotlin.config.validateOrUseDefault
-import io.opentelemetry.kotlin.error.NoopSdkErrorHandler
 import io.opentelemetry.kotlin.error.SdkErrorHandler
 
 internal class PersistedTelemetryConfig(
     maxBatchedItemsPerSignal: Int = DEFAULT_MAX_BATCHED_ITEMS_PER_SIGNAL,
     maxTelemetryAgeInDays: Long = DEFAULT_MAX_TELEMETRY_AGE_IN_DAYS,
-    sdkErrorHandler: SdkErrorHandler = NoopSdkErrorHandler,
+    sdkErrorHandler: SdkErrorHandler,
 ) {
     /**
      * Maximum number of batches that should be stored for each telemetry signal. 100 by default.

--- a/exporters-persistence/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/PersistingLogRecordProcessorApi.kt
+++ b/exporters-persistence/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/PersistingLogRecordProcessorApi.kt
@@ -2,7 +2,6 @@
 package io.opentelemetry.kotlin.logging.export
 
 import io.opentelemetry.kotlin.ExperimentalApi
-import io.opentelemetry.kotlin.error.NoopSdkErrorHandler
 import io.opentelemetry.kotlin.error.SdkErrorHandler
 import io.opentelemetry.kotlin.export.BatchTelemetryDefaults
 import io.opentelemetry.kotlin.export.PersistedTelemetryConfig
@@ -57,7 +56,7 @@ internal fun LogExportConfigDsl.persistingLogRecordProcessorImpl(
     scheduleDelayMs: Long = BatchTelemetryDefaults.LOG_SCHEDULE_DELAY_MS,
     exportTimeoutMs: Long = BatchTelemetryDefaults.EXPORT_TIMEOUT_MS,
     maxExportBatchSize: Int = BatchTelemetryDefaults.MAX_EXPORT_BATCH_SIZE,
-    sdkErrorHandler: SdkErrorHandler = NoopSdkErrorHandler,
+    sdkErrorHandler: SdkErrorHandler = this.sdkErrorHandler,
     dispatcher: CoroutineDispatcher = Dispatchers.Default,
 ): LogRecordProcessor {
     return PersistingLogRecordProcessor(
@@ -67,7 +66,7 @@ internal fun LogExportConfigDsl.persistingLogRecordProcessorImpl(
         dsl = this,
         serializer = { it.toProtobufByteArray() },
         deserializer = { it.toReadableLogRecordList() },
-        config = PersistedTelemetryConfig(),
+        config = PersistedTelemetryConfig(sdkErrorHandler = sdkErrorHandler),
         maxQueueSize = maxQueueSize,
         scheduleDelayMs = scheduleDelayMs,
         exportTimeoutMs = exportTimeoutMs,

--- a/exporters-persistence/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/PersistingSpanProcessorApi.kt
+++ b/exporters-persistence/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/PersistingSpanProcessorApi.kt
@@ -2,7 +2,6 @@
 package io.opentelemetry.kotlin.tracing.export
 
 import io.opentelemetry.kotlin.ExperimentalApi
-import io.opentelemetry.kotlin.error.NoopSdkErrorHandler
 import io.opentelemetry.kotlin.error.SdkErrorHandler
 import io.opentelemetry.kotlin.export.BatchTelemetryDefaults
 import io.opentelemetry.kotlin.export.PersistedTelemetryConfig
@@ -57,7 +56,7 @@ internal fun TraceExportConfigDsl.persistingSpanProcessorImpl(
     scheduleDelayMs: Long = BatchTelemetryDefaults.SPAN_SCHEDULE_DELAY_MS,
     exportTimeoutMs: Long = BatchTelemetryDefaults.EXPORT_TIMEOUT_MS,
     maxExportBatchSize: Int = BatchTelemetryDefaults.MAX_EXPORT_BATCH_SIZE,
-    sdkErrorHandler: SdkErrorHandler = NoopSdkErrorHandler,
+    sdkErrorHandler: SdkErrorHandler = this.sdkErrorHandler,
     dispatcher: CoroutineDispatcher = Dispatchers.Default,
 ): SpanProcessor {
     return PersistingSpanProcessor(
@@ -67,7 +66,7 @@ internal fun TraceExportConfigDsl.persistingSpanProcessorImpl(
         dsl = this,
         serializer = { it.toProtobufByteArray() },
         deserializer = { it.toSpanDataList() },
-        config = PersistedTelemetryConfig(),
+        config = PersistedTelemetryConfig(sdkErrorHandler = sdkErrorHandler),
         maxQueueSize = maxQueueSize,
         scheduleDelayMs = scheduleDelayMs,
         exportTimeoutMs = exportTimeoutMs,

--- a/exporters-persistence/src/commonTest/kotlin/io/opentelemetry/kotlin/export/PersistedTelemetryConfigTest.kt
+++ b/exporters-persistence/src/commonTest/kotlin/io/opentelemetry/kotlin/export/PersistedTelemetryConfigTest.kt
@@ -1,6 +1,7 @@
 package io.opentelemetry.kotlin.export
 
 import io.opentelemetry.kotlin.error.FakeSdkErrorHandler
+import io.opentelemetry.kotlin.error.NoopSdkErrorHandler
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -8,7 +9,7 @@ internal class PersistedTelemetryConfigTest {
 
     @Test
     fun testDefaults() {
-        val cfg = PersistedTelemetryConfig()
+        val cfg = PersistedTelemetryConfig(sdkErrorHandler = NoopSdkErrorHandler)
         assertEquals(30, cfg.maxTelemetryAgeInDays)
         assertEquals(100, cfg.maxBatchedItemsPerSignal)
     }
@@ -22,7 +23,7 @@ internal class PersistedTelemetryConfigTest {
             sdkErrorHandler = handler,
         )
         assertEquals(2, handler.apiMisuses.size)
-        val default = PersistedTelemetryConfig()
+        val default = PersistedTelemetryConfig(sdkErrorHandler = NoopSdkErrorHandler)
         assertEquals(default.maxBatchedItemsPerSignal, cfg.maxBatchedItemsPerSignal)
         assertEquals(default.maxTelemetryAgeInDays, cfg.maxTelemetryAgeInDays)
     }

--- a/exporters-persistence/src/commonTest/kotlin/io/opentelemetry/kotlin/export/TelemetryRepositoryImplTest.kt
+++ b/exporters-persistence/src/commonTest/kotlin/io/opentelemetry/kotlin/export/TelemetryRepositoryImplTest.kt
@@ -2,6 +2,7 @@ package io.opentelemetry.kotlin.export
 
 import io.opentelemetry.kotlin.clock.FakeClock
 import io.opentelemetry.kotlin.error.FakeSdkErrorHandler
+import io.opentelemetry.kotlin.error.NoopSdkErrorHandler
 import io.opentelemetry.kotlin.export.PersistedTelemetryType.LOGS
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -166,7 +167,7 @@ internal class TelemetryRepositoryImplTest {
 
     @Test
     fun testMaxStorageLimitExceeded() {
-        val config = PersistedTelemetryConfig(maxBatchedItemsPerSignal = 3)
+        val config = PersistedTelemetryConfig(maxBatchedItemsPerSignal = 3, sdkErrorHandler = NoopSdkErrorHandler)
         val repository = createRepository(config = config)
 
         val items = listOf("first", "second", "third", "fourth")
@@ -186,7 +187,7 @@ internal class TelemetryRepositoryImplTest {
 
     @Test
     fun testOldTelemetryPolicy() {
-        val config = PersistedTelemetryConfig(maxTelemetryAgeInDays = 7)
+        val config = PersistedTelemetryConfig(maxTelemetryAgeInDays = 7, sdkErrorHandler = NoopSdkErrorHandler)
         val repository = createRepository(config = config)
 
         repository.store(listOf(FakeTelemetryObject("a")))
@@ -238,7 +239,7 @@ internal class TelemetryRepositoryImplTest {
     private class FakeTelemetryObject(val value: String)
 
     private fun createRepository(
-        config: PersistedTelemetryConfig = PersistedTelemetryConfig(),
+        config: PersistedTelemetryConfig = PersistedTelemetryConfig(sdkErrorHandler = NoopSdkErrorHandler),
         serializer: (List<FakeTelemetryObject>) -> ByteArray = { telemetry ->
             telemetry.joinToString(DELIMITER) { it.value }.encodeToByteArray()
         },

--- a/exporters-persistence/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/export/PersistingLogRecordProcessorTest.kt
+++ b/exporters-persistence/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/export/PersistingLogRecordProcessorTest.kt
@@ -5,6 +5,8 @@ import io.opentelemetry.kotlin.FakeInstrumentationScopeInfo
 import io.opentelemetry.kotlin.clock.FakeClock
 import io.opentelemetry.kotlin.context.Context
 import io.opentelemetry.kotlin.context.FakeContext
+import io.opentelemetry.kotlin.error.NoopSdkErrorHandler
+import io.opentelemetry.kotlin.error.SdkErrorHandler
 import io.opentelemetry.kotlin.export.FakeTelemetryFileSystem
 import io.opentelemetry.kotlin.export.OperationResultCode
 import io.opentelemetry.kotlin.export.OperationResultCode.Failure
@@ -636,7 +638,10 @@ internal class PersistingLogRecordProcessorTest {
         )
     }
 
-    private class FakeLogExportConfig(override val clock: Clock = FakeClock()) : LogExportConfigDsl
+    private class FakeLogExportConfig(
+        override val clock: Clock = FakeClock(),
+        override val sdkErrorHandler: SdkErrorHandler = NoopSdkErrorHandler,
+    ) : LogExportConfigDsl
 
     private class DelayingLogRecordProcessor(
         private val flushDelayMs: Long = 0,

--- a/exporters-persistence/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/export/PersistingSpanProcessorTest.kt
+++ b/exporters-persistence/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/export/PersistingSpanProcessorTest.kt
@@ -4,6 +4,8 @@ import io.opentelemetry.kotlin.Clock
 import io.opentelemetry.kotlin.clock.FakeClock
 import io.opentelemetry.kotlin.context.Context
 import io.opentelemetry.kotlin.context.FakeContext
+import io.opentelemetry.kotlin.error.NoopSdkErrorHandler
+import io.opentelemetry.kotlin.error.SdkErrorHandler
 import io.opentelemetry.kotlin.export.FakeTelemetryFileSystem
 import io.opentelemetry.kotlin.export.OperationResultCode
 import io.opentelemetry.kotlin.export.OperationResultCode.Failure
@@ -603,8 +605,10 @@ internal class PersistingSpanProcessorTest {
         )
     }
 
-    private class FakeTraceExportConfig(override val clock: Clock = FakeClock()) :
-        TraceExportConfigDsl
+    private class FakeTraceExportConfig(
+        override val clock: Clock = FakeClock(),
+        override val sdkErrorHandler: SdkErrorHandler = NoopSdkErrorHandler,
+    ) : TraceExportConfigDsl
 
     private class DelayingSpanProcessor(
         private val flushDelayMs: Long = 0,

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/OpenTelemetryImplEntrypoint.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/OpenTelemetryImplEntrypoint.kt
@@ -1,5 +1,7 @@
 package io.opentelemetry.kotlin
 
+import io.opentelemetry.kotlin.error.NoopSdkErrorHandler
+import io.opentelemetry.kotlin.error.SdkErrorHandler
 import io.opentelemetry.kotlin.factory.BaggageFactoryImpl
 import io.opentelemetry.kotlin.factory.ContextFactoryImpl
 import io.opentelemetry.kotlin.factory.ResourceFactoryImpl
@@ -29,7 +31,8 @@ public fun createOpenTelemetry(
      */
     config: OpenTelemetryConfigDsl.() -> Unit = {}
 ): OpenTelemetry {
-    val cfg = OpenTelemetryConfigImpl(clock).apply(config)
+    val sdkErrorHandler: SdkErrorHandler = NoopSdkErrorHandler
+    val cfg = OpenTelemetryConfigImpl(clock, sdkErrorHandler).apply(config)
     val idGenerator = cfg.resolveIdGenerator()
 
     val resourceFactory = ResourceFactoryImpl()

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/config/envar/OpenTelemetryEnvVarConfigProcessorImplEntrypoint.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/config/envar/OpenTelemetryEnvVarConfigProcessorImplEntrypoint.kt
@@ -3,6 +3,7 @@ package io.opentelemetry.kotlin.config.envar
 import io.opentelemetry.kotlin.Clock
 import io.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.kotlin.config.envar.logging.LogLimitEnvVarConfigProcessorImpl
+import io.opentelemetry.kotlin.error.NoopSdkErrorHandler
 import io.opentelemetry.kotlin.init.OpenTelemetryConfigDsl
 import io.opentelemetry.kotlin.init.OpenTelemetryConfigImpl
 
@@ -26,7 +27,7 @@ internal fun createOpenTelemetryEnvVarConfigProcessorImpl(
     clock: Clock,
     config: OpenTelemetryConfigDsl.() -> Unit
 ): OpenTelemetryEnvVarConfigProcessor {
-    val cfg = OpenTelemetryConfigImpl(clock).apply(config)
+    val cfg = OpenTelemetryConfigImpl(clock, NoopSdkErrorHandler).apply(config)
     val logLimitProcessor = LogLimitEnvVarConfigProcessorImpl(
         envVars = EnvVarConstants.LogLimits.envVars
     )

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/LogExportConfigImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/LogExportConfigImpl.kt
@@ -1,5 +1,9 @@
 package io.opentelemetry.kotlin.init
 
 import io.opentelemetry.kotlin.Clock
+import io.opentelemetry.kotlin.error.SdkErrorHandler
 
-internal class LogExportConfigImpl(override val clock: Clock) : LogExportConfigDsl
+internal class LogExportConfigImpl(
+    override val clock: Clock,
+    override val sdkErrorHandler: SdkErrorHandler,
+) : LogExportConfigDsl

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/LoggerProviderConfigImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/LoggerProviderConfigImpl.kt
@@ -1,6 +1,7 @@
 package io.opentelemetry.kotlin.init
 
 import io.opentelemetry.kotlin.Clock
+import io.opentelemetry.kotlin.error.SdkErrorHandler
 import io.opentelemetry.kotlin.init.config.LogLimitConfig
 import io.opentelemetry.kotlin.init.config.LoggingConfig
 import io.opentelemetry.kotlin.logging.export.LogRecordProcessor
@@ -9,6 +10,7 @@ import io.opentelemetry.kotlin.resource.Resource
 
 internal class LoggerProviderConfigImpl(
     private val clock: Clock,
+    private val sdkErrorHandler: SdkErrorHandler,
     private val resourceConfigImpl: ResourceConfigImpl = ResourceConfigImpl()
 ) : LoggerProviderConfigDsl, ResourceConfigDsl by resourceConfigImpl {
 
@@ -20,7 +22,7 @@ internal class LoggerProviderConfigImpl(
             platformLog("export() should only be called once.")
             return
         }
-        processor = LogExportConfigImpl(clock).action()
+        processor = LogExportConfigImpl(clock, sdkErrorHandler).action()
     }
 
     override fun logLimits(action: LogLimitsConfigDsl.() -> Unit) {
@@ -31,6 +33,7 @@ internal class LoggerProviderConfigImpl(
         processor = processor,
         logLimits = generateLogLimitsConfig(globalLimits),
         resource = base.merge(resourceConfigImpl.generateResource()),
+        sdkErrorHandler = sdkErrorHandler,
     )
 
     private fun generateLogLimitsConfig(globalLimits: AttributeLimitsConfigImpl?): LogLimitConfig {

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/MeterProviderConfigImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/MeterProviderConfigImpl.kt
@@ -1,13 +1,16 @@
 package io.opentelemetry.kotlin.init
 
+import io.opentelemetry.kotlin.error.SdkErrorHandler
 import io.opentelemetry.kotlin.init.config.MetricsConfig
 import io.opentelemetry.kotlin.resource.Resource
 
 internal class MeterProviderConfigImpl(
+    private val sdkErrorHandler: SdkErrorHandler,
     private val resourceConfigImpl: ResourceConfigImpl = ResourceConfigImpl()
 ) : MeterProviderConfigDsl, ResourceConfigDsl by resourceConfigImpl {
 
     fun generateMetricsConfig(base: Resource): MetricsConfig = MetricsConfig(
         resource = base.merge(resourceConfigImpl.generateResource()),
+        sdkErrorHandler = sdkErrorHandler,
     )
 }

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/OpenTelemetryConfigImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/OpenTelemetryConfigImpl.kt
@@ -1,18 +1,20 @@
 package io.opentelemetry.kotlin.init
 
 import io.opentelemetry.kotlin.Clock
+import io.opentelemetry.kotlin.error.SdkErrorHandler
 import io.opentelemetry.kotlin.factory.IdGenerator
 import io.opentelemetry.kotlin.factory.IdGeneratorImpl
 import io.opentelemetry.kotlin.propagation.TextMapPropagator
 
 internal class OpenTelemetryConfigImpl(
     clock: Clock,
+    sdkErrorHandler: SdkErrorHandler,
     private val globalResourceConfig: ResourceConfigImpl = ResourceConfigImpl(),
 ) : OpenTelemetryConfigDsl, ResourceConfigDsl by globalResourceConfig {
 
-    internal val tracingConfig: TracerProviderConfigImpl = TracerProviderConfigImpl(clock)
-    internal val loggingConfig: LoggerProviderConfigImpl = LoggerProviderConfigImpl(clock)
-    internal val metricsConfig: MeterProviderConfigImpl = MeterProviderConfigImpl()
+    internal val tracingConfig: TracerProviderConfigImpl = TracerProviderConfigImpl(clock, sdkErrorHandler)
+    internal val loggingConfig: LoggerProviderConfigImpl = LoggerProviderConfigImpl(clock, sdkErrorHandler)
+    internal val metricsConfig: MeterProviderConfigImpl = MeterProviderConfigImpl(sdkErrorHandler)
     internal val contextConfig: ContextConfigImpl = ContextConfigImpl()
     internal val propagatorCfg: PropagatorConfigImpl = PropagatorConfigImpl()
     private val globalAttributeLimits = AttributeLimitsConfigImpl()

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/TraceExportConfigImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/TraceExportConfigImpl.kt
@@ -1,5 +1,9 @@
 package io.opentelemetry.kotlin.init
 
 import io.opentelemetry.kotlin.Clock
+import io.opentelemetry.kotlin.error.SdkErrorHandler
 
-internal class TraceExportConfigImpl(override val clock: Clock) : TraceExportConfigDsl
+internal class TraceExportConfigImpl(
+    override val clock: Clock,
+    override val sdkErrorHandler: SdkErrorHandler,
+) : TraceExportConfigDsl

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/TracerProviderConfigImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/TracerProviderConfigImpl.kt
@@ -1,6 +1,7 @@
 package io.opentelemetry.kotlin.init
 
 import io.opentelemetry.kotlin.Clock
+import io.opentelemetry.kotlin.error.SdkErrorHandler
 import io.opentelemetry.kotlin.factory.SpanFactory
 import io.opentelemetry.kotlin.init.config.SpanLimitConfig
 import io.opentelemetry.kotlin.init.config.TracingConfig
@@ -13,6 +14,7 @@ import io.opentelemetry.kotlin.tracing.sampling.parentBased
 
 internal class TracerProviderConfigImpl(
     private val clock: Clock,
+    private val sdkErrorHandler: SdkErrorHandler,
     private val resourceConfigImpl: ResourceConfigImpl = ResourceConfigImpl()
 ) : TracerProviderConfigDsl, ResourceConfigDsl by resourceConfigImpl {
 
@@ -29,7 +31,7 @@ internal class TracerProviderConfigImpl(
             platformLog("export() should only be called once.")
             return
         }
-        processor = TraceExportConfigImpl(clock).action()
+        processor = TraceExportConfigImpl(clock, sdkErrorHandler).action()
     }
 
     override fun sampler(action: SamplerConfigDsl.() -> Sampler) {
@@ -40,6 +42,7 @@ internal class TracerProviderConfigImpl(
         processor = processor,
         spanLimits = generateSpanLimitsConfig(globalLimits),
         resource = base.merge(resourceConfigImpl.generateResource()),
+        sdkErrorHandler = sdkErrorHandler,
         samplerFactory = { spanFactory -> SamplerConfigImpl(spanFactory).samplerAction() },
     )
 

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/config/LoggingConfig.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/config/LoggingConfig.kt
@@ -1,6 +1,7 @@
 package io.opentelemetry.kotlin.init.config
 
 import io.opentelemetry.kotlin.ThreadSafe
+import io.opentelemetry.kotlin.error.SdkErrorHandler
 import io.opentelemetry.kotlin.logging.export.LogRecordProcessor
 import io.opentelemetry.kotlin.resource.Resource
 
@@ -23,5 +24,10 @@ internal class LoggingConfig(
     /**
      * A resource to append to spans.
      */
-    val resource: Resource
+    val resource: Resource,
+
+    /**
+     * Handler used to report errors and misuse of the SDK.
+     */
+    val sdkErrorHandler: SdkErrorHandler,
 )

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/config/MetricsConfig.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/config/MetricsConfig.kt
@@ -1,6 +1,7 @@
 package io.opentelemetry.kotlin.init.config
 
 import io.opentelemetry.kotlin.ThreadSafe
+import io.opentelemetry.kotlin.error.SdkErrorHandler
 import io.opentelemetry.kotlin.resource.Resource
 
 /**
@@ -13,4 +14,9 @@ internal class MetricsConfig(
      * A resource to append to metrics.
      */
     val resource: Resource,
+
+    /**
+     * Handler used to report errors and misuse of the SDK.
+     */
+    val sdkErrorHandler: SdkErrorHandler,
 )

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/config/TracingConfig.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/config/TracingConfig.kt
@@ -1,6 +1,7 @@
 package io.opentelemetry.kotlin.init.config
 
 import io.opentelemetry.kotlin.ThreadSafe
+import io.opentelemetry.kotlin.error.SdkErrorHandler
 import io.opentelemetry.kotlin.factory.SpanFactory
 import io.opentelemetry.kotlin.resource.Resource
 import io.opentelemetry.kotlin.tracing.export.SpanProcessor
@@ -29,6 +30,11 @@ internal class TracingConfig(
      * A resource to append to spans.
      */
     val resource: Resource,
+
+    /**
+     * Handler used to report errors and misuse of the SDK.
+     */
+    val sdkErrorHandler: SdkErrorHandler,
 
     /**
      * Factory that produces the sampler to use when creating spans.

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/LoggerProviderImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/LoggerProviderImpl.kt
@@ -24,7 +24,8 @@ internal class LoggerProviderImpl(
 
     private val shutdownState: MutableShutdownState = MutableShutdownState()
     private val closeable: TelemetryCloseable = CompositeTelemetryCloseable(
-        loggingConfig.processor?.let { listOf(it) } ?: emptyList()
+        loggingConfig.processor?.let { listOf(it) } ?: emptyList(),
+        loggingConfig.sdkErrorHandler,
     )
     private val noopLogger = NoopOpenTelemetry.loggerProvider.getLogger("")
 

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/MeterProviderImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/MeterProviderImpl.kt
@@ -17,7 +17,7 @@ internal class MeterProviderImpl(
 ) : MeterProvider, TelemetryCloseable {
 
     private val shutdownState: MutableShutdownState = MutableShutdownState()
-    private val closeable: TelemetryCloseable = CompositeTelemetryCloseable(emptyList())
+    private val closeable: TelemetryCloseable = CompositeTelemetryCloseable(emptyList(), metricsConfig.sdkErrorHandler)
     private val noopMeter = NoopOpenTelemetry.meterProvider.getMeter("")
 
     private val apiProvider by lazy {

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/TracerProviderImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/TracerProviderImpl.kt
@@ -30,7 +30,8 @@ internal class TracerProviderImpl(
 
     private val shutdownState: MutableShutdownState = MutableShutdownState()
     private val closeable: TelemetryCloseable = CompositeTelemetryCloseable(
-        tracingConfig.processor?.let { listOf(it) } ?: emptyList()
+        tracingConfig.processor?.let { listOf(it) } ?: emptyList(),
+        tracingConfig.sdkErrorHandler,
     )
     private val noopTracer = NoopOpenTelemetry.tracerProvider.getTracer("")
 

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/config/envar/OpenTelemetryEnvVarConfigProcessorImplTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/config/envar/OpenTelemetryEnvVarConfigProcessorImplTest.kt
@@ -1,6 +1,7 @@
 package io.opentelemetry.kotlin.config.envar
 
 import io.opentelemetry.kotlin.clock.FakeClock
+import io.opentelemetry.kotlin.error.NoopSdkErrorHandler
 import io.opentelemetry.kotlin.init.OpenTelemetryConfigImpl
 import io.opentelemetry.kotlin.logging.export.FakeLogRecordProcessor
 import kotlin.test.Test
@@ -12,7 +13,7 @@ internal class OpenTelemetryEnvVarConfigProcessorImplTest {
     fun `should successfully parse env var value`() {
         // given
         val clock = FakeClock()
-        val cfg = OpenTelemetryConfigImpl(clock)
+        val cfg = OpenTelemetryConfigImpl(clock, NoopSdkErrorHandler)
         cfg.loggerProvider {
             export { FakeLogRecordProcessor() }
         }

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/config/envar/logging/LogLimitEnvVarConfigProcessorImplTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/config/envar/logging/LogLimitEnvVarConfigProcessorImplTest.kt
@@ -2,6 +2,7 @@ package io.opentelemetry.kotlin.config.envar.logging
 
 import io.opentelemetry.kotlin.clock.FakeClock
 import io.opentelemetry.kotlin.config.envar.EnvVarConstants
+import io.opentelemetry.kotlin.error.NoopSdkErrorHandler
 import io.opentelemetry.kotlin.init.OpenTelemetryConfigImpl
 import io.opentelemetry.kotlin.logging.export.FakeLogRecordProcessor
 import kotlin.test.Test
@@ -16,7 +17,7 @@ internal class LogLimitEnvVarConfigProcessorImplTest {
             envVars = EnvVarConstants.LogLimits.envVars
         )
         val clock = FakeClock()
-        val otelConfig = OpenTelemetryConfigImpl(clock)
+        val otelConfig = OpenTelemetryConfigImpl(clock, NoopSdkErrorHandler)
         otelConfig.loggerProvider {
             export { FakeLogRecordProcessor() }
         }
@@ -39,7 +40,7 @@ internal class LogLimitEnvVarConfigProcessorImplTest {
             envVars = EnvVarConstants.LogLimits.envVars
         )
         val clock = FakeClock()
-        val otelConfig = OpenTelemetryConfigImpl(clock)
+        val otelConfig = OpenTelemetryConfigImpl(clock, NoopSdkErrorHandler)
         otelConfig.loggerProvider {
             export { FakeLogRecordProcessor() }
         }
@@ -60,7 +61,7 @@ internal class LogLimitEnvVarConfigProcessorImplTest {
             envVars = EnvVarConstants.LogLimits.envVars
         )
         val clock = FakeClock()
-        val otelConfig = OpenTelemetryConfigImpl(clock)
+        val otelConfig = OpenTelemetryConfigImpl(clock, NoopSdkErrorHandler)
         otelConfig.loggerProvider {
             export { FakeLogRecordProcessor() }
         }
@@ -79,7 +80,7 @@ internal class LogLimitEnvVarConfigProcessorImplTest {
         // given
         val processor = LogLimitEnvVarConfigProcessorImpl(envVars = emptyList())
         val clock = FakeClock()
-        val otelConfig = OpenTelemetryConfigImpl(clock)
+        val otelConfig = OpenTelemetryConfigImpl(clock, NoopSdkErrorHandler)
         otelConfig.loggerProvider {
             export { FakeLogRecordProcessor() }
         }

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/config/envar/model/EnvironmentConfigurationTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/config/envar/model/EnvironmentConfigurationTest.kt
@@ -1,6 +1,7 @@
 package io.opentelemetry.kotlin.config.envar.model
 
 import io.opentelemetry.kotlin.clock.FakeClock
+import io.opentelemetry.kotlin.error.NoopSdkErrorHandler
 import io.opentelemetry.kotlin.init.OpenTelemetryConfigImpl
 import io.opentelemetry.kotlin.logging.export.FakeLogRecordProcessor
 import kotlin.test.Test
@@ -11,7 +12,7 @@ internal class EnvironmentConfigurationTest {
     fun `should successfully create an environment configuration`() {
         // given
         val clock = FakeClock()
-        val otelConfig = OpenTelemetryConfigImpl(clock)
+        val otelConfig = OpenTelemetryConfigImpl(clock, NoopSdkErrorHandler)
         otelConfig.loggerProvider {
             export { FakeLogRecordProcessor() }
         }

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/init/LoggerProviderConfigImplTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/init/LoggerProviderConfigImplTest.kt
@@ -2,6 +2,7 @@ package io.opentelemetry.kotlin.init
 
 import io.opentelemetry.kotlin.attributes.DEFAULT_ATTRIBUTE_LIMIT
 import io.opentelemetry.kotlin.clock.FakeClock
+import io.opentelemetry.kotlin.error.NoopSdkErrorHandler
 import io.opentelemetry.kotlin.logging.export.FakeLogRecordProcessor
 import io.opentelemetry.kotlin.logging.export.LogRecordProcessor
 import io.opentelemetry.kotlin.logging.export.compositeLogRecordProcessor
@@ -24,7 +25,7 @@ internal class LoggerProviderConfigImplTest {
 
     @Test
     fun testDefaultLoggingConfig() {
-        val cfg = LoggerProviderConfigImpl(clock).generateLoggingConfig(base)
+        val cfg = LoggerProviderConfigImpl(clock, NoopSdkErrorHandler).generateLoggingConfig(base)
         assertNull(cfg.processor)
         assertEquals(sdkDefaultAttributes, cfg.resource.attributes)
         assertNull(cfg.resource.schemaUrl)
@@ -43,7 +44,7 @@ internal class LoggerProviderConfigImplTest {
         val attrValueCount = 200
         val schemaUrl = "https://example.com/schema"
 
-        val cfg = LoggerProviderConfigImpl(clock).apply {
+        val cfg = LoggerProviderConfigImpl(clock, NoopSdkErrorHandler).apply {
             export { compositeLogRecordProcessor(firstProcessor, secondProcessor) }
 
             resource(schemaUrl) {
@@ -70,7 +71,7 @@ internal class LoggerProviderConfigImplTest {
     fun testDoubleExportConfigKeepsFirst() {
         var first: LogRecordProcessor? = null
         var second: LogRecordProcessor? = null
-        val cfg = LoggerProviderConfigImpl(clock).apply {
+        val cfg = LoggerProviderConfigImpl(clock, NoopSdkErrorHandler).apply {
             export {
                 simpleLogRecordProcessor(stdoutLogRecordExporter()).apply {
                     first = this
@@ -88,7 +89,7 @@ internal class LoggerProviderConfigImplTest {
 
     @Test
     fun testResourceOverride() {
-        val cfg = LoggerProviderConfigImpl(clock).apply {
+        val cfg = LoggerProviderConfigImpl(clock, NoopSdkErrorHandler).apply {
             resource(mapOf("extra" to true))
         }.generateLoggingConfig(base)
         assertEquals(sdkDefaultAttributes + mapOf("extra" to true), cfg.resource.attributes)
@@ -96,7 +97,7 @@ internal class LoggerProviderConfigImplTest {
 
     @Test
     fun testSimpleResourceConfig() {
-        val cfg = LoggerProviderConfigImpl(clock).apply {
+        val cfg = LoggerProviderConfigImpl(clock, NoopSdkErrorHandler).apply {
             resource(mapOf("key" to "value"))
         }.generateLoggingConfig(base)
         assertEquals(sdkDefaultAttributes + mapOf("key" to "value"), cfg.resource.attributes)
@@ -105,7 +106,7 @@ internal class LoggerProviderConfigImplTest {
     @Test
     fun testSdkDefaultAttributes() {
         val value = "my-custom-sdk"
-        val cfg = LoggerProviderConfigImpl(clock).apply {
+        val cfg = LoggerProviderConfigImpl(clock, NoopSdkErrorHandler).apply {
             resource(mapOf(TelemetryAttributes.TELEMETRY_SDK_NAME to value))
         }.generateLoggingConfig(base)
         assertEquals(value, cfg.resource.attributes[TelemetryAttributes.TELEMETRY_SDK_NAME])
@@ -114,7 +115,7 @@ internal class LoggerProviderConfigImplTest {
     @Test
     fun testServiceNameDefaults() {
         val value = "my-service"
-        val cfg = LoggerProviderConfigImpl(clock).apply {
+        val cfg = LoggerProviderConfigImpl(clock, NoopSdkErrorHandler).apply {
             resource(mapOf(ServiceAttributes.SERVICE_NAME to value))
         }.generateLoggingConfig(base)
         assertEquals(value, cfg.resource.attributes[ServiceAttributes.SERVICE_NAME])
@@ -124,7 +125,7 @@ internal class LoggerProviderConfigImplTest {
     fun testNoResourceLimit() {
         val count = DEFAULT_ATTRIBUTE_LIMIT + 3
         val attrs = (0 until count).associate { "key$it" to "value$it" }
-        val cfg = LoggerProviderConfigImpl(clock).apply {
+        val cfg = LoggerProviderConfigImpl(clock, NoopSdkErrorHandler).apply {
             resource(attrs)
         }.generateLoggingConfig(base)
         assertEquals(count + sdkDefaultAttributes.size, cfg.resource.attributes.size)

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/init/MeterProviderConfigImplTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/init/MeterProviderConfigImplTest.kt
@@ -2,6 +2,7 @@ package io.opentelemetry.kotlin.init
 
 import io.opentelemetry.kotlin.assertHasSdkDefaultAttributes
 import io.opentelemetry.kotlin.attributes.DEFAULT_ATTRIBUTE_LIMIT
+import io.opentelemetry.kotlin.error.NoopSdkErrorHandler
 import io.opentelemetry.kotlin.sdkDefaultAttributes
 import io.opentelemetry.kotlin.semconv.ServiceAttributes
 import io.opentelemetry.kotlin.semconv.TelemetryAttributes
@@ -15,14 +16,14 @@ internal class MeterProviderConfigImplTest {
 
     @Test
     fun testDefaultMetricsConfig() {
-        val cfg = MeterProviderConfigImpl().generateMetricsConfig(base)
+        val cfg = MeterProviderConfigImpl(NoopSdkErrorHandler).generateMetricsConfig(base)
         assertEquals(sdkDefaultAttributes, cfg.resource.attributes)
         assertNull(cfg.resource.schemaUrl)
     }
 
     @Test
     fun testSdkDefaultAttributes() {
-        val cfg = MeterProviderConfigImpl().generateMetricsConfig(base)
+        val cfg = MeterProviderConfigImpl(NoopSdkErrorHandler).generateMetricsConfig(base)
         assertHasSdkDefaultAttributes(cfg.resource.attributes)
     }
 
@@ -30,7 +31,7 @@ internal class MeterProviderConfigImplTest {
     fun testOverrideMetricsConfig() {
         val schemaUrl = "https://example.com/schema"
 
-        val cfg = MeterProviderConfigImpl().apply {
+        val cfg = MeterProviderConfigImpl(NoopSdkErrorHandler).apply {
             resource(schemaUrl) {
                 setStringAttribute("key", "value")
             }
@@ -42,7 +43,7 @@ internal class MeterProviderConfigImplTest {
 
     @Test
     fun testResourceOverride() {
-        val cfg = MeterProviderConfigImpl().apply {
+        val cfg = MeterProviderConfigImpl(NoopSdkErrorHandler).apply {
             resource(mapOf("extra" to true))
         }.generateMetricsConfig(base)
         assertEquals(sdkDefaultAttributes + mapOf("extra" to true), cfg.resource.attributes)
@@ -50,7 +51,7 @@ internal class MeterProviderConfigImplTest {
 
     @Test
     fun testSimpleResourceConfig() {
-        val cfg = MeterProviderConfigImpl().apply {
+        val cfg = MeterProviderConfigImpl(NoopSdkErrorHandler).apply {
             resource(mapOf("key" to "value"))
         }.generateMetricsConfig(base)
         assertEquals(sdkDefaultAttributes + mapOf("key" to "value"), cfg.resource.attributes)
@@ -60,7 +61,7 @@ internal class MeterProviderConfigImplTest {
     fun testNoResourceLimit() {
         val count = DEFAULT_ATTRIBUTE_LIMIT + 3
         val attrs = (0 until count).associate { "key$it" to "value$it" }
-        val cfg = MeterProviderConfigImpl().apply {
+        val cfg = MeterProviderConfigImpl(NoopSdkErrorHandler).apply {
             resource(attrs)
         }.generateMetricsConfig(base)
         assertEquals(count + sdkDefaultAttributes.size, cfg.resource.attributes.size)
@@ -69,7 +70,7 @@ internal class MeterProviderConfigImplTest {
     @Test
     fun testSdkDefaultAttributesOverride() {
         val value = "my-custom-sdk"
-        val cfg = MeterProviderConfigImpl().apply {
+        val cfg = MeterProviderConfigImpl(NoopSdkErrorHandler).apply {
             resource(mapOf(TelemetryAttributes.TELEMETRY_SDK_NAME to value))
         }.generateMetricsConfig(base)
         assertEquals(value, cfg.resource.attributes[TelemetryAttributes.TELEMETRY_SDK_NAME])
@@ -78,7 +79,7 @@ internal class MeterProviderConfigImplTest {
     @Test
     fun testServiceNameDefaults() {
         val value = "my-service"
-        val cfg = MeterProviderConfigImpl().apply {
+        val cfg = MeterProviderConfigImpl(NoopSdkErrorHandler).apply {
             resource(mapOf(ServiceAttributes.SERVICE_NAME to value))
         }.generateMetricsConfig(base)
         assertEquals(value, cfg.resource.attributes[ServiceAttributes.SERVICE_NAME])
@@ -87,7 +88,7 @@ internal class MeterProviderConfigImplTest {
     @Test
     fun testServiceNameOverride() {
         val value = "my-service"
-        val cfg = MeterProviderConfigImpl().apply {
+        val cfg = MeterProviderConfigImpl(NoopSdkErrorHandler).apply {
             serviceName = value
         }.generateMetricsConfig(base)
         assertEquals(value, cfg.resource.attributes[ServiceAttributes.SERVICE_NAME])
@@ -96,7 +97,7 @@ internal class MeterProviderConfigImplTest {
     @Test
     fun testServiceNamePrecedence() {
         val value = "custom"
-        val cfg = MeterProviderConfigImpl().apply {
+        val cfg = MeterProviderConfigImpl(NoopSdkErrorHandler).apply {
             resource(mapOf(ServiceAttributes.SERVICE_NAME to "res"))
             serviceName = value
         }.generateMetricsConfig(base)

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/init/OpenTelemetryConfigImplTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/init/OpenTelemetryConfigImplTest.kt
@@ -9,6 +9,7 @@ import io.opentelemetry.kotlin.context.DefaultImplicitContextStorage
 import io.opentelemetry.kotlin.context.FakeContext
 import io.opentelemetry.kotlin.context.FakeImplicitContextStorage
 import io.opentelemetry.kotlin.context.ImplicitContextStorageMode
+import io.opentelemetry.kotlin.error.NoopSdkErrorHandler
 import io.opentelemetry.kotlin.factory.FakeIdGenerator
 import io.opentelemetry.kotlin.logging.export.FakeLogRecordProcessor
 import io.opentelemetry.kotlin.propagation.CompositeTextMapPropagator
@@ -28,7 +29,7 @@ internal class OpenTelemetryConfigImplTest {
 
     @Test
     fun testDefaultConfig() {
-        val cfg = OpenTelemetryConfigImpl(clock)
+        val cfg = OpenTelemetryConfigImpl(clock, NoopSdkErrorHandler)
         assertNull(cfg.generateTracingConfig().processor)
         assertNull(cfg.generateLoggingConfig().processor)
         assertEquals(ImplicitContextStorageMode.GLOBAL, cfg.contextConfig.storageMode)
@@ -37,7 +38,7 @@ internal class OpenTelemetryConfigImplTest {
 
     @Test
     fun testPropagatorOverride() {
-        val cfg = OpenTelemetryConfigImpl(clock).apply {
+        val cfg = OpenTelemetryConfigImpl(clock, NoopSdkErrorHandler).apply {
             propagator { w3cBaggage() }
         }
         assertSame(W3CBaggagePropagator, cfg.propagatorCfg.buildPropagator())
@@ -45,7 +46,7 @@ internal class OpenTelemetryConfigImplTest {
 
     @Test
     fun testCompositePropagatorOverride() {
-        val cfg = OpenTelemetryConfigImpl(clock).apply {
+        val cfg = OpenTelemetryConfigImpl(clock, NoopSdkErrorHandler).apply {
             propagator { composite(w3cBaggage()) }
         }
         val composite = cfg.propagatorCfg.buildPropagator()
@@ -55,7 +56,7 @@ internal class OpenTelemetryConfigImplTest {
 
     @Test
     fun testOverrideConfig() {
-        val cfg = OpenTelemetryConfigImpl(clock)
+        val cfg = OpenTelemetryConfigImpl(clock, NoopSdkErrorHandler)
         cfg.loggerProvider {
             export { FakeLogRecordProcessor() }
         }
@@ -71,14 +72,14 @@ internal class OpenTelemetryConfigImplTest {
 
     @Test
     fun testIdGeneratorDefault() {
-        val cfg = OpenTelemetryConfigImpl(clock)
+        val cfg = OpenTelemetryConfigImpl(clock, NoopSdkErrorHandler)
         assertNotNull(cfg.resolveIdGenerator())
     }
 
     @Test
     fun testIdGeneratorOverride() {
         val custom = FakeIdGenerator()
-        val cfg = OpenTelemetryConfigImpl(clock).apply {
+        val cfg = OpenTelemetryConfigImpl(clock, NoopSdkErrorHandler).apply {
             idGenerator { custom }
         }
         assertSame(custom, cfg.resolveIdGenerator())
@@ -86,7 +87,7 @@ internal class OpenTelemetryConfigImplTest {
 
     @Test
     fun testGlobalAttrLimits() {
-        val cfg = OpenTelemetryConfigImpl(clock).apply {
+        val cfg = OpenTelemetryConfigImpl(clock, NoopSdkErrorHandler).apply {
             attributeLimits {
                 attributeCountLimit = 64
             }
@@ -97,7 +98,7 @@ internal class OpenTelemetryConfigImplTest {
 
     @Test
     fun testLocalAttrLimits() {
-        val cfg = OpenTelemetryConfigImpl(clock).apply {
+        val cfg = OpenTelemetryConfigImpl(clock, NoopSdkErrorHandler).apply {
             attributeLimits {
                 attributeCountLimit = 64
             }
@@ -113,7 +114,7 @@ internal class OpenTelemetryConfigImplTest {
 
     @Test
     fun testLocalAttrLimits2() {
-        val cfg = OpenTelemetryConfigImpl(clock).apply {
+        val cfg = OpenTelemetryConfigImpl(clock, NoopSdkErrorHandler).apply {
             attributeLimits {
                 attributeCountLimit = 64
             }
@@ -132,7 +133,7 @@ internal class OpenTelemetryConfigImplTest {
 
     @Test
     fun testDefaultStorage() {
-        val cfg = OpenTelemetryConfigImpl(clock)
+        val cfg = OpenTelemetryConfigImpl(clock, NoopSdkErrorHandler)
         val rootContext = FakeContext()
         val storage = cfg.contextConfig.generateStorage { rootContext }
         assertTrue(storage is DefaultImplicitContextStorage)
@@ -140,7 +141,7 @@ internal class OpenTelemetryConfigImplTest {
 
     @Test
     fun testThreadLocalStorage() {
-        val cfg = OpenTelemetryConfigImpl(clock).apply {
+        val cfg = OpenTelemetryConfigImpl(clock, NoopSdkErrorHandler).apply {
             context {
                 storageMode = ImplicitContextStorageMode.THREAD_LOCAL
             }
@@ -155,7 +156,7 @@ internal class OpenTelemetryConfigImplTest {
     @Test
     fun testCustomStorage() {
         val custom = FakeImplicitContextStorage()
-        val cfg = OpenTelemetryConfigImpl(clock).apply {
+        val cfg = OpenTelemetryConfigImpl(clock, NoopSdkErrorHandler).apply {
             context {
                 storage { custom }
             }
@@ -166,7 +167,7 @@ internal class OpenTelemetryConfigImplTest {
     @Test
     fun testCustomStorageOverridesStorageMode() {
         val custom = FakeImplicitContextStorage()
-        val cfg = OpenTelemetryConfigImpl(clock).apply {
+        val cfg = OpenTelemetryConfigImpl(clock, NoopSdkErrorHandler).apply {
             context {
                 storageMode = ImplicitContextStorageMode.GLOBAL
                 storage { custom }
@@ -179,7 +180,7 @@ internal class OpenTelemetryConfigImplTest {
     fun testCustomStorageReceivesRootSupplier() {
         val root = FakeContext()
         var captured: (() -> Context)? = null
-        val cfg = OpenTelemetryConfigImpl(clock).apply {
+        val cfg = OpenTelemetryConfigImpl(clock, NoopSdkErrorHandler).apply {
             context {
                 storage { rootSupplier ->
                     captured = rootSupplier
@@ -194,7 +195,7 @@ internal class OpenTelemetryConfigImplTest {
 
     @Test
     fun testDefaultAttrLimits() {
-        val cfg = OpenTelemetryConfigImpl(clock)
+        val cfg = OpenTelemetryConfigImpl(clock, NoopSdkErrorHandler)
         with(cfg.generateTracingConfig().spanLimits) {
             assertEquals(DEFAULT_ATTRIBUTE_LIMIT, attributeCountLimit)
             assertEquals(DEFAULT_ATTRIBUTE_VALUE_LENGTH_LIMIT, attributeValueLengthLimit)

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/init/ResourcePrecedenceOrderTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/init/ResourcePrecedenceOrderTest.kt
@@ -1,6 +1,7 @@
 package io.opentelemetry.kotlin.init
 
 import io.opentelemetry.kotlin.clock.FakeClock
+import io.opentelemetry.kotlin.error.NoopSdkErrorHandler
 import io.opentelemetry.kotlin.semconv.TelemetryAttributes
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -13,7 +14,7 @@ internal class ResourcePrecedenceOrderTest {
 
     @Test
     fun testSdkDefaults() {
-        val cfg = OpenTelemetryConfigImpl(clock)
+        val cfg = OpenTelemetryConfigImpl(clock, NoopSdkErrorHandler)
         val tracing = cfg.generateTracingConfig()
         val logging = cfg.generateLoggingConfig()
 
@@ -30,7 +31,7 @@ internal class ResourcePrecedenceOrderTest {
 
     @Test
     fun testGlobalOverrides() {
-        val cfg = OpenTelemetryConfigImpl(clock)
+        val cfg = OpenTelemetryConfigImpl(clock, NoopSdkErrorHandler)
         cfg.resource(mapOf(TelemetryAttributes.TELEMETRY_SDK_NAME to "custom-sdk"))
 
         assertEquals(
@@ -45,7 +46,7 @@ internal class ResourcePrecedenceOrderTest {
 
     @Test
     fun testSpecificOverrides() {
-        val cfg = OpenTelemetryConfigImpl(clock)
+        val cfg = OpenTelemetryConfigImpl(clock, NoopSdkErrorHandler)
         cfg.tracerProvider {
             resource(mapOf(TelemetryAttributes.TELEMETRY_SDK_NAME to "tracer-sdk"))
         }
@@ -58,7 +59,7 @@ internal class ResourcePrecedenceOrderTest {
 
     @Test
     fun testOverridePrecedence() {
-        val cfg = OpenTelemetryConfigImpl(clock)
+        val cfg = OpenTelemetryConfigImpl(clock, NoopSdkErrorHandler)
         cfg.resource(mapOf(testKey to "top"))
         cfg.tracerProvider {
             resource(mapOf(testKey to "provider"))
@@ -70,7 +71,7 @@ internal class ResourcePrecedenceOrderTest {
 
     @Test
     fun testOverridePrecedence2() {
-        val cfg = OpenTelemetryConfigImpl(clock)
+        val cfg = OpenTelemetryConfigImpl(clock, NoopSdkErrorHandler)
         cfg.resource(mapOf(testKey to "top"))
         cfg.tracerProvider {
             resource(mapOf(testKey to "tracer-only"))

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/init/TracerProviderConfigImplTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/init/TracerProviderConfigImplTest.kt
@@ -5,6 +5,7 @@ import io.opentelemetry.kotlin.attributes.AttributesModel
 import io.opentelemetry.kotlin.attributes.DEFAULT_ATTRIBUTE_LIMIT
 import io.opentelemetry.kotlin.clock.FakeClock
 import io.opentelemetry.kotlin.context.Context
+import io.opentelemetry.kotlin.error.NoopSdkErrorHandler
 import io.opentelemetry.kotlin.factory.ContextFactoryImpl
 import io.opentelemetry.kotlin.factory.FakeSpanFactory
 import io.opentelemetry.kotlin.factory.IdGeneratorImpl
@@ -48,7 +49,7 @@ internal class TracerProviderConfigImplTest {
 
     @Test
     fun testDefaultSamplerParentBased() {
-        val cfg = TracerProviderConfigImpl(clock).generateTracingConfig(base)
+        val cfg = TracerProviderConfigImpl(clock, NoopSdkErrorHandler).generateTracingConfig(base)
         val sampler = assertIs<ParentBasedSampler>(cfg.samplerFactory(FakeSpanFactory()))
         assertContains(sampler.description, "root:AlwaysOnSampler")
     }
@@ -84,7 +85,7 @@ internal class TracerProviderConfigImplTest {
 
     @Test
     fun testBuiltInSamplerConfig() {
-        val cfg = TracerProviderConfigImpl(clock).apply {
+        val cfg = TracerProviderConfigImpl(clock, NoopSdkErrorHandler).apply {
             sampler { alwaysOn() }
         }.generateTracingConfig(base)
         assertNotNull(cfg.samplerFactory(FakeSpanFactory()))
@@ -93,7 +94,7 @@ internal class TracerProviderConfigImplTest {
     @Test
     fun testCustomSamplerConfig() {
         val sampler = FakeSampler()
-        val cfg = TracerProviderConfigImpl(clock).apply {
+        val cfg = TracerProviderConfigImpl(clock, NoopSdkErrorHandler).apply {
             sampler {
                 sampler
             }
@@ -103,7 +104,7 @@ internal class TracerProviderConfigImplTest {
 
     @Test
     fun testDefaultTracingConfig() {
-        val cfg = TracerProviderConfigImpl(clock).generateTracingConfig(base)
+        val cfg = TracerProviderConfigImpl(clock, NoopSdkErrorHandler).generateTracingConfig(base)
         assertNull(cfg.processor)
         assertEquals(sdkDefaultAttributes, cfg.resource.attributes)
         assertNull(cfg.resource.schemaUrl)
@@ -120,7 +121,7 @@ internal class TracerProviderConfigImplTest {
 
     @Test
     fun testSdkDefaultAttributes() {
-        val cfg = TracerProviderConfigImpl(clock).generateTracingConfig(base)
+        val cfg = TracerProviderConfigImpl(clock, NoopSdkErrorHandler).generateTracingConfig(base)
         assertHasSdkDefaultAttributes(cfg.resource.attributes)
     }
 
@@ -136,7 +137,7 @@ internal class TracerProviderConfigImplTest {
         val attrValueLength = 600
         val schemaUrl = "https://example.com/schema"
 
-        val cfg = TracerProviderConfigImpl(clock).apply {
+        val cfg = TracerProviderConfigImpl(clock, NoopSdkErrorHandler).apply {
             export { compositeSpanProcessor(firstProcessor, secondProcessor) }
 
             resource(schemaUrl) {
@@ -171,7 +172,7 @@ internal class TracerProviderConfigImplTest {
     fun testDoubleExportConfigKeepsFirst() {
         var first: SpanProcessor? = null
         var second: SpanProcessor? = null
-        val cfg = TracerProviderConfigImpl(clock).apply {
+        val cfg = TracerProviderConfigImpl(clock, NoopSdkErrorHandler).apply {
             export {
                 compositeSpanProcessor(FakeSpanProcessor()).apply {
                     first = this
@@ -189,7 +190,7 @@ internal class TracerProviderConfigImplTest {
 
     @Test
     fun testResourceOverride() {
-        val cfg = TracerProviderConfigImpl(clock).apply {
+        val cfg = TracerProviderConfigImpl(clock, NoopSdkErrorHandler).apply {
             resource(mapOf("extra" to true))
         }.generateTracingConfig(base)
         assertEquals(sdkDefaultAttributes + mapOf("extra" to true), cfg.resource.attributes)
@@ -197,7 +198,7 @@ internal class TracerProviderConfigImplTest {
 
     @Test
     fun testSimpleResourceConfig() {
-        val cfg = TracerProviderConfigImpl(clock).apply {
+        val cfg = TracerProviderConfigImpl(clock, NoopSdkErrorHandler).apply {
             resource(mapOf("key" to "value"))
         }.generateTracingConfig(base)
         assertEquals(sdkDefaultAttributes + mapOf("key" to "value"), cfg.resource.attributes)
@@ -207,7 +208,7 @@ internal class TracerProviderConfigImplTest {
     fun testNoResourceLimit() {
         val count = DEFAULT_ATTRIBUTE_LIMIT + 3
         val attrs = (0 until count).associate { "key$it" to "value$it" }
-        val cfg = TracerProviderConfigImpl(clock).apply {
+        val cfg = TracerProviderConfigImpl(clock, NoopSdkErrorHandler).apply {
             resource(attrs)
         }.generateTracingConfig(base)
         assertEquals(count + sdkDefaultAttributes.size, cfg.resource.attributes.size)
@@ -216,7 +217,7 @@ internal class TracerProviderConfigImplTest {
     @Test
     fun testSdkDefaultAttributes2() {
         val value = "my-custom-sdk"
-        val cfg = TracerProviderConfigImpl(clock).apply {
+        val cfg = TracerProviderConfigImpl(clock, NoopSdkErrorHandler).apply {
             resource(mapOf(TelemetryAttributes.TELEMETRY_SDK_NAME to value))
         }.generateTracingConfig(base)
         assertEquals(value, cfg.resource.attributes[TelemetryAttributes.TELEMETRY_SDK_NAME])
@@ -225,7 +226,7 @@ internal class TracerProviderConfigImplTest {
     @Test
     fun testServiceNameDefaults() {
         val value = "my-service"
-        val cfg = TracerProviderConfigImpl(clock).apply {
+        val cfg = TracerProviderConfigImpl(clock, NoopSdkErrorHandler).apply {
             resource(mapOf(ServiceAttributes.SERVICE_NAME to value))
         }.generateTracingConfig(base)
         assertEquals(value, cfg.resource.attributes[ServiceAttributes.SERVICE_NAME])
@@ -234,7 +235,7 @@ internal class TracerProviderConfigImplTest {
     @Test
     fun testServiceNameOverride() {
         val value = "my-service"
-        val cfg = TracerProviderConfigImpl(clock).apply {
+        val cfg = TracerProviderConfigImpl(clock, NoopSdkErrorHandler).apply {
             serviceName = value
         }.generateTracingConfig(base)
         assertEquals(value, cfg.resource.attributes[ServiceAttributes.SERVICE_NAME])
@@ -243,7 +244,7 @@ internal class TracerProviderConfigImplTest {
     @Test
     fun testServiceNamePrecedence() {
         val value = "custom"
-        val cfg = TracerProviderConfigImpl(clock).apply {
+        val cfg = TracerProviderConfigImpl(clock, NoopSdkErrorHandler).apply {
             resource(mapOf(ServiceAttributes.SERVICE_NAME to "res"))
             serviceName = value
         }.generateTracingConfig(base)
@@ -251,7 +252,7 @@ internal class TracerProviderConfigImplTest {
     }
 
     private fun defaultSampler(): Sampler =
-        TracerProviderConfigImpl(clock).generateTracingConfig(base).samplerFactory(FakeSpanFactory())
+        TracerProviderConfigImpl(clock, NoopSdkErrorHandler).generateTracingConfig(base).samplerFactory(FakeSpanFactory())
 
     private fun contextWithParent(sampled: Boolean, isRemote: Boolean): Context {
         val traceFlags = when {

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/LoggerProviderImplTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/LoggerProviderImplTest.kt
@@ -2,6 +2,7 @@ package io.opentelemetry.kotlin.logging
 
 import io.opentelemetry.kotlin.attributes.AttributesModel
 import io.opentelemetry.kotlin.clock.FakeClock
+import io.opentelemetry.kotlin.error.NoopSdkErrorHandler
 import io.opentelemetry.kotlin.export.OperationResultCode
 import io.opentelemetry.kotlin.factory.FakeContextFactory
 import io.opentelemetry.kotlin.factory.FakeSpanContextFactory
@@ -25,7 +26,8 @@ internal class LoggerProviderImplTest {
     private val loggingConfig = LoggingConfig(
         null,
         LogLimitConfig(100, 100),
-        ResourceImpl(AttributesModel(), null)
+        ResourceImpl(AttributesModel(), null),
+        NoopSdkErrorHandler,
     )
     private val contextFactory = FakeContextFactory()
     private val spanContextFactory = FakeSpanContextFactory()
@@ -120,6 +122,7 @@ internal class LoggerProviderImplTest {
             processor,
             LogLimitConfig(100, 100),
             FakeResource(),
+            NoopSdkErrorHandler,
         )
         impl = LoggerProviderImpl(clock, config, contextFactory, spanContextFactory)
         impl.getLogger(name = "test")
@@ -142,6 +145,7 @@ internal class LoggerProviderImplTest {
             processor,
             LogLimitConfig(100, 100),
             FakeResource(),
+            NoopSdkErrorHandler,
         )
         impl = LoggerProviderImpl(clock, config, contextFactory, spanContextFactory)
         impl.getLogger(name = "test")
@@ -165,6 +169,7 @@ internal class LoggerProviderImplTest {
             processor,
             LogLimitConfig(100, 100),
             FakeResource(),
+            NoopSdkErrorHandler,
         )
         impl = LoggerProviderImpl(clock, config, contextFactory, spanContextFactory)
         val logger = impl.getLogger(name = "test")

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/metrics/MeterProviderImplTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/metrics/MeterProviderImplTest.kt
@@ -2,6 +2,7 @@ package io.opentelemetry.kotlin.metrics
 
 import io.opentelemetry.kotlin.NoopOpenTelemetry
 import io.opentelemetry.kotlin.attributes.AttributesModel
+import io.opentelemetry.kotlin.error.NoopSdkErrorHandler
 import io.opentelemetry.kotlin.export.OperationResultCode
 import io.opentelemetry.kotlin.init.config.MetricsConfig
 import io.opentelemetry.kotlin.resource.ResourceImpl
@@ -17,6 +18,7 @@ internal class MeterProviderImplTest {
 
     private val metricsConfig = MetricsConfig(
         resource = ResourceImpl(AttributesModel(), null),
+        sdkErrorHandler = NoopSdkErrorHandler,
     )
     private lateinit var impl: MeterProviderImpl
 

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/TracerProviderImplTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/TracerProviderImplTest.kt
@@ -2,6 +2,7 @@ package io.opentelemetry.kotlin.tracing
 
 import io.opentelemetry.kotlin.attributes.AttributesModel
 import io.opentelemetry.kotlin.clock.FakeClock
+import io.opentelemetry.kotlin.error.NoopSdkErrorHandler
 import io.opentelemetry.kotlin.export.OperationResultCode
 import io.opentelemetry.kotlin.factory.FakeContextFactory
 import io.opentelemetry.kotlin.factory.FakeIdGenerator
@@ -26,7 +27,8 @@ internal class TracerProviderImplTest {
     private val tracingConfig = TracingConfig(
         null,
         fakeSpanLimitsConfig,
-        ResourceImpl(AttributesModel(), null)
+        ResourceImpl(AttributesModel(), null),
+        NoopSdkErrorHandler,
     )
 
     private lateinit var impl: TracerProviderImpl
@@ -128,6 +130,7 @@ internal class TracerProviderImplTest {
             processor,
             fakeSpanLimitsConfig,
             FakeResource(),
+            NoopSdkErrorHandler,
         )
         val provider = TracerProviderImpl(
             clock = FakeClock(),
@@ -158,6 +161,7 @@ internal class TracerProviderImplTest {
             processor,
             fakeSpanLimitsConfig,
             FakeResource(),
+            NoopSdkErrorHandler,
         )
         val provider = TracerProviderImpl(
             clock = FakeClock(),

--- a/sdk-api/api/jvm/sdk-api.api
+++ b/sdk-api/api/jvm/sdk-api.api
@@ -109,6 +109,7 @@ public abstract interface class io/opentelemetry/kotlin/init/ContextConfigDsl {
 
 public abstract interface class io/opentelemetry/kotlin/init/LogExportConfigDsl {
 	public abstract fun getClock ()Lio/opentelemetry/kotlin/Clock;
+	public abstract fun getSdkErrorHandler ()Lio/opentelemetry/kotlin/error/SdkErrorHandler;
 }
 
 public abstract interface class io/opentelemetry/kotlin/init/LogLimitsConfigDsl : io/opentelemetry/kotlin/init/AttributeLimitsConfigDsl {
@@ -166,6 +167,7 @@ public abstract interface class io/opentelemetry/kotlin/init/SpanLimitsConfigDsl
 
 public abstract interface class io/opentelemetry/kotlin/init/TraceExportConfigDsl {
 	public abstract fun getClock ()Lio/opentelemetry/kotlin/Clock;
+	public abstract fun getSdkErrorHandler ()Lio/opentelemetry/kotlin/error/SdkErrorHandler;
 }
 
 public abstract interface class io/opentelemetry/kotlin/init/TracerProviderConfigDsl : io/opentelemetry/kotlin/init/ResourceConfigDsl {

--- a/sdk-api/src/commonMain/kotlin/io/opentelemetry/kotlin/init/LogExportConfigDsl.kt
+++ b/sdk-api/src/commonMain/kotlin/io/opentelemetry/kotlin/init/LogExportConfigDsl.kt
@@ -2,6 +2,7 @@ package io.opentelemetry.kotlin.init
 
 import io.opentelemetry.kotlin.Clock
 import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.error.SdkErrorHandler
 
 /**
  * Configures how log records are exported.
@@ -14,4 +15,9 @@ public interface LogExportConfigDsl {
      * The [Clock] implementation that will be used by the OpenTelemetry implementation.
      */
     public val clock: Clock
+
+    /**
+     * The [SdkErrorHandler] used to report errors and misuse of the SDK.
+     */
+    public val sdkErrorHandler: SdkErrorHandler
 }

--- a/sdk-api/src/commonMain/kotlin/io/opentelemetry/kotlin/init/TraceExportConfigDsl.kt
+++ b/sdk-api/src/commonMain/kotlin/io/opentelemetry/kotlin/init/TraceExportConfigDsl.kt
@@ -2,6 +2,7 @@ package io.opentelemetry.kotlin.init
 
 import io.opentelemetry.kotlin.Clock
 import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.error.SdkErrorHandler
 
 /**
  * Configures how traces are exported.
@@ -14,4 +15,9 @@ public interface TraceExportConfigDsl {
      * The [Clock] implementation that will be used by the OpenTelemetry implementation.
      */
     public val clock: Clock
+
+    /**
+     * The [SdkErrorHandler] used to report errors and misuse of the SDK.
+     */
+    public val sdkErrorHandler: SdkErrorHandler
 }

--- a/sdk-common/api/jvm/sdk-common.api
+++ b/sdk-common/api/jvm/sdk-common.api
@@ -19,7 +19,6 @@ public final class io/opentelemetry/kotlin/export/CompositeTelemetryCloseable : 
 	public static final field FORCE_FLUSH_TIMEOUT_MS J
 	public static final field SHUTDOWN_TIMEOUT_MS J
 	public fun <init> (Ljava/util/List;Lio/opentelemetry/kotlin/error/SdkErrorHandler;)V
-	public synthetic fun <init> (Ljava/util/List;Lio/opentelemetry/kotlin/error/SdkErrorHandler;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun forceFlush (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun shutdown (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }

--- a/sdk-common/src/commonMain/kotlin/io/opentelemetry/kotlin/export/CompositeTelemetryCloseable.kt
+++ b/sdk-common/src/commonMain/kotlin/io/opentelemetry/kotlin/export/CompositeTelemetryCloseable.kt
@@ -1,7 +1,6 @@
 package io.opentelemetry.kotlin.export
 
 import io.opentelemetry.kotlin.ExperimentalApi
-import io.opentelemetry.kotlin.error.NoopSdkErrorHandler
 import io.opentelemetry.kotlin.error.SdkErrorHandler
 
 /**
@@ -11,7 +10,7 @@ import io.opentelemetry.kotlin.error.SdkErrorHandler
 @ExperimentalApi
 public class CompositeTelemetryCloseable(
     private val closeables: List<TelemetryCloseable>,
-    private val sdkErrorHandler: SdkErrorHandler = NoopSdkErrorHandler,
+    private val sdkErrorHandler: SdkErrorHandler,
 ) : TelemetryCloseable {
 
     override suspend fun forceFlush(): OperationResultCode =


### PR DESCRIPTION
## Goal

Injects the `SdkErrorHandler` rather than defaulting to `NoopSdkErrorHandler` at individual callsites. This is a prerequisite for completing #671.

## Testing

Relied on existing test coverage.
