### PR TITLE
Implement TracerConfigurator

### DIFF
--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/init/CompatTracerProviderConfig.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/init/CompatTracerProviderConfig.kt
@@ -4,8 +4,11 @@ import io.opentelemetry.kotlin.Clock
 import io.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.kotlin.aliases.OtelJavaIdGenerator
 import io.opentelemetry.kotlin.aliases.OtelJavaResource
+import io.opentelemetry.kotlin.aliases.OtelJavaScopeConfigurator
 import io.opentelemetry.kotlin.aliases.OtelJavaSdkTracerProvider
 import io.opentelemetry.kotlin.aliases.OtelJavaSdkTracerProviderBuilder
+import io.opentelemetry.kotlin.aliases.OtelJavaSdkTracerProviderUtil
+import io.opentelemetry.kotlin.aliases.OtelJavaTracerConfig
 import io.opentelemetry.kotlin.attributes.AttributesMutator
 import io.opentelemetry.kotlin.attributes.CompatAttributesModel
 import io.opentelemetry.kotlin.attributes.setAttributes
@@ -15,7 +18,9 @@ import io.opentelemetry.kotlin.factory.IdGenerator
 import io.opentelemetry.kotlin.factory.OtelJavaIdGeneratorAdapter
 import io.opentelemetry.kotlin.resource.Resource
 import io.opentelemetry.kotlin.resource.ResourceAdapter
+import io.opentelemetry.kotlin.scope.toOtelKotlinInstrumentationScopeInfo
 import io.opentelemetry.kotlin.semconv.ServiceAttributes
+import io.opentelemetry.kotlin.tracing.TracerConfigurator
 import io.opentelemetry.kotlin.tracing.TracerProvider
 import io.opentelemetry.kotlin.tracing.TracerProviderAdapter
 import io.opentelemetry.kotlin.tracing.export.OtelJavaSpanProcessorAdapter
