### PR TITLE
feat(Tracing API): Implement CompositeSampler and built-in composable samplers

### DIFF
--- a/implementation/api/jvm/implementation.api
+++ b/implementation/api/jvm/implementation.api
@@ -7,7 +7,43 @@ public final class io/opentelemetry/kotlin/tracing/sampling/BuiltInSamplerApiKt 
 	public static final fun alwaysOff (Lio/opentelemetry/kotlin/init/SamplerConfigDsl;)Lio/opentelemetry/kotlin/tracing/sampling/Sampler;
 	public static final fun alwaysOn (Lio/opentelemetry/kotlin/init/SamplerConfigDsl;)Lio/opentelemetry/kotlin/tracing/sampling/Sampler;
 	public static final fun alwaysRecord (Lio/opentelemetry/kotlin/init/SamplerConfigDsl;Lio/opentelemetry/kotlin/tracing/sampling/Sampler;)Lio/opentelemetry/kotlin/tracing/sampling/Sampler;
+	public static final fun composableAlwaysOff (Lio/opentelemetry/kotlin/init/SamplerConfigDsl;)Lio/opentelemetry/kotlin/tracing/sampling/ComposableSampler;
+	public static final fun composableAlwaysOn (Lio/opentelemetry/kotlin/init/SamplerConfigDsl;)Lio/opentelemetry/kotlin/tracing/sampling/ComposableSampler;
+	public static final fun composableParentThreshold (Lio/opentelemetry/kotlin/init/SamplerConfigDsl;Lio/opentelemetry/kotlin/tracing/sampling/ComposableSampler;)Lio/opentelemetry/kotlin/tracing/sampling/ComposableSampler;
+	public static final fun composableProbability (Lio/opentelemetry/kotlin/init/SamplerConfigDsl;D)Lio/opentelemetry/kotlin/tracing/sampling/ComposableSampler;
+	public static final fun composite (Lio/opentelemetry/kotlin/init/SamplerConfigDsl;Lkotlin/jvm/functions/Function1;)Lio/opentelemetry/kotlin/tracing/sampling/Sampler;
 	public static final fun parentBased (Lio/opentelemetry/kotlin/init/SamplerConfigDsl;Lio/opentelemetry/kotlin/tracing/sampling/Sampler;Lio/opentelemetry/kotlin/tracing/sampling/Sampler;Lio/opentelemetry/kotlin/tracing/sampling/Sampler;Lio/opentelemetry/kotlin/tracing/sampling/Sampler;Lio/opentelemetry/kotlin/tracing/sampling/Sampler;)Lio/opentelemetry/kotlin/tracing/sampling/Sampler;
 	public static synthetic fun parentBased$default (Lio/opentelemetry/kotlin/init/SamplerConfigDsl;Lio/opentelemetry/kotlin/tracing/sampling/Sampler;Lio/opentelemetry/kotlin/tracing/sampling/Sampler;Lio/opentelemetry/kotlin/tracing/sampling/Sampler;Lio/opentelemetry/kotlin/tracing/sampling/Sampler;Lio/opentelemetry/kotlin/tracing/sampling/Sampler;ILjava/lang/Object;)Lio/opentelemetry/kotlin/tracing/sampling/Sampler;
+}
+
+public final class io/opentelemetry/kotlin/tracing/sampling/ComposableAlwaysOffSampler : io/opentelemetry/kotlin/tracing/sampling/ComposableSampler {
+	public fun <init> ()V
+	public fun getDescription ()Ljava/lang/String;
+	public fun getSamplingIntent (Lio/opentelemetry/kotlin/context/Context;Ljava/lang/String;Lio/opentelemetry/kotlin/tracing/SpanKind;Lio/opentelemetry/kotlin/attributes/AttributeContainer;Ljava/util/List;)Lio/opentelemetry/kotlin/tracing/sampling/SamplingIntent;
+}
+
+public final class io/opentelemetry/kotlin/tracing/sampling/ComposableAlwaysOnSampler : io/opentelemetry/kotlin/tracing/sampling/ComposableSampler {
+	public fun <init> ()V
+	public fun getDescription ()Ljava/lang/String;
+	public fun getSamplingIntent (Lio/opentelemetry/kotlin/context/Context;Ljava/lang/String;Lio/opentelemetry/kotlin/tracing/SpanKind;Lio/opentelemetry/kotlin/attributes/AttributeContainer;Ljava/util/List;)Lio/opentelemetry/kotlin/tracing/sampling/SamplingIntent;
+}
+
+public final class io/opentelemetry/kotlin/tracing/sampling/ComposableParentThresholdSampler : io/opentelemetry/kotlin/tracing/sampling/ComposableSampler {
+	public fun <init> (Lio/opentelemetry/kotlin/tracing/sampling/ComposableSampler;)V
+	public fun getDescription ()Ljava/lang/String;
+	public fun getSamplingIntent (Lio/opentelemetry/kotlin/context/Context;Ljava/lang/String;Lio/opentelemetry/kotlin/tracing/SpanKind;Lio/opentelemetry/kotlin/attributes/AttributeContainer;Ljava/util/List;)Lio/opentelemetry/kotlin/tracing/sampling/SamplingIntent;
+}
+
+public final class io/opentelemetry/kotlin/tracing/sampling/ComposableProbabilitySampler : io/opentelemetry/kotlin/tracing/sampling/ComposableSampler {
+	public fun <init> (D)V
+	public fun getDescription ()Ljava/lang/String;
+	public fun getSamplingIntent (Lio/opentelemetry/kotlin/context/Context;Ljava/lang/String;Lio/opentelemetry/kotlin/tracing/SpanKind;Lio/opentelemetry/kotlin/attributes/AttributeContainer;Ljava/util/List;)Lio/opentelemetry/kotlin/tracing/sampling/SamplingIntent;
+}
+
+public final class io/opentelemetry/kotlin/tracing/sampling/CompositeSampler : io/opentelemetry/kotlin/tracing/sampling/Sampler {
+	public fun <init> (Lio/opentelemetry/kotlin/tracing/sampling/ComposableSampler;Lkotlin/random/Random;)V
+	public synthetic fun <init> (Lio/opentelemetry/kotlin/tracing/sampling/ComposableSampler;Lkotlin/random/Random;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun getDescription ()Ljava/lang/String;
+	public fun shouldSample (Lio/opentelemetry/kotlin/context/Context;Ljava/lang/String;Ljava/lang/String;Lio/opentelemetry/kotlin/tracing/SpanKind;Lio/opentelemetry/kotlin/attributes/AttributeContainer;Ljava/util/List;)Lio/opentelemetry/kotlin/tracing/sampling/SamplingResult;
 }
 

--- a/implementation/api/jvm/implementation.api
+++ b/implementation/api/jvm/implementation.api
@@ -16,34 +16,3 @@ public final class io/opentelemetry/kotlin/tracing/sampling/BuiltInSamplerApiKt 
 	public static synthetic fun parentBased$default (Lio/opentelemetry/kotlin/init/SamplerConfigDsl;Lio/opentelemetry/kotlin/tracing/sampling/Sampler;Lio/opentelemetry/kotlin/tracing/sampling/Sampler;Lio/opentelemetry/kotlin/tracing/sampling/Sampler;Lio/opentelemetry/kotlin/tracing/sampling/Sampler;Lio/opentelemetry/kotlin/tracing/sampling/Sampler;ILjava/lang/Object;)Lio/opentelemetry/kotlin/tracing/sampling/Sampler;
 }
 
