### PR TITLE
Use environment secrets for publishing

### DIFF
--- a/.github/repository_settings.md
+++ b/.github/repository_settings.md
@@ -4,9 +4,13 @@ This document describes any changes that have been made to the
 settings for this repository beyond the [OpenTelemetry default repository
 settings](https://github.com/open-telemetry/community/blob/main/docs/how-to-configure-new-repository.md#repository-settings).
  
-## Secrets and variables > Actions
+## Environments
 
-The following repository secrets are stored in OpenTelemetry-Kotlin 1Password:
+### `protected` environment
+
+Deployment branches: `release/*`
+
+Secrets (stored in OpenTelemetry-Kotlin 1Password):
 
 * `ORG_GRADLE_PROJECT_MAVENCENTRALPASSWORD`
 * `ORG_GRADLE_PROJECT_MAVENCENTRALUSERNAME`

--- a/.github/repository_settings.md
+++ b/.github/repository_settings.md
@@ -8,7 +8,7 @@ settings](https://github.com/open-telemetry/community/blob/main/docs/how-to-conf
 
 ### `protected` environment
 
-Deployment branches: `release/*`
+Deployment branches: `main`, `release/*`
 
 Secrets (stored in OpenTelemetry-Kotlin 1Password):
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,13 +1,6 @@
 ---
 name: Release
 
-env:
-  ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.ORG_GRADLE_PROJECT_MAVENCENTRALUSERNAME }}
-  ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.ORG_GRADLE_PROJECT_MAVENCENTRALPASSWORD }}
-  ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGINMEMORYKEYID }}
-  ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGINMEMORYKEY }}
-  ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGINMEMORYKEYPASSWORD }}
-
 on:
   workflow_dispatch:
 
@@ -16,6 +9,13 @@ permissions:
 
 jobs:
   release:
+    environment: protected
+    env:
+      ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.ORG_GRADLE_PROJECT_MAVENCENTRALUSERNAME }}
+      ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.ORG_GRADLE_PROJECT_MAVENCENTRALPASSWORD }}
+      ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGINMEMORYKEYID }}
+      ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGINMEMORYKEY }}
+      ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGINMEMORYKEYPASSWORD }}
     permissions:
       contents: write # for creating the release
     name: "release"


### PR DESCRIPTION
This allows us to only have the secrets defined for the `protected` environment, which is then only used for publishing jobs. This reduces the surface area of jobs for which the secrets apply and improves the security posture of other non-publishing jobs.