@@ -32,6 +37,7 @@ internal class CompatTracerProviderConfig(
     private val builder: OtelJavaSdkTracerProviderBuilder = OtelJavaSdkTracerProvider.builder()
     internal val spanLimitsConfig = CompatSpanLimitsConfig()
     private var spanLimitsAction: (SpanLimitsConfigDsl.() -> Unit)? = null
+    private var tracerConfigurator: TracerConfigurator? = null
     private var serviceNameOverride: String? = null
 
     private val resourceAttrs = CompatAttributesModel()
@@ -74,6 +80,21 @@ internal class CompatTracerProviderConfig(
         builder.setSampler(otelJavaSampler)
     }
 
+    override fun tracerConfigurator(configurator: TracerConfigurator) {
+        tracerConfigurator = configurator
+    }
+
+    private fun applyTracerConfigurator(configurator: TracerConfigurator) {
+        val scopeConfigurator = OtelJavaScopeConfigurator<OtelJavaTracerConfig> { javaScope ->
+            val scope = javaScope.toOtelKotlinInstrumentationScopeInfo()
+            when (configurator.tracerConfig(scope).enabled) {
+                true -> OtelJavaTracerConfig.enabled()
+                false -> OtelJavaTracerConfig.disabled()
+            }
+        }
+        OtelJavaSdkTracerProviderUtil.setTracerConfigurator(builder, scopeConfigurator)
+    }
+
     fun build(
         clock: Clock,
         idGenerator: IdGenerator,
@@ -94,6 +115,7 @@ internal class CompatTracerProviderConfig(
         }
         spanLimitsAction?.invoke(spanLimitsConfig)
         builder.setSpanLimits(spanLimitsConfig.build())
+        tracerConfigurator?.let(::applyTracerConfigurator)
         val resource = ResourceAdapter(
             OtelJavaResource.create(resourceAttrs.otelJavaAttributes(), resourceSchemaUrl)
         )

--- a/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/tracing/TracerConfigTest.kt
+++ b/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/tracing/TracerConfigTest.kt
@@ -1,0 +1,36 @@
+package io.opentelemetry.kotlin.tracing
+
+import io.opentelemetry.kotlin.framework.OtelKotlinHarness
+import kotlinx.coroutines.test.runTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+internal class TracerConfigTest {
+
+    private lateinit var harness: OtelKotlinHarness
+
+    @BeforeTest
+    fun setUp() = runTest {
+        harness = OtelKotlinHarness(testScheduler)
+    }
+
+    @Test
+    fun `tracerConfigurator disables matching scope`() = runTest {
+        harness.config.tracerProvider = {
+            tracerConfigurator { scope ->
+                object : TracerConfig {
+                    override val enabled = scope.name != "disabled"
+                }
+            }
+        }
+
+        val tracerProvider = harness.kotlinApi.tracerProvider
+        tracerProvider.getTracer("disabled").startSpan("dropped").end()
+        tracerProvider.getTracer("enabled").startSpan("kept").end()
+
+        harness.assertSpans(expectedCount = 1) { spans ->
+            assertEquals("kept", spans.single().name)
+        }
+    }
+}

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/TracerProviderConfigImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/TracerProviderConfigImpl.kt
@@ -6,6 +6,8 @@ import io.opentelemetry.kotlin.init.config.SpanLimitConfig
 import io.opentelemetry.kotlin.init.config.TracingConfig
 import io.opentelemetry.kotlin.platformLog
 import io.opentelemetry.kotlin.resource.Resource
+import io.opentelemetry.kotlin.tracing.TracerConfigImpl
+import io.opentelemetry.kotlin.tracing.TracerConfigurator
 import io.opentelemetry.kotlin.tracing.export.SpanProcessor
 import io.opentelemetry.kotlin.tracing.sampling.Sampler
 import io.opentelemetry.kotlin.tracing.sampling.alwaysOn
@@ -19,6 +21,10 @@ internal class TracerProviderConfigImpl(
     private var processor: SpanProcessor? = null
     private var spanLimitsAction: SpanLimitsConfigDsl.() -> Unit = {}
     private var samplerAction: SamplerConfigDsl.() -> Sampler = { parentBased(root = alwaysOn()) }
+    private val defaultTracerConfig = TracerConfigImpl(true)
+    private var tracerConfigurator: TracerConfigurator = TracerConfigurator {
+        defaultTracerConfig
+    }
 
     override fun spanLimits(action: SpanLimitsConfigDsl.() -> Unit) {
         spanLimitsAction = action
@@ -36,11 +42,16 @@ internal class TracerProviderConfigImpl(
         samplerAction = action
     }
 
+    override fun tracerConfigurator(configurator: TracerConfigurator) {
+        tracerConfigurator = configurator
+    }
+
     fun generateTracingConfig(base: Resource, globalLimits: AttributeLimitsConfigImpl? = null): TracingConfig = TracingConfig(
         processor = processor,
         spanLimits = generateSpanLimitsConfig(globalLimits),
         resource = base.merge(resourceConfigImpl.generateResource()),
         samplerFactory = { spanFactory -> SamplerConfigImpl(spanFactory).samplerAction() },
+        tracerConfigurator = tracerConfigurator,
     )
 
     private class SamplerConfigImpl(override val spanFactory: SpanFactory) : SamplerConfigDsl

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/config/TracingConfig.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/config/TracingConfig.kt
@@ -3,6 +3,8 @@ package io.opentelemetry.kotlin.init.config
 import io.opentelemetry.kotlin.ThreadSafe
 import io.opentelemetry.kotlin.factory.SpanFactory
 import io.opentelemetry.kotlin.resource.Resource
+import io.opentelemetry.kotlin.tracing.TracerConfigImpl
+import io.opentelemetry.kotlin.tracing.TracerConfigurator
 import io.opentelemetry.kotlin.tracing.export.SpanProcessor
 import io.opentelemetry.kotlin.tracing.sampling.AlwaysOffSampler
 import io.opentelemetry.kotlin.tracing.sampling.AlwaysOnSampler
@@ -42,4 +44,9 @@ internal class TracingConfig(
             localParentNotSampled = AlwaysOffSampler(),
         )
     },
+
+    /**
+     * Computes the per-tracer config.
+     */
+    val tracerConfigurator: TracerConfigurator = TracerConfigurator { TracerConfigImpl(true) },
 )

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/TracerConfigImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/TracerConfigImpl.kt
@@ -1,0 +1,6 @@
+package io.opentelemetry.kotlin.tracing
+
+/**
+ * Internal implementation of [TracerConfig].
+ */
+internal class TracerConfigImpl(override val enabled: Boolean) : TracerConfig

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/TracerProviderImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/TracerProviderImpl.kt
@@ -37,19 +37,24 @@ internal class TracerProviderImpl(
     private val sampler = tracingConfig.samplerFactory(spanFactory)
 
     private val apiProvider = ApiProviderImpl<Tracer> { key ->
-        TracerImpl(
-            clock = clock,
-            processor = tracingConfig.processor,
-            contextFactory = contextFactory,
-            spanContextFactory = spanContextFactory,
-            traceFlagsFactory = traceFlagsFactory,
-            scope = key,
-            resource = tracingConfig.resource,
-            spanLimitConfig = tracingConfig.spanLimits,
-            idGenerator = idGenerator,
-            shutdownState = shutdownState,
-            sampler = sampler,
-        )
+        val tracerConfig = tracingConfig.tracerConfigurator.tracerConfig(key)
+        if (!tracerConfig.enabled) {
+            noopTracer
+        } else {
+            TracerImpl(
+                clock = clock,
+                processor = tracingConfig.processor,
+                contextFactory = contextFactory,
+                spanContextFactory = spanContextFactory,
+                traceFlagsFactory = traceFlagsFactory,
+                scope = key,
+                resource = tracingConfig.resource,
+                spanLimitConfig = tracingConfig.spanLimits,
+                idGenerator = idGenerator,
+                shutdownState = shutdownState,
+                sampler = sampler,
+            )
+        }
     }
 
     override fun getTracer(

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/integration/test/tracing/TracerConfigTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/integration/test/tracing/TracerConfigTest.kt
@@ -1,0 +1,46 @@
+package io.opentelemetry.kotlin.integration.test.tracing
+
+import io.opentelemetry.kotlin.integration.test.IntegrationTestHarness
+import io.opentelemetry.kotlin.tracing.TracerConfigImpl
+import kotlinx.coroutines.test.runTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+internal class TracerConfigTest {
+
+    private lateinit var harness: IntegrationTestHarness
+
+    @BeforeTest
+    fun setUp() = runTest {
+        harness = IntegrationTestHarness(testScheduler)
+    }
+
+    @Test
+    fun testTracerConfiguratorDisablesMatchingScope() = runTest {
+        harness.config.tracerProvider = {
+            tracerConfigurator { scope ->
+                when (scope.name) {
+                    "disabled" -> TracerConfigImpl(false)
+                    else -> TracerConfigImpl(true)
+                }
+            }
+        }
+
+        val tracerProvider = harness.tracerProvider
+        val disabled = tracerProvider.getTracer("disabled")
+        val enabled = tracerProvider.getTracer("enabled")
+
+        assertFalse(disabled.enabled())
+        assertTrue(enabled.enabled())
+
+        disabled.startSpan("dropped").end()
+        enabled.startSpan("kept").end()
+
+        harness.assertSpans(expectedCount = 1) { spans ->
+            assertEquals("kept", spans.single().name)
+        }
+    }
+}

--- a/integration-test/src/commonMain/kotlin/io/opentelemetry/kotlin/framework/OtelKotlinTestRule.kt
+++ b/integration-test/src/commonMain/kotlin/io/opentelemetry/kotlin/framework/OtelKotlinTestRule.kt
@@ -78,6 +78,7 @@ abstract class OtelKotlinTestRule(context: TestCoroutineScheduler) {
             )
         }
         spanLimits(config.spanLimits)
+        config.tracerProvider(this)
     }
 
     /**

--- a/integration-test/src/commonMain/kotlin/io/opentelemetry/kotlin/framework/TestHarnessConfig.kt
+++ b/integration-test/src/commonMain/kotlin/io/opentelemetry/kotlin/framework/TestHarnessConfig.kt
@@ -3,6 +3,7 @@ package io.opentelemetry.kotlin.framework
 import io.opentelemetry.kotlin.attributes.AttributesMutator
 import io.opentelemetry.kotlin.init.LogLimitsConfigDsl
 import io.opentelemetry.kotlin.init.SpanLimitsConfigDsl
+import io.opentelemetry.kotlin.init.TracerProviderConfigDsl
 import io.opentelemetry.kotlin.logging.export.LogRecordProcessor
 import io.opentelemetry.kotlin.tracing.export.SpanProcessor
 
@@ -13,4 +14,5 @@ data class TestHarnessConfig(
     val logRecordProcessors: MutableList<LogRecordProcessor> = mutableListOf(),
     var spanLimits: SpanLimitsConfigDsl.() -> Unit = {},
     var logLimits: LogLimitsConfigDsl.() -> Unit = {},
+    var tracerProvider: TracerProviderConfigDsl.() -> Unit = {},
 )

--- a/java-typealiases/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/aliases/Aliases.kt
+++ b/java-typealiases/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/aliases/Aliases.kt
@@ -134,7 +134,6 @@ typealias OtelJavaSdkTracerProvider = SdkTracerProvider
 typealias OtelJavaSdkTracerProviderBuilder = SdkTracerProviderBuilder
 typealias OtelJavaSdkTracerProviderUtil = SdkTracerProviderUtil
 typealias OtelJavaTracerConfig = TracerConfig
-typealias OtelJavaScopeConfigurator<T> = ScopeConfigurator<T>
 typealias OtelJavaBody = Body
 typealias OtelJavaInstrumentationLibraryInfo = InstrumentationLibraryInfo
 typealias OtelJavaAttributesBuilder = AttributesBuilder

--- a/java-typealiases/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/aliases/Aliases.kt
+++ b/java-typealiases/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/aliases/Aliases.kt
@@ -45,6 +45,7 @@ import io.opentelemetry.sdk.common.Clock
 import io.opentelemetry.sdk.common.CompletableResultCode
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo
 import io.opentelemetry.sdk.common.InstrumentationScopeInfo
+import io.opentelemetry.sdk.common.internal.ScopeConfigurator
 import io.opentelemetry.sdk.extension.incubator.trace.samplers.AlwaysRecordSampler
 import io.opentelemetry.sdk.logs.LogLimits
 import io.opentelemetry.sdk.logs.LogRecordProcessor
@@ -71,6 +72,8 @@ import io.opentelemetry.sdk.trace.data.SpanData
 import io.opentelemetry.sdk.trace.data.StatusData
 import io.opentelemetry.sdk.trace.export.SpanExporter
 import io.opentelemetry.sdk.trace.internal.ExtendedSpanProcessor
+import io.opentelemetry.sdk.trace.internal.SdkTracerProviderUtil
+import io.opentelemetry.sdk.trace.internal.TracerConfig
 import io.opentelemetry.sdk.trace.samplers.Sampler
 import io.opentelemetry.sdk.trace.samplers.SamplingDecision
 import io.opentelemetry.sdk.trace.samplers.SamplingResult
@@ -124,6 +127,9 @@ typealias OtelJavaSdkMeterProvider = SdkMeterProvider
 typealias OtelJavaSdkMeterProviderBuilder = SdkMeterProviderBuilder
 typealias OtelJavaSdkTracerProvider = SdkTracerProvider
 typealias OtelJavaSdkTracerProviderBuilder = SdkTracerProviderBuilder
+typealias OtelJavaSdkTracerProviderUtil = SdkTracerProviderUtil
+typealias OtelJavaTracerConfig = TracerConfig
+typealias OtelJavaScopeConfigurator<T> = ScopeConfigurator<T>
 typealias OtelJavaBody = Body
 typealias OtelJavaInstrumentationLibraryInfo = InstrumentationLibraryInfo
 typealias OtelJavaAttributesBuilder = AttributesBuilder

--- a/sdk-api/api/jvm/sdk-api.api
+++ b/sdk-api/api/jvm/sdk-api.api
@@ -172,6 +172,7 @@ public abstract interface class io/opentelemetry/kotlin/init/TracerProviderConfi
 	public abstract fun export (Lkotlin/jvm/functions/Function1;)V
 	public abstract fun sampler (Lkotlin/jvm/functions/Function1;)V
 	public abstract fun spanLimits (Lkotlin/jvm/functions/Function1;)V
+	public abstract fun tracerConfigurator (Lio/opentelemetry/kotlin/tracing/TracerConfigurator;)V
 }
 
 public abstract interface class io/opentelemetry/kotlin/logging/export/LogRecordExporter : io/opentelemetry/kotlin/export/TelemetryCloseable {
@@ -227,6 +228,14 @@ public abstract interface class io/opentelemetry/kotlin/resource/Resource : io/o
 	public abstract fun asNewResource (Lkotlin/jvm/functions/Function1;)Lio/opentelemetry/kotlin/resource/Resource;
 	public abstract fun getSchemaUrl ()Ljava/lang/String;
 	public abstract fun merge (Lio/opentelemetry/kotlin/resource/Resource;)Lio/opentelemetry/kotlin/resource/Resource;
+}
+
+public abstract interface class io/opentelemetry/kotlin/tracing/TracerConfig {
+	public abstract fun getEnabled ()Z
+}
+
+public abstract interface class io/opentelemetry/kotlin/tracing/TracerConfigurator {
+	public abstract fun tracerConfig (Lio/opentelemetry/kotlin/InstrumentationScopeInfo;)Lio/opentelemetry/kotlin/tracing/TracerConfig;
 }
 
 public abstract interface class io/opentelemetry/kotlin/tracing/data/SpanData : io/opentelemetry/kotlin/attributes/AttributeContainer {

--- a/sdk-api/src/commonMain/kotlin/io/opentelemetry/kotlin/init/TracerProviderConfigDsl.kt
+++ b/sdk-api/src/commonMain/kotlin/io/opentelemetry/kotlin/init/TracerProviderConfigDsl.kt
@@ -1,6 +1,7 @@
 package io.opentelemetry.kotlin.init
 
 import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.tracing.TracerConfigurator
 import io.opentelemetry.kotlin.tracing.export.SpanProcessor
 import io.opentelemetry.kotlin.tracing.sampling.Sampler
 
@@ -26,4 +27,9 @@ public interface TracerProviderConfigDsl : ResourceConfigDsl {
      * Configures the strategy that should be used for sampling.
      */
     public fun sampler(action: SamplerConfigDsl.() -> Sampler)
+
+    /**
+     * Configures behavior of the tracer.
+     */
+    public fun tracerConfigurator(configurator: TracerConfigurator)
 }

--- a/sdk-api/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/TracerConfig.kt
+++ b/sdk-api/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/TracerConfig.kt
@@ -1,0 +1,15 @@
+package io.opentelemetry.kotlin.tracing
+
+import io.opentelemetry.kotlin.ExperimentalApi
+
+/**
+ * Immutable model of how a [Tracer] should behave.
+ */
+@ExperimentalApi
+public interface TracerConfig {
+
+    /**
+     * Whether the tracer is enabled.
+     */
+    public val enabled: Boolean
+}

--- a/sdk-api/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/TracerConfigurator.kt
+++ b/sdk-api/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/TracerConfigurator.kt
@@ -1,0 +1,19 @@
+package io.opentelemetry.kotlin.tracing
+
+import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.InstrumentationScopeInfo
+
+/**
+ * Dynamically controls how a [Tracer] should behave by constructing a [TracerConfig].
+ * Implementations must return quickly as this code may be invoked frequently.
+ *
+ * https://opentelemetry.io/docs/specs/otel/trace/sdk/#tracerconfigurator
+ */
+@ExperimentalApi
+public fun interface TracerConfigurator {
+
+    /**
+     * Returns the [TracerConfig] for the given [scope].
+     */
+    public fun tracerConfig(scope: InstrumentationScopeInfo): TracerConfig
+}


### PR DESCRIPTION
## Goal

Closes #672 by implementing `TracerConfigurator` that controls whether tracers should be enabled or not.

## Testing

Added unit tests.
