### PR TITLE
turn gradle tooling parallel on

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -15,3 +15,6 @@ android.nonTransitiveRClass=true
 
 #Custom
 version=0.6.0
+
+# Enabled parallel sync for Gradle 9.4+
+org.gradle.tooling.parallel=true


### PR DESCRIPTION
New feature in gradle allows parallel gradle sync in IDEs without impacting the main production builds.

https://docs.gradle.org/current/userguide/performance.html#sec:configure_tooling_api_actions_parallelism

Seems like a reasonable thing to me. 