### PR TITLE
Mark Context API as stable

### DIFF
--- a/api/src/commonMain/kotlin/io/opentelemetry/kotlin/context/Context.kt
+++ b/api/src/commonMain/kotlin/io/opentelemetry/kotlin/context/Context.kt
@@ -10,7 +10,6 @@ import io.opentelemetry.kotlin.tracing.Span
  *
  * https://opentelemetry.io/docs/specs/otel/context/
  */
-@ExperimentalApi
 @ThreadSafe
 public interface Context {
 
@@ -50,6 +49,7 @@ public interface Context {
      *
      * https://opentelemetry.io/docs/specs/otel/trace/api/#context-interaction
      */
+    @OptIn(ExperimentalApi::class)
     @ThreadSafe
     public fun storeSpan(span: Span): Context
 
@@ -58,6 +58,7 @@ public interface Context {
      *
      * https://opentelemetry.io/docs/specs/otel/trace/api/#context-interaction
      */
+    @OptIn(ExperimentalApi::class)
     @ThreadSafe
     public fun extractSpan(): Span
 
@@ -66,6 +67,7 @@ public interface Context {
      *
      * https://opentelemetry.io/docs/specs/otel/baggage/api/#context-interaction
      */
+    @OptIn(ExperimentalApi::class)
     @ThreadSafe
     public fun storeBaggage(baggage: Baggage): Context
 
@@ -74,6 +76,7 @@ public interface Context {
      *
      * https://opentelemetry.io/docs/specs/otel/baggage/api/#context-interaction
      */
+    @OptIn(ExperimentalApi::class)
     @ThreadSafe
     public fun extractBaggage(): Baggage
 

--- a/api/src/commonMain/kotlin/io/opentelemetry/kotlin/context/ContextKey.kt
+++ b/api/src/commonMain/kotlin/io/opentelemetry/kotlin/context/ContextKey.kt
@@ -1,11 +1,9 @@
 package io.opentelemetry.kotlin.context
 
-import io.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.kotlin.ThreadSafe
 
 /**
  * A key that identifies a value in a [Context].
  */
-@ExperimentalApi
 @ThreadSafe
 public interface ContextKey<T>

--- a/api/src/commonMain/kotlin/io/opentelemetry/kotlin/context/Scope.kt
+++ b/api/src/commonMain/kotlin/io/opentelemetry/kotlin/context/Scope.kt
@@ -1,13 +1,10 @@
 package io.opentelemetry.kotlin.context
 
-import io.opentelemetry.kotlin.ExperimentalApi
-
 /**
  * Defines a 'scope' of execution in which an implicit Context is set. A scope
  * must be closed when an operation has finished, as this allows the previous context to be
  * restored.
  */
-@ExperimentalApi
 public interface Scope {
 
     /**


### PR DESCRIPTION
## Goal

Removes the `ExperimentalApi` annotations and therefore marks the Context API (Context.kt, Scope.kt, and ContextKey.kt within the api module) as stable, as discussed in the SIG. Closes #651.