-public final class io/opentelemetry/kotlin/tracing/sampling/ComposableAlwaysOffSampler : io/opentelemetry/kotlin/tracing/sampling/ComposableSampler {
-	public fun <init> ()V
-	public fun getDescription ()Ljava/lang/String;
-	public fun getSamplingIntent (Lio/opentelemetry/kotlin/context/Context;Ljava/lang/String;Lio/opentelemetry/kotlin/tracing/SpanKind;Lio/opentelemetry/kotlin/attributes/AttributeContainer;Ljava/util/List;)Lio/opentelemetry/kotlin/tracing/sampling/SamplingIntent;
-}
-
-public final class io/opentelemetry/kotlin/tracing/sampling/ComposableAlwaysOnSampler : io/opentelemetry/kotlin/tracing/sampling/ComposableSampler {
-	public fun <init> ()V
-	public fun getDescription ()Ljava/lang/String;
-	public fun getSamplingIntent (Lio/opentelemetry/kotlin/context/Context;Ljava/lang/String;Lio/opentelemetry/kotlin/tracing/SpanKind;Lio/opentelemetry/kotlin/attributes/AttributeContainer;Ljava/util/List;)Lio/opentelemetry/kotlin/tracing/sampling/SamplingIntent;
-}
-
-public final class io/opentelemetry/kotlin/tracing/sampling/ComposableParentThresholdSampler : io/opentelemetry/kotlin/tracing/sampling/ComposableSampler {
-	public fun <init> (Lio/opentelemetry/kotlin/tracing/sampling/ComposableSampler;)V
-	public fun getDescription ()Ljava/lang/String;
-	public fun getSamplingIntent (Lio/opentelemetry/kotlin/context/Context;Ljava/lang/String;Lio/opentelemetry/kotlin/tracing/SpanKind;Lio/opentelemetry/kotlin/attributes/AttributeContainer;Ljava/util/List;)Lio/opentelemetry/kotlin/tracing/sampling/SamplingIntent;
-}
-
-public final class io/opentelemetry/kotlin/tracing/sampling/ComposableProbabilitySampler : io/opentelemetry/kotlin/tracing/sampling/ComposableSampler {
-	public fun <init> (D)V
-	public fun getDescription ()Ljava/lang/String;
-	public fun getSamplingIntent (Lio/opentelemetry/kotlin/context/Context;Ljava/lang/String;Lio/opentelemetry/kotlin/tracing/SpanKind;Lio/opentelemetry/kotlin/attributes/AttributeContainer;Ljava/util/List;)Lio/opentelemetry/kotlin/tracing/sampling/SamplingIntent;
-}
-
-public final class io/opentelemetry/kotlin/tracing/sampling/CompositeSampler : io/opentelemetry/kotlin/tracing/sampling/Sampler {
-	public fun <init> (Lio/opentelemetry/kotlin/tracing/sampling/ComposableSampler;Lkotlin/random/Random;)V
-	public synthetic fun <init> (Lio/opentelemetry/kotlin/tracing/sampling/ComposableSampler;Lkotlin/random/Random;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun getDescription ()Ljava/lang/String;
-	public fun shouldSample (Lio/opentelemetry/kotlin/context/Context;Ljava/lang/String;Ljava/lang/String;Lio/opentelemetry/kotlin/tracing/SpanKind;Lio/opentelemetry/kotlin/attributes/AttributeContainer;Ljava/util/List;)Lio/opentelemetry/kotlin/tracing/sampling/SamplingResult;
-}
-

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/sampling/BuiltInSamplerApi.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/sampling/BuiltInSamplerApi.kt
@@ -47,3 +47,25 @@ public fun SamplerConfigDsl.parentBased(
     localParentSampled = localParentSampled,
     localParentNotSampled = localParentNotSampled,
 )
+
+@ExperimentalApi
+public fun SamplerConfigDsl.composite(block: SamplerConfigDsl.() -> ComposableSampler): Sampler =
+    CompositeSampler(block())
+
+@ExperimentalApi
+public fun SamplerConfigDsl.composableAlwaysOn(): ComposableSampler = ComposableAlwaysOnSampler()
+
+@ExperimentalApi
+public fun SamplerConfigDsl.composableAlwaysOff(): ComposableSampler = ComposableAlwaysOffSampler()
+
+@ExperimentalApi
+public fun SamplerConfigDsl.composableProbability(ratio: Double): ComposableSampler =
+    if (ratio == 0.0) {
+        ComposableAlwaysOffSampler()
+    } else {
+        ComposableProbabilitySampler(ratio)
+    }
+
+@ExperimentalApi
+public fun SamplerConfigDsl.composableParentThreshold(root: ComposableSampler): ComposableSampler =
+    ComposableParentThresholdSampler(root)

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/sampling/BuiltInSamplerApi.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/sampling/BuiltInSamplerApi.kt
@@ -48,16 +48,37 @@ public fun SamplerConfigDsl.parentBased(
     localParentNotSampled = localParentNotSampled,
 )
 
+/**
+ * Configures sampling by delegating to a [ComposableSampler], using consistent probability
+ * sampling over the OpenTelemetry TraceState `ot` `th`/`rv` sub-keys.
+ *
+ * https://opentelemetry.io/docs/specs/otel/trace/sdk/#compositesampler
+ */
 @ExperimentalApi
 public fun SamplerConfigDsl.composite(block: SamplerConfigDsl.() -> ComposableSampler): Sampler =
     CompositeSampler(block())
 
+/**
+ * A [ComposableSampler] that always samples, regardless of parent trace state.
+ *
+ * https://opentelemetry.io/docs/specs/otel/trace/sdk/#composablealwayson
+ */
 @ExperimentalApi
 public fun SamplerConfigDsl.composableAlwaysOn(): ComposableSampler = ComposableAlwaysOnSampler()
 
+/**
+ * A [ComposableSampler] that never samples.
+ *
+ * https://opentelemetry.io/docs/specs/otel/trace/sdk/#composablealwaysoff
+ */
 @ExperimentalApi
 public fun SamplerConfigDsl.composableAlwaysOff(): ComposableSampler = ComposableAlwaysOffSampler()
 
+/**
+ * A [ComposableSampler] that samples spans with the given probability [ratio].
+ *
+ * https://opentelemetry.io/docs/specs/otel/trace/sdk/#composableprobability
+ */
 @ExperimentalApi
 public fun SamplerConfigDsl.composableProbability(ratio: Double): ComposableSampler =
     if (ratio == 0.0) {
@@ -66,6 +87,12 @@ public fun SamplerConfigDsl.composableProbability(ratio: Double): ComposableSamp
         ComposableProbabilitySampler(ratio)
     }
 
+/**
+ * A [ComposableSampler] that honors the parent's sampling threshold when present, falling back
+ * to [root] when there is no valid parent.
+ *
+ * https://opentelemetry.io/docs/specs/otel/trace/sdk/#composableparentthreshold
+ */
 @ExperimentalApi
 public fun SamplerConfigDsl.composableParentThreshold(root: ComposableSampler): ComposableSampler =
     ComposableParentThresholdSampler(root)

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/sampling/ComposableAlwaysOffSampler.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/sampling/ComposableAlwaysOffSampler.kt
@@ -1,0 +1,28 @@
+package io.opentelemetry.kotlin.tracing.sampling
+
+import io.opentelemetry.kotlin.attributes.AttributeContainer
+import io.opentelemetry.kotlin.context.Context
+import io.opentelemetry.kotlin.tracing.SpanKind
+import io.opentelemetry.kotlin.tracing.model.SpanLink
+
+/**
+ * A [ComposableSampler] that never samples, regardless of parent trace state.
+ *
+ * https://opentelemetry.io/docs/specs/otel/trace/sdk/#composablealwaysoff
+ */
+public class ComposableAlwaysOffSampler : ComposableSampler {
+
+    override fun getSamplingIntent(
+        context: Context,
+        name: String,
+        spanKind: SpanKind,
+        attributes: AttributeContainer,
+        links: List<SpanLink>
+    ): SamplingIntent = SamplingIntentImpl(
+        threshold = null,
+        adjustedCountReliable = false
+    )
+
+    override val description: String
+        get() = "ComposableAlwaysOffSampler"
+}

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/sampling/ComposableAlwaysOffSampler.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/sampling/ComposableAlwaysOffSampler.kt
@@ -10,7 +10,7 @@ import io.opentelemetry.kotlin.tracing.model.SpanLink
  *
  * https://opentelemetry.io/docs/specs/otel/trace/sdk/#composablealwaysoff
  */
-public class ComposableAlwaysOffSampler : ComposableSampler {
+internal class ComposableAlwaysOffSampler : ComposableSampler {
 
     override fun getSamplingIntent(
         context: Context,

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/sampling/ComposableAlwaysOnSampler.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/sampling/ComposableAlwaysOnSampler.kt
@@ -1,0 +1,31 @@
+package io.opentelemetry.kotlin.tracing.sampling
+
+import io.opentelemetry.kotlin.attributes.AttributeContainer
+import io.opentelemetry.kotlin.context.Context
+import io.opentelemetry.kotlin.tracing.SpanKind
+import io.opentelemetry.kotlin.tracing.model.SpanLink
+
+/**
+ * A [ComposableSampler] that always samples, regardless of parent trace state.
+ *
+ * The rejection threshold is always `0`, meaning every randomness value satisfies `R >= T`,
+ * and the resulting adjusted count is always reliable since the threshold is not data-dependent.
+ *
+ * https://opentelemetry.io/docs/specs/otel/trace/sdk/#composablealwayson
+ */
+public class ComposableAlwaysOnSampler : ComposableSampler {
+
+    override fun getSamplingIntent(
+        context: Context,
+        name: String,
+        spanKind: SpanKind,
+        attributes: AttributeContainer,
+        links: List<SpanLink>
+    ): SamplingIntent = SamplingIntentImpl(
+        threshold = 0,
+        adjustedCountReliable = true
+    )
+
+    override val description: String
+        get() = "ComposableAlwaysOnSampler"
+}

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/sampling/ComposableAlwaysOnSampler.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/sampling/ComposableAlwaysOnSampler.kt
@@ -13,7 +13,7 @@ import io.opentelemetry.kotlin.tracing.model.SpanLink
  *
  * https://opentelemetry.io/docs/specs/otel/trace/sdk/#composablealwayson
  */
-public class ComposableAlwaysOnSampler : ComposableSampler {
+internal class ComposableAlwaysOnSampler : ComposableSampler {
 
     override fun getSamplingIntent(
         context: Context,

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/sampling/ComposableParentThresholdSampler.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/sampling/ComposableParentThresholdSampler.kt
@@ -1,0 +1,36 @@
+package io.opentelemetry.kotlin.tracing.sampling
+
+import io.opentelemetry.kotlin.attributes.AttributeContainer
+import io.opentelemetry.kotlin.context.Context
+import io.opentelemetry.kotlin.tracing.SpanKind
+import io.opentelemetry.kotlin.tracing.model.SpanLink
+
+/**
+ * A [ComposableSampler] that honors the parent's sampling threshold when present, falling back
+ * to [root] when there is no valid parent.
+ *
+ * https://opentelemetry.io/docs/specs/otel/trace/sdk/#composableparentthreshold
+ */
+public class ComposableParentThresholdSampler(private val root: ComposableSampler) : ComposableSampler {
+
+    override fun getSamplingIntent(
+        context: Context,
+        name: String,
+        spanKind: SpanKind,
+        attributes: AttributeContainer,
+        links: List<SpanLink>
+    ): SamplingIntent {
+        val parent = context.extractSpan().spanContext
+        val parentThreshold = parent.traceState.get(KnownTraceState.OT)?.let(OtelTraceState::parse)?.th
+
+        return when {
+            !parent.isValid -> root.getSamplingIntent(context, name, spanKind, attributes, links)
+            parentThreshold != null -> SamplingIntentImpl(threshold = parentThreshold, adjustedCountReliable = true)
+            parent.traceFlags.isSampled -> SamplingIntentImpl(threshold = 0, adjustedCountReliable = false)
+            else -> SamplingIntentImpl(threshold = null, adjustedCountReliable = false)
+        }
+    }
+
+    override val description: String
+        get() = "ComposableParentThresholdSampler{root:${root.description}}"
+}

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/sampling/ComposableParentThresholdSampler.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/sampling/ComposableParentThresholdSampler.kt
@@ -11,7 +11,7 @@ import io.opentelemetry.kotlin.tracing.model.SpanLink
  *
  * https://opentelemetry.io/docs/specs/otel/trace/sdk/#composableparentthreshold
  */
-public class ComposableParentThresholdSampler(private val root: ComposableSampler) : ComposableSampler {
+internal class ComposableParentThresholdSampler(private val root: ComposableSampler) : ComposableSampler {
 
     override fun getSamplingIntent(
         context: Context,

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/sampling/ComposableProbabilitySampler.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/sampling/ComposableProbabilitySampler.kt
@@ -1,0 +1,35 @@
+package io.opentelemetry.kotlin.tracing.sampling
+
+import io.opentelemetry.kotlin.attributes.AttributeContainer
+import io.opentelemetry.kotlin.context.Context
+import io.opentelemetry.kotlin.tracing.SpanKind
+import io.opentelemetry.kotlin.tracing.model.SpanLink
+
+/**
+ * A [ComposableSampler] that samples a fixed percentage of traces, based on the consistent
+ * probability sampling (R >= T) algorithm.
+ *
+ * https://opentelemetry.io/docs/specs/otel/trace/sdk/#composableprobabilitybased
+ */
+public class ComposableProbabilitySampler(private val ratio: Double) : ComposableSampler {
+
+    init {
+        validateRatio(ratio)
+    }
+
+    private val threshold: Long = thresholdFromRatio(ratio)
+
+    override fun getSamplingIntent(
+        context: Context,
+        name: String,
+        spanKind: SpanKind,
+        attributes: AttributeContainer,
+        links: List<SpanLink>
+    ): SamplingIntent = SamplingIntentImpl(
+        threshold = threshold,
+        adjustedCountReliable = false
+    )
+
+    override val description: String
+        get() = "ComposableProbabilitySampler{$ratio}"
+}

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/sampling/ComposableProbabilitySampler.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/sampling/ComposableProbabilitySampler.kt
@@ -11,7 +11,7 @@ import io.opentelemetry.kotlin.tracing.model.SpanLink
  *
  * https://opentelemetry.io/docs/specs/otel/trace/sdk/#composableprobabilitybased
  */
-public class ComposableProbabilitySampler(private val ratio: Double) : ComposableSampler {
+internal class ComposableProbabilitySampler(private val ratio: Double) : ComposableSampler {
 
     init {
         validateRatio(ratio)
@@ -27,7 +27,7 @@ public class ComposableProbabilitySampler(private val ratio: Double) : Composabl
         links: List<SpanLink>
     ): SamplingIntent = SamplingIntentImpl(
         threshold = threshold,
-        adjustedCountReliable = false
+        adjustedCountReliable = true
     )
 
     override val description: String

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/sampling/CompositeSampler.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/sampling/CompositeSampler.kt
@@ -1,0 +1,80 @@
+package io.opentelemetry.kotlin.tracing.sampling
+
+import io.opentelemetry.kotlin.attributes.AttributeContainer
+import io.opentelemetry.kotlin.attributes.AttributesModel
+import io.opentelemetry.kotlin.context.Context
+import io.opentelemetry.kotlin.tracing.SpanKind
+import io.opentelemetry.kotlin.tracing.model.SpanLink
+import kotlin.random.Random
+
+/**
+ * A [Sampler] that delegates its sampling preference to a [ComposableSampler], then applies the
+ * consistent probability sampling (R >= T) algorithm to reach a final [SamplingResult].
+ *
+ * https://opentelemetry.io/docs/specs/otel/trace/sdk/#compositesampler
+ */
+public class CompositeSampler(
+    private val delegate: ComposableSampler,
+    private val random: Random = Random.Default,
+) : Sampler {
+
+    override fun shouldSample(
+        context: Context,
+        traceId: String,
+        name: String,
+        spanKind: SpanKind,
+        attributes: AttributeContainer,
+        links: List<SpanLink>
+    ): SamplingResult {
+        val traceState = context.extractSpan().spanContext.traceState
+        val otelTraceState = OtelTraceState.parse(traceState.get(KnownTraceState.OT))
+
+        val intent = delegate.getSamplingIntent(context, name, spanKind, attributes, links)
+        // this unlocks smart-cast
+        val intentThreshold = intent.threshold
+
+        val adjustableThreshold = intentThreshold != null && intent.adjustedCountReliable
+        val sampled = intentThreshold?.let {
+            val randomVal = if (adjustableThreshold) {
+                otelTraceState.rv ?: randomnessFromTraceId(traceId)
+            } else {
+                // Use last 56 bits of random number
+                random.nextLong() and 0x00FFFFFFFFFFFFFFL
+            }
+            intentThreshold <= randomVal
+        } ?: false
+
+        val decision = if (sampled) {
+            SamplingResult.Decision.RECORD_AND_SAMPLE
+        } else {
+            SamplingResult.Decision.DROP
+        }
+
+        val derivedOtelTraceState = intent.traceStateProvider
+            ?.invoke(traceState, decision)
+            ?.get(KnownTraceState.OT)
+            ?.let(OtelTraceState::parse)
+            ?: otelTraceState
+        if (sampled && adjustableThreshold) {
+            intentThreshold?.let(derivedOtelTraceState::setThreshold)
+        } else {
+            derivedOtelTraceState.eraseThreshold()
+        }
+
+        val derivedTraceState = if (derivedOtelTraceState.encode().isEmpty()) {
+            traceState.remove(KnownTraceState.OT)
+        } else {
+            traceState.put(KnownTraceState.OT, derivedOtelTraceState.encode())
+        }
+        val attr = if (sampled) {
+            intent.attributesProvider?.invoke() ?: AttributesModel()
+        } else {
+            AttributesModel()
+        }
+
+        return SamplingResultImpl(decision, attr, derivedTraceState)
+    }
+
+    override val description: String
+        get() = "CompositeSampler{${delegate.description}}"
+}

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/sampling/CompositeSampler.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/sampling/CompositeSampler.kt
@@ -13,7 +13,7 @@ import kotlin.random.Random
  *
  * https://opentelemetry.io/docs/specs/otel/trace/sdk/#compositesampler
  */
-public class CompositeSampler(
+internal class CompositeSampler(
     private val delegate: ComposableSampler,
     private val random: Random = Random.Default,
 ) : Sampler {

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/sampling/KnownTraceState.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/sampling/KnownTraceState.kt
@@ -1,0 +1,5 @@
+package io.opentelemetry.kotlin.tracing.sampling
+
+internal object KnownTraceState {
+    const val OT: String = "ot"
+}

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/sampling/OtelTraceState.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/sampling/OtelTraceState.kt
@@ -6,14 +6,14 @@ internal class OtelTraceState private constructor(
     private val pairs: LinkedHashMap<String, String>
 ) {
     val rv: Long?
-        get() = pairs["rv"]?.randomness()
+        get() = pairs[RANDOM_VAL_KEY]?.randomness()
 
     val th: Long?
-        get() = pairs["th"]?.threshold()
+        get() = pairs[THRESHOLD_KEY]?.threshold()
 
     fun setThreshold(threshold: Long) {
         require(threshold in 0x0..0xffffffffffffff)
-        pairs["th"] = if (threshold == 0L) {
+        pairs[THRESHOLD_KEY] = if (threshold == 0L) {
             "0"
         } else {
             threshold.toString(16).padStart(14, '0').trimEnd('0')
@@ -21,12 +21,19 @@ internal class OtelTraceState private constructor(
     }
 
     fun eraseThreshold() {
-        pairs.remove("th")
+        pairs.remove(THRESHOLD_KEY)
+    }
+
+    fun eraseRandomValue() {
+        pairs.remove(RANDOM_VAL_KEY)
     }
 
     fun encode(): String = pairs.entries.joinToString(";") { (key, value) -> "$key:$value" }
 
     companion object {
+        private const val RANDOM_VAL_KEY = "rv"
+        private const val THRESHOLD_KEY = "th"
+
         fun parse(raw: String?): OtelTraceState {
             val pairs = linkedMapOf<String, String>()
             if (raw.isNullOrBlank()) {

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/sampling/ProbabilitySampler.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/sampling/ProbabilitySampler.kt
@@ -13,8 +13,6 @@ import kotlin.math.max
 internal class ProbabilitySampler(ratio: Double) : Sampler {
 
     private companion object {
-        private const val MAX_THRESHOLD: Long = 1L shl 56
-
         @Volatile
         private var compatibilityWarningLogged = false
         const val COMPATIBILITY_WARNING = "WARNING: The ProbabilitySampler sampler is presuming TraceIDs are random " +
@@ -23,10 +21,10 @@ internal class ProbabilitySampler(ratio: Double) : Sampler {
     }
 
     init {
-        require(ratio in (1.0 / MAX_THRESHOLD)..1.0) { "ratio must be between 2^-56 and 1, got $ratio" }
+        validateRatio(ratio)
     }
 
-    private val rejectionThreshold: Long = MAX_THRESHOLD - (ratio * MAX_THRESHOLD).toLong()
+    private val rejectionThreshold: Long = thresholdFromRatio(ratio)
 
     override val description: String = "ProbabilitySampler{$ratio}"
 
@@ -40,7 +38,7 @@ internal class ProbabilitySampler(ratio: Double) : Sampler {
     ): SamplingResult {
         val parentSpanContext = context.extractSpan().spanContext
         val traceState = parentSpanContext.traceState
-        val otelTraceState = OtelTraceState.parse(traceState.get("ot"))
+        val otelTraceState = OtelTraceState.parse(traceState.get(KnownTraceState.OT))
 
         val explicitRandomness = otelTraceState.rv
         val randomness = if (explicitRandomness != null) {
@@ -73,19 +71,7 @@ internal class ProbabilitySampler(ratio: Double) : Sampler {
         return SamplingResultImpl(
             decision = decision,
             attributes = AttributesModel(),
-            traceState = traceState.put("ot", otelTraceState.encode()),
+            traceState = traceState.put(KnownTraceState.OT, otelTraceState.encode()),
         )
     }
-
-    private fun randomnessFromTraceId(traceId: String): Long =
-        (byteFromBase16(traceId[18], traceId[19]) shl 48) or
-            (byteFromBase16(traceId[20], traceId[21]) shl 40) or
-            (byteFromBase16(traceId[22], traceId[23]) shl 32) or
-            (byteFromBase16(traceId[24], traceId[25]) shl 24) or
-            (byteFromBase16(traceId[26], traceId[27]) shl 16) or
-            (byteFromBase16(traceId[28], traceId[29]) shl 8) or
-            byteFromBase16(traceId[30], traceId[31])
-
-    private fun byteFromBase16(first: Char, second: Char): Long =
-        ((first.digitToInt(16) shl 4) or second.digitToInt(16)).toLong()
 }

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/sampling/SamplingIntentImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/sampling/SamplingIntentImpl.kt
@@ -1,0 +1,11 @@
+package io.opentelemetry.kotlin.tracing.sampling
+
+import io.opentelemetry.kotlin.attributes.AttributeContainer
+import io.opentelemetry.kotlin.tracing.TraceState
+
+internal data class SamplingIntentImpl(
+    override val threshold: Long?,
+    override val adjustedCountReliable: Boolean,
+    override val attributesProvider: (() -> AttributeContainer)? = null,
+    override val traceStateProvider: ((TraceState, SamplingResult.Decision) -> TraceState)? = null
+) : SamplingIntent

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/sampling/SamplingRandomness.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/sampling/SamplingRandomness.kt
@@ -1,0 +1,40 @@
+package io.opentelemetry.kotlin.tracing.sampling
+
+/**
+ * Derives the 56-bit randomness value (R) from the least-significant 7 bytes of a hex-encoded
+ * trace ID, per W3C Trace Context Level 2.
+ *
+ * https://opentelemetry.io/docs/specs/otel/trace/tracestate-probability-sampling/#randomness-value-r
+ * https://www.w3.org/TR/trace-context-2/#randomness-of-trace-id
+ */
+internal fun randomnessFromTraceId(traceId: String): Long =
+    (byteFromBase16(traceId[18], traceId[19]) shl 48) or
+        (byteFromBase16(traceId[20], traceId[21]) shl 40) or
+        (byteFromBase16(traceId[22], traceId[23]) shl 32) or
+        (byteFromBase16(traceId[24], traceId[25]) shl 24) or
+        (byteFromBase16(traceId[26], traceId[27]) shl 16) or
+        (byteFromBase16(traceId[28], traceId[29]) shl 8) or
+        byteFromBase16(traceId[30], traceId[31])
+
+/** Parses a single byte (two hex characters) into its numeric value. */
+internal fun byteFromBase16(first: Char, second: Char): Long =
+    ((first.digitToInt(16) shl 4) or second.digitToInt(16)).toLong()
+
+private const val MAX_THRESHOLD: Long = 1L shl 56
+
+/**
+ * Validates that [ratio] is a usable sampling probability, i.e. in `[2^-56, 1]`.
+ *
+ * https://opentelemetry.io/docs/specs/otel/trace/tracestate-probability-sampling/#sampling-probability
+ */
+internal fun validateRatio(ratio: Double) {
+    require(ratio in (1.0 / MAX_THRESHOLD)..1.0) { "ratio must be between 2^-56 and 1, got $ratio" }
+}
+
+/**
+ * Converts a sampling probability [ratio] into its equivalent rejection threshold (T).
+ *
+ * https://opentelemetry.io/docs/specs/otel/trace/tracestate-probability-sampling/#rejection-threshold-t
+ * https://opentelemetry.io/docs/specs/otel/trace/tracestate-probability-sampling/#converting-floating-point-probability-to-threshold-value
+ */
+internal fun thresholdFromRatio(ratio: Double) = MAX_THRESHOLD - (ratio * MAX_THRESHOLD).toLong()

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/sampling/BuiltInCompositeSamplerTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/sampling/BuiltInCompositeSamplerTest.kt
@@ -1,0 +1,193 @@
+package io.opentelemetry.kotlin.tracing.sampling
+
+import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.attributes.AttributesModel
+import io.opentelemetry.kotlin.context.Context
+import io.opentelemetry.kotlin.factory.ContextFactoryImpl
+import io.opentelemetry.kotlin.factory.IdGeneratorImpl
+import io.opentelemetry.kotlin.factory.SpanContextFactoryImpl
+import io.opentelemetry.kotlin.factory.SpanFactoryImpl
+import io.opentelemetry.kotlin.factory.TraceFlagsFactoryImpl
+import io.opentelemetry.kotlin.factory.TraceStateFactoryImpl
+import io.opentelemetry.kotlin.init.SamplerConfigDsl
+import io.opentelemetry.kotlin.tracing.NonRecordingSpan
+import io.opentelemetry.kotlin.tracing.SpanKind
+import io.opentelemetry.kotlin.tracing.TraceFlagsImpl
+import kotlin.random.Random
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalApi::class)
+internal class BuiltInCompositeSamplerTest {
+
+    private val idGenerator = IdGeneratorImpl()
+    private val traceFlagsFactory = TraceFlagsFactoryImpl()
+    private val traceStateFactory = TraceStateFactoryImpl()
+    private val spanContextFactory = SpanContextFactoryImpl(idGenerator, traceFlagsFactory, traceStateFactory)
+    private val spanFactory = SpanFactoryImpl(spanContextFactory)
+    private val contextFactory = ContextFactoryImpl(spanFactory)
+
+    private val samplerDsl = object : SamplerConfigDsl {
+        override val spanFactory = this@BuiltInCompositeSamplerTest.spanFactory
+    }
+
+    private val traceId = "000000000000000000ffffffffffffff"
+
+    private fun contextWithParent(sampled: Boolean, isRemote: Boolean, otValue: String? = null): Context {
+        val traceFlags = if (sampled) {
+            traceFlagsFactory.default
+        } else {
+            TraceFlagsImpl(isSampled = false, isRandom = false)
+        }
+        val traceState = otValue?.let { traceStateFactory.default.put("ot", it) } ?: traceStateFactory.default
+        val parentSpanContext = spanContextFactory.create(
+            traceId = "12345678901234567890123456789012",
+            spanId = "1234567890123456",
+            traceFlags = traceFlags,
+            traceState = traceState,
+            isRemote = isRemote,
+        )
+        val parentSpan = NonRecordingSpan(spanContextFactory.invalid, parentSpanContext)
+        return contextFactory.root().storeSpan(parentSpan)
+    }
+
+    @Test
+    fun `always samples when delegate is composableAlwaysOn`() {
+        val result = samplerDsl.composite { composableAlwaysOn() }.shouldSample(
+            context = contextFactory.root(),
+            traceId = traceId,
+            name = "span",
+            spanKind = SpanKind.INTERNAL,
+            attributes = AttributesModel(),
+            links = emptyList(),
+        )
+        assertEquals(SamplingResult.Decision.RECORD_AND_SAMPLE, result.decision)
+        assertEquals("th:0", result.traceState.get("ot"))
+        assertTrue(result.attributes.attributes.isEmpty())
+    }
+
+    @Test
+    fun `never samples when delegate is composableAlwaysOff`() {
+        val result = samplerDsl.composite { composableAlwaysOff() }.shouldSample(
+            context = contextFactory.root(),
+            traceId = traceId,
+            name = "span",
+            spanKind = SpanKind.INTERNAL,
+            attributes = AttributesModel(),
+            links = emptyList(),
+        )
+        assertEquals(SamplingResult.Decision.DROP, result.decision)
+        assertNull(result.traceState.get("ot"))
+        assertTrue(result.attributes.attributes.isEmpty())
+    }
+
+    @Test
+    fun `composableProbability with ratio 0 behaves like composableAlwaysOff`() {
+        val result = samplerDsl.composite { composableProbability(0.0) }.shouldSample(
+            context = contextFactory.root(),
+            traceId = traceId,
+            name = "span",
+            spanKind = SpanKind.INTERNAL,
+            attributes = AttributesModel(),
+            links = emptyList(),
+        )
+        assertEquals(SamplingResult.Decision.DROP, result.decision)
+    }
+
+    @Test
+    fun `always samples when delegate is composableProbability at ratio 1 without publishing threshold`() {
+        val result = samplerDsl.composite { composableProbability(1.0) }.shouldSample(
+            context = contextFactory.root(),
+            traceId = traceId,
+            name = "span",
+            spanKind = SpanKind.INTERNAL,
+            attributes = AttributesModel(),
+            links = emptyList(),
+        )
+        assertEquals(SamplingResult.Decision.RECORD_AND_SAMPLE, result.decision)
+        assertNull(result.traceState.get("ot"))
+    }
+
+    @Test
+    fun `decision matches injected randomness when delegate is composableProbability`() {
+        val seed = 42L
+        val ratio = 0.5
+        val expectedRandomValue = Random(seed).nextLong() and 0x00FFFFFFFFFFFFFFL
+        val expectedDecision = if (thresholdFromRatio(ratio) <= expectedRandomValue) {
+            SamplingResult.Decision.RECORD_AND_SAMPLE
+        } else {
+            SamplingResult.Decision.DROP
+        }
+
+        val sampler = CompositeSampler(samplerDsl.composableProbability(ratio), random = Random(seed))
+        val result = sampler.shouldSample(
+            context = contextFactory.root(),
+            traceId = traceId,
+            name = "span",
+            spanKind = SpanKind.INTERNAL,
+            attributes = AttributesModel(),
+            links = emptyList(),
+        )
+        assertEquals(expectedDecision, result.decision)
+    }
+
+    @Test
+    fun `delegates to root when delegate is composableParentThreshold and there is no valid parent`() {
+        val result = samplerDsl.composite { composableParentThreshold(root = composableAlwaysOn()) }.shouldSample(
+            context = contextFactory.root(),
+            traceId = traceId,
+            name = "span",
+            spanKind = SpanKind.INTERNAL,
+            attributes = AttributesModel(),
+            links = emptyList(),
+        )
+        assertEquals(SamplingResult.Decision.RECORD_AND_SAMPLE, result.decision)
+    }
+
+    @Test
+    fun `propagates parent threshold when delegate is composableParentThreshold`() {
+        val context = contextWithParent(sampled = true, isRemote = true, otValue = "th:8")
+        val result = samplerDsl.composite { composableParentThreshold(root = composableAlwaysOff()) }.shouldSample(
+            context = context,
+            traceId = traceId,
+            name = "span",
+            spanKind = SpanKind.INTERNAL,
+            attributes = AttributesModel(),
+            links = emptyList(),
+        )
+        assertEquals(SamplingResult.Decision.RECORD_AND_SAMPLE, result.decision)
+        assertEquals("th:8", result.traceState.get("ot"))
+    }
+
+    @Test
+    fun `does not publish threshold when parent sampled without a threshold via composableParentThreshold`() {
+        val context = contextWithParent(sampled = true, isRemote = true)
+        val result = samplerDsl.composite { composableParentThreshold(root = composableAlwaysOff()) }.shouldSample(
+            context = context,
+            traceId = traceId,
+            name = "span",
+            spanKind = SpanKind.INTERNAL,
+            attributes = AttributesModel(),
+            links = emptyList(),
+        )
+        assertEquals(SamplingResult.Decision.RECORD_AND_SAMPLE, result.decision)
+        assertNull(result.traceState.get("ot"))
+    }
+
+    @Test
+    fun `drops when parent not sampled without a threshold via composableParentThreshold`() {
+        val context = contextWithParent(sampled = false, isRemote = true)
+        val result = samplerDsl.composite { composableParentThreshold(root = composableAlwaysOn()) }.shouldSample(
+            context = context,
+            traceId = traceId,
+            name = "span",
+            spanKind = SpanKind.INTERNAL,
+            attributes = AttributesModel(),
+            links = emptyList(),
+        )
+        assertEquals(SamplingResult.Decision.DROP, result.decision)
+        assertNull(result.traceState.get("ot"))
+    }
+}

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/sampling/BuiltInCompositeSamplerTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/sampling/BuiltInCompositeSamplerTest.kt
@@ -97,7 +97,19 @@ internal class BuiltInCompositeSamplerTest {
     }
 
     @Test
-    fun `always samples when delegate is composableProbability at ratio 1 without publishing threshold`() {
+    fun `composableProbability reports adjustedCountReliable true per spec`() {
+        val intent = samplerDsl.composableProbability(0.5).getSamplingIntent(
+            context = contextFactory.root(),
+            name = "span",
+            spanKind = SpanKind.INTERNAL,
+            attributes = AttributesModel(),
+            links = emptyList(),
+        )
+        assertTrue(intent.adjustedCountReliable)
+    }
+
+    @Test
+    fun `always samples when delegate is composableProbability at ratio 1 and publishes threshold`() {
         val result = samplerDsl.composite { composableProbability(1.0) }.shouldSample(
             context = contextFactory.root(),
             traceId = traceId,
@@ -107,21 +119,75 @@ internal class BuiltInCompositeSamplerTest {
             links = emptyList(),
         )
         assertEquals(SamplingResult.Decision.RECORD_AND_SAMPLE, result.decision)
+        assertEquals("th:0", result.traceState.get("ot"))
+    }
+
+    @Test
+    fun `samples using trace id derived randomness when delegate is composableProbability`() {
+        val result = samplerDsl.composite { composableProbability(0.5) }.shouldSample(
+            context = contextFactory.root(),
+            traceId = "000000000000000000ffffffffffffff",
+            name = "span",
+            spanKind = SpanKind.INTERNAL,
+            attributes = AttributesModel(),
+            links = emptyList(),
+        )
+        assertEquals(SamplingResult.Decision.RECORD_AND_SAMPLE, result.decision)
+        assertEquals("th:8", result.traceState.get("ot"))
+    }
+
+    @Test
+    fun `drops using trace id derived randomness when delegate is composableProbability`() {
+        val result = samplerDsl.composite { composableProbability(0.5) }.shouldSample(
+            context = contextFactory.root(),
+            traceId = "ffffffffffffffffff00000000000000",
+            name = "span",
+            spanKind = SpanKind.INTERNAL,
+            attributes = AttributesModel(),
+            links = emptyList(),
+        )
+        assertEquals(SamplingResult.Decision.DROP, result.decision)
         assertNull(result.traceState.get("ot"))
     }
 
     @Test
-    fun `decision matches injected randomness when delegate is composableProbability`() {
+    fun `rewrites stale parent threshold when delegate is composableProbability`() {
+        val context = contextWithParent(sampled = true, isRemote = true, otValue = "th:123")
+        val result = samplerDsl.composite { composableProbability(0.5) }.shouldSample(
+            context = context,
+            traceId = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            name = "span",
+            spanKind = SpanKind.INTERNAL,
+            attributes = AttributesModel(),
+            links = emptyList(),
+        )
+        assertEquals("th:8", result.traceState.get("ot"))
+    }
+
+    @Test
+    fun `decision matches injected randomness when delegate reports adjustedCountReliable false`() {
         val seed = 42L
-        val ratio = 0.5
+        val threshold = thresholdFromRatio(0.5)
         val expectedRandomValue = Random(seed).nextLong() and 0x00FFFFFFFFFFFFFFL
-        val expectedDecision = if (thresholdFromRatio(ratio) <= expectedRandomValue) {
+        val expectedDecision = if (threshold <= expectedRandomValue) {
             SamplingResult.Decision.RECORD_AND_SAMPLE
         } else {
             SamplingResult.Decision.DROP
         }
 
-        val sampler = CompositeSampler(samplerDsl.composableProbability(ratio), random = Random(seed))
+        val unreliableDelegate = object : ComposableSampler {
+            override fun getSamplingIntent(
+                context: Context,
+                name: String,
+                spanKind: SpanKind,
+                attributes: io.opentelemetry.kotlin.attributes.AttributeContainer,
+                links: List<io.opentelemetry.kotlin.tracing.model.SpanLink>
+            ) = SamplingIntentImpl(threshold = threshold, adjustedCountReliable = false)
+
+            override val description = "Unreliable"
+        }
+
+        val sampler = CompositeSampler(unreliableDelegate, random = Random(seed))
         val result = sampler.shouldSample(
             context = contextFactory.root(),
             traceId = traceId,
@@ -131,6 +197,7 @@ internal class BuiltInCompositeSamplerTest {
             links = emptyList(),
         )
         assertEquals(expectedDecision, result.decision)
+        assertNull(result.traceState.get("ot"))
     }
 
     @Test

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/sampling/OtelTraceStateTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/sampling/OtelTraceStateTest.kt
@@ -4,6 +4,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 internal class OtelTraceStateTest {
     @Test
@@ -94,9 +95,11 @@ internal class OtelTraceStateTest {
     }
 
     @Test
-    fun erasesThreshold() {
+    fun erasesAttributes() {
         val ot = OtelTraceState.parse("rv:123456789abcde;th:123")
         ot.eraseThreshold()
         assertEquals("rv:123456789abcde", ot.encode())
+        ot.eraseRandomValue()
+        assertTrue(ot.encode().isEmpty())
     }
 }

--- a/sdk-api/api/jvm/sdk-api.api
+++ b/sdk-api/api/jvm/sdk-api.api
@@ -323,9 +323,21 @@ public abstract interface class io/opentelemetry/kotlin/tracing/model/SpanEvent 
 public abstract interface class io/opentelemetry/kotlin/tracing/model/SpanLink : io/opentelemetry/kotlin/attributes/AttributesMutator, io/opentelemetry/kotlin/tracing/data/SpanLinkData {
 }
 
+public abstract interface class io/opentelemetry/kotlin/tracing/sampling/ComposableSampler {
+	public abstract fun getDescription ()Ljava/lang/String;
+	public abstract fun getSamplingIntent (Lio/opentelemetry/kotlin/context/Context;Ljava/lang/String;Lio/opentelemetry/kotlin/tracing/SpanKind;Lio/opentelemetry/kotlin/attributes/AttributeContainer;Ljava/util/List;)Lio/opentelemetry/kotlin/tracing/sampling/SamplingIntent;
+}
+
 public abstract interface class io/opentelemetry/kotlin/tracing/sampling/Sampler {
 	public abstract fun getDescription ()Ljava/lang/String;
 	public abstract fun shouldSample (Lio/opentelemetry/kotlin/context/Context;Ljava/lang/String;Ljava/lang/String;Lio/opentelemetry/kotlin/tracing/SpanKind;Lio/opentelemetry/kotlin/attributes/AttributeContainer;Ljava/util/List;)Lio/opentelemetry/kotlin/tracing/sampling/SamplingResult;
+}
+
+public abstract interface class io/opentelemetry/kotlin/tracing/sampling/SamplingIntent {
+	public abstract fun getAdjustedCountReliable ()Z
+	public abstract fun getAttributesProvider ()Lkotlin/jvm/functions/Function0;
+	public abstract fun getThreshold ()Ljava/lang/Long;
+	public abstract fun getTraceStateProvider ()Lkotlin/jvm/functions/Function2;
 }
 
 public abstract interface class io/opentelemetry/kotlin/tracing/sampling/SamplingResult {

--- a/sdk-api/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/sampling/CompositeSampler.kt
+++ b/sdk-api/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/sampling/CompositeSampler.kt
@@ -1,0 +1,49 @@
+package io.opentelemetry.kotlin.tracing.sampling
+
+import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.attributes.AttributeContainer
+import io.opentelemetry.kotlin.context.Context
+import io.opentelemetry.kotlin.tracing.SpanKind
+import io.opentelemetry.kotlin.tracing.TraceState
+import io.opentelemetry.kotlin.tracing.model.SpanLink
+
+/**
+ * ComposableSampler is a specialized interface that is used by the CompositeSampler.
+ * It introduces a composable approach to sampling by defining a new method called GetSamplingIntent,
+ * which allows multiple samplers to work together in making a sampling decision.
+ */
+@ExperimentalApi
+public interface ComposableSampler {
+
+    /**
+     * Returns a [SamplingIntent] structure that indicates the sampler’s preference for sampling a Span,
+     * without actually making the final decision.
+     */
+    public fun getSamplingIntent(
+        context: Context,
+        name: String,
+        spanKind: SpanKind,
+        attributes: AttributeContainer,
+        links: List<SpanLink>,
+    ): SamplingIntent
+
+    /**
+     * Returns the sampler name or short description with the configuration. This may be displayed on debug pages or in the logs.
+     */
+    public val description: String
+}
+
+@ExperimentalApi
+public interface SamplingIntent {
+    /** Rejection threshold in [0, 2^56). `null` means DROP. Lower ⇒ more likely to sample. */
+    public val threshold: Long?
+
+    /** Whether the threshold is reliable for span-to-metrics estimation. */
+    public val adjustedCountReliable: Boolean
+
+    /** Optional provider of attributes added when the span is sampled. */
+    public val attributesProvider: (() -> AttributeContainer)?
+
+    /** Optional provider of a modified TraceState, given the parent state + final decision. */
+    public val traceStateProvider: ((TraceState, SamplingResult.Decision) -> TraceState)?
+}


### PR DESCRIPTION
## Goal

Implements the `CompositeSampler` and `ComposableSampler` abstractions from the OTel spec (https://opentelemetry.io/docs/specs/otel/trace/sdk/#compositesampler), along with the built-in composable samplers: ComposableAlwaysOn, ComposableAlwaysOff, ComposableProbability, and ComposableParentThreshold.

Part of #659

Split from #696 

## Changes

### `sdk-api` / `implementation` (common, all targets)
- New ComposableSampler interface: a sampler that returns a SamplingIntent instead of a final decision
- New SamplingIntent interface: carries threshold, adjusted-count reliability, optional attributes, and optional TraceState updater
- `composite {}` DSL entry point that wraps a ComposableSampler into a regular Sampler (see comments, the other option was `composite(...)`
- Built-in composable samplers: `composableAlwaysOn`, `composableAlwaysOff`, `composableProbability`, `composableParentThreshold`



### Out of scope (follow-up)

- [ ] `ComposableRuleBased` and `ComposableAnnotating` are not included to keep this PR reviewable. They can be added as a follow-up.

- [x] `compat` and `examples` added as follow up PR #709 

## Testing


- Unit tests covering all new code
