### PR TITLE
Mark Baggage API as stable

### DIFF
--- a/api/src/commonMain/kotlin/io/opentelemetry/kotlin/baggage/Baggage.kt
+++ b/api/src/commonMain/kotlin/io/opentelemetry/kotlin/baggage/Baggage.kt
@@ -1,6 +1,5 @@
 package io.opentelemetry.kotlin.baggage
 
-import io.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.kotlin.ThreadSafe
 
 /**
@@ -10,7 +9,6 @@ import io.opentelemetry.kotlin.ThreadSafe
  *
  * https://opentelemetry.io/docs/specs/otel/baggage/api/
  */
-@ExperimentalApi
 @ThreadSafe
 public interface Baggage {
 

--- a/api/src/commonMain/kotlin/io/opentelemetry/kotlin/baggage/BaggageCreationAction.kt
+++ b/api/src/commonMain/kotlin/io/opentelemetry/kotlin/baggage/BaggageCreationAction.kt
@@ -1,7 +1,5 @@
 package io.opentelemetry.kotlin.baggage
 
-import io.opentelemetry.kotlin.ExperimentalApi
-
 /**
  * DSL receiver for assembling a [Baggage] instance.
  *
@@ -11,7 +9,6 @@ import io.opentelemetry.kotlin.ExperimentalApi
  *
  * https://opentelemetry.io/docs/specs/otel/baggage/api/#baggage-builder
  */
-@ExperimentalApi
 public interface BaggageCreationAction {
 
     /**

--- a/api/src/commonMain/kotlin/io/opentelemetry/kotlin/baggage/BaggageEntry.kt
+++ b/api/src/commonMain/kotlin/io/opentelemetry/kotlin/baggage/BaggageEntry.kt
@@ -1,13 +1,10 @@
 package io.opentelemetry.kotlin.baggage
 
-import io.opentelemetry.kotlin.ExperimentalApi
-
 /**
  * An entry in [Baggage], consisting of a string value and optional [BaggageEntryMetadata].
  *
  * https://opentelemetry.io/docs/specs/otel/baggage/api/#baggageentry
  */
-@ExperimentalApi
 public interface BaggageEntry {
 
     /** The baggage entry value. */

--- a/api/src/commonMain/kotlin/io/opentelemetry/kotlin/baggage/BaggageEntryMetadata.kt
+++ b/api/src/commonMain/kotlin/io/opentelemetry/kotlin/baggage/BaggageEntryMetadata.kt
@@ -1,7 +1,5 @@
 package io.opentelemetry.kotlin.baggage
 
-import io.opentelemetry.kotlin.ExperimentalApi
-
 /**
  * Opaque metadata associated with a [BaggageEntry].
  *
@@ -11,7 +9,6 @@ import io.opentelemetry.kotlin.ExperimentalApi
  *
  * https://opentelemetry.io/docs/specs/otel/baggage/api/#baggageentrymetadata
  */
-@ExperimentalApi
 public interface BaggageEntryMetadata {
 
     /** The raw metadata string. */


### PR DESCRIPTION
## Goal

Removes the `ExperimentalApi` annotations and therefore marks the Baggage API (Baggage.kt, BaggageCreationAction.kt, BaggageEntry.kt, and BaggageEntryMetadata.kt within the api module) as stable, as discussed in the SIG. Closes #650.
