### PR TITLE
build: prevent r8 warning

### DIFF
--- a/buildSrc/src/main/kotlin/io/opentelemetry/kotlin/KotlinAndroidTargetConfig.kt
+++ b/buildSrc/src/main/kotlin/io/opentelemetry/kotlin/KotlinAndroidTargetConfig.kt
@@ -14,6 +14,18 @@ fun Project.configureKotlinAndroidTarget(kotlinAndroidTarget: KotlinMultiplatfor
         // https://kotlinlang.org/docs/gradle-configure-project.html#apply-the-plugin
         aarMetadata.minAgpVersion = findVersion("android-minAgpVersion")
 
+        // Consumer keep rules are opt-in per module: any module that needs to ship R8 rules with
+        // its AAR just adds a consumer-rules.pro alongside its build.gradle.kts.
+        val consumerRules = project.file("consumer-rules.pro")
+        if (consumerRules.exists()) {
+            optimization {
+                consumerKeepRules.file(consumerRules)
+
+                // required, or the rules are not packaged into the AAR
+                consumerKeepRules.publish = true
+            }
+        }
+
         compilations.configureEach {
             compileTaskProvider.configure {
                 compilerOptions.configureCompiler()

--- a/compat/consumer-rules.pro
+++ b/compat/consumer-rules.pro
@@ -1,0 +1,2 @@
+# The OTel autoconfigure SPI is compileOnly in opentelemetry-java and is never present on Android.
+-dontwarn io.opentelemetry.sdk.autoconfigure.spi.**

--- a/java-typealiases/consumer-rules.pro
+++ b/java-typealiases/consumer-rules.pro
@@ -1,0 +1,2 @@
+# The OTel autoconfigure SPI is compileOnly in opentelemetry-java and is never present on Android.
+-dontwarn io.opentelemetry.sdk.autoconfigure.spi.**


### PR DESCRIPTION
## Goal

`opentelemetry-kotlin` 0.6.0 adds a new runtime dependency on `io.opentelemetry:opentelemetry-extension-trace-propagators`, which has classes that implement `io.opentelemetry.sdk.autoconfigure.spi.ConfigurablePropagatorProvider`.  This causes R8 warnings when compiling, such as [this one](https://github.com/embrace-io/embrace-android-sdk/actions/runs/30540000440/job/90865197591).

I've added a rule to the R8 consumer proguard files so that library users don't run into this.

Originally spotted here: https://github.com/embrace-io/embrace-android-sdk/pull/3702