### PR TITLE
Correctly link child span to parent span when Span is decorated

### DIFF
--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/logging/LoggerAdapter.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/logging/LoggerAdapter.kt
@@ -6,14 +6,12 @@ import io.opentelemetry.kotlin.attributes.AttributesMutator
 import io.opentelemetry.kotlin.attributes.CompatAttributesModel
 import io.opentelemetry.kotlin.attributes.setExceptionAttributes
 import io.opentelemetry.kotlin.context.Context
-import io.opentelemetry.kotlin.context.OtelJavaContextAdapter
-import io.opentelemetry.kotlin.context.OtelJavaContextKeyRepository
+import io.opentelemetry.kotlin.context.toOtelJavaContext
 import java.util.concurrent.TimeUnit
 
 @ExperimentalApi
 internal class LoggerAdapter(
     private val impl: OtelJavaLogger,
-    private val contextKeyRepository: OtelJavaContextKeyRepository = OtelJavaContextKeyRepository.INSTANCE,
 ) : Logger {
 
     override fun enabled(
@@ -25,7 +23,7 @@ internal class LoggerAdapter(
         val severity = (severityNumber ?: SeverityNumber.UNKNOWN).toOtelJavaSeverityNumber()
         return when (context) {
             null -> impl.isEnabled(severity)
-            else -> impl.isEnabled(severity, OtelJavaContextAdapter(context, contextKeyRepository))
+            else -> impl.isEnabled(severity, context.toOtelJavaContext())
         }
     }
 
@@ -79,7 +77,7 @@ internal class LoggerAdapter(
             builder.setObservedTimestamp(observedTimestamp, TimeUnit.NANOSECONDS)
         }
         if (context != null) {
-            builder.setContext(OtelJavaContextAdapter(context, contextKeyRepository))
+            builder.setContext(context.toOtelJavaContext())
         }
         if (severityNumber != null) {
             builder.setSeverity(severityNumber.toOtelJavaSeverityNumber())

--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/tracing/TracerAdapter.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/tracing/TracerAdapter.kt
@@ -4,7 +4,6 @@ import io.opentelemetry.kotlin.Clock
 import io.opentelemetry.kotlin.aliases.OtelJavaContext
 import io.opentelemetry.kotlin.aliases.OtelJavaTracer
 import io.opentelemetry.kotlin.context.Context
-import io.opentelemetry.kotlin.context.OtelJavaContextAdapter
 import io.opentelemetry.kotlin.context.toOtelJavaContext
 import io.opentelemetry.kotlin.init.CompatSpanLimitsConfig
 import io.opentelemetry.kotlin.tracing.ext.toOtelJavaSpanKind
@@ -41,7 +40,7 @@ internal class TracerAdapter(
         return SpanAdapter(
             impl = span,
             clock = clock,
-            parentCtx = parentContext?.let(::OtelJavaContextAdapter) ?: OtelJavaContext.current(),
+            parentCtx = parentContext?.toOtelJavaContext() ?: OtelJavaContext.current(),
             spanKind = spanKind,
             startTimestamp = start,
             spanLimitsConfig = spanLimitsConfig,

--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/tracing/ext/SpanContextStorageExt.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/tracing/ext/SpanContextStorageExt.kt
@@ -1,18 +1,19 @@
 
 package io.opentelemetry.kotlin.tracing.ext
 
-import io.opentelemetry.kotlin.aliases.OtelJavaContext
-import io.opentelemetry.kotlin.aliases.OtelJavaSpan
 import io.opentelemetry.kotlin.context.Context
 import io.opentelemetry.kotlin.context.ContextAdapter
+import io.opentelemetry.kotlin.context.toOtelJavaContext
 import io.opentelemetry.kotlin.tracing.Span
+import io.opentelemetry.kotlin.tracing.model.OtelJavaSpanAdapter
 import io.opentelemetry.kotlin.tracing.model.SpanAdapter
 
 /**
  * Stores a span in the supplied [Context], returning the new context.
  */
 public fun Span.storeInContext(context: Context): Context {
-    val otelJavaCtx = (context as? ContextAdapter)?.impl ?: OtelJavaContext.root()
-    val otelJavaSpan = this as? SpanAdapter ?: OtelJavaSpan.getInvalid()
-    return ContextAdapter(otelJavaCtx.with(otelJavaSpan))
+    // spans created by this implementation wrap an opentelemetry-java span, so store that
+    // directly. Any other implementation is wrapped so that its span context still survives.
+    val otelJavaSpan = (this as? SpanAdapter)?.impl ?: OtelJavaSpanAdapter(this)
+    return ContextAdapter(context.toOtelJavaContext().with(otelJavaSpan))
 }

--- a/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/logging/LogExportTest.kt
+++ b/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/logging/LogExportTest.kt
@@ -1,11 +1,13 @@
 package io.opentelemetry.kotlin.logging
 
+import io.opentelemetry.kotlin.assertions.assertSpanContextsMatch
 import io.opentelemetry.kotlin.context.Context
 import io.opentelemetry.kotlin.export.OperationResultCode
 import io.opentelemetry.kotlin.framework.OtelKotlinHarness
 import io.opentelemetry.kotlin.logging.export.LogRecordProcessor
 import io.opentelemetry.kotlin.logging.model.ReadWriteLogRecord
 import io.opentelemetry.kotlin.semconv.ExceptionAttributes
+import io.opentelemetry.kotlin.tracing.Span
 import kotlinx.coroutines.test.runTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -158,6 +160,23 @@ internal class LogExportTest {
             goldenFileName = "event.json",
         )
     }
+
+    @Test
+    fun `test log with decorated parent span in context`() = runTest {
+        // a decorating Span is not a SpanAdapter, so storing it must still correlate the log
+        val span = DecoratedSpan(harness.tracer.startSpan("span"))
+        val ctx = harness.kotlinApi.context.root().storeSpan(span)
+        harness.logger.emit("test", context = ctx)
+
+        harness.assertLogRecords(1, "log_decorated_span_context.json") { logs ->
+            assertSpanContextsMatch(span.spanContext, logs.single().spanContext)
+        }
+    }
+
+    /**
+     * Mimics a third party implementation that decorates the span returned by the SDK.
+     */
+    private class DecoratedSpan(impl: Span) : Span by impl
 
     /**
      * Custom processor that captures the context passed to onEmit

--- a/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/tracing/SpanExportTest.kt
+++ b/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/tracing/SpanExportTest.kt
@@ -134,6 +134,30 @@ internal class SpanExportTest {
     }
 
     @Test
+    fun `test span context parent for decorated span`() = runTest {
+        val root = harness.kotlinApi.context.root()
+
+        // a decorating Span is not a SpanAdapter, so storing it must still preserve its span context
+        val parent = DecoratedSpan(harness.tracer.startSpan("decorated_parent"))
+        val child = harness.tracer.startSpan(
+            name = "decorated_child",
+            parentContext = parent.storeInContext(root)
+        )
+
+        parent.end()
+        child.end()
+
+        harness.assertSpans(2, "span_decorated_parent.json") { spans ->
+            val exportedParent = spans.first { it.name == "decorated_parent" }
+            val exportedChild = spans.first { it.name == "decorated_child" }
+
+            assertFalse(exportedParent.parent.isValid)
+            assertSpanContextsMatch(exportedParent.spanContext, exportedChild.parent)
+            assertEquals(exportedParent.spanContext.traceId, exportedChild.spanContext.traceId)
+        }
+    }
+
+    @Test
     fun `test span trace flags`() = runTest {
         val span = harness.tracer.startSpan("my_span")
         val flags = span.spanContext.traceFlags
@@ -437,6 +461,11 @@ internal class SpanExportTest {
         setStringAttribute("key1", "value")
         setStringAttribute("key2", "value")
     }
+
+    /**
+     * Mimics a third party implementation that decorates the span returned by the SDK.
+     */
+    private class DecoratedSpan(impl: Span) : Span by impl
 
     /**
      * Custom processor that captures the context passed to onStart

--- a/compat/src/jvmTest/resources/log_decorated_span_context.json
+++ b/compat/src/jvmTest/resources/log_decorated_span_context.json
@@ -1,0 +1,32 @@
+[
+  {
+    "resource": {
+      "schemaUrl": "null",
+      "attributes": {
+        "service.name": "unknown_service:java",
+        "telemetry.sdk.language": "java",
+        "telemetry.sdk.name": "opentelemetry",
+        "telemetry.sdk.version": "UNKNOWN"
+      }
+    },
+    "instrumentationScopeInfo": {
+      "name": "test_logger",
+      "version": "null",
+      "schemaUrl": "null",
+      "attributes": {}
+    },
+    "timestampEpochNanos": 0,
+    "observedTimestampEpochNanos": 0,
+    "spanContext": {
+      "traceId": "1e6b4ea924f9baa8e77bcc2f537f0b02",
+      "spanId": "2cc2b48c50aefe53",
+      "traceFlags": "01",
+      "traceState": {}
+    },
+    "severity": "UNKNOWN",
+    "severityText": null,
+    "body": "test",
+    "attributes": {},
+    "totalAttributeCount": 0
+  }
+]

--- a/compat/src/jvmTest/resources/span_decorated_parent.json
+++ b/compat/src/jvmTest/resources/span_decorated_parent.json
@@ -1,0 +1,90 @@
+[
+  {
+    "name": "decorated_parent",
+    "kind": "INTERNAL",
+    "statusData": {
+      "name": "UNSET",
+      "description": ""
+    },
+    "spanContext": {
+      "traceId": "1e6b4ea924f9baa8e77bcc2f537f0b02",
+      "spanId": "2cc2b48c50aefe53",
+      "traceFlags": "01",
+      "traceState": {}
+    },
+    "parentSpanContext": {
+      "traceId": "00000000000000000000000000000000",
+      "spanId": "0000000000000000",
+      "traceFlags": "00",
+      "traceState": {}
+    },
+    "startTimestamp": 0,
+    "attributes": {},
+    "events": [],
+    "links": [],
+    "endTimestamp": 0,
+    "ended": true,
+    "totalRecordedEvents": 0,
+    "totalRecordedLinks": 0,
+    "totalAttributeCount": 0,
+    "resource": {
+      "schemaUrl": "null",
+      "attributes": {
+        "service.name": "unknown_service:java",
+        "telemetry.sdk.language": "java",
+        "telemetry.sdk.name": "opentelemetry",
+        "telemetry.sdk.version": "UNKNOWN"
+      }
+    },
+    "instrumentationScopeInfo": {
+      "name": "test_tracer",
+      "version": "0.1.0",
+      "schemaUrl": "null",
+      "attributes": {}
+    }
+  },
+  {
+    "name": "decorated_child",
+    "kind": "INTERNAL",
+    "statusData": {
+      "name": "UNSET",
+      "description": ""
+    },
+    "spanContext": {
+      "traceId": "1e6b4ea924f9baa8e77bcc2f537f0b02",
+      "spanId": "ac2c315346a8f5dc",
+      "traceFlags": "01",
+      "traceState": {}
+    },
+    "parentSpanContext": {
+      "traceId": "1e6b4ea924f9baa8e77bcc2f537f0b02",
+      "spanId": "2cc2b48c50aefe53",
+      "traceFlags": "01",
+      "traceState": {}
+    },
+    "startTimestamp": 0,
+    "attributes": {},
+    "events": [],
+    "links": [],
+    "endTimestamp": 0,
+    "ended": true,
+    "totalRecordedEvents": 0,
+    "totalRecordedLinks": 0,
+    "totalAttributeCount": 0,
+    "resource": {
+      "schemaUrl": "null",
+      "attributes": {
+        "service.name": "unknown_service:java",
+        "telemetry.sdk.language": "java",
+        "telemetry.sdk.name": "opentelemetry",
+        "telemetry.sdk.version": "UNKNOWN"
+      }
+    },
+    "instrumentationScopeInfo": {
+      "name": "test_tracer",
+      "version": "0.1.0",
+      "schemaUrl": "null",
+      "attributes": {}
+    }
+  }
+]


### PR DESCRIPTION
## Goal

If `Span` is decorated in the `compat` implementation the child span doesn't correctly reference its parent span when `Span.storeInContext` is called. This is because that function does an explicit cast to `SpanAdapter` rather than `toOtelJavaContext()`.

I've resolved this problem and tidied up a few additional cases when `OtelJavaContextAdapter` was being constructed directly, rather than using `toOtelJavaContext()`.