### PR TITLE
Populate event name in compat

### DIFF
--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/logging/OtelJavaLogRecordDataImpl.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/logging/OtelJavaLogRecordDataImpl.kt
@@ -24,6 +24,7 @@ internal class OtelJavaLogRecordDataImpl(
     private val severityTextImpl: String?,
     private val bodyImpl: OtelJavaBody,
     private val attributesImpl: OtelJavaAttributes,
+    private val eventNameImpl: String?,
 ) : OtelJavaLogRecordData {
 
     override fun getResource(): OtelJavaResource = resourceImpl
@@ -33,6 +34,7 @@ internal class OtelJavaLogRecordDataImpl(
     override fun getSpanContext(): OtelJavaSpanContext = spanContextImpl
     override fun getSeverity(): OtelJavaSeverity = severityImpl
     override fun getSeverityText(): String? = severityTextImpl
+    override fun getEventName(): String? = eventNameImpl
 
     @Deprecated("Deprecated in Java")
     override fun getBody(): OtelJavaBody = bodyImpl

--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/logging/export/ReadableLogRecordExt.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/logging/export/ReadableLogRecordExt.kt
@@ -24,6 +24,7 @@ internal fun ReadableLogRecord.toLogRecordData(): OtelJavaLogRecordData {
             ?: OtelJavaSeverity.UNDEFINED_SEVERITY_NUMBER,
         bodyImpl = body.toOtelJavaBody(),
         attributesImpl = attrsFromMap(attributes),
+        eventNameImpl = eventName,
         resourceImpl = resourceFromMap(resource),
         scopeImpl = instrumentationScopeInfo.toOtelJavaInstrumentationScopeInfo()
     )

--- a/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/logging/export/ReadableLogRecordExtTest.kt
+++ b/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/logging/export/ReadableLogRecordExtTest.kt
@@ -18,6 +18,14 @@ internal class ReadableLogRecordExtTest {
         assertEquals(record.severityText, observed.severityText)
         assertEquals(OtelJavaSeverity.WARN, observed.severity)
         assertEquals(record.body, observed.bodyValue?.asString())
+        assertNull(observed.eventName)
+    }
+
+    @Test
+    fun testLogRecordEventNameConversion() {
+        val record = FakeReadableLogRecord(eventName = "my_event_name")
+        val observed = record.toLogRecordData()
+        assertEquals("my_event_name", observed.eventName)
     }
 
     @Test
@@ -58,5 +66,6 @@ internal class ReadableLogRecordExtTest {
         assertEquals(OtelJavaSeverity.UNDEFINED_SEVERITY_NUMBER, observed.severity)
         assertNull(observed.severityText)
         assertNull(observed.bodyValue?.asString())
+        assertNull(observed.eventName)
     }
 }


### PR DESCRIPTION
## Goal

Populates the event name correctly in the compat layer. `OtelJavaLogRecordDataImpl` did not override `getEventName()` which returns null by default, meaning `eventName` did not propagate to the opentelemetry-java SDK.