### PR TITLE
Provide API to enhance implicit context use in coroutines

### DIFF
--- a/context-coroutines/api/jvm/context-coroutines.api
+++ b/context-coroutines/api/jvm/context-coroutines.api
@@ -1,0 +1,4 @@
+public final class io/opentelemetry/kotlin/context/CoroutineContextElementKt {
+	public static final fun asCoroutineContextElement (Lio/opentelemetry/kotlin/context/Context;)Lkotlin/coroutines/CoroutineContext$Element;
+}
+

--- a/context-coroutines/build.gradle.kts
+++ b/context-coroutines/build.gradle.kts
@@ -1,0 +1,25 @@
+plugins {
+    kotlin("multiplatform")
+    id("com.android.kotlin.multiplatform.library")
+    id("io.opentelemetry.kotlin.build-logic")
+    id("signing")
+    id("com.vanniktech.maven.publish")
+    id("org.jetbrains.kotlinx.kover")
+}
+
+kotlin {
+    sourceSets {
+        val jvmAndAndroidMain by getting {
+            dependencies {
+                api(project(":api"))
+                implementation(libs.kotlinx.coroutines)
+            }
+        }
+        val jvmTest by getting {
+            dependencies {
+                implementation(project(":test-fakes"))
+                implementation(libs.kotlinx.coroutines.test)
+            }
+        }
+    }
+}

--- a/context-coroutines/gradle.properties
+++ b/context-coroutines/gradle.properties
@@ -1,0 +1,1 @@
+io.opentelemetry.kotlin.jvmAndroidModule=true

--- a/context-coroutines/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/context/CoroutineContextElement.kt
+++ b/context-coroutines/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/context/CoroutineContextElement.kt
@@ -1,0 +1,47 @@
+package io.opentelemetry.kotlin.context
+
+import io.opentelemetry.kotlin.ExperimentalApi
+import kotlinx.coroutines.ThreadContextElement
+import kotlin.coroutines.AbstractCoroutineContextElement
+import kotlin.coroutines.CoroutineContext
+
+/**
+ * Returns a [CoroutineContext.Element] that installs this [Context] as the implicit context whenever
+ * a coroutine using it is resumed on a thread. When the coroutine suspends the previous context will
+ * be restored. This makes the implicit context follow the coroutine across suspension, thread hops,
+ * and into child coroutines.
+ *
+ * The SDK must be configured with thread-local implicit-context storage (the `THREAD_LOCAL` storage
+ * mode) for this to behave correctly. You should also avoid setting the implicit context in
+ * any other way if you use this method.
+ *
+ * This API is only available on JVM/Android as it's backed by
+ * `kotlinx.coroutines.ThreadContextElement`, which itself is JVM-only.
+ *
+ * Example usage:
+ *
+ * ```
+ * withContext(myOtelContext.asCoroutineContextElement()) {
+ *     // perform operation
+ * }
+ * ```
+ */
+@ExperimentalApi
+public fun Context.asCoroutineContextElement(): CoroutineContext.Element = OtelContextElement(this)
+
+/**
+ * Bridges a [Context] into the coroutine machinery by attaching it (and restoring the previous
+ * context) at each resume/suspend boundary.
+ */
+internal class OtelContextElement(
+    private val context: Context,
+) : ThreadContextElement<Scope>, AbstractCoroutineContextElement(Key) {
+
+    companion object Key : CoroutineContext.Key<OtelContextElement>
+
+    override fun updateThreadContext(context: CoroutineContext): Scope = this.context.attach()
+
+    override fun restoreThreadContext(context: CoroutineContext, oldState: Scope) {
+        oldState.detach()
+    }
+}

