### PR TITLE
Allow configuring SDK error handler

### DIFF
--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/OpenTelemetryCompatEntrypoint.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/OpenTelemetryCompatEntrypoint.kt
@@ -1,8 +1,6 @@
 package io.opentelemetry.kotlin
 
 import io.opentelemetry.kotlin.clock.ClockAdapter
-import io.opentelemetry.kotlin.error.NoopSdkErrorHandler
-import io.opentelemetry.kotlin.error.SdkErrorHandler
 import io.opentelemetry.kotlin.factory.CompatBaggageFactory
 import io.opentelemetry.kotlin.factory.CompatContextFactory
 import io.opentelemetry.kotlin.factory.CompatResourceFactory
@@ -33,8 +31,7 @@ public fun createCompatOpenTelemetry(
     val contextFactory = CompatContextFactory()
     val span = CompatSpanFactory(spanContext)
 
-    val sdkErrorHandler: SdkErrorHandler = NoopSdkErrorHandler
-    val cfg = CompatOpenTelemetryConfig(clock, sdkErrorHandler).apply(config)
+    val cfg = CompatOpenTelemetryConfig(clock).apply(config)
     val resolvedIdGenerator = cfg.resolveIdGenerator()
     val base = cfg.buildGlobalResource()
     return CompatOpenTelemetryImpl(

--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/init/CompatOpenTelemetryConfig.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/init/CompatOpenTelemetryConfig.kt
@@ -6,6 +6,7 @@ import io.opentelemetry.kotlin.aliases.OtelJavaResource
 import io.opentelemetry.kotlin.attributes.AttributesMutator
 import io.opentelemetry.kotlin.attributes.CompatAttributesModel
 import io.opentelemetry.kotlin.attributes.setAttributes
+import io.opentelemetry.kotlin.error.NoopSdkErrorHandler
 import io.opentelemetry.kotlin.error.SdkErrorHandler
 import io.opentelemetry.kotlin.factory.CompatIdGenerator
 import io.opentelemetry.kotlin.factory.IdGenerator
@@ -14,12 +15,15 @@ import io.opentelemetry.kotlin.propagation.TextMapPropagator
 import io.opentelemetry.kotlin.resource.Resource
 import io.opentelemetry.kotlin.resource.ResourceAdapter
 import io.opentelemetry.kotlin.semconv.ServiceAttributes
+import kotlin.concurrent.Volatile
 
 @ExperimentalApi
 internal class CompatOpenTelemetryConfig(
     clock: Clock,
-    sdkErrorHandler: SdkErrorHandler,
 ) : OpenTelemetryConfigDsl {
+
+    @Volatile private var configuredErrorHandler: SdkErrorHandler = NoopSdkErrorHandler
+    private val sdkErrorHandler = SdkErrorHandler { configuredErrorHandler.onError(it) }
 
     internal val tracerProviderConfig = CompatTracerProviderConfig(clock, sdkErrorHandler)
     internal val loggerProviderConfig = CompatLoggerProviderConfig(clock, sdkErrorHandler)
@@ -78,6 +82,10 @@ internal class CompatOpenTelemetryConfig(
 
     override fun idGenerator(action: () -> IdGenerator) {
         customIdGenerator = action
+    }
+
+    override fun errorHandler(handler: SdkErrorHandler) {
+        configuredErrorHandler = handler
     }
 
     internal fun resolveIdGenerator(): IdGenerator = customIdGenerator?.invoke() ?: CompatIdGenerator()

--- a/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/init/CompatErrorHandlerConfigTest.kt
+++ b/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/init/CompatErrorHandlerConfigTest.kt
@@ -1,0 +1,69 @@
+package io.opentelemetry.kotlin.init
+
+import io.opentelemetry.kotlin.clock.FakeClock
+import io.opentelemetry.kotlin.error.FakeSdkErrorHandler
+import io.opentelemetry.kotlin.error.SdkError
+import io.opentelemetry.kotlin.error.SdkErrorHandler
+import io.opentelemetry.kotlin.error.SdkErrorSeverity
+import io.opentelemetry.kotlin.tracing.export.FakeSpanProcessor
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+internal class CompatErrorHandlerConfigTest {
+
+    private val clock = FakeClock()
+
+    @Test
+    fun `configured error handler receives reports`() {
+        val handler = FakeSdkErrorHandler()
+        val captured = captureExportErrorHandler {
+            errorHandler(handler)
+        }
+        captured.onError(sdkError())
+        assertEquals(1, handler.apiMisuses.size)
+    }
+
+    @Test
+    fun `error handler configured after the export block still receives reports`() {
+        val handler = FakeSdkErrorHandler()
+        val captured = captureExportErrorHandler(configureHandlerFirst = false) {
+            errorHandler(handler)
+        }
+        captured.onError(sdkError())
+        assertEquals(1, handler.apiMisuses.size)
+    }
+
+    @Test
+    fun `reports are discarded when no error handler is configured`() {
+        val captured = captureExportErrorHandler { }
+        captured.onError(sdkError())
+    }
+
+    /**
+     * Builds a compat config, capturing the [SdkErrorHandler] handed to the `export` block. When
+     * [configureHandlerFirst] is false the handler is configured after that block has already run.
+     */
+    private fun captureExportErrorHandler(
+        configureHandlerFirst: Boolean = true,
+        configure: CompatOpenTelemetryConfig.() -> Unit,
+    ): SdkErrorHandler {
+        var captured: SdkErrorHandler? = null
+        val cfg = CompatOpenTelemetryConfig(clock)
+        if (configureHandlerFirst) {
+            cfg.configure()
+        }
+        cfg.tracerProvider {
+            export {
+                captured = sdkErrorHandler
+                FakeSpanProcessor()
+            }
+        }
+        if (!configureHandlerFirst) {
+            cfg.configure()
+        }
+        return assertNotNull(captured)
+    }
+
+    private fun sdkError() = SdkError.ApiMisuse("TestApi", "boom", SdkErrorSeverity.WARNING)
+}

--- a/exporters-persistence/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/PersistingLogRecordProcessor.kt
+++ b/exporters-persistence/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/PersistingLogRecordProcessor.kt
@@ -2,6 +2,7 @@ package io.opentelemetry.kotlin.logging.export
 
 import io.opentelemetry.kotlin.InstrumentationScopeInfo
 import io.opentelemetry.kotlin.context.Context
+import io.opentelemetry.kotlin.error.SdkError
 import io.opentelemetry.kotlin.error.SdkErrorHandler
 import io.opentelemetry.kotlin.error.SdkErrorSeverity
 import io.opentelemetry.kotlin.export.MutableShutdownState
@@ -100,10 +101,12 @@ internal class PersistingLogRecordProcessor(
             try {
                 composite.onEmit(log, context)
             } catch (e: Throwable) {
-                sdkErrorHandler.onUserCodeError(
-                    e,
-                    "LogRecordProcessor.onEmit failed",
-                    SdkErrorSeverity.WARNING
+                sdkErrorHandler.onError(
+                    SdkError.UserCodeError(
+                        e,
+                        "LogRecordProcessor.onEmit failed",
+                        SdkErrorSeverity.WARNING
+                    )
                 )
             }
         }

--- a/exporters-persistence/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/PersistingSpanProcessor.kt
+++ b/exporters-persistence/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/PersistingSpanProcessor.kt
@@ -1,6 +1,7 @@
 package io.opentelemetry.kotlin.tracing.export
 
 import io.opentelemetry.kotlin.context.Context
+import io.opentelemetry.kotlin.error.SdkError
 import io.opentelemetry.kotlin.error.SdkErrorHandler
 import io.opentelemetry.kotlin.error.SdkErrorSeverity
 import io.opentelemetry.kotlin.export.MutableShutdownState
@@ -98,10 +99,12 @@ internal class PersistingSpanProcessor(
         try {
             composite.onStart(span, parentContext)
         } catch (e: Throwable) {
-            sdkErrorHandler.onUserCodeError(
-                e,
-                "SpanProcessor.onStart failed",
-                SdkErrorSeverity.WARNING
+            sdkErrorHandler.onError(
+                SdkError.UserCodeError(
+                    e,
+                    "SpanProcessor.onStart failed",
+                    SdkErrorSeverity.WARNING
+                )
             )
         }
     }
@@ -110,10 +113,12 @@ internal class PersistingSpanProcessor(
         try {
             composite.onEnding(span)
         } catch (e: Throwable) {
-            sdkErrorHandler.onUserCodeError(
-                e,
-                "SpanProcessor.onEnding failed",
-                SdkErrorSeverity.WARNING
+            sdkErrorHandler.onError(
+                SdkError.UserCodeError(
+                    e,
+                    "SpanProcessor.onEnding failed",
+                    SdkErrorSeverity.WARNING
+                )
             )
         }
     }
@@ -122,10 +127,12 @@ internal class PersistingSpanProcessor(
         try {
             composite.onEnd(span)
         } catch (e: Throwable) {
-            sdkErrorHandler.onUserCodeError(
-                e,
-                "SpanProcessor.onEnd failed",
-                SdkErrorSeverity.WARNING
+            sdkErrorHandler.onError(
+                SdkError.UserCodeError(
+                    e,
+                    "SpanProcessor.onEnd failed",
+                    SdkErrorSeverity.WARNING
+                )
             )
         }
     }

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/OpenTelemetryImplEntrypoint.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/OpenTelemetryImplEntrypoint.kt
@@ -1,7 +1,5 @@
 package io.opentelemetry.kotlin
 
-import io.opentelemetry.kotlin.error.NoopSdkErrorHandler
-import io.opentelemetry.kotlin.error.SdkErrorHandler
 import io.opentelemetry.kotlin.factory.BaggageFactoryImpl
 import io.opentelemetry.kotlin.factory.ContextFactoryImpl
 import io.opentelemetry.kotlin.factory.ResourceFactoryImpl
@@ -31,8 +29,7 @@ public fun createOpenTelemetry(
      */
     config: OpenTelemetryConfigDsl.() -> Unit = {}
 ): OpenTelemetry {
-    val sdkErrorHandler: SdkErrorHandler = NoopSdkErrorHandler
-    val cfg = OpenTelemetryConfigImpl(clock, sdkErrorHandler).apply(config)
+    val cfg = OpenTelemetryConfigImpl(clock).apply(config)
     val idGenerator = cfg.resolveIdGenerator()
 
     val resourceFactory = ResourceFactoryImpl()

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/config/envar/OpenTelemetryEnvVarConfigProcessorImplEntrypoint.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/config/envar/OpenTelemetryEnvVarConfigProcessorImplEntrypoint.kt
@@ -3,7 +3,6 @@ package io.opentelemetry.kotlin.config.envar
 import io.opentelemetry.kotlin.Clock
 import io.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.kotlin.config.envar.logging.LogLimitEnvVarConfigProcessorImpl
-import io.opentelemetry.kotlin.error.NoopSdkErrorHandler
 import io.opentelemetry.kotlin.init.OpenTelemetryConfigDsl
 import io.opentelemetry.kotlin.init.OpenTelemetryConfigImpl
 
@@ -27,7 +26,7 @@ internal fun createOpenTelemetryEnvVarConfigProcessorImpl(
     clock: Clock,
     config: OpenTelemetryConfigDsl.() -> Unit
 ): OpenTelemetryEnvVarConfigProcessor {
-    val cfg = OpenTelemetryConfigImpl(clock, NoopSdkErrorHandler).apply(config)
+    val cfg = OpenTelemetryConfigImpl(clock).apply(config)
     val logLimitProcessor = LogLimitEnvVarConfigProcessorImpl(
         envVars = EnvVarConstants.LogLimits.envVars
     )

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/OpenTelemetryConfigImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/OpenTelemetryConfigImpl.kt
@@ -1,16 +1,25 @@
 package io.opentelemetry.kotlin.init
 
 import io.opentelemetry.kotlin.Clock
+import io.opentelemetry.kotlin.error.NoopSdkErrorHandler
 import io.opentelemetry.kotlin.error.SdkErrorHandler
 import io.opentelemetry.kotlin.factory.IdGenerator
 import io.opentelemetry.kotlin.factory.IdGeneratorImpl
 import io.opentelemetry.kotlin.propagation.TextMapPropagator
+import kotlin.concurrent.Volatile
 
 internal class OpenTelemetryConfigImpl(
     clock: Clock,
-    sdkErrorHandler: SdkErrorHandler,
     private val globalResourceConfig: ResourceConfigImpl = ResourceConfigImpl(),
 ) : OpenTelemetryConfigDsl, ResourceConfigDsl by globalResourceConfig {
+
+    @Volatile private var configuredErrorHandler: SdkErrorHandler = NoopSdkErrorHandler
+
+    /**
+     * The handler is configured after the sub-configs below have been created, so they receive a
+     * forwarder that resolves the configured handler on each report instead.
+     */
+    private val sdkErrorHandler = SdkErrorHandler { configuredErrorHandler.onError(it) }
 
     internal val tracingConfig: TracerProviderConfigImpl = TracerProviderConfigImpl(clock, sdkErrorHandler)
     internal val loggingConfig: LoggerProviderConfigImpl = LoggerProviderConfigImpl(clock, sdkErrorHandler)
@@ -47,6 +56,10 @@ internal class OpenTelemetryConfigImpl(
 
     override fun idGenerator(action: () -> IdGenerator) {
         customIdGenerator = action
+    }
+
+    override fun errorHandler(handler: SdkErrorHandler) {
+        configuredErrorHandler = handler
     }
 
     internal fun resolveIdGenerator(): IdGenerator = customIdGenerator?.invoke() ?: IdGeneratorImpl()

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/CreateOpenTelemetryErrorHandlerTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/CreateOpenTelemetryErrorHandlerTest.kt
@@ -1,0 +1,69 @@
+package io.opentelemetry.kotlin
+
+import io.opentelemetry.kotlin.error.FakeSdkErrorHandler
+import io.opentelemetry.kotlin.error.SdkErrorSeverity
+import io.opentelemetry.kotlin.export.OperationResultCode
+import io.opentelemetry.kotlin.export.TelemetryCloseable
+import io.opentelemetry.kotlin.tracing.export.FakeSpanProcessor
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalApi::class)
+internal class CreateOpenTelemetryErrorHandlerTest {
+
+    @Test
+    fun `handler configured via the DSL receives errors thrown by user code`() = runTest {
+        val handler = FakeSdkErrorHandler()
+        val api = createOpenTelemetry {
+            errorHandler(handler)
+            tracerProvider {
+                export { throwingProcessor() }
+            }
+        }
+
+        val result = tracerCloseable(api).shutdown()
+
+        assertEquals(OperationResultCode.Failure, result)
+        val error = handler.userCodeErrors.single()
+        assertEquals(SdkErrorSeverity.WARNING, error.severity)
+        assertEquals("boom", error.cause.message)
+    }
+
+    @Test
+    fun `handler is reached when configured after the signal it reports for`() = runTest {
+        val handler = FakeSdkErrorHandler()
+        val api = createOpenTelemetry {
+            tracerProvider {
+                export { throwingProcessor() }
+            }
+            errorHandler(handler)
+        }
+
+        tracerCloseable(api).shutdown()
+
+        assertTrue(handler.hasErrors())
+    }
+
+    @Test
+    fun `errors are discarded when no handler is configured`() = runTest {
+        val handler = FakeSdkErrorHandler()
+        val api = createOpenTelemetry {
+            tracerProvider {
+                export { throwingProcessor() }
+            }
+        }
+
+        // the throwing processor must not surface as an exception to the caller
+        assertEquals(OperationResultCode.Failure, tracerCloseable(api).shutdown())
+        assertFalse(handler.hasErrors())
+    }
+
+    private fun throwingProcessor() = FakeSpanProcessor(
+        shutdownCode = { throw IllegalStateException("boom") }
+    )
+
+    private fun tracerCloseable(api: OpenTelemetry) = api.tracerProvider as TelemetryCloseable
+}

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/config/envar/OpenTelemetryEnvVarConfigProcessorImplTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/config/envar/OpenTelemetryEnvVarConfigProcessorImplTest.kt
@@ -1,7 +1,6 @@
 package io.opentelemetry.kotlin.config.envar
 
 import io.opentelemetry.kotlin.clock.FakeClock
-import io.opentelemetry.kotlin.error.NoopSdkErrorHandler
 import io.opentelemetry.kotlin.init.OpenTelemetryConfigImpl
 import io.opentelemetry.kotlin.logging.export.FakeLogRecordProcessor
 import kotlin.test.Test
@@ -13,7 +12,7 @@ internal class OpenTelemetryEnvVarConfigProcessorImplTest {
     fun `should successfully parse env var value`() {
         // given
         val clock = FakeClock()
-        val cfg = OpenTelemetryConfigImpl(clock, NoopSdkErrorHandler)
+        val cfg = OpenTelemetryConfigImpl(clock)
         cfg.loggerProvider {
             export { FakeLogRecordProcessor() }
         }

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/config/envar/logging/LogLimitEnvVarConfigProcessorImplTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/config/envar/logging/LogLimitEnvVarConfigProcessorImplTest.kt
@@ -2,7 +2,6 @@ package io.opentelemetry.kotlin.config.envar.logging
 
 import io.opentelemetry.kotlin.clock.FakeClock
 import io.opentelemetry.kotlin.config.envar.EnvVarConstants
-import io.opentelemetry.kotlin.error.NoopSdkErrorHandler
 import io.opentelemetry.kotlin.init.OpenTelemetryConfigImpl
 import io.opentelemetry.kotlin.logging.export.FakeLogRecordProcessor
 import kotlin.test.Test
@@ -17,7 +16,7 @@ internal class LogLimitEnvVarConfigProcessorImplTest {
             envVars = EnvVarConstants.LogLimits.envVars
         )
         val clock = FakeClock()
-        val otelConfig = OpenTelemetryConfigImpl(clock, NoopSdkErrorHandler)
+        val otelConfig = OpenTelemetryConfigImpl(clock)
         otelConfig.loggerProvider {
             export { FakeLogRecordProcessor() }
         }
@@ -40,7 +39,7 @@ internal class LogLimitEnvVarConfigProcessorImplTest {
             envVars = EnvVarConstants.LogLimits.envVars
         )
         val clock = FakeClock()
-        val otelConfig = OpenTelemetryConfigImpl(clock, NoopSdkErrorHandler)
+        val otelConfig = OpenTelemetryConfigImpl(clock)
         otelConfig.loggerProvider {
             export { FakeLogRecordProcessor() }
         }
@@ -61,7 +60,7 @@ internal class LogLimitEnvVarConfigProcessorImplTest {
             envVars = EnvVarConstants.LogLimits.envVars
         )
         val clock = FakeClock()
-        val otelConfig = OpenTelemetryConfigImpl(clock, NoopSdkErrorHandler)
+        val otelConfig = OpenTelemetryConfigImpl(clock)
         otelConfig.loggerProvider {
             export { FakeLogRecordProcessor() }
         }
@@ -80,7 +79,7 @@ internal class LogLimitEnvVarConfigProcessorImplTest {
         // given
         val processor = LogLimitEnvVarConfigProcessorImpl(envVars = emptyList())
         val clock = FakeClock()
-        val otelConfig = OpenTelemetryConfigImpl(clock, NoopSdkErrorHandler)
+        val otelConfig = OpenTelemetryConfigImpl(clock)
         otelConfig.loggerProvider {
             export { FakeLogRecordProcessor() }
         }

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/config/envar/model/EnvironmentConfigurationTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/config/envar/model/EnvironmentConfigurationTest.kt
@@ -1,7 +1,6 @@
 package io.opentelemetry.kotlin.config.envar.model
 
 import io.opentelemetry.kotlin.clock.FakeClock
-import io.opentelemetry.kotlin.error.NoopSdkErrorHandler
 import io.opentelemetry.kotlin.init.OpenTelemetryConfigImpl
 import io.opentelemetry.kotlin.logging.export.FakeLogRecordProcessor
 import kotlin.test.Test
@@ -12,7 +11,7 @@ internal class EnvironmentConfigurationTest {
     fun `should successfully create an environment configuration`() {
         // given
         val clock = FakeClock()
-        val otelConfig = OpenTelemetryConfigImpl(clock, NoopSdkErrorHandler)
+        val otelConfig = OpenTelemetryConfigImpl(clock)
         otelConfig.loggerProvider {
             export { FakeLogRecordProcessor() }
         }

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/init/OpenTelemetryConfigImplTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/init/OpenTelemetryConfigImplTest.kt
@@ -9,7 +9,10 @@ import io.opentelemetry.kotlin.context.DefaultImplicitContextStorage
 import io.opentelemetry.kotlin.context.FakeContext
 import io.opentelemetry.kotlin.context.FakeImplicitContextStorage
 import io.opentelemetry.kotlin.context.ImplicitContextStorageMode
-import io.opentelemetry.kotlin.error.NoopSdkErrorHandler
+import io.opentelemetry.kotlin.error.FakeSdkErrorHandler
+import io.opentelemetry.kotlin.error.SdkError
+import io.opentelemetry.kotlin.error.SdkErrorHandler
+import io.opentelemetry.kotlin.error.SdkErrorSeverity
 import io.opentelemetry.kotlin.factory.FakeIdGenerator
 import io.opentelemetry.kotlin.logging.export.FakeLogRecordProcessor
 import io.opentelemetry.kotlin.propagation.CompositeTextMapPropagator
@@ -29,7 +32,7 @@ internal class OpenTelemetryConfigImplTest {
 
     @Test
     fun testDefaultConfig() {
-        val cfg = OpenTelemetryConfigImpl(clock, NoopSdkErrorHandler)
+        val cfg = OpenTelemetryConfigImpl(clock)
         assertNull(cfg.generateTracingConfig().processor)
         assertNull(cfg.generateLoggingConfig().processor)
         assertEquals(ImplicitContextStorageMode.GLOBAL, cfg.contextConfig.storageMode)
@@ -38,7 +41,7 @@ internal class OpenTelemetryConfigImplTest {
 
     @Test
     fun testPropagatorOverride() {
-        val cfg = OpenTelemetryConfigImpl(clock, NoopSdkErrorHandler).apply {
+        val cfg = OpenTelemetryConfigImpl(clock).apply {
             propagator { w3cBaggage() }
         }
         assertSame(W3CBaggagePropagator, cfg.propagatorCfg.buildPropagator())
@@ -46,7 +49,7 @@ internal class OpenTelemetryConfigImplTest {
 
     @Test
     fun testCompositePropagatorOverride() {
-        val cfg = OpenTelemetryConfigImpl(clock, NoopSdkErrorHandler).apply {
+        val cfg = OpenTelemetryConfigImpl(clock).apply {
             propagator { composite(w3cBaggage()) }
         }
         val composite = cfg.propagatorCfg.buildPropagator()
@@ -56,7 +59,7 @@ internal class OpenTelemetryConfigImplTest {
 
     @Test
     fun testOverrideConfig() {
-        val cfg = OpenTelemetryConfigImpl(clock, NoopSdkErrorHandler)
+        val cfg = OpenTelemetryConfigImpl(clock)
         cfg.loggerProvider {
             export { FakeLogRecordProcessor() }
         }
@@ -72,14 +75,14 @@ internal class OpenTelemetryConfigImplTest {
 
     @Test
     fun testIdGeneratorDefault() {
-        val cfg = OpenTelemetryConfigImpl(clock, NoopSdkErrorHandler)
+        val cfg = OpenTelemetryConfigImpl(clock)
         assertNotNull(cfg.resolveIdGenerator())
     }
 
     @Test
     fun testIdGeneratorOverride() {
         val custom = FakeIdGenerator()
-        val cfg = OpenTelemetryConfigImpl(clock, NoopSdkErrorHandler).apply {
+        val cfg = OpenTelemetryConfigImpl(clock).apply {
             idGenerator { custom }
         }
         assertSame(custom, cfg.resolveIdGenerator())
@@ -87,7 +90,7 @@ internal class OpenTelemetryConfigImplTest {
 
     @Test
     fun testGlobalAttrLimits() {
-        val cfg = OpenTelemetryConfigImpl(clock, NoopSdkErrorHandler).apply {
+        val cfg = OpenTelemetryConfigImpl(clock).apply {
             attributeLimits {
                 attributeCountLimit = 64
             }
@@ -98,7 +101,7 @@ internal class OpenTelemetryConfigImplTest {
 
     @Test
     fun testLocalAttrLimits() {
-        val cfg = OpenTelemetryConfigImpl(clock, NoopSdkErrorHandler).apply {
+        val cfg = OpenTelemetryConfigImpl(clock).apply {
             attributeLimits {
                 attributeCountLimit = 64
             }
@@ -114,7 +117,7 @@ internal class OpenTelemetryConfigImplTest {
 
     @Test
     fun testLocalAttrLimits2() {
-        val cfg = OpenTelemetryConfigImpl(clock, NoopSdkErrorHandler).apply {
+        val cfg = OpenTelemetryConfigImpl(clock).apply {
             attributeLimits {
                 attributeCountLimit = 64
             }
@@ -133,7 +136,7 @@ internal class OpenTelemetryConfigImplTest {
 
     @Test
     fun testDefaultStorage() {
-        val cfg = OpenTelemetryConfigImpl(clock, NoopSdkErrorHandler)
+        val cfg = OpenTelemetryConfigImpl(clock)
         val rootContext = FakeContext()
         val storage = cfg.contextConfig.generateStorage { rootContext }
         assertTrue(storage is DefaultImplicitContextStorage)
@@ -141,7 +144,7 @@ internal class OpenTelemetryConfigImplTest {
 
     @Test
     fun testThreadLocalStorage() {
-        val cfg = OpenTelemetryConfigImpl(clock, NoopSdkErrorHandler).apply {
+        val cfg = OpenTelemetryConfigImpl(clock).apply {
             context {
                 storageMode = ImplicitContextStorageMode.THREAD_LOCAL
             }
@@ -156,7 +159,7 @@ internal class OpenTelemetryConfigImplTest {
     @Test
     fun testCustomStorage() {
         val custom = FakeImplicitContextStorage()
-        val cfg = OpenTelemetryConfigImpl(clock, NoopSdkErrorHandler).apply {
+        val cfg = OpenTelemetryConfigImpl(clock).apply {
             context {
                 storage { custom }
             }
@@ -167,7 +170,7 @@ internal class OpenTelemetryConfigImplTest {
     @Test
     fun testCustomStorageOverridesStorageMode() {
         val custom = FakeImplicitContextStorage()
-        val cfg = OpenTelemetryConfigImpl(clock, NoopSdkErrorHandler).apply {
+        val cfg = OpenTelemetryConfigImpl(clock).apply {
             context {
                 storageMode = ImplicitContextStorageMode.GLOBAL
                 storage { custom }
@@ -180,7 +183,7 @@ internal class OpenTelemetryConfigImplTest {
     fun testCustomStorageReceivesRootSupplier() {
         val root = FakeContext()
         var captured: (() -> Context)? = null
-        val cfg = OpenTelemetryConfigImpl(clock, NoopSdkErrorHandler).apply {
+        val cfg = OpenTelemetryConfigImpl(clock).apply {
             context {
                 storage { rootSupplier ->
                     captured = rootSupplier
@@ -194,8 +197,69 @@ internal class OpenTelemetryConfigImplTest {
     }
 
     @Test
+    fun testDefaultErrorHandlerDiscardsReports() {
+        val cfg = OpenTelemetryConfigImpl(clock)
+        // no handler configured, so reports are swallowed rather than thrown
+        cfg.generateTracingConfig().sdkErrorHandler.onError(sdkError())
+    }
+
+    @Test
+    fun testCustomErrorHandlerReceivesReports() {
+        val handler = FakeSdkErrorHandler()
+        val cfg = OpenTelemetryConfigImpl(clock).apply {
+            errorHandler(handler)
+        }
+        cfg.generateTracingConfig().sdkErrorHandler.onError(sdkError("trace"))
+        cfg.generateLoggingConfig().sdkErrorHandler.onError(sdkError("log"))
+        cfg.generateMetricsConfig().sdkErrorHandler.onError(sdkError("metric"))
+        assertEquals(listOf("trace", "log", "metric"), handler.errors.map { it.message })
+    }
+
+    @Test
+    fun testCustomErrorHandlerReceivesReportsWhenConfiguredLast() {
+        val handler = FakeSdkErrorHandler()
+        var captured: SdkErrorHandler? = null
+        OpenTelemetryConfigImpl(clock).apply {
+            tracerProvider {
+                export {
+                    captured = sdkErrorHandler
+                    FakeSpanProcessor()
+                }
+            }
+            errorHandler(handler)
+        }
+        // the processor above was built before the handler was configured
+        assertNotNull(captured).onError(sdkError())
+        assertEquals(1, handler.apiMisuses.size)
+    }
+
+    @Test
+    fun testLastConfiguredErrorHandlerWins() {
+        val first = FakeSdkErrorHandler()
+        val second = FakeSdkErrorHandler()
+        val cfg = OpenTelemetryConfigImpl(clock).apply {
+            errorHandler(first)
+            errorHandler(second)
+        }
+        cfg.generateTracingConfig().sdkErrorHandler.onError(sdkError())
+        assertTrue(first.errors.isEmpty())
+        assertEquals(1, second.errors.size)
+    }
+
+    @Test
+    fun testErrorHandlerAcceptsLambda() {
+        val received = mutableListOf<SdkError>()
+        val cfg = OpenTelemetryConfigImpl(clock).apply {
+            errorHandler { received.add(it) }
+        }
+        cfg.generateTracingConfig().sdkErrorHandler.onError(sdkError())
+        assertEquals(1, received.size)
+        assertIs<SdkError.ApiMisuse>(received.single())
+    }
+
+    @Test
     fun testDefaultAttrLimits() {
-        val cfg = OpenTelemetryConfigImpl(clock, NoopSdkErrorHandler)
+        val cfg = OpenTelemetryConfigImpl(clock)
         with(cfg.generateTracingConfig().spanLimits) {
             assertEquals(DEFAULT_ATTRIBUTE_LIMIT, attributeCountLimit)
             assertEquals(DEFAULT_ATTRIBUTE_VALUE_LENGTH_LIMIT, attributeValueLengthLimit)
@@ -205,4 +269,7 @@ internal class OpenTelemetryConfigImplTest {
             assertEquals(DEFAULT_ATTRIBUTE_VALUE_LENGTH_LIMIT, attributeValueLengthLimit)
         }
     }
+
+    private fun sdkError(message: String = "boom") =
+        SdkError.ApiMisuse("TestApi", message, SdkErrorSeverity.WARNING)
 }

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/init/ResourcePrecedenceOrderTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/init/ResourcePrecedenceOrderTest.kt
@@ -1,7 +1,6 @@
 package io.opentelemetry.kotlin.init
 
 import io.opentelemetry.kotlin.clock.FakeClock
-import io.opentelemetry.kotlin.error.NoopSdkErrorHandler
 import io.opentelemetry.kotlin.semconv.TelemetryAttributes
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -14,7 +13,7 @@ internal class ResourcePrecedenceOrderTest {
 
     @Test
     fun testSdkDefaults() {
-        val cfg = OpenTelemetryConfigImpl(clock, NoopSdkErrorHandler)
+        val cfg = OpenTelemetryConfigImpl(clock)
         val tracing = cfg.generateTracingConfig()
         val logging = cfg.generateLoggingConfig()
 
@@ -31,7 +30,7 @@ internal class ResourcePrecedenceOrderTest {
 
     @Test
     fun testGlobalOverrides() {
-        val cfg = OpenTelemetryConfigImpl(clock, NoopSdkErrorHandler)
+        val cfg = OpenTelemetryConfigImpl(clock)
         cfg.resource(mapOf(TelemetryAttributes.TELEMETRY_SDK_NAME to "custom-sdk"))
 
         assertEquals(
@@ -46,7 +45,7 @@ internal class ResourcePrecedenceOrderTest {
 
     @Test
     fun testSpecificOverrides() {
-        val cfg = OpenTelemetryConfigImpl(clock, NoopSdkErrorHandler)
+        val cfg = OpenTelemetryConfigImpl(clock)
         cfg.tracerProvider {
             resource(mapOf(TelemetryAttributes.TELEMETRY_SDK_NAME to "tracer-sdk"))
         }
@@ -59,7 +58,7 @@ internal class ResourcePrecedenceOrderTest {
 
     @Test
     fun testOverridePrecedence() {
-        val cfg = OpenTelemetryConfigImpl(clock, NoopSdkErrorHandler)
+        val cfg = OpenTelemetryConfigImpl(clock)
         cfg.resource(mapOf(testKey to "top"))
         cfg.tracerProvider {
             resource(mapOf(testKey to "provider"))
@@ -71,7 +70,7 @@ internal class ResourcePrecedenceOrderTest {
 
     @Test
     fun testOverridePrecedence2() {
-        val cfg = OpenTelemetryConfigImpl(clock, NoopSdkErrorHandler)
+        val cfg = OpenTelemetryConfigImpl(clock)
         cfg.resource(mapOf(testKey to "top"))
         cfg.tracerProvider {
             resource(mapOf(testKey to "tracer-only"))

--- a/sdk-api/api/jvm/sdk-api.api
+++ b/sdk-api/api/jvm/sdk-api.api
@@ -34,15 +34,35 @@ public final class io/opentelemetry/kotlin/context/ImplicitContextStorageMode : 
 
 public final class io/opentelemetry/kotlin/error/NoopSdkErrorHandler : io/opentelemetry/kotlin/error/SdkErrorHandler {
 	public static final field INSTANCE Lio/opentelemetry/kotlin/error/NoopSdkErrorHandler;
-	public fun onApiMisuse (Ljava/lang/String;Ljava/lang/String;Lio/opentelemetry/kotlin/error/SdkErrorSeverity;)V
-	public fun onSdkCodeError (Ljava/lang/Throwable;Ljava/lang/String;Lio/opentelemetry/kotlin/error/SdkErrorSeverity;)V
-	public fun onUserCodeError (Ljava/lang/Throwable;Ljava/lang/String;Lio/opentelemetry/kotlin/error/SdkErrorSeverity;)V
+	public fun onError (Lio/opentelemetry/kotlin/error/SdkError;)V
+}
+
+public abstract class io/opentelemetry/kotlin/error/SdkError {
+	public synthetic fun <init> (Ljava/lang/String;Lio/opentelemetry/kotlin/error/SdkErrorSeverity;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getMessage ()Ljava/lang/String;
+	public final fun getSeverity ()Lio/opentelemetry/kotlin/error/SdkErrorSeverity;
+}
+
+public final class io/opentelemetry/kotlin/error/SdkError$ApiMisuse : io/opentelemetry/kotlin/error/SdkError {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lio/opentelemetry/kotlin/error/SdkErrorSeverity;)V
+	public final fun getApi ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/opentelemetry/kotlin/error/SdkError$SdkCodeError : io/opentelemetry/kotlin/error/SdkError {
+	public fun <init> (Ljava/lang/Throwable;Ljava/lang/String;Lio/opentelemetry/kotlin/error/SdkErrorSeverity;)V
+	public final fun getCause ()Ljava/lang/Throwable;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/opentelemetry/kotlin/error/SdkError$UserCodeError : io/opentelemetry/kotlin/error/SdkError {
+	public fun <init> (Ljava/lang/Throwable;Ljava/lang/String;Lio/opentelemetry/kotlin/error/SdkErrorSeverity;)V
+	public final fun getCause ()Ljava/lang/Throwable;
+	public fun toString ()Ljava/lang/String;
 }
 
 public abstract interface class io/opentelemetry/kotlin/error/SdkErrorHandler {
-	public abstract fun onApiMisuse (Ljava/lang/String;Ljava/lang/String;Lio/opentelemetry/kotlin/error/SdkErrorSeverity;)V
-	public abstract fun onSdkCodeError (Ljava/lang/Throwable;Ljava/lang/String;Lio/opentelemetry/kotlin/error/SdkErrorSeverity;)V
-	public abstract fun onUserCodeError (Ljava/lang/Throwable;Ljava/lang/String;Lio/opentelemetry/kotlin/error/SdkErrorSeverity;)V
+	public abstract fun onError (Lio/opentelemetry/kotlin/error/SdkError;)V
 }
 
 public final class io/opentelemetry/kotlin/error/SdkErrorSeverity : java/lang/Enum {
@@ -135,6 +155,7 @@ public abstract interface class io/opentelemetry/kotlin/init/MeterProviderConfig
 public abstract interface class io/opentelemetry/kotlin/init/OpenTelemetryConfigDsl : io/opentelemetry/kotlin/init/ResourceConfigDsl {
 	public abstract fun attributeLimits (Lkotlin/jvm/functions/Function1;)V
 	public abstract fun context (Lkotlin/jvm/functions/Function1;)V
+	public abstract fun errorHandler (Lio/opentelemetry/kotlin/error/SdkErrorHandler;)V
 	public abstract fun idGenerator (Lkotlin/jvm/functions/Function0;)V
 	public abstract fun loggerProvider (Lkotlin/jvm/functions/Function1;)V
 	public abstract fun meterProvider (Lkotlin/jvm/functions/Function1;)V

--- a/sdk-api/src/commonMain/kotlin/io/opentelemetry/kotlin/error/NoopSdkErrorHandler.kt
+++ b/sdk-api/src/commonMain/kotlin/io/opentelemetry/kotlin/error/NoopSdkErrorHandler.kt
@@ -1,25 +1,11 @@
 package io.opentelemetry.kotlin.error
 
+/**
+ * An [SdkErrorHandler] that silently discards everything reported to it. This is the default
+ * behavior when no handler is configured.
+ */
 public object NoopSdkErrorHandler : SdkErrorHandler {
 
-    override fun onApiMisuse(
-        api: String,
-        details: String,
-        severity: SdkErrorSeverity
-    ) {
-    }
-
-    override fun onUserCodeError(
-        exc: Throwable,
-        details: String,
-        severity: SdkErrorSeverity
-    ) {
-    }
-
-    override fun onSdkCodeError(
-        exc: Throwable,
-        details: String,
-        severity: SdkErrorSeverity
-    ) {
+    override fun onError(error: SdkError) {
     }
 }

--- a/sdk-api/src/commonMain/kotlin/io/opentelemetry/kotlin/error/SdkError.kt
+++ b/sdk-api/src/commonMain/kotlin/io/opentelemetry/kotlin/error/SdkError.kt
@@ -1,0 +1,51 @@
+package io.opentelemetry.kotlin.error
+
+/**
+ * An error or misuse detected by the SDK, as reported to an [SdkErrorHandler].
+ */
+public sealed class SdkError(
+
+    /**
+     * Human-readable description of what went wrong.
+     */
+    public val message: String,
+
+    /**
+     * How serious the problem is.
+     */
+    public val severity: SdkErrorSeverity,
+) {
+
+    /**
+     * The API was misused (e.g. passing an empty string to something that requires non-empty).
+     */
+    public class ApiMisuse(
+        public val api: String,
+        message: String,
+        severity: SdkErrorSeverity,
+    ) : SdkError(message, severity) {
+        override fun toString(): String = "[$severity] $api misused: $message"
+    }
+
+    /**
+     * User-supplied code, such as an exporter or processor, threw.
+     */
+    public class UserCodeError(
+        public val cause: Throwable,
+        message: String,
+        severity: SdkErrorSeverity,
+    ) : SdkError(message, severity) {
+        override fun toString(): String = "[$severity] user code failed: $message ($cause)"
+    }
+
+    /**
+     * SDK code threw.
+     */
+    public class SdkCodeError(
+        public val cause: Throwable,
+        message: String,
+        severity: SdkErrorSeverity,
+    ) : SdkError(message, severity) {
+        override fun toString(): String = "[$severity] SDK code failed: $message ($cause)"
+    }
+}

--- a/sdk-api/src/commonMain/kotlin/io/opentelemetry/kotlin/error/SdkErrorHandler.kt
+++ b/sdk-api/src/commonMain/kotlin/io/opentelemetry/kotlin/error/SdkErrorHandler.kt
@@ -2,21 +2,14 @@ package io.opentelemetry.kotlin.error
 
 /**
  * Handles errors and misuse of the SDK.
+ *
+ * Telemetry must never destabilize the host application, so implementations should not throw.
+ * https://opentelemetry.io/docs/specs/otel/error-handling/
  */
-public interface SdkErrorHandler {
+public fun interface SdkErrorHandler {
 
     /**
-     * Called when the API was misused (e.g. passing an empty string to something that requires non-empty)
+     * Called when the SDK detects an error or misuse.
      */
-    public fun onApiMisuse(api: String, details: String, severity: SdkErrorSeverity)
-
-    /**
-     * Called when user-supplied code throws
-     */
-    public fun onUserCodeError(exc: Throwable, details: String, severity: SdkErrorSeverity)
-
-    /**
-     * Called when SDK code throws
-     */
-    public fun onSdkCodeError(exc: Throwable, details: String, severity: SdkErrorSeverity)
+    public fun onError(error: SdkError)
 }

--- a/sdk-api/src/commonMain/kotlin/io/opentelemetry/kotlin/init/OpenTelemetryConfigDsl.kt
+++ b/sdk-api/src/commonMain/kotlin/io/opentelemetry/kotlin/init/OpenTelemetryConfigDsl.kt
@@ -1,6 +1,7 @@
 package io.opentelemetry.kotlin.init
 
 import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.error.SdkErrorHandler
 import io.opentelemetry.kotlin.factory.IdGenerator
 import io.opentelemetry.kotlin.propagation.TextMapPropagator
 
@@ -49,4 +50,11 @@ public interface OpenTelemetryConfigDsl : ResourceConfigDsl {
      * https://opentelemetry.io/docs/specs/otel/trace/sdk/#id-generators
      */
     public fun idGenerator(action: () -> IdGenerator)
+
+    /**
+     * Configures the [SdkErrorHandler] that is notified of errors and misuse detected by the SDK.
+     * If this is not set the SDK discards these reports silently.
+     * https://opentelemetry.io/docs/specs/otel/error-handling/#configuring-error-handlers
+     */
+    public fun errorHandler(handler: SdkErrorHandler)
 }

--- a/sdk-common/src/commonMain/kotlin/io/opentelemetry/kotlin/config/Validation.kt
+++ b/sdk-common/src/commonMain/kotlin/io/opentelemetry/kotlin/config/Validation.kt
@@ -1,5 +1,6 @@
 package io.opentelemetry.kotlin.config
 
+import io.opentelemetry.kotlin.error.SdkError
 import io.opentelemetry.kotlin.error.SdkErrorHandler
 import io.opentelemetry.kotlin.error.SdkErrorSeverity
 
@@ -16,10 +17,12 @@ public fun <T> validateOrUseDefault(
 ): T = if (validator(value)) {
     value
 } else {
-    sdkErrorHandler.onApiMisuse(
-        api,
-        "$value is not a valid value for $configParameterName. $default used instead.",
-        SdkErrorSeverity.WARNING,
+    sdkErrorHandler.onError(
+        SdkError.ApiMisuse(
+            api,
+            "$value is not a valid value for $configParameterName. $default used instead.",
+            SdkErrorSeverity.WARNING,
+        )
     )
     default
 }

--- a/sdk-common/src/commonMain/kotlin/io/opentelemetry/kotlin/export/BatchExportOperation.kt
+++ b/sdk-common/src/commonMain/kotlin/io/opentelemetry/kotlin/export/BatchExportOperation.kt
@@ -1,5 +1,6 @@
 package io.opentelemetry.kotlin.export
 
+import io.opentelemetry.kotlin.error.SdkError
 import io.opentelemetry.kotlin.error.SdkErrorHandler
 import io.opentelemetry.kotlin.error.SdkErrorSeverity
 
@@ -20,10 +21,12 @@ public fun <T> batchExportOperation(
             success = success && exportResult == OperationResultCode.Success
         } catch (exc: Throwable) {
             success = false
-            sdkErrorHandler.onUserCodeError(
-                exc,
-                "Export operation failed",
-                SdkErrorSeverity.WARNING
+            sdkErrorHandler.onError(
+                SdkError.UserCodeError(
+                    exc,
+                    "Export operation failed",
+                    SdkErrorSeverity.WARNING
+                )
             )
         }
     }
@@ -50,10 +53,12 @@ public suspend fun <T> batchExportOperationSuspend(
             success = success && exportResult == OperationResultCode.Success
         } catch (exc: Throwable) {
             success = false
-            sdkErrorHandler.onUserCodeError(
-                exc,
-                "Export operation failed",
-                SdkErrorSeverity.WARNING
+            sdkErrorHandler.onError(
+                SdkError.UserCodeError(
+                    exc,
+                    "Export operation failed",
+                    SdkErrorSeverity.WARNING
+                )
             )
         }
     }

--- a/test-fakes/src/commonMain/kotlin/io/opentelemetry/kotlin/error/FakeSdkErrorHandler.kt
+++ b/test-fakes/src/commonMain/kotlin/io/opentelemetry/kotlin/error/FakeSdkErrorHandler.kt
@@ -2,45 +2,20 @@ package io.opentelemetry.kotlin.error
 
 class FakeSdkErrorHandler : SdkErrorHandler {
 
-    class ApiMisuseDetails(
-        val api: String,
-        val details: String,
-        val severity: SdkErrorSeverity
-    )
+    val errors = mutableListOf<SdkError>()
 
-    class SdkErrorDetails(
-        val exc: Throwable,
-        val details: String,
-        val severity: SdkErrorSeverity
-    )
+    val apiMisuses: List<SdkError.ApiMisuse>
+        get() = errors.filterIsInstance<SdkError.ApiMisuse>()
 
-    val apiMisuses = mutableListOf<ApiMisuseDetails>()
-    val userCodeErrors = mutableListOf<SdkErrorDetails>()
-    val sdkCodeErrors = mutableListOf<SdkErrorDetails>()
+    val userCodeErrors: List<SdkError.UserCodeError>
+        get() = errors.filterIsInstance<SdkError.UserCodeError>()
 
-    fun hasErrors(): Boolean = apiMisuses.isNotEmpty() || userCodeErrors.isNotEmpty() || sdkCodeErrors.isNotEmpty()
+    val sdkCodeErrors: List<SdkError.SdkCodeError>
+        get() = errors.filterIsInstance<SdkError.SdkCodeError>()
 
-    override fun onApiMisuse(
-        api: String,
-        details: String,
-        severity: SdkErrorSeverity
-    ) {
-        apiMisuses.add(ApiMisuseDetails(api, details, severity))
-    }
+    fun hasErrors(): Boolean = errors.isNotEmpty()
 
-    override fun onUserCodeError(
-        exc: Throwable,
-        details: String,
-        severity: SdkErrorSeverity
-    ) {
-        userCodeErrors.add(SdkErrorDetails(exc, details, severity))
-    }
-
-    override fun onSdkCodeError(
-        exc: Throwable,
-        details: String,
-        severity: SdkErrorSeverity
-    ) {
-        sdkCodeErrors.add(SdkErrorDetails(exc, details, severity))
+    override fun onError(error: SdkError) {
+        errors.add(error)
     }
 }


### PR DESCRIPTION
## Goal

Allows library consumers to configure a custom SDK error handler. Closes #671.

## Testing

Added unit tests.