--- a/context-coroutines/src/jvmTest/kotlin/io/opentelemetry/kotlin/context/CoroutineContextElementTest.kt
+++ b/context-coroutines/src/jvmTest/kotlin/io/opentelemetry/kotlin/context/CoroutineContextElementTest.kt
@@ -1,0 +1,213 @@
+package io.opentelemetry.kotlin.context
+
+import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.ThreadLocal
+import kotlinx.coroutines.ExecutorCoroutineDispatcher
+import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.async
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.yield
+import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalApi::class)
+internal class CoroutineContextElementTest {
+
+    private lateinit var storage: TestStorage
+
+    @BeforeTest
+    fun setUp() {
+        storage = TestStorage()
+    }
+
+    @Test
+    fun testContextVisibleInsideCoroutine() = runBlocking {
+        val ctx = TestContext("ctx", storage)
+        withContext(ctx.asCoroutineContextElement()) {
+            assertSame(ctx, storage.implicitContext())
+        }
+    }
+
+    @Test
+    fun testRootVisibleWhenNoElementPresent() = runBlocking {
+        assertSame(storage.root, storage.implicitContext())
+        launch { assertSame(storage.root, storage.implicitContext()) }.join()
+    }
+
+    @Test
+    fun testContextSurvivesSuspension() = runTest {
+        val ctx = TestContext("ctx", storage)
+        withContext(ctx.asCoroutineContextElement()) {
+            assertSame(ctx, storage.implicitContext())
+            yield()
+            assertSame(ctx, storage.implicitContext())
+        }
+    }
+
+    @Test
+    fun testThreadHops() {
+        val ctx = TestContext("ctx", storage)
+        val first = singleThreadDispatcher("otel-test-1")
+        val second = singleThreadDispatcher("otel-test-2")
+        try {
+            runBlocking {
+                val threads = mutableSetOf<String>()
+                withContext(first + ctx.asCoroutineContextElement()) {
+                    threads += Thread.currentThread().name
+                    assertSame(ctx, storage.implicitContext())
+                    withContext(second) {
+                        threads += Thread.currentThread().name
+                        assertSame(ctx, storage.implicitContext())
+                    }
+                    assertSame(ctx, storage.implicitContext())
+                }
+                assertEquals(2, threads.size)
+            }
+        } finally {
+            first.close()
+            second.close()
+        }
+    }
+
+    @Test
+    fun testChildCoroutinesInheritance() = runBlocking {
+        val ctx = TestContext("ctx", storage)
+        withContext(ctx.asCoroutineContextElement()) {
+            launch { assertSame(ctx, storage.implicitContext()) }.join()
+            val result = async { storage.implicitContext() }.await()
+            assertSame(ctx, result)
+        }
+    }
+
+    @Test
+    fun testNestedContextRestoration() = runBlocking {
+        val outer = TestContext("outer", storage)
+        val inner = TestContext("inner", storage)
+        withContext(outer.asCoroutineContextElement()) {
+            assertSame(outer, storage.implicitContext())
+            withContext(inner.asCoroutineContextElement()) {
+                assertSame(inner, storage.implicitContext())
+            }
+            assertSame(outer, storage.implicitContext())
+        }
+        assertSame(storage.root, storage.implicitContext())
+    }
+
+    @Test
+    fun testConcurrentCoroutinesIsolation() {
+        val ctxA = TestContext("a", storage)
+        val ctxB = TestContext("b", storage)
+
+        val dispatcher = singleThreadDispatcher("otel-shared")
+        dispatcher.use {
+            runBlocking(dispatcher) {
+                val a = launch(ctxA.asCoroutineContextElement()) {
+                    repeat(5) {
+                        assertSame(ctxA, storage.implicitContext())
+                        yield()
+                    }
+                }
+                val b = launch(ctxB.asCoroutineContextElement()) {
+                    repeat(5) {
+                        assertSame(ctxB, storage.implicitContext())
+                        yield()
+                    }
+                }
+                a.join()
+                b.join()
+            }
+        }
+    }
+
+    @Test
+    fun testCallingThreadUnaffected() {
+        val ctx = TestContext("ctx", storage)
+        val dispatcher = singleThreadDispatcher("otel-worker")
+        dispatcher.use {
+            runBlocking {
+                assertSame(storage.root, storage.implicitContext())
+                withContext(dispatcher + ctx.asCoroutineContextElement()) {
+                    assertSame(ctx, storage.implicitContext())
+                }
+                assertSame(storage.root, storage.implicitContext())
+            }
+        }
+    }
+
+    @Test
+    fun testRestorationAfterThrow() = runBlocking {
+        val ctx = TestContext("ctx", storage)
+        assertFailsWith<IllegalStateException> {
+            withContext(ctx.asCoroutineContextElement()) {
+                assertSame(ctx, storage.implicitContext())
+                error("boom")
+            }
+        }
+        assertSame(storage.root, storage.implicitContext())
+    }
+
+    @Test
+    fun testScopeSuspension() = runBlocking {
+        val ctx = TestContext("ctx", storage)
+        withContext(ctx.asCoroutineContextElement()) {
+            yield()
+            yield()
+        }
+        assertTrue(ctx.attachCount.get() > 1, "expected repeated attaches, got ${ctx.attachCount.get()}")
+        assertEquals(ctx.attachCount.get(), ctx.detachCount.get())
+        assertSame(storage.root, storage.implicitContext())
+    }
+
+    private fun singleThreadDispatcher(name: String): ExecutorCoroutineDispatcher =
+        Executors.newSingleThreadExecutor { runnable -> Thread(runnable, name) }.asCoroutineDispatcher()
+}
+
+@OptIn(ExperimentalApi::class)
+private class TestStorage : ImplicitContextStorage {
+    val root: Context = FakeContext()
+    private val current = ThreadLocal<Context>()
+
+    override fun implicitContext(): Context = current.get() ?: root
+
+    override fun setImplicitContext(context: Context) {
+        current.set(context)
+    }
+}
+
+@OptIn(ExperimentalApi::class)
+private class TestContext(
+    private val name: String,
+    private val storage: TestStorage,
+    delegate: Context = FakeContext(),
+) : Context by delegate {
+
+    val attachCount = AtomicInteger()
+    val detachCount = AtomicInteger()
+
+    override fun attach(): Scope {
+        attachCount.incrementAndGet()
+        val previous = storage.implicitContext()
+        storage.setImplicitContext(this)
+        var detached = false
+        return FakeScope {
+            if (detached) {
+                false
+            } else {
+                detached = true
+                detachCount.incrementAndGet()
+                storage.setImplicitContext(previous)
+                true
+            }
+        }
+    }
+    override fun toString(): String = "TestContext($name)"
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -18,6 +18,7 @@ include(
     ":core",
     ":api",
     ":api-ext",
+    ":context-coroutines",
     ":sdk-ext",
     ":sdk-api",
     ":sdk-common",


### PR DESCRIPTION
## Goal

Closes #478 by providing an API that can be used to manage implicit context from coroutines. This API has the caveat that it's only available for the JVM target due to a restriction in the API of kotlinx.coroutines where [ThreadContextElement](https://kotlinlang.org/api/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines/-thread-context-element/) is only available on the JVM. Consequently this is provided as an opt-in module for users who want this functionality.

Usage would look like this:

```
withContext(Dispatchers.Default + myOtelContext.asCoroutineContextElement()) {
     // perform operation
 }
```

`withContext` is the kotlinx.coroutine API to launch a coroutine. Along with the dispatcher, opentelemetry-kotlin's `Context` object is converted to `CoroutineContextElement` via `asCoroutineContextElement()`. Under the hood, this will be invoked by the coroutine when the coroutine is suspended and restored, which allows for the context to be tracked appropriately within the coroutine.

There are limitations about how automatic it's possible to make this due to the existing APIs. IMO this is probably one of the best, less invasive approaches we could take.

## Testing

Added unit tests.
