### PR TITLE
Route SDK errors through sdkErrorHandler instead of platformLog (#711)

### DIFF
--- a/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/export/BatchTelemetryConfig.kt
+++ b/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/export/BatchTelemetryConfig.kt
@@ -9,7 +9,7 @@ internal class BatchTelemetryConfig(
     exportTimeoutMs: Long = BatchTelemetryDefaults.EXPORT_TIMEOUT_MS,
     maxExportBatchSize: Int = BatchTelemetryDefaults.MAX_EXPORT_BATCH_SIZE,
     forceFlushTimeoutMs: Long = BatchTelemetryDefaults.FORCE_FLUSH_TIMEOUT_MS,
-    sdkErrorHandler: SdkErrorHandler,
+    val sdkErrorHandler: SdkErrorHandler,
 ) {
     /**
      * Maximum number of telemetry items the queue can hold before items are dropped.

--- a/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/export/BatchTelemetryProcessor.kt
+++ b/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/export/BatchTelemetryProcessor.kt
@@ -19,7 +19,9 @@ internal class BatchTelemetryProcessor<T>(
 
     private val shutdownState: MutableShutdownState = MutableShutdownState()
     private val scope =
-        CoroutineScope(SupervisorJob() + dispatcher + telemetryExceptionHandler("Batch processor"))
+        CoroutineScope(
+            SupervisorJob() + dispatcher + telemetryExceptionHandler("Batch processor", config.sdkErrorHandler)
+        )
     private val mutex = Mutex()
     private val queue = mutableListOf<T>()
 

--- a/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/CoreLogRecordExporterApi.kt
+++ b/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/CoreLogRecordExporterApi.kt
@@ -2,10 +2,11 @@
 package io.opentelemetry.kotlin.logging.export
 
 import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.error.SdkError
+import io.opentelemetry.kotlin.error.SdkErrorSeverity
 import io.opentelemetry.kotlin.export.BatchTelemetryDefaults
 import io.opentelemetry.kotlin.export.telemetryExceptionHandler
 import io.opentelemetry.kotlin.init.LogExportConfigDsl
-import io.opentelemetry.kotlin.platformLog
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -17,7 +18,13 @@ import kotlinx.coroutines.SupervisorJob
 @ExperimentalApi
 public fun LogExportConfigDsl.compositeLogRecordProcessor(vararg processors: LogRecordProcessor): LogRecordProcessor {
     if (processors.isEmpty()) {
-        platformLog("At least one processor must be provided")
+        sdkErrorHandler.onError(
+            SdkError.ApiMisuse(
+                api = "LogExportConfigDsl.compositeLogRecordProcessor",
+                message = "At least one processor must be provided",
+                severity = SdkErrorSeverity.WARNING,
+            )
+        )
         return NoopLogRecordProcessor
     }
     return CompositeLogRecordProcessor(processors.toList(), sdkErrorHandler)
@@ -30,7 +37,7 @@ public fun LogExportConfigDsl.compositeLogRecordProcessor(vararg processors: Log
 public fun LogExportConfigDsl.simpleLogRecordProcessor(exporter: LogRecordExporter): LogRecordProcessor {
     val dispatcher: CoroutineDispatcher = Dispatchers.Default
     val scope = CoroutineScope(
-        SupervisorJob() + dispatcher + telemetryExceptionHandler("Simple log record processor")
+        SupervisorJob() + dispatcher + telemetryExceptionHandler("Simple log record processor", sdkErrorHandler)
     )
     return SimpleLogRecordProcessor(exporter, scope)
 }
@@ -41,7 +48,13 @@ public fun LogExportConfigDsl.simpleLogRecordProcessor(exporter: LogRecordExport
 @ExperimentalApi
 public fun LogExportConfigDsl.compositeLogRecordExporter(vararg exporters: LogRecordExporter): LogRecordExporter {
     if (exporters.isEmpty()) {
-        platformLog("At least one exporter must be provided")
+        sdkErrorHandler.onError(
+            SdkError.ApiMisuse(
+                api = "LogExportConfigDsl.compositeLogRecordExporter",
+                message = "At least one exporter must be provided",
+                severity = SdkErrorSeverity.WARNING,
+            )
+        )
         return NoopLogRecordExporter
     }
     return CompositeLogRecordExporter(exporters.toList(), sdkErrorHandler)

--- a/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/CoreSpanExporterApi.kt
+++ b/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/CoreSpanExporterApi.kt
@@ -1,10 +1,11 @@
 package io.opentelemetry.kotlin.tracing.export
 
 import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.error.SdkError
+import io.opentelemetry.kotlin.error.SdkErrorSeverity
 import io.opentelemetry.kotlin.export.BatchTelemetryDefaults
 import io.opentelemetry.kotlin.export.telemetryExceptionHandler
 import io.opentelemetry.kotlin.init.TraceExportConfigDsl
-import io.opentelemetry.kotlin.platformLog
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -16,7 +17,13 @@ import kotlinx.coroutines.SupervisorJob
 @ExperimentalApi
 public fun TraceExportConfigDsl.compositeSpanProcessor(vararg processors: SpanProcessor): SpanProcessor {
     if (processors.isEmpty()) {
-        platformLog("At least one processor must be provided")
+        sdkErrorHandler.onError(
+            SdkError.ApiMisuse(
+                api = "TraceExportConfigDsl.compositeSpanProcessor",
+                message = "At least one processor must be provided",
+                severity = SdkErrorSeverity.WARNING,
+            )
+        )
         return NoopSpanProcessor
     }
     return CompositeSpanProcessor(processors.toList(), sdkErrorHandler)
@@ -29,7 +36,7 @@ public fun TraceExportConfigDsl.compositeSpanProcessor(vararg processors: SpanPr
 public fun TraceExportConfigDsl.simpleSpanProcessor(exporter: SpanExporter): SpanProcessor {
     val dispatcher: CoroutineDispatcher = Dispatchers.Default
     val scope = CoroutineScope(
-        SupervisorJob() + dispatcher + telemetryExceptionHandler("Simple span processor")
+        SupervisorJob() + dispatcher + telemetryExceptionHandler("Simple span processor", sdkErrorHandler)
     )
     return SimpleSpanProcessor(exporter, scope)
 }
@@ -40,7 +47,13 @@ public fun TraceExportConfigDsl.simpleSpanProcessor(exporter: SpanExporter): Spa
 @ExperimentalApi
 public fun TraceExportConfigDsl.compositeSpanExporter(vararg exporters: SpanExporter): SpanExporter {
     if (exporters.isEmpty()) {
-        platformLog("At least one exporter must be provided")
+        sdkErrorHandler.onError(
+            SdkError.ApiMisuse(
+                api = "TraceExportConfigDsl.compositeSpanExporter",
+                message = "At least one exporter must be provided",
+                severity = SdkErrorSeverity.WARNING,
+            )
+        )
         return NoopSpanExporter
     }
     return CompositeSpanExporter(exporters.toList(), sdkErrorHandler)

--- a/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/export/CoreLogRecordExporterApiTest.kt
+++ b/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/export/CoreLogRecordExporterApiTest.kt
@@ -2,6 +2,7 @@ package io.opentelemetry.kotlin.logging.export
 
 import io.opentelemetry.kotlin.FakeInstrumentationScopeInfo
 import io.opentelemetry.kotlin.context.FakeContext
+import io.opentelemetry.kotlin.error.FakeSdkErrorHandler
 import io.opentelemetry.kotlin.export.FakeLogExportConfig
 import io.opentelemetry.kotlin.export.OperationResultCode
 import io.opentelemetry.kotlin.logging.model.FakeReadWriteLogRecord
@@ -38,5 +39,29 @@ internal class CoreLogRecordExporterApiTest {
             assertEquals(OperationResultCode.Success, shutdown())
         }
         assertSame(NoopLogRecordExporter, emptyExporter)
+    }
+
+    @Test
+    fun compositeLogRecordProcessorEmptyReportsApiMisuse() {
+        val handler = FakeSdkErrorHandler()
+        val config = FakeLogExportConfig(sdkErrorHandler = handler)
+        config.compositeLogRecordProcessor()
+        assertEquals(1, handler.apiMisuses.size)
+        assertEquals(
+            "LogExportConfigDsl.compositeLogRecordProcessor",
+            handler.apiMisuses.single().api,
+        )
+    }
+
+    @Test
+    fun compositeLogRecordExporterEmptyReportsApiMisuse() {
+        val handler = FakeSdkErrorHandler()
+        val config = FakeLogExportConfig(sdkErrorHandler = handler)
+        config.compositeLogRecordExporter()
+        assertEquals(1, handler.apiMisuses.size)
+        assertEquals(
+            "LogExportConfigDsl.compositeLogRecordExporter",
+            handler.apiMisuses.single().api,
+        )
     }
 }

--- a/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/export/CoreSpanExporterApiTest.kt
+++ b/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/export/CoreSpanExporterApiTest.kt
@@ -1,6 +1,7 @@
 package io.opentelemetry.kotlin.tracing.export
 
 import io.opentelemetry.kotlin.context.FakeContext
+import io.opentelemetry.kotlin.error.FakeSdkErrorHandler
 import io.opentelemetry.kotlin.export.FakeTraceExportConfig
 import io.opentelemetry.kotlin.export.OperationResultCode
 import io.opentelemetry.kotlin.tracing.FakeReadWriteSpan
@@ -36,5 +37,29 @@ internal class CoreSpanExporterApiTest {
             assertEquals(OperationResultCode.Success, shutdown())
         }
         assertSame(NoopSpanExporter, emptyExporter)
+    }
+
+    @Test
+    fun compositeSpanProcessorEmptyReportsApiMisuse() {
+        val handler = FakeSdkErrorHandler()
+        val config = FakeTraceExportConfig(sdkErrorHandler = handler)
+        config.compositeSpanProcessor()
+        assertEquals(1, handler.apiMisuses.size)
+        assertEquals(
+            "TraceExportConfigDsl.compositeSpanProcessor",
+            handler.apiMisuses.single().api,
+        )
+    }
+
+    @Test
+    fun compositeSpanExporterEmptyReportsApiMisuse() {
+        val handler = FakeSdkErrorHandler()
+        val config = FakeTraceExportConfig(sdkErrorHandler = handler)
+        config.compositeSpanExporter()
+        assertEquals(1, handler.apiMisuses.size)
+        assertEquals(
+            "TraceExportConfigDsl.compositeSpanExporter",
+            handler.apiMisuses.single().api,
+        )
     }
 }

--- a/exporters-otlp/src/commonMain/kotlin/io/opentelemetry/kotlin/export/OtlpClient.kt
+++ b/exporters-otlp/src/commonMain/kotlin/io/opentelemetry/kotlin/export/OtlpClient.kt
@@ -11,6 +11,9 @@ import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
 import io.ktor.http.contentType
 import io.ktor.utils.io.readRemaining
+import io.opentelemetry.kotlin.error.SdkError
+import io.opentelemetry.kotlin.error.SdkErrorHandler
+import io.opentelemetry.kotlin.error.SdkErrorSeverity
 import io.opentelemetry.kotlin.export.OtlpClient.Companion.MAX_ERROR_BODY_BYTES
 import io.opentelemetry.kotlin.export.OtlpResponse.ClientError
 import io.opentelemetry.kotlin.export.OtlpResponse.PartialSuccess
@@ -21,7 +24,6 @@ import io.opentelemetry.kotlin.export.OtlpResponse.Unknown
 import io.opentelemetry.kotlin.logging.export.deserializeLogRecordPartialSuccess
 import io.opentelemetry.kotlin.logging.export.toProtobufByteArray
 import io.opentelemetry.kotlin.logging.model.ReadableLogRecord
-import io.opentelemetry.kotlin.platformLog
 import io.opentelemetry.kotlin.tracing.data.SpanData
 import io.opentelemetry.kotlin.tracing.export.deserializeTraceRecordPartialSuccess
 import io.opentelemetry.kotlin.tracing.export.toProtobufByteArray
@@ -30,7 +32,8 @@ import kotlin.coroutines.cancellation.CancellationException
 
 internal class OtlpClient(
     private val baseUrl: String,
-    private val httpClient: HttpClient = defaultHttpClient
+    private val httpClient: HttpClient = defaultHttpClient,
+    private val sdkErrorHandler: SdkErrorHandler,
 ) {
 
     private val contentType = ContentType.parse("application/x-protobuf")
@@ -81,7 +84,13 @@ internal class OtlpClient(
         } catch (e: CancellationException) {
             throw e
         } catch (e: Throwable) {
-            platformLog("OTLP export failed: ${e.message}")
+            sdkErrorHandler.onError(
+                SdkError.UserCodeError(
+                    e,
+                    "OTLP export failed",
+                    SdkErrorSeverity.WARNING,
+                )
+            )
             Unknown
         }
     }

--- a/exporters-otlp/src/commonMain/kotlin/io/opentelemetry/kotlin/export/TelemetryExporter.kt
+++ b/exporters-otlp/src/commonMain/kotlin/io/opentelemetry/kotlin/export/TelemetryExporter.kt
@@ -1,5 +1,6 @@
 package io.opentelemetry.kotlin.export
 
+import io.opentelemetry.kotlin.error.SdkErrorHandler
 import io.opentelemetry.kotlin.export.OperationResultCode.Success
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -16,6 +17,7 @@ internal class TelemetryExporter<T>(
     private val initialDelayMs: Long,
     private val maxAttemptIntervalMs: Long,
     private val maxAttempts: Int,
+    private val sdkErrorHandler: SdkErrorHandler,
     coroutineContext: CoroutineContext = Dispatchers.Default,
     private val random: Random = Random.Default,
     private val exportAction: suspend (telemetry: List<T>) -> OtlpResponse,
@@ -23,7 +25,7 @@ internal class TelemetryExporter<T>(
 
     private val shutdownState: MutableShutdownState = MutableShutdownState()
     private val scope: CoroutineScope =
-        CoroutineScope(SupervisorJob() + coroutineContext + telemetryExceptionHandler("OTLP exporter"))
+        CoroutineScope(SupervisorJob() + coroutineContext + telemetryExceptionHandler("OTLP exporter", sdkErrorHandler))
 
     /**
      * Exports telemetry via coroutines and uses exponential backoff when a failure

--- a/exporters-otlp/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/OtlpHttpLogRecordExporter.kt
+++ b/exporters-otlp/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/OtlpHttpLogRecordExporter.kt
@@ -1,5 +1,6 @@
 package io.opentelemetry.kotlin.logging.export
 
+import io.opentelemetry.kotlin.error.SdkErrorHandler
 import io.opentelemetry.kotlin.export.OperationResultCode
 import io.opentelemetry.kotlin.export.OtlpClient
 import io.opentelemetry.kotlin.export.TelemetryExporter
@@ -10,9 +11,15 @@ internal class OtlpHttpLogRecordExporter(
     initialDelayMs: Long,
     maxAttemptIntervalMs: Long,
     maxAttempts: Int,
+    sdkErrorHandler: SdkErrorHandler,
 ) : LogRecordExporter {
 
-    private val exporter = TelemetryExporter(initialDelayMs, maxAttemptIntervalMs, maxAttempts) {
+    private val exporter = TelemetryExporter(
+        initialDelayMs,
+        maxAttemptIntervalMs,
+        maxAttempts,
+        sdkErrorHandler,
+    ) {
         otlpClient.exportLogs(it)
     }
 

--- a/exporters-otlp/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/OtlpLogRecordExporterApi.kt
+++ b/exporters-otlp/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/OtlpLogRecordExporterApi.kt
@@ -23,10 +23,11 @@ public fun LogExportConfigDsl.otlpHttpLogRecordExporter(
     timeoutMs: Long = EXPORT_REQUEST_TIMEOUT_MS,
 ): LogRecordExporter =
     OtlpHttpLogRecordExporter(
-        OtlpClient(baseUrl, createDefaultHttpClient(requestTimeoutMs = timeoutMs, engine = httpClientEngine)),
+        OtlpClient(baseUrl, createDefaultHttpClient(requestTimeoutMs = timeoutMs, engine = httpClientEngine), sdkErrorHandler),
         EXPORT_INITIAL_DELAY_MS,
         EXPORT_MAX_ATTEMPT_INTERVAL_MS,
-        EXPORT_MAX_ATTEMPTS
+        EXPORT_MAX_ATTEMPTS,
+        sdkErrorHandler,
     )
 
 /**
@@ -45,8 +46,9 @@ public fun LogExportConfigDsl.otlpHttpLogRecordExporter(
     httpClient: HttpClient,
 ): LogRecordExporter =
     OtlpHttpLogRecordExporter(
-        OtlpClient(baseUrl, httpClient),
+        OtlpClient(baseUrl, httpClient, sdkErrorHandler),
         EXPORT_INITIAL_DELAY_MS,
         EXPORT_MAX_ATTEMPT_INTERVAL_MS,
-        EXPORT_MAX_ATTEMPTS
+        EXPORT_MAX_ATTEMPTS,
+        sdkErrorHandler,
     )

--- a/exporters-otlp/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/OtlpHttpSpanExporter.kt
+++ b/exporters-otlp/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/OtlpHttpSpanExporter.kt
@@ -1,5 +1,6 @@
 package io.opentelemetry.kotlin.tracing.export
 
+import io.opentelemetry.kotlin.error.SdkErrorHandler
 import io.opentelemetry.kotlin.export.OperationResultCode
 import io.opentelemetry.kotlin.export.OtlpClient
 import io.opentelemetry.kotlin.export.TelemetryExporter
@@ -10,9 +11,15 @@ internal class OtlpHttpSpanExporter(
     initialDelayMs: Long,
     maxAttemptIntervalMs: Long,
     maxAttempts: Int,
+    sdkErrorHandler: SdkErrorHandler,
 ) : SpanExporter {
 
-    private val exporter = TelemetryExporter(initialDelayMs, maxAttemptIntervalMs, maxAttempts) {
+    private val exporter = TelemetryExporter(
+        initialDelayMs,
+        maxAttemptIntervalMs,
+        maxAttempts,
+        sdkErrorHandler,
+    ) {
         otlpClient.exportTraces(it)
     }
 

--- a/exporters-otlp/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/OtlpSpanExporterApi.kt
+++ b/exporters-otlp/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/OtlpSpanExporterApi.kt
@@ -21,10 +21,11 @@ public fun TraceExportConfigDsl.otlpHttpSpanExporter(
     httpClientEngine: HttpClientEngine = createHttpEngine(),
     timeoutMs: Long = EXPORT_REQUEST_TIMEOUT_MS,
 ): SpanExporter = OtlpHttpSpanExporter(
-    OtlpClient(baseUrl, createDefaultHttpClient(requestTimeoutMs = timeoutMs, engine = httpClientEngine)),
+    OtlpClient(baseUrl, createDefaultHttpClient(requestTimeoutMs = timeoutMs, engine = httpClientEngine), sdkErrorHandler),
     EXPORT_INITIAL_DELAY_MS,
     EXPORT_MAX_ATTEMPT_INTERVAL_MS,
-    EXPORT_MAX_ATTEMPTS
+    EXPORT_MAX_ATTEMPTS,
+    sdkErrorHandler,
 )
 
 /**
@@ -42,8 +43,9 @@ public fun TraceExportConfigDsl.otlpHttpSpanExporter(
     baseUrl: String,
     httpClient: HttpClient,
 ): SpanExporter = OtlpHttpSpanExporter(
-    OtlpClient(baseUrl, httpClient),
+    OtlpClient(baseUrl, httpClient, sdkErrorHandler),
     EXPORT_INITIAL_DELAY_MS,
     EXPORT_MAX_ATTEMPT_INTERVAL_MS,
-    EXPORT_MAX_ATTEMPTS
+    EXPORT_MAX_ATTEMPTS,
+    sdkErrorHandler,
 )

--- a/exporters-otlp/src/commonTest/kotlin/io/opentelemetry/kotlin/export/OtlpClientTest.kt
+++ b/exporters-otlp/src/commonTest/kotlin/io/opentelemetry/kotlin/export/OtlpClientTest.kt
@@ -11,6 +11,8 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.http.headersOf
 import io.ktor.util.toMap
 import io.ktor.utils.io.ByteReadChannel
+import io.opentelemetry.kotlin.error.FakeSdkErrorHandler
+import io.opentelemetry.kotlin.error.NoopSdkErrorHandler
 import io.opentelemetry.kotlin.logging.export.toProtobufByteArray
 import io.opentelemetry.kotlin.logging.model.FakeReadableLogRecord
 import io.opentelemetry.kotlin.logging.model.ReadableLogRecord
@@ -42,6 +44,7 @@ internal class OtlpClientTest {
     private val expectedUserAgent = "OTel-OTLP-Exporter-Kotlin/${BuildKonfig.VERSION}"
 
     private lateinit var client: OtlpClient
+    private var errorHandler: FakeSdkErrorHandler = FakeSdkErrorHandler()
     private lateinit var server: MockEngine
     private lateinit var mockResponseStatus: HttpStatusCode
     private var mockResponseHeaders: Headers = Headers.Empty
@@ -51,6 +54,7 @@ internal class OtlpClientTest {
 
     @BeforeTest
     fun setUp() {
+        errorHandler = FakeSdkErrorHandler()
         server = MockEngine {
             if (serverThrows) {
                 error("network unreachable")
@@ -65,7 +69,7 @@ internal class OtlpClientTest {
             )
         }
         val httpClient = createDefaultHttpClient(INFINITE_TIMEOUT_MS, server)
-        client = OtlpClient(baseUrl, httpClient = httpClient)
+        client = OtlpClient(baseUrl, httpClient = httpClient, sdkErrorHandler = errorHandler)
     }
 
     @Test
@@ -173,6 +177,8 @@ internal class OtlpClientTest {
         serverThrows = true
         val response = client.exportLogs(logRecords)
         assertIs<OtlpResponse.Unknown>(response)
+        assertEquals(1, errorHandler.userCodeErrors.size)
+        assertEquals("OTLP export failed", errorHandler.userCodeErrors.single().message)
     }
 
     @Test
@@ -180,6 +186,8 @@ internal class OtlpClientTest {
         serverThrows = true
         val response = client.exportTraces(spans)
         assertIs<OtlpResponse.Unknown>(response)
+        assertEquals(1, errorHandler.userCodeErrors.size)
+        assertEquals("OTLP export failed", errorHandler.userCodeErrors.single().message)
     }
 
     @Test
@@ -385,6 +393,6 @@ internal class OtlpClientTest {
 
     private fun useRequestTimeout() {
         val httpClient = createDefaultHttpClient(requestTimeoutMs, server)
-        client = OtlpClient(baseUrl, httpClient = httpClient)
+        client = OtlpClient(baseUrl, httpClient = httpClient, sdkErrorHandler = NoopSdkErrorHandler)
     }
 }

--- a/exporters-otlp/src/commonTest/kotlin/io/opentelemetry/kotlin/export/TelemetryExporterTest.kt
+++ b/exporters-otlp/src/commonTest/kotlin/io/opentelemetry/kotlin/export/TelemetryExporterTest.kt
@@ -1,6 +1,7 @@
 package io.opentelemetry.kotlin.export
 
 import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.error.NoopSdkErrorHandler
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -22,7 +23,8 @@ internal class TelemetryExporterTest {
             initialDelayMs = 100,
             maxAttemptIntervalMs = 1000,
             maxAttempts = 3,
-            exportAction = { OtlpResponse.Success }
+            sdkErrorHandler = NoopSdkErrorHandler,
+            exportAction = { OtlpResponse.Success },
         )
     }
 
@@ -56,6 +58,7 @@ internal class TelemetryExporterTest {
             initialDelayMs = 100,
             maxAttemptIntervalMs = 1000,
             maxAttempts = 3,
+            sdkErrorHandler = NoopSdkErrorHandler,
             coroutineContext = StandardTestDispatcher(testScheduler),
         ) {
             attempts++
@@ -73,6 +76,7 @@ internal class TelemetryExporterTest {
             initialDelayMs = 100,
             maxAttemptIntervalMs = 1000,
             maxAttempts = 3,
+            sdkErrorHandler = NoopSdkErrorHandler,
             coroutineContext = StandardTestDispatcher(testScheduler),
         ) {
             attempts++
@@ -93,6 +97,7 @@ internal class TelemetryExporterTest {
             initialDelayMs = initialDelayMs,
             maxAttemptIntervalMs = maxIntervalMs,
             maxAttempts = maxAttempts,
+            sdkErrorHandler = NoopSdkErrorHandler,
             coroutineContext = StandardTestDispatcher(testScheduler),
             random = Random(0),
         ) {
@@ -126,6 +131,7 @@ internal class TelemetryExporterTest {
             maxAttempts = 3,
             coroutineContext = StandardTestDispatcher(testScheduler),
             random = Random(0),
+            sdkErrorHandler = NoopSdkErrorHandler,
         ) {
             timestamps += testScheduler.currentTime
             if (attempts++ == 0) {
@@ -146,7 +152,8 @@ internal class TelemetryExporterTest {
             initialDelayMs = 1,
             maxAttemptIntervalMs = 1,
             maxAttempts = 1,
-            exportAction = { error("network unreachable") }
+            sdkErrorHandler = NoopSdkErrorHandler,
+            exportAction = { error("network unreachable") },
         )
         // The failure occurs on a background coroutine whose scope has a CoroutineExceptionHandler,
         // so it must not propagate to the caller nor crash the process.

--- a/exporters-otlp/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/export/OtlpHttpLogRecordExporterTest.kt
+++ b/exporters-otlp/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/export/OtlpHttpLogRecordExporterTest.kt
@@ -49,12 +49,13 @@ internal class OtlpHttpLogRecordExporterTest {
             )
         }
         val httpClient = createDefaultHttpClient(engine = server)
-        client = OtlpClient(baseUrl, httpClient = httpClient)
+        client = OtlpClient(baseUrl, httpClient = httpClient, sdkErrorHandler = NoopSdkErrorHandler)
         exporter = OtlpHttpLogRecordExporter(
             client,
             initialDelayMs = 3,
             maxAttemptIntervalMs = 5,
-            maxAttempts = 3
+            maxAttempts = 3,
+            sdkErrorHandler = NoopSdkErrorHandler,
         )
     }
 

--- a/exporters-otlp/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/export/OtlpHttpSpanExporterTest.kt
+++ b/exporters-otlp/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/export/OtlpHttpSpanExporterTest.kt
@@ -49,12 +49,13 @@ internal class OtlpHttpSpanExporterTest {
             )
         }
         val httpClient = createDefaultHttpClient(engine = server)
-        client = OtlpClient(baseUrl, httpClient = httpClient)
+        client = OtlpClient(baseUrl, httpClient = httpClient, sdkErrorHandler = NoopSdkErrorHandler)
         exporter = OtlpHttpSpanExporter(
             client,
             initialDelayMs = 3,
             maxAttemptIntervalMs = 5,
-            maxAttempts = 3
+            maxAttempts = 3,
+            sdkErrorHandler = NoopSdkErrorHandler,
         )
     }
 

--- a/exporters-persistence/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/PersistingLogRecordProcessor.kt
+++ b/exporters-persistence/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/PersistingLogRecordProcessor.kt
@@ -84,7 +84,7 @@ internal class PersistingLogRecordProcessor(
 
     private val flushMutex = Mutex()
     private val flushScope = CoroutineScope(
-        SupervisorJob() + dispatcher + telemetryExceptionHandler("Persisting log record processor")
+        SupervisorJob() + dispatcher + telemetryExceptionHandler("Persisting log record processor", sdkErrorHandler)
     )
 
     init {

--- a/exporters-persistence/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/PersistingSpanProcessor.kt
+++ b/exporters-persistence/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/PersistingSpanProcessor.kt
@@ -83,7 +83,7 @@ internal class PersistingSpanProcessor(
 
     private val flushMutex = Mutex()
     private val flushScope = CoroutineScope(
-        SupervisorJob() + dispatcher + telemetryExceptionHandler("Persisting span processor")
+        SupervisorJob() + dispatcher + telemetryExceptionHandler("Persisting span processor", sdkErrorHandler)
     )
 
     init {

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/OpenTelemetryImplEntrypoint.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/OpenTelemetryImplEntrypoint.kt
@@ -38,12 +38,13 @@ public fun createOpenTelemetry(
     val spanContext = SpanContextFactoryImpl(idGenerator, traceFlags, traceState)
 
     val span = SpanFactoryImpl(spanContext)
-    val contextFactory = ContextFactoryImpl(span, cfg.contextConfig::generateStorage)
+    val contextFactory = ContextFactoryImpl(span, cfg.sdkErrorHandler, cfg.contextConfig::generateStorage)
     cfg.propagatorCfg.installFactories(
         traceFlagsFactory = traceFlags,
         traceStateFactory = traceState,
         spanContextFactory = spanContext,
         spanFactory = span,
+        sdkErrorHandler = cfg.sdkErrorHandler,
     )
 
     val tracingConfig = cfg.generateTracingConfig()

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/context/ContextImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/context/ContextImpl.kt
@@ -2,6 +2,7 @@ package io.opentelemetry.kotlin.context
 
 import io.opentelemetry.kotlin.baggage.Baggage
 import io.opentelemetry.kotlin.baggage.BaggageImpl
+import io.opentelemetry.kotlin.error.SdkErrorHandler
 import io.opentelemetry.kotlin.factory.SpanFactory
 import io.opentelemetry.kotlin.tracing.Span
 
@@ -11,6 +12,7 @@ private val SPAN_KEY: ContextKey<Span> = ContextKeyImpl("otel-kotlin-span")
 internal class ContextImpl(
     private val storage: ImplicitContextStorage,
     private val spanFactory: SpanFactory,
+    private val sdkErrorHandler: SdkErrorHandler,
     private val impl: Map<ContextKey<*>, Any?> = emptyMap()
 ) : Context {
 
@@ -19,7 +21,7 @@ internal class ContextImpl(
         value: T?
     ): Context {
         val newValues = impl.plus(Pair(key, value))
-        return ContextImpl(storage, spanFactory, newValues)
+        return ContextImpl(storage, spanFactory, sdkErrorHandler, newValues)
     }
 
     @Suppress("UNCHECKED_CAST")
@@ -33,7 +35,7 @@ internal class ContextImpl(
         }
         val current = storage.implicitContext()
         storage.setImplicitContext(this)
-        return ScopeImpl.create(current, this, storage)
+        return ScopeImpl.create(current, this, storage, sdkErrorHandler)
     }
 
     override fun storeSpan(span: Span): Context = set(SPAN_KEY, span)

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/context/ScopeImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/context/ScopeImpl.kt
@@ -1,12 +1,15 @@
 package io.opentelemetry.kotlin.context
 
-import io.opentelemetry.kotlin.platformLog
+import io.opentelemetry.kotlin.error.SdkError
+import io.opentelemetry.kotlin.error.SdkErrorHandler
+import io.opentelemetry.kotlin.error.SdkErrorSeverity
 import kotlin.concurrent.Volatile
 
 internal class ScopeImpl private constructor(
     private val previousContext: Context,
     private val currentContext: Context,
     private val storage: ImplicitContextStorage,
+    private val sdkErrorHandler: SdkErrorHandler,
 ) : Scope {
 
     @Volatile
@@ -14,10 +17,22 @@ internal class ScopeImpl private constructor(
 
     override fun detach(): Boolean {
         return if (detached) {
-            platformLog("Scope.detach() called on an already-detached scope")
+            sdkErrorHandler.onError(
+                SdkError.ApiMisuse(
+                    api = "Scope.detach",
+                    message = "Scope.detach() called on an already-detached scope",
+                    severity = SdkErrorSeverity.WARNING,
+                )
+            )
             false
         } else if (storage.implicitContext() != currentContext) {
-            platformLog("Scope.detach() called out of order — context has already changed")
+            sdkErrorHandler.onError(
+                SdkError.ApiMisuse(
+                    api = "Scope.detach",
+                    message = "Scope.detach() called out of order — context has already changed",
+                    severity = SdkErrorSeverity.WARNING,
+                )
+            )
             false
         } else {
             detached = true
@@ -31,15 +46,23 @@ internal class ScopeImpl private constructor(
             previousContext: Context,
             currentContext: Context,
             storage: ImplicitContextStorage,
+            sdkErrorHandler: SdkErrorHandler,
         ): Scope =
             if (previousContext == currentContext) {
-                platformLog("Cannot create scope with two matching contexts")
+                sdkErrorHandler.onError(
+                    SdkError.ApiMisuse(
+                        api = "Context.attach",
+                        message = "Cannot create scope with two matching contexts",
+                        severity = SdkErrorSeverity.WARNING,
+                    )
+                )
                 DetachedScope
             } else {
                 ScopeImpl(
                     previousContext = previousContext,
                     currentContext = currentContext,
-                    storage = storage
+                    storage = storage,
+                    sdkErrorHandler = sdkErrorHandler,
                 )
             }
     }

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/factory/ContextFactoryImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/factory/ContextFactoryImpl.kt
@@ -6,14 +6,17 @@ import io.opentelemetry.kotlin.context.ContextKey
 import io.opentelemetry.kotlin.context.ContextKeyImpl
 import io.opentelemetry.kotlin.context.DefaultImplicitContextStorage
 import io.opentelemetry.kotlin.context.ImplicitContextStorage
+import io.opentelemetry.kotlin.error.NoopSdkErrorHandler
+import io.opentelemetry.kotlin.error.SdkErrorHandler
 
 internal class ContextFactoryImpl(
     private val spanFactory: SpanFactory,
+    private val sdkErrorHandler: SdkErrorHandler = NoopSdkErrorHandler,
     storageFactory: (supplier: () -> Context) -> ImplicitContextStorage = ::DefaultImplicitContextStorage,
 ) : ContextFactory {
 
     private val storage: ImplicitContextStorage = storageFactory { root }
-    private val root by lazy { ContextImpl(storage, spanFactory) }
+    private val root by lazy { ContextImpl(storage, spanFactory, sdkErrorHandler) }
 
     override fun root(): Context = root
 

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/LoggerProviderConfigImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/LoggerProviderConfigImpl.kt
@@ -1,13 +1,14 @@
 package io.opentelemetry.kotlin.init
 
 import io.opentelemetry.kotlin.Clock
+import io.opentelemetry.kotlin.error.SdkError
 import io.opentelemetry.kotlin.error.SdkErrorHandler
+import io.opentelemetry.kotlin.error.SdkErrorSeverity
 import io.opentelemetry.kotlin.init.config.LogLimitConfig
 import io.opentelemetry.kotlin.init.config.LoggingConfig
 import io.opentelemetry.kotlin.logging.LoggerConfigImpl
 import io.opentelemetry.kotlin.logging.LoggerConfigurator
 import io.opentelemetry.kotlin.logging.export.LogRecordProcessor
-import io.opentelemetry.kotlin.platformLog
 import io.opentelemetry.kotlin.resource.Resource
 
 internal class LoggerProviderConfigImpl(
@@ -25,7 +26,13 @@ internal class LoggerProviderConfigImpl(
 
     override fun export(action: LogExportConfigDsl.() -> LogRecordProcessor) {
         if (processor != null) {
-            platformLog("export() should only be called once.")
+            sdkErrorHandler.onError(
+                SdkError.ApiMisuse(
+                    api = "LoggerProviderConfigDsl.export",
+                    message = "export() should only be called once.",
+                    severity = SdkErrorSeverity.WARNING,
+                )
+            )
             return
         }
         processor = LogExportConfigImpl(clock, sdkErrorHandler).action()

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/OpenTelemetryConfigImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/OpenTelemetryConfigImpl.kt
@@ -13,13 +13,13 @@ internal class OpenTelemetryConfigImpl(
     private val globalResourceConfig: ResourceConfigImpl = ResourceConfigImpl(),
 ) : OpenTelemetryConfigDsl, ResourceConfigDsl by globalResourceConfig {
 
-    @Volatile private var configuredErrorHandler: SdkErrorHandler = NoopSdkErrorHandler
-
     /**
      * The handler is configured after the sub-configs below have been created, so they receive a
      * forwarder that resolves the configured handler on each report instead.
      */
-    private val sdkErrorHandler = SdkErrorHandler { configuredErrorHandler.onError(it) }
+    internal val sdkErrorHandler = SdkErrorHandler { configuredErrorHandler.onError(it) }
+
+    @Volatile private var configuredErrorHandler: SdkErrorHandler = NoopSdkErrorHandler
 
     internal val tracingConfig: TracerProviderConfigImpl = TracerProviderConfigImpl(clock, sdkErrorHandler)
     internal val loggingConfig: LoggerProviderConfigImpl = LoggerProviderConfigImpl(clock, sdkErrorHandler)

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/PropagatorConfigImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/PropagatorConfigImpl.kt
@@ -3,6 +3,7 @@ package io.opentelemetry.kotlin.init
 import io.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.kotlin.NoopOpenTelemetry
 import io.opentelemetry.kotlin.context.Context
+import io.opentelemetry.kotlin.error.SdkErrorHandler
 import io.opentelemetry.kotlin.factory.SpanContextFactory
 import io.opentelemetry.kotlin.factory.SpanFactory
 import io.opentelemetry.kotlin.factory.TraceFlagsFactory
@@ -58,15 +59,31 @@ internal class PropagatorConfigImpl : PropagatorConfigDsl {
         traceStateFactory: TraceStateFactory,
         spanContextFactory: SpanContextFactory,
         spanFactory: SpanFactory,
+        sdkErrorHandler: SdkErrorHandler,
     ) {
         w3cTraceContextImpl = W3CTraceContextPropagator(
             traceFlagsFactory = traceFlagsFactory,
             traceStateFactory = traceStateFactory,
             spanContextFactory = spanContextFactory,
             spanFactory = spanFactory,
+            sdkErrorHandler = sdkErrorHandler,
         )
-        b3SingleImpl = B3Propagator(B3Format.SINGLE, traceFlagsFactory, traceStateFactory, spanContextFactory, spanFactory)
-        b3MultiImpl = B3Propagator(B3Format.MULTI, traceFlagsFactory, traceStateFactory, spanContextFactory, spanFactory)
+        b3SingleImpl = B3Propagator(
+            B3Format.SINGLE,
+            traceFlagsFactory,
+            traceStateFactory,
+            spanContextFactory,
+            spanFactory,
+            sdkErrorHandler,
+        )
+        b3MultiImpl = B3Propagator(
+            B3Format.MULTI,
+            traceFlagsFactory,
+            traceStateFactory,
+            spanContextFactory,
+            spanFactory,
+            sdkErrorHandler,
+        )
     }
 
     internal fun buildPropagator(): TextMapPropagator = configured

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/TracerProviderConfigImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/TracerProviderConfigImpl.kt
@@ -1,11 +1,12 @@
 package io.opentelemetry.kotlin.init
 
 import io.opentelemetry.kotlin.Clock
+import io.opentelemetry.kotlin.error.SdkError
 import io.opentelemetry.kotlin.error.SdkErrorHandler
+import io.opentelemetry.kotlin.error.SdkErrorSeverity
 import io.opentelemetry.kotlin.factory.SpanFactory
 import io.opentelemetry.kotlin.init.config.SpanLimitConfig
 import io.opentelemetry.kotlin.init.config.TracingConfig
-import io.opentelemetry.kotlin.platformLog
 import io.opentelemetry.kotlin.resource.Resource
 import io.opentelemetry.kotlin.tracing.TracerConfigImpl
 import io.opentelemetry.kotlin.tracing.TracerConfigurator
@@ -34,7 +35,13 @@ internal class TracerProviderConfigImpl(
 
     override fun export(action: TraceExportConfigDsl.() -> SpanProcessor) {
         if (processor != null) {
-            platformLog("export() should only be called once.")
+            sdkErrorHandler.onError(
+                SdkError.ApiMisuse(
+                    api = "TracerProviderConfigDsl.export",
+                    message = "export() should only be called once.",
+                    severity = SdkErrorSeverity.WARNING,
+                )
+            )
             return
         }
         processor = TraceExportConfigImpl(clock, sdkErrorHandler).action()

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/LoggerProviderImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/LoggerProviderImpl.kt
@@ -3,6 +3,8 @@ package io.opentelemetry.kotlin.logging
 import io.opentelemetry.kotlin.Clock
 import io.opentelemetry.kotlin.NoopOpenTelemetry
 import io.opentelemetry.kotlin.attributes.AttributesMutator
+import io.opentelemetry.kotlin.error.SdkError
+import io.opentelemetry.kotlin.error.SdkErrorSeverity
 import io.opentelemetry.kotlin.export.BatchTelemetryDefaults
 import io.opentelemetry.kotlin.export.CompositeTelemetryCloseable
 import io.opentelemetry.kotlin.export.MutableShutdownState
@@ -12,7 +14,6 @@ import io.opentelemetry.kotlin.export.runWithTimeout
 import io.opentelemetry.kotlin.factory.ContextFactory
 import io.opentelemetry.kotlin.factory.SpanContextFactory
 import io.opentelemetry.kotlin.init.config.LoggingConfig
-import io.opentelemetry.kotlin.platformLog
 import io.opentelemetry.kotlin.provider.ApiProviderImpl
 
 internal class LoggerProviderImpl(
@@ -23,6 +24,7 @@ internal class LoggerProviderImpl(
 ) : LoggerProvider, TelemetryCloseable {
 
     private val shutdownState: MutableShutdownState = MutableShutdownState()
+    private val sdkErrorHandler = loggingConfig.sdkErrorHandler
     private val closeable: TelemetryCloseable = CompositeTelemetryCloseable(
         loggingConfig.processor?.let { listOf(it) } ?: emptyList(),
         loggingConfig.sdkErrorHandler,
@@ -58,7 +60,13 @@ internal class LoggerProviderImpl(
     ): Logger =
         shutdownState.ifActiveOrElse(noopLogger) {
             if (name.isEmpty()) {
-                platformLog("Logger requested without instrumentation scope name")
+                sdkErrorHandler.onError(
+                    SdkError.ApiMisuse(
+                        api = "LoggerProvider.getLogger",
+                        message = "Logger requested without instrumentation scope name",
+                        severity = SdkErrorSeverity.WARNING,
+                    )
+                )
             }
             val key = apiProvider.createInstrumentationScopeInfo(name, version, schemaUrl, attributes)
             apiProvider.getOrCreate(key)

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/MeterProviderImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/MeterProviderImpl.kt
@@ -2,6 +2,8 @@ package io.opentelemetry.kotlin.metrics
 
 import io.opentelemetry.kotlin.NoopOpenTelemetry
 import io.opentelemetry.kotlin.attributes.AttributesMutator
+import io.opentelemetry.kotlin.error.SdkError
+import io.opentelemetry.kotlin.error.SdkErrorSeverity
 import io.opentelemetry.kotlin.export.BatchTelemetryDefaults
 import io.opentelemetry.kotlin.export.CompositeTelemetryCloseable
 import io.opentelemetry.kotlin.export.MutableShutdownState
@@ -9,7 +11,6 @@ import io.opentelemetry.kotlin.export.OperationResultCode
 import io.opentelemetry.kotlin.export.TelemetryCloseable
 import io.opentelemetry.kotlin.export.runWithTimeout
 import io.opentelemetry.kotlin.init.config.MetricsConfig
-import io.opentelemetry.kotlin.platformLog
 import io.opentelemetry.kotlin.provider.ApiProviderImpl
 
 internal class MeterProviderImpl(
@@ -17,6 +18,7 @@ internal class MeterProviderImpl(
 ) : MeterProvider, TelemetryCloseable {
 
     private val shutdownState: MutableShutdownState = MutableShutdownState()
+    private val sdkErrorHandler = metricsConfig.sdkErrorHandler
     private val closeable: TelemetryCloseable = CompositeTelemetryCloseable(emptyList(), metricsConfig.sdkErrorHandler)
     private val noopMeter = NoopOpenTelemetry.meterProvider.getMeter("")
 
@@ -37,7 +39,13 @@ internal class MeterProviderImpl(
     ): Meter =
         shutdownState.ifActiveOrElse(noopMeter) {
             if (name.isEmpty()) {
-                platformLog("Meter requested without instrumentation scope name")
+                sdkErrorHandler.onError(
+                    SdkError.ApiMisuse(
+                        api = "MeterProvider.getMeter",
+                        message = "Meter requested without instrumentation scope name",
+                        severity = SdkErrorSeverity.WARNING,
+                    )
+                )
             }
             val key = apiProvider.createInstrumentationScopeInfo(name, version, schemaUrl, attributes)
             apiProvider.getOrCreate(key)

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/propagation/B3Propagator.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/propagation/B3Propagator.kt
@@ -4,6 +4,9 @@ import io.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.kotlin.context.Context
 import io.opentelemetry.kotlin.context.ContextKey
 import io.opentelemetry.kotlin.context.ContextKeyImpl
+import io.opentelemetry.kotlin.error.SdkError
+import io.opentelemetry.kotlin.error.SdkErrorHandler
+import io.opentelemetry.kotlin.error.SdkErrorSeverity
 import io.opentelemetry.kotlin.factory.SpanContextFactory
 import io.opentelemetry.kotlin.factory.SpanFactory
 import io.opentelemetry.kotlin.factory.TraceFlagsFactory
@@ -11,7 +14,6 @@ import io.opentelemetry.kotlin.factory.TraceStateFactory
 import io.opentelemetry.kotlin.factory.isAllZerosHex
 import io.opentelemetry.kotlin.factory.isValidHex
 import io.opentelemetry.kotlin.init.B3Format
-import io.opentelemetry.kotlin.platformLog
 import io.opentelemetry.kotlin.tracing.SpanContext
 
 /**
@@ -29,6 +31,7 @@ internal class B3Propagator(
     private val traceStateFactory: TraceStateFactory,
     private val spanContextFactory: SpanContextFactory,
     private val spanFactory: SpanFactory,
+    private val sdkErrorHandler: SdkErrorHandler,
 ) : TextMapPropagator {
 
     override fun fields(): Collection<String> = when (format) {
@@ -93,11 +96,23 @@ internal class B3Propagator(
         val header = getter.get(carrier, COMBINED_HEADER) ?: return null
         val parts = header.split(DELIMITER)
         if (parts.size !in 2..4) {
-            platformLog("B3 single header has wrong number of parts: $header")
+            sdkErrorHandler.onError(
+                SdkError.ApiMisuse(
+                    api = "B3Propagator.extractSingle",
+                    message = "B3 single header has wrong number of parts: $header",
+                    severity = SdkErrorSeverity.WARNING,
+                )
+            )
             return null
         }
         val traceId = normalizeTraceId(parts[0]) ?: run {
-            platformLog("B3 invalid traceId in single header: ${parts[0]}")
+            sdkErrorHandler.onError(
+                SdkError.ApiMisuse(
+                    api = "B3Propagator.extractSingle",
+                    message = "B3 invalid traceId in single header: ${parts[0]}",
+                    severity = SdkErrorSeverity.WARNING,
+                )
+            )
             return null
         }
         val rawSpanId = parts[1]
@@ -105,7 +120,13 @@ internal class B3Propagator(
         val debug = sampled == "d"
         val spanContext = buildContext(debug, sampled, traceId, rawSpanId)
         if (!spanContext.isValid) {
-            platformLog("B3 invalid spanId in single header: $rawSpanId")
+            sdkErrorHandler.onError(
+                SdkError.ApiMisuse(
+                    api = "B3Propagator.extractSingle",
+                    message = "B3 invalid spanId in single header: $rawSpanId",
+                    severity = SdkErrorSeverity.WARNING,
+                )
+            )
             return null
         }
         return context.storeSpan(spanFactory.fromSpanContext(spanContext)).let {
@@ -117,14 +138,28 @@ internal class B3Propagator(
         val rawTraceId = getter.get(carrier, TRACE_ID_HEADER)
         val rawSpanId = getter.get(carrier, SPAN_ID_HEADER) ?: return null
         val traceId = normalizeTraceId(rawTraceId) ?: run {
-            if (rawTraceId != null) { platformLog("B3 invalid traceId in multi header: $rawTraceId") }
+            if (rawTraceId != null) {
+                sdkErrorHandler.onError(
+                    SdkError.ApiMisuse(
+                        api = "B3Propagator.extractMulti",
+                        message = "B3 invalid traceId in multi header: $rawTraceId",
+                        severity = SdkErrorSeverity.WARNING,
+                    )
+                )
+            }
             return null
         }
         val debug = getter.get(carrier, DEBUG_HEADER) == "1"
         val sampled = getter.get(carrier, SAMPLED_HEADER)
         val spanContext = buildContext(debug, sampled, traceId, rawSpanId)
         if (!spanContext.isValid) {
-            platformLog("B3 invalid spanId in multi header: $rawSpanId")
+            sdkErrorHandler.onError(
+                SdkError.ApiMisuse(
+                    api = "B3Propagator.extractMulti",
+                    message = "B3 invalid spanId in multi header: $rawSpanId",
+                    severity = SdkErrorSeverity.WARNING,
+                )
+            )
             return null
         }
         return context.storeSpan(spanFactory.fromSpanContext(spanContext)).let {

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/propagation/TraceParent.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/propagation/TraceParent.kt
@@ -1,8 +1,10 @@
 package io.opentelemetry.kotlin.propagation
 
 import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.error.SdkError
+import io.opentelemetry.kotlin.error.SdkErrorHandler
+import io.opentelemetry.kotlin.error.SdkErrorSeverity
 import io.opentelemetry.kotlin.factory.TraceFlagsFactory
-import io.opentelemetry.kotlin.platformLog
 import io.opentelemetry.kotlin.tracing.TraceFlags
 
 /**
@@ -52,6 +54,7 @@ internal class TraceParent private constructor(
             traceId: String,
             spanId: String,
             traceFlags: TraceFlags,
+            sdkErrorHandler: SdkErrorHandler,
         ): TraceParent? {
             val errorMessage =
                 if (version.length != VERSION_LEN || !version.isLowerHex() || version == FORBIDDEN_VERSION) {
@@ -67,12 +70,22 @@ internal class TraceParent private constructor(
             return if (errorMessage == null) {
                 TraceParent(version, traceId, spanId, traceFlags)
             } else {
-                platformLog(errorMessage)
+                sdkErrorHandler.onError(
+                    SdkError.ApiMisuse(
+                        api = "TraceParent.create",
+                        message = errorMessage,
+                        severity = SdkErrorSeverity.WARNING,
+                    )
+                )
                 null
             }
         }
 
-        fun decode(header: String, traceFlagsFactory: TraceFlagsFactory): TraceParent? {
+        fun decode(
+            header: String,
+            traceFlagsFactory: TraceFlagsFactory,
+            sdkErrorHandler: SdkErrorHandler,
+        ): TraceParent? {
             if (header.length < LEN_V00) {
                 return null
             }
@@ -101,6 +114,7 @@ internal class TraceParent private constructor(
                 traceId = parts[1],
                 spanId = parts[2],
                 traceFlags = traceFlagsFactory.fromHex(flagsStr),
+                sdkErrorHandler = sdkErrorHandler,
             )
         }
 

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/propagation/W3CTraceContextPropagator.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/propagation/W3CTraceContextPropagator.kt
@@ -2,6 +2,7 @@ package io.opentelemetry.kotlin.propagation
 
 import io.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.kotlin.context.Context
+import io.opentelemetry.kotlin.error.SdkErrorHandler
 import io.opentelemetry.kotlin.factory.SpanContextFactory
 import io.opentelemetry.kotlin.factory.SpanFactory
 import io.opentelemetry.kotlin.factory.TraceFlagsFactory
@@ -18,6 +19,7 @@ internal class W3CTraceContextPropagator(
     private val traceStateFactory: TraceStateFactory,
     private val spanContextFactory: SpanContextFactory,
     private val spanFactory: SpanFactory,
+    private val sdkErrorHandler: SdkErrorHandler,
 ) : TextMapPropagator {
 
     override fun fields(): Collection<String> = FIELDS
@@ -33,6 +35,7 @@ internal class W3CTraceContextPropagator(
             traceId = spanContext.traceId,
             spanId = spanContext.spanId,
             traceFlags = spanContext.traceFlags,
+            sdkErrorHandler = sdkErrorHandler,
         )?.let {
             setter.set(carrier, TRACEPARENT, it.encode())
         }
@@ -45,7 +48,7 @@ internal class W3CTraceContextPropagator(
 
     override fun <T> extract(context: Context, carrier: T?, getter: TextMapGetter<T>): Context {
         val rawTraceparent = getter.get(carrier, TRACEPARENT) ?: return context
-        val parsed = TraceParent.decode(rawTraceparent, traceFlagsFactory) ?: return context
+        val parsed = TraceParent.decode(rawTraceparent, traceFlagsFactory, sdkErrorHandler) ?: return context
 
         val rawTracestate = getter.get(carrier, TRACESTATE)
         val traceState = when (rawTracestate) {

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/TracerProviderImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/TracerProviderImpl.kt
@@ -3,6 +3,8 @@ package io.opentelemetry.kotlin.tracing
 import io.opentelemetry.kotlin.Clock
 import io.opentelemetry.kotlin.NoopOpenTelemetry
 import io.opentelemetry.kotlin.attributes.AttributesMutator
+import io.opentelemetry.kotlin.error.SdkError
+import io.opentelemetry.kotlin.error.SdkErrorSeverity
 import io.opentelemetry.kotlin.export.BatchTelemetryDefaults
 import io.opentelemetry.kotlin.export.CompositeTelemetryCloseable
 import io.opentelemetry.kotlin.export.MutableShutdownState
@@ -15,7 +17,6 @@ import io.opentelemetry.kotlin.factory.SpanContextFactory
 import io.opentelemetry.kotlin.factory.SpanFactory
 import io.opentelemetry.kotlin.factory.TraceFlagsFactory
 import io.opentelemetry.kotlin.init.config.TracingConfig
-import io.opentelemetry.kotlin.platformLog
 import io.opentelemetry.kotlin.provider.ApiProviderImpl
 
 internal class TracerProviderImpl(
@@ -29,6 +30,7 @@ internal class TracerProviderImpl(
 ) : TracerProvider, TelemetryCloseable {
 
     private val shutdownState: MutableShutdownState = MutableShutdownState()
+    private val sdkErrorHandler = tracingConfig.sdkErrorHandler
     private val closeable: TelemetryCloseable = CompositeTelemetryCloseable(
         tracingConfig.processor?.let { listOf(it) } ?: emptyList(),
         tracingConfig.sdkErrorHandler,
@@ -66,7 +68,13 @@ internal class TracerProviderImpl(
     ): Tracer =
         shutdownState.ifActiveOrElse(noopTracer) {
             if (name.isEmpty()) {
-                platformLog("Tracer requested without instrumentation scope name")
+                sdkErrorHandler.onError(
+                    SdkError.ApiMisuse(
+                        api = "TracerProvider.getTracer",
+                        message = "Tracer requested without instrumentation scope name",
+                        severity = SdkErrorSeverity.WARNING,
+                    )
+                )
             }
             val key = apiProvider.createInstrumentationScopeInfo(
                 name = name,

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/sampling/ProbabilitySampler.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/sampling/ProbabilitySampler.kt
@@ -3,14 +3,19 @@ package io.opentelemetry.kotlin.tracing.sampling
 import io.opentelemetry.kotlin.attributes.AttributeContainer
 import io.opentelemetry.kotlin.attributes.AttributesModel
 import io.opentelemetry.kotlin.context.Context
-import io.opentelemetry.kotlin.platformLog
+import io.opentelemetry.kotlin.error.SdkError
+import io.opentelemetry.kotlin.error.SdkErrorHandler
+import io.opentelemetry.kotlin.error.SdkErrorSeverity
 import io.opentelemetry.kotlin.tracing.SpanKind
 import io.opentelemetry.kotlin.tracing.model.SpanLink
 import io.opentelemetry.kotlin.tracing.sampling.SamplingResult.Decision
 import kotlin.concurrent.Volatile
 import kotlin.math.max
 
-internal class ProbabilitySampler(ratio: Double) : Sampler {
+internal class ProbabilitySampler(
+    ratio: Double,
+    private val sdkErrorHandler: SdkErrorHandler,
+) : Sampler {
 
     private companion object {
         @Volatile
@@ -46,7 +51,13 @@ internal class ProbabilitySampler(ratio: Double) : Sampler {
         } else {
             if (parentSpanContext.isValid && !parentSpanContext.traceFlags.isRandom && !compatibilityWarningLogged) {
                 compatibilityWarningLogged = true
-                platformLog(COMPATIBILITY_WARNING)
+                sdkErrorHandler.onError(
+                    SdkError.ApiMisuse(
+                        api = "ProbabilitySampler.shouldSample",
+                        message = COMPATIBILITY_WARNING,
+                        severity = SdkErrorSeverity.WARNING,
+                    )
+                )
             }
             randomnessFromTraceId(traceId)
         }

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/context/ImplicitContextTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/context/ImplicitContextTest.kt
@@ -1,5 +1,6 @@
 package io.opentelemetry.kotlin.context
 
+import io.opentelemetry.kotlin.error.NoopSdkErrorHandler
 import io.opentelemetry.kotlin.factory.ContextFactory
 import io.opentelemetry.kotlin.factory.ContextFactoryImpl
 import io.opentelemetry.kotlin.factory.IdGeneratorImpl
@@ -26,6 +27,7 @@ internal class ImplicitContextTest {
             factory.root(),
             factory.root(),
             DefaultImplicitContextStorage(factory::root),
+            NoopSdkErrorHandler,
         )
         assertTrue(scope.detach())
     }

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/context/ScopeImplTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/context/ScopeImplTest.kt
@@ -1,0 +1,75 @@
+package io.opentelemetry.kotlin.context
+
+import io.opentelemetry.kotlin.error.FakeSdkErrorHandler
+import io.opentelemetry.kotlin.error.SdkErrorSeverity
+import io.opentelemetry.kotlin.factory.ContextFactoryImpl
+import io.opentelemetry.kotlin.factory.IdGeneratorImpl
+import io.opentelemetry.kotlin.factory.SpanContextFactoryImpl
+import io.opentelemetry.kotlin.factory.SpanFactoryImpl
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+internal class ScopeImplTest {
+
+    private lateinit var handler: FakeSdkErrorHandler
+    private lateinit var factory: ContextFactoryImpl
+    private lateinit var storage: DefaultImplicitContextStorage
+
+    @BeforeTest
+    fun setUp() {
+        handler = FakeSdkErrorHandler()
+        factory = ContextFactoryImpl(
+            SpanFactoryImpl(SpanContextFactoryImpl(IdGeneratorImpl())),
+            sdkErrorHandler = handler,
+        )
+        storage = DefaultImplicitContextStorage(factory::root)
+    }
+
+    @Test
+    fun testCreateWithMatchingContextsReportsApiMisuse() {
+        val root = factory.root()
+        val scope = ScopeImpl.create(root, root, storage, handler)
+
+        assertTrue(scope.detach())
+        assertEquals(1, handler.apiMisuses.size)
+        val error = handler.apiMisuses.single()
+        assertEquals("Context.attach", error.api)
+        assertEquals("Cannot create scope with two matching contexts", error.message)
+        assertEquals(SdkErrorSeverity.WARNING, error.severity)
+    }
+
+    @Test
+    fun testDoubleDetachReportsApiMisuse() {
+        val newCtx = factory.with(factory.root(), mapOf("key" to "value"))
+        val scope = newCtx.attach()
+
+        assertTrue(scope.detach())
+        assertFalse(scope.detach())
+
+        assertEquals(1, handler.apiMisuses.size)
+        val error = handler.apiMisuses.single()
+        assertEquals("Scope.detach", error.api)
+        assertEquals("Scope.detach() called on an already-detached scope", error.message)
+        assertEquals(SdkErrorSeverity.WARNING, error.severity)
+    }
+
+    @Test
+    fun testOutOfOrderDetachReportsApiMisuse() {
+        val ctx1 = factory.with(factory.root(), mapOf("key" to "value"))
+        val scope1 = ctx1.attach()
+        val ctx2 = factory.with(factory.root(), mapOf("another" to "value"))
+        val scope2 = ctx2.attach()
+
+        assertFalse(scope1.detach())
+        assertTrue(scope2.detach())
+
+        assertEquals(1, handler.apiMisuses.size)
+        val error = handler.apiMisuses.single()
+        assertEquals("Scope.detach", error.api)
+        assertEquals("Scope.detach() called out of order — context has already changed", error.message)
+        assertEquals(SdkErrorSeverity.WARNING, error.severity)
+    }
+}

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/init/LoggerProviderConfigImplTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/init/LoggerProviderConfigImplTest.kt
@@ -2,6 +2,7 @@ package io.opentelemetry.kotlin.init
 
 import io.opentelemetry.kotlin.attributes.DEFAULT_ATTRIBUTE_LIMIT
 import io.opentelemetry.kotlin.clock.FakeClock
+import io.opentelemetry.kotlin.error.FakeSdkErrorHandler
 import io.opentelemetry.kotlin.error.NoopSdkErrorHandler
 import io.opentelemetry.kotlin.logging.export.FakeLogRecordProcessor
 import io.opentelemetry.kotlin.logging.export.LogRecordProcessor
@@ -85,6 +86,18 @@ internal class LoggerProviderConfigImplTest {
         }.generateLoggingConfig(base)
         assertSame(first, cfg.processor)
         assertNotSame(second, cfg.processor)
+    }
+
+    @Test
+    fun testDoubleExportReportsApiMisuse() {
+        val handler = FakeSdkErrorHandler()
+        LoggerProviderConfigImpl(clock, handler).apply {
+            export { simpleLogRecordProcessor(stdoutLogRecordExporter()) }
+            export { simpleLogRecordProcessor(stdoutLogRecordExporter()) }
+        }.generateLoggingConfig(base)
+        assertEquals(1, handler.apiMisuses.size)
+        assertEquals("LoggerProviderConfigDsl.export", handler.apiMisuses.single().api)
+        assertEquals("export() should only be called once.", handler.apiMisuses.single().message)
     }
 
     @Test

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/init/PropagatorConfigImplTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/init/PropagatorConfigImplTest.kt
@@ -1,6 +1,7 @@
 package io.opentelemetry.kotlin.init
 
 import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.error.NoopSdkErrorHandler
 import io.opentelemetry.kotlin.factory.ContextFactoryImpl
 import io.opentelemetry.kotlin.factory.IdGeneratorImpl
 import io.opentelemetry.kotlin.factory.SpanContextFactoryImpl
@@ -47,7 +48,7 @@ internal class PropagatorConfigImplTest {
     @Test
     fun `w3cTraceContext routes through delegate once factories are installed`() {
         val config = PropagatorConfigImpl().apply { w3cTraceContext() }
-        config.installFactories(traceFlagsFactory, traceStateFactory, spanContextFactory, spanFactory)
+        config.installFactories(traceFlagsFactory, traceStateFactory, spanContextFactory, spanFactory, NoopSdkErrorHandler)
         val propagator = config.buildPropagator()
         assertEquals(listOf("traceparent", "tracestate"), propagator.fields().toList())
 

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/init/TracerProviderConfigImplTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/init/TracerProviderConfigImplTest.kt
@@ -5,6 +5,7 @@ import io.opentelemetry.kotlin.attributes.AttributesModel
 import io.opentelemetry.kotlin.attributes.DEFAULT_ATTRIBUTE_LIMIT
 import io.opentelemetry.kotlin.clock.FakeClock
 import io.opentelemetry.kotlin.context.Context
+import io.opentelemetry.kotlin.error.FakeSdkErrorHandler
 import io.opentelemetry.kotlin.error.NoopSdkErrorHandler
 import io.opentelemetry.kotlin.factory.ContextFactoryImpl
 import io.opentelemetry.kotlin.factory.FakeSpanFactory
@@ -186,6 +187,18 @@ internal class TracerProviderConfigImplTest {
         }.generateTracingConfig(base)
         assertSame(first, cfg.processor)
         assertNotSame(second, cfg.processor)
+    }
+
+    @Test
+    fun testDoubleExportReportsApiMisuse() {
+        val handler = FakeSdkErrorHandler()
+        TracerProviderConfigImpl(clock, handler).apply {
+            export { compositeSpanProcessor(FakeSpanProcessor()) }
+            export { compositeSpanProcessor(FakeSpanProcessor()) }
+        }.generateTracingConfig(base)
+        assertEquals(1, handler.apiMisuses.size)
+        assertEquals("TracerProviderConfigDsl.export", handler.apiMisuses.single().api)
+        assertEquals("export() should only be called once.", handler.apiMisuses.single().message)
     }
 
     @Test

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/LoggerProviderImplTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/LoggerProviderImplTest.kt
@@ -2,6 +2,7 @@ package io.opentelemetry.kotlin.logging
 
 import io.opentelemetry.kotlin.attributes.AttributesModel
 import io.opentelemetry.kotlin.clock.FakeClock
+import io.opentelemetry.kotlin.error.FakeSdkErrorHandler
 import io.opentelemetry.kotlin.error.NoopSdkErrorHandler
 import io.opentelemetry.kotlin.export.OperationResultCode
 import io.opentelemetry.kotlin.factory.FakeContextFactory
@@ -43,6 +44,22 @@ internal class LoggerProviderImplTest {
     @Test
     fun testMinimalLoggerProvider() {
         assertNotNull(impl.getLogger(name = ""))
+    }
+
+    @Test
+    fun testEmptyLoggerNameReportsApiMisuse() {
+        val handler = FakeSdkErrorHandler()
+        val config = LoggingConfig(
+            null,
+            LogLimitConfig(100, 100),
+            ResourceImpl(AttributesModel(), null),
+            handler,
+            loggerConfigurator,
+        )
+        val provider = LoggerProviderImpl(clock, config, contextFactory, spanContextFactory)
+        provider.getLogger(name = "")
+        assertEquals(1, handler.apiMisuses.size)
+        assertEquals("LoggerProvider.getLogger", handler.apiMisuses.single().api)
     }
 
     @Test

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/metrics/MeterProviderImplTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/metrics/MeterProviderImplTest.kt
@@ -2,6 +2,7 @@ package io.opentelemetry.kotlin.metrics
 
 import io.opentelemetry.kotlin.NoopOpenTelemetry
 import io.opentelemetry.kotlin.attributes.AttributesModel
+import io.opentelemetry.kotlin.error.FakeSdkErrorHandler
 import io.opentelemetry.kotlin.error.NoopSdkErrorHandler
 import io.opentelemetry.kotlin.export.OperationResultCode
 import io.opentelemetry.kotlin.init.config.MetricsConfig
@@ -30,6 +31,19 @@ internal class MeterProviderImplTest {
     @Test
     fun testMinimalMeterProvider() {
         assertNotNull(impl.getMeter(name = ""))
+    }
+
+    @Test
+    fun testEmptyMeterNameReportsApiMisuse() {
+        val handler = FakeSdkErrorHandler()
+        val config = MetricsConfig(
+            resource = ResourceImpl(AttributesModel(), null),
+            sdkErrorHandler = handler,
+        )
+        val provider = MeterProviderImpl(config)
+        provider.getMeter(name = "")
+        assertEquals(1, handler.apiMisuses.size)
+        assertEquals("MeterProvider.getMeter", handler.apiMisuses.single().api)
     }
 
     @Test

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/propagation/B3PropagatorErrorReportingTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/propagation/B3PropagatorErrorReportingTest.kt
@@ -1,0 +1,130 @@
+package io.opentelemetry.kotlin.propagation
+
+import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.error.FakeSdkErrorHandler
+import io.opentelemetry.kotlin.error.SdkErrorSeverity
+import io.opentelemetry.kotlin.factory.ContextFactoryImpl
+import io.opentelemetry.kotlin.factory.IdGeneratorImpl
+import io.opentelemetry.kotlin.factory.SpanContextFactoryImpl
+import io.opentelemetry.kotlin.factory.SpanFactoryImpl
+import io.opentelemetry.kotlin.factory.TraceFlagsFactoryImpl
+import io.opentelemetry.kotlin.factory.TraceStateFactoryImpl
+import io.opentelemetry.kotlin.init.B3Format
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertSame
+
+@OptIn(ExperimentalApi::class)
+internal class B3PropagatorErrorReportingTest {
+
+    private val traceFlagsFactory = TraceFlagsFactoryImpl()
+    private val traceStateFactory = TraceStateFactoryImpl()
+    private val spanContextFactory = SpanContextFactoryImpl(IdGeneratorImpl(), traceFlagsFactory, traceStateFactory)
+    private val spanFactory = SpanFactoryImpl(spanContextFactory)
+    private val contextFactory = ContextFactoryImpl(spanFactory)
+
+    private lateinit var handler: FakeSdkErrorHandler
+    private lateinit var singlePropagator: B3Propagator
+    private lateinit var multiPropagator: B3Propagator
+
+    private val traceId = "0af7651916cd43dd8448eb211c80319c"
+    private val spanId = "b7ad6b7169203331"
+
+    @BeforeTest
+    fun setUp() {
+        handler = FakeSdkErrorHandler()
+        singlePropagator = B3Propagator(
+            B3Format.SINGLE,
+            traceFlagsFactory,
+            traceStateFactory,
+            spanContextFactory,
+            spanFactory,
+            handler,
+        )
+        multiPropagator = B3Propagator(
+            B3Format.MULTI,
+            traceFlagsFactory,
+            traceStateFactory,
+            spanContextFactory,
+            spanFactory,
+            handler,
+        )
+    }
+
+    @Test
+    fun `extract single reports ApiMisuse for wrong number of parts`() {
+        val ctx = contextFactory.root()
+        assertSame(ctx, singlePropagator.extract(ctx, mapOf("b3" to traceId), MapTextMapGetter))
+
+        assertEquals(1, handler.apiMisuses.size)
+        val error = handler.apiMisuses.single()
+        assertEquals("B3Propagator.extractSingle", error.api)
+        assertEquals("B3 single header has wrong number of parts: $traceId", error.message)
+        assertEquals(SdkErrorSeverity.WARNING, error.severity)
+    }
+
+    @Test
+    fun `extract single reports ApiMisuse for invalid traceId`() {
+        val ctx = contextFactory.root()
+        assertSame(
+            ctx,
+            singlePropagator.extract(ctx, mapOf("b3" to "${"0".repeat(32)}-$spanId-1"), MapTextMapGetter),
+        )
+
+        assertEquals(1, handler.apiMisuses.size)
+        val error = handler.apiMisuses.single()
+        assertEquals("B3Propagator.extractSingle", error.api)
+        assertEquals("B3 invalid traceId in single header: ${"0".repeat(32)}", error.message)
+    }
+
+    @Test
+    fun `extract single reports ApiMisuse for invalid spanId`() {
+        val ctx = contextFactory.root()
+        assertSame(
+            ctx,
+            singlePropagator.extract(ctx, mapOf("b3" to "$traceId-${"0".repeat(16)}-1"), MapTextMapGetter),
+        )
+
+        assertEquals(1, handler.apiMisuses.size)
+        val error = handler.apiMisuses.single()
+        assertEquals("B3Propagator.extractSingle", error.api)
+        assertEquals("B3 invalid spanId in single header: ${"0".repeat(16)}", error.message)
+    }
+
+    @Test
+    fun `extract multi reports ApiMisuse for invalid traceId`() {
+        val ctx = contextFactory.root()
+        assertSame(
+            ctx,
+            multiPropagator.extract(
+                ctx,
+                mapOf("X-B3-TraceId" to "not-a-valid-trace-id", "X-B3-SpanId" to spanId),
+                MapTextMapGetter,
+            ),
+        )
+
+        assertEquals(1, handler.apiMisuses.size)
+        val error = handler.apiMisuses.single()
+        assertEquals("B3Propagator.extractMulti", error.api)
+        assertEquals("B3 invalid traceId in multi header: not-a-valid-trace-id", error.message)
+    }
+
+    @Test
+    fun `extract multi reports ApiMisuse for invalid spanId`() {
+        val ctx = contextFactory.root()
+        assertSame(
+            ctx,
+            multiPropagator.extract(
+                ctx,
+                mapOf("X-B3-TraceId" to traceId, "X-B3-SpanId" to "short"),
+                MapTextMapGetter,
+            ),
+        )
+
+        assertEquals(1, handler.apiMisuses.size)
+        val error = handler.apiMisuses.single()
+        assertEquals("B3Propagator.extractMulti", error.api)
+        assertEquals("B3 invalid spanId in multi header: short", error.message)
+    }
+}

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/propagation/B3PropagatorTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/propagation/B3PropagatorTest.kt
@@ -1,6 +1,7 @@
 package io.opentelemetry.kotlin.propagation
 
 import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.error.NoopSdkErrorHandler
 import io.opentelemetry.kotlin.factory.ContextFactoryImpl
 import io.opentelemetry.kotlin.factory.IdGeneratorImpl
 import io.opentelemetry.kotlin.factory.SpanContextFactoryImpl
@@ -25,9 +26,9 @@ internal class B3PropagatorTest {
     private val contextFactory = ContextFactoryImpl(spanFactory)
 
     private val singlePropagator =
-        B3Propagator(B3Format.SINGLE, traceFlagsFactory, traceStateFactory, spanContextFactory, spanFactory)
+        B3Propagator(B3Format.SINGLE, traceFlagsFactory, traceStateFactory, spanContextFactory, spanFactory, NoopSdkErrorHandler)
     private val multiPropagator =
-        B3Propagator(B3Format.MULTI, traceFlagsFactory, traceStateFactory, spanContextFactory, spanFactory)
+        B3Propagator(B3Format.MULTI, traceFlagsFactory, traceStateFactory, spanContextFactory, spanFactory, NoopSdkErrorHandler)
 
     private val traceId = "0af7651916cd43dd8448eb211c80319c"
     private val spanId = "b7ad6b7169203331"

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/propagation/CorePropagatorApiTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/propagation/CorePropagatorApiTest.kt
@@ -3,6 +3,7 @@ package io.opentelemetry.kotlin.propagation
 import io.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.kotlin.context.Context
 import io.opentelemetry.kotlin.context.ContextKey
+import io.opentelemetry.kotlin.error.NoopSdkErrorHandler
 import io.opentelemetry.kotlin.factory.ContextFactoryImpl
 import io.opentelemetry.kotlin.factory.IdGeneratorImpl
 import io.opentelemetry.kotlin.factory.SpanContextFactoryImpl
@@ -131,6 +132,7 @@ internal class CorePropagatorApiTest {
             traceStateFactory = traceStateFactory,
             spanContextFactory = spanContextFactory,
             spanFactory = spanFactory,
+            sdkErrorHandler = NoopSdkErrorHandler,
         )
     }
 }

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/propagation/TraceParentErrorReportingTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/propagation/TraceParentErrorReportingTest.kt
@@ -1,0 +1,85 @@
+package io.opentelemetry.kotlin.propagation
+
+import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.error.FakeSdkErrorHandler
+import io.opentelemetry.kotlin.error.SdkErrorSeverity
+import io.opentelemetry.kotlin.factory.TraceFlagsFactoryImpl
+import io.opentelemetry.kotlin.tracing.TraceFlagsImpl
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+@OptIn(ExperimentalApi::class)
+internal class TraceParentErrorReportingTest {
+
+    private val flagsFactory = TraceFlagsFactoryImpl()
+    private val traceId = "0af7651916cd43dd8448eb211c80319c"
+    private val spanId = "b7ad6b7169203331"
+    private val traceFlags = TraceFlagsImpl(isSampled = true, isRandom = false)
+
+    private lateinit var handler: FakeSdkErrorHandler
+
+    @BeforeTest
+    fun setUp() {
+        handler = FakeSdkErrorHandler()
+    }
+
+    @Test
+    fun `create reports ApiMisuse for forbidden version`() {
+        assertNull(TraceParent.create("ff", traceId, spanId, traceFlags, handler))
+
+        assertEquals(1, handler.apiMisuses.size)
+        val error = handler.apiMisuses.single()
+        assertEquals("TraceParent.create", error.api)
+        assertEquals(
+            "version must be 2 lowercase hex characters and not ff",
+            error.message,
+        )
+        assertEquals(SdkErrorSeverity.WARNING, error.severity)
+    }
+
+    @Test
+    fun `create reports ApiMisuse for invalid traceId`() {
+        assertNull(
+            TraceParent.create(
+                "00",
+                traceId.replaceFirst('a', 'g'),
+                spanId,
+                traceFlags,
+                handler,
+            )
+        )
+
+        assertEquals(1, handler.apiMisuses.size)
+        assertEquals("traceId must be 32 lowercase hex characters", handler.apiMisuses.single().message)
+    }
+
+    @Test
+    fun `create reports ApiMisuse for invalid spanId`() {
+        assertNull(
+            TraceParent.create(
+                "00",
+                traceId,
+                spanId.replaceFirst('b', 'g'),
+                traceFlags,
+                handler,
+            )
+        )
+
+        assertEquals(1, handler.apiMisuses.size)
+        assertEquals("spanId must be 16 lowercase hex characters", handler.apiMisuses.single().message)
+    }
+
+    @Test
+    fun `decode reports ApiMisuse when parsed fields fail create validation`() {
+        val invalidTraceId = traceId.replaceFirst('a', 'g')
+        assertNull(
+            TraceParent.decode("00-$invalidTraceId-$spanId-01", flagsFactory, handler),
+        )
+
+        assertEquals(1, handler.apiMisuses.size)
+        assertEquals("TraceParent.create", handler.apiMisuses.single().api)
+        assertEquals("traceId must be 32 lowercase hex characters", handler.apiMisuses.single().message)
+    }
+}

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/propagation/TraceParentTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/propagation/TraceParentTest.kt
@@ -1,6 +1,7 @@
 package io.opentelemetry.kotlin.propagation
 
 import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.error.NoopSdkErrorHandler
 import io.opentelemetry.kotlin.factory.TraceFlagsFactoryImpl
 import io.opentelemetry.kotlin.tracing.TraceFlagsImpl
 import kotlin.test.Test
@@ -18,6 +19,7 @@ import kotlin.test.assertTrue
 internal class TraceParentTest {
 
     private val flagsFactory = TraceFlagsFactoryImpl()
+    private val sdkErrorHandler = NoopSdkErrorHandler
     private val traceId = "0af7651916cd43dd8448eb211c80319c"
     private val spanId = "b7ad6b7169203331"
     private val canonicalHeader = "00-$traceId-$spanId-01"
@@ -30,6 +32,7 @@ internal class TraceParentTest {
             traceId = traceId,
             spanId = spanId,
             traceFlags = traceFlags,
+            sdkErrorHandler = sdkErrorHandler,
         )
         assertNotNull(tp)
         assertEquals(canonicalHeader, tp.encode())
@@ -42,6 +45,7 @@ internal class TraceParentTest {
             traceId = traceId,
             spanId = spanId,
             traceFlags = traceFlags,
+            sdkErrorHandler = sdkErrorHandler,
         )
         assertNotNull(tp)
         assertEquals(55, tp.encode().length)
@@ -54,6 +58,7 @@ internal class TraceParentTest {
             traceId = traceId,
             spanId = spanId,
             traceFlags = TraceFlagsImpl(isSampled = false, isRandom = false),
+            sdkErrorHandler = sdkErrorHandler,
         )
         assertNotNull(tp)
         assertEquals("00-$traceId-$spanId-00", tp.encode())
@@ -66,6 +71,7 @@ internal class TraceParentTest {
             traceId = traceId,
             spanId = spanId,
             traceFlags = TraceFlagsImpl(isSampled = false, isRandom = true),
+            sdkErrorHandler = sdkErrorHandler,
         )
         assertNotNull(tp)
         assertEquals("00-$traceId-$spanId-02", tp.encode())
@@ -78,6 +84,7 @@ internal class TraceParentTest {
             traceId = traceId,
             spanId = spanId,
             traceFlags = TraceFlagsImpl(isSampled = true, isRandom = true),
+            sdkErrorHandler = sdkErrorHandler,
         )
         assertNotNull(tp)
         assertEquals("00-$traceId-$spanId-03", tp.encode())
@@ -90,6 +97,7 @@ internal class TraceParentTest {
             traceId = traceId,
             spanId = spanId,
             traceFlags = TraceFlagsImpl(isSampled = false, isRandom = false),
+            sdkErrorHandler = sdkErrorHandler,
         )
         assertNotNull(tp)
         val flags = tp.encode().substringAfterLast('-')
@@ -99,7 +107,7 @@ internal class TraceParentTest {
 
     @Test
     fun `decode parses the canonical version 00 traceparent header`() {
-        val tp = TraceParent.decode(canonicalHeader, flagsFactory)
+        val tp = TraceParent.decode(canonicalHeader, flagsFactory, sdkErrorHandler)
         assertNotNull(tp)
         assertEquals("00", tp.version)
         assertEquals(traceId, tp.traceId)
@@ -110,7 +118,7 @@ internal class TraceParentTest {
 
     @Test
     fun `decode populates flags via the supplied factory`() {
-        val tp = TraceParent.decode("00-$traceId-$spanId-03", flagsFactory)
+        val tp = TraceParent.decode("00-$traceId-$spanId-03", flagsFactory, sdkErrorHandler)
         assertNotNull(tp)
         assertTrue(tp.traceFlags.isSampled)
         assertTrue(tp.traceFlags.isRandom)
@@ -118,7 +126,7 @@ internal class TraceParentTest {
 
     @Test
     fun `decode handles flags 00 by reporting both flags off`() {
-        val tp = TraceParent.decode("00-$traceId-$spanId-00", flagsFactory)
+        val tp = TraceParent.decode("00-$traceId-$spanId-00", flagsFactory, sdkErrorHandler)
         assertNotNull(tp)
         assertFalse(tp.traceFlags.isSampled)
         assertFalse(tp.traceFlags.isRandom)
@@ -126,7 +134,7 @@ internal class TraceParentTest {
 
     @Test
     fun `decode round-trips into encode without loss`() {
-        val tp = TraceParent.decode(canonicalHeader, flagsFactory)
+        val tp = TraceParent.decode(canonicalHeader, flagsFactory, sdkErrorHandler)
         assertNotNull(tp)
         assertEquals(canonicalHeader, tp.encode())
     }
@@ -137,7 +145,7 @@ internal class TraceParentTest {
         // these headers may carry additional `-`-separated fields after flags,
         // so length and field count constraints from version 00 do not apply.
         val header = "01-$traceId-$spanId-01-extra"
-        val tp = TraceParent.decode(header, flagsFactory)
+        val tp = TraceParent.decode(header, flagsFactory, sdkErrorHandler)
         assertNotNull(tp)
         assertEquals("01", tp.version)
         assertEquals(traceId, tp.traceId)
@@ -147,94 +155,94 @@ internal class TraceParentTest {
 
     @Test
     fun `decode rejects an empty header`() {
-        assertNull(TraceParent.decode("", flagsFactory))
+        assertNull(TraceParent.decode("", flagsFactory, sdkErrorHandler))
     }
 
     @Test
     fun `decode rejects a header shorter than 55 chars`() {
         val header = "00-$traceId-${spanId.dropLast(1)}-01"
         assertTrue(header.length < 55)
-        assertNull(TraceParent.decode(header, flagsFactory))
+        assertNull(TraceParent.decode(header, flagsFactory, sdkErrorHandler))
     }
 
     @Test
     fun `decode rejects any uppercase character per spec`() {
         val uppercaseTraceId = traceId.replaceFirst('a', 'A')
-        assertNull(TraceParent.decode("00-$uppercaseTraceId-$spanId-01", flagsFactory))
+        assertNull(TraceParent.decode("00-$uppercaseTraceId-$spanId-01", flagsFactory, sdkErrorHandler))
     }
 
     @Test
     fun `decode rejects header with fewer than four fields`() {
         val header = "0".repeat(55)
-        assertNull(TraceParent.decode(header, flagsFactory))
+        assertNull(TraceParent.decode(header, flagsFactory, sdkErrorHandler))
     }
 
     @Test
     fun `decode rejects forbidden ff version per spec`() {
-        assertNull(TraceParent.decode("ff-$traceId-$spanId-01", flagsFactory))
+        assertNull(TraceParent.decode("ff-$traceId-$spanId-01", flagsFactory, sdkErrorHandler))
     }
 
     @Test
     fun `decode rejects non-hex version`() {
-        assertNull(TraceParent.decode("0g-$traceId-$spanId-01", flagsFactory))
+        assertNull(TraceParent.decode("0g-$traceId-$spanId-01", flagsFactory, sdkErrorHandler))
     }
 
     @Test
     fun `decode rejects version of wrong length`() {
         val header = "001-$traceId-$spanId-01"
-        assertNull(TraceParent.decode(header, flagsFactory))
+        assertNull(TraceParent.decode(header, flagsFactory, sdkErrorHandler))
     }
 
     @Test
     fun `decode rejects version 00 with an additional field`() {
         val header = "00-$traceId-$spanId-01-extra"
-        assertNull(TraceParent.decode(header, flagsFactory))
+        assertNull(TraceParent.decode(header, flagsFactory, sdkErrorHandler))
     }
 
     @Test
     fun `decode rejects trace id of wrong length`() {
         val longTrace = "0".repeat(33)
-        assertNull(TraceParent.decode("01-$longTrace-$spanId-01", flagsFactory))
+        assertNull(TraceParent.decode("01-$longTrace-$spanId-01", flagsFactory, sdkErrorHandler))
     }
 
     @Test
     fun `decode rejects non-hex trace id`() {
         val invalidTraceId = traceId.replaceFirst('a', 'g')
-        assertNull(TraceParent.decode("00-$invalidTraceId-$spanId-01", flagsFactory))
+        assertNull(TraceParent.decode("00-$invalidTraceId-$spanId-01", flagsFactory, sdkErrorHandler))
     }
 
     @Test
     fun `decode rejects span id of wrong length`() {
         val longSpan = "0".repeat(17)
-        assertNull(TraceParent.decode("01-$traceId-$longSpan-01", flagsFactory))
+        assertNull(TraceParent.decode("01-$traceId-$longSpan-01", flagsFactory, sdkErrorHandler))
     }
 
     @Test
     fun `decode rejects non-hex span id`() {
         val invalidSpanId = spanId.replaceFirst('b', 'g')
-        assertNull(TraceParent.decode("00-$traceId-$invalidSpanId-01", flagsFactory))
+        assertNull(TraceParent.decode("00-$traceId-$invalidSpanId-01", flagsFactory, sdkErrorHandler))
     }
 
     @Test
     fun `decode rejects flags of wrong length`() {
-        assertNull(TraceParent.decode("01-$traceId-$spanId-001", flagsFactory))
+        assertNull(TraceParent.decode("01-$traceId-$spanId-001", flagsFactory, sdkErrorHandler))
     }
 
     @Test
     fun `decode rejects non-hex flags`() {
-        assertNull(TraceParent.decode("00-$traceId-$spanId-zz", flagsFactory))
+        assertNull(TraceParent.decode("00-$traceId-$spanId-zz", flagsFactory, sdkErrorHandler))
     }
 
     @Test
     fun `decode rejects header with uppercase version`() {
         val header = "0A-$traceId-$spanId-01"
-        assertNull(TraceParent.decode(header, flagsFactory))
+        assertNull(TraceParent.decode(header, flagsFactory, sdkErrorHandler))
     }
 
     @Test
     fun `decode rejects header with uppercase flags`() {
         val header = "00-$traceId-$spanId-0A"
-        assertNull(TraceParent.decode(header, flagsFactory))
+        assertNull(TraceParent.decode(header, flagsFactory, sdkErrorHandler))
     }
 
     @Test
@@ -244,6 +252,7 @@ internal class TraceParentTest {
             traceId = traceId,
             spanId = spanId,
             traceFlags = traceFlags,
+            sdkErrorHandler = sdkErrorHandler,
         )
         assertNotNull(tp)
         assertEquals(canonicalHeader, tp.encode())
@@ -251,36 +260,36 @@ internal class TraceParentTest {
 
     @Test
     fun `create returns null for version of wrong length`() {
-        assertNull(TraceParent.create("0", traceId, spanId, traceFlags))
+        assertNull(TraceParent.create("0", traceId, spanId, traceFlags, sdkErrorHandler))
     }
 
     @Test
     fun `create returns null for non-hex version`() {
-        assertNull(TraceParent.create("pp", traceId, spanId, traceFlags))
+        assertNull(TraceParent.create("pp", traceId, spanId, traceFlags, sdkErrorHandler))
     }
 
     @Test
     fun `create returns null for forbidden version`() {
-        assertNull(TraceParent.create("ff", traceId, spanId, traceFlags))
+        assertNull(TraceParent.create("ff", traceId, spanId, traceFlags, sdkErrorHandler))
     }
 
     @Test
     fun `create returns null for trace id of wrong length`() {
-        assertNull(TraceParent.create("00", "1234", spanId, traceFlags))
+        assertNull(TraceParent.create("00", "1234", spanId, traceFlags, sdkErrorHandler))
     }
 
     @Test
     fun `create returns null for non-hex trace id`() {
-        assertNull(TraceParent.create("00", traceId.replaceFirst('a', 'g'), spanId, traceFlags))
+        assertNull(TraceParent.create("00", traceId.replaceFirst('a', 'g'), spanId, traceFlags, sdkErrorHandler))
     }
 
     @Test
     fun `create returns null for span id of wrong length`() {
-        assertNull(TraceParent.create("00", traceId, "1234", traceFlags))
+        assertNull(TraceParent.create("00", traceId, "1234", traceFlags, sdkErrorHandler))
     }
 
     @Test
     fun `create returns null for non-hex span id`() {
-        assertNull(TraceParent.create("00", traceId, spanId.replaceFirst('b', 'g'), traceFlags))
+        assertNull(TraceParent.create("00", traceId, spanId.replaceFirst('b', 'g'), traceFlags, sdkErrorHandler))
     }
 }

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/propagation/W3CTraceContextPropagatorFuzzTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/propagation/W3CTraceContextPropagatorFuzzTest.kt
@@ -6,6 +6,7 @@ import io.kotest.property.arbitrary.boolean
 import io.kotest.property.arbitrary.filter
 import io.kotest.property.checkAll
 import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.error.NoopSdkErrorHandler
 import io.opentelemetry.kotlin.factory.ContextFactoryImpl
 import io.opentelemetry.kotlin.factory.IdGeneratorImpl
 import io.opentelemetry.kotlin.factory.SpanContextFactoryImpl
@@ -40,6 +41,7 @@ internal class W3CTraceContextPropagatorFuzzTest {
         traceStateFactory = traceStateFactory,
         spanContextFactory = spanContextFactory,
         spanFactory = spanFactory,
+        sdkErrorHandler = NoopSdkErrorHandler,
     )
 
     private val headerArb = arbitrary { rs ->

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/propagation/W3CTraceContextPropagatorTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/propagation/W3CTraceContextPropagatorTest.kt
@@ -2,6 +2,7 @@ package io.opentelemetry.kotlin.propagation
 
 import io.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.kotlin.context.Context
+import io.opentelemetry.kotlin.error.NoopSdkErrorHandler
 import io.opentelemetry.kotlin.factory.ContextFactoryImpl
 import io.opentelemetry.kotlin.factory.IdGeneratorImpl
 import io.opentelemetry.kotlin.factory.SpanContextFactoryImpl
@@ -37,6 +38,7 @@ internal class W3CTraceContextPropagatorTest {
         traceStateFactory = traceStateFactory,
         spanContextFactory = spanContextFactory,
         spanFactory = spanFactory,
+        sdkErrorHandler = NoopSdkErrorHandler,
     )
 
     private val traceId = "0af7651916cd43dd8448eb211c80319c"

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/TracerProviderImplTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/TracerProviderImplTest.kt
@@ -2,6 +2,7 @@ package io.opentelemetry.kotlin.tracing
 
 import io.opentelemetry.kotlin.attributes.AttributesModel
 import io.opentelemetry.kotlin.clock.FakeClock
+import io.opentelemetry.kotlin.error.FakeSdkErrorHandler
 import io.opentelemetry.kotlin.error.NoopSdkErrorHandler
 import io.opentelemetry.kotlin.export.OperationResultCode
 import io.opentelemetry.kotlin.factory.FakeContextFactory
@@ -49,6 +50,29 @@ internal class TracerProviderImplTest {
     @Test
     fun testMinimalTracerProvider() {
         assertNotNull(impl.getTracer(name = ""))
+    }
+
+    @Test
+    fun testEmptyTracerNameReportsApiMisuse() {
+        val handler = FakeSdkErrorHandler()
+        val config = TracingConfig(
+            null,
+            fakeSpanLimitsConfig,
+            ResourceImpl(AttributesModel(), null),
+            handler,
+        )
+        val provider = TracerProviderImpl(
+            clock = FakeClock(),
+            tracingConfig = config,
+            contextFactory = FakeContextFactory(),
+            spanContextFactory = FakeSpanContextFactory(),
+            traceFlagsFactory = FakeTraceFlagsFactory(),
+            spanFactory = FakeSpanFactory(),
+            idGenerator = FakeIdGenerator(),
+        )
+        provider.getTracer(name = "")
+        assertEquals(1, handler.apiMisuses.size)
+        assertEquals("TracerProvider.getTracer", handler.apiMisuses.single().api)
     }
 
     @Test

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/sampling/ProbabilitySamplerTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/sampling/ProbabilitySamplerTest.kt
@@ -3,6 +3,7 @@ package io.opentelemetry.kotlin.tracing.sampling
 import io.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.kotlin.attributes.AttributesModel
 import io.opentelemetry.kotlin.context.Context
+import io.opentelemetry.kotlin.error.NoopSdkErrorHandler
 import io.opentelemetry.kotlin.factory.ContextFactoryImpl
 import io.opentelemetry.kotlin.factory.IdGeneratorImpl
 import io.opentelemetry.kotlin.factory.SpanContextFactoryImpl
@@ -26,6 +27,7 @@ internal class ProbabilitySamplerTest {
     private val spanContextFactory = SpanContextFactoryImpl(idGenerator, traceFlagsFactory, traceStateFactory)
     private val spanFactory = SpanFactoryImpl(spanContextFactory)
     private val contextFactory = ContextFactoryImpl(spanFactory)
+    private val sdkErrorHandler = NoopSdkErrorHandler
 
     private fun createParentContext(traceId: String, otTraceStateValue: String, flags: TraceFlags): Context {
         val traceState = traceStateFactory.default.put("ot", otTraceStateValue)
@@ -41,7 +43,7 @@ internal class ProbabilitySamplerTest {
 
     @Test
     fun testRecordsAndSamplesSpan() {
-        val result = ProbabilitySampler(0.5).shouldSample(
+        val result = ProbabilitySampler(0.5, sdkErrorHandler).shouldSample(
             context = contextFactory.root(),
             traceId = "000000000000000000ffffffffffffff",
             name = "span",
@@ -54,7 +56,7 @@ internal class ProbabilitySamplerTest {
 
     @Test
     fun testDropsSpan() {
-        val result = ProbabilitySampler(0.5).shouldSample(
+        val result = ProbabilitySampler(0.5, sdkErrorHandler).shouldSample(
             context = contextFactory.root(),
             traceId = "ffffffffffffffffff00000000000000",
             name = "span",
@@ -68,7 +70,7 @@ internal class ProbabilitySamplerTest {
     @Test
     fun testRecordsAndSamplesSpanAtMinimumRatio() {
         val ratio = 1.0 / (1L shl 56).toDouble()
-        val result = ProbabilitySampler(ratio).shouldSample(
+        val result = ProbabilitySampler(ratio, sdkErrorHandler).shouldSample(
             context = contextFactory.root(),
             traceId = "000000000000000000ffffffffffffff",
             name = "span",
@@ -82,7 +84,7 @@ internal class ProbabilitySamplerTest {
     @Test
     fun testDropsSpanAtMinimumRatio() {
         val ratio = 1.0 / (1L shl 56).toDouble()
-        val result = ProbabilitySampler(ratio).shouldSample(
+        val result = ProbabilitySampler(ratio, sdkErrorHandler).shouldSample(
             context = contextFactory.root(),
             traceId = "000000000000000000fffffffffffffe",
             name = "span",
@@ -96,10 +98,10 @@ internal class ProbabilitySamplerTest {
     @Test
     fun testThrowsOnInvalidRatio() {
         assertFailsWith(IllegalArgumentException::class) {
-            ProbabilitySampler(0.0)
+            ProbabilitySampler(0.0, sdkErrorHandler)
         }
         assertFailsWith(IllegalArgumentException::class) {
-            ProbabilitySampler(2.0)
+            ProbabilitySampler(2.0, sdkErrorHandler)
         }
     }
 
@@ -114,7 +116,7 @@ internal class ProbabilitySamplerTest {
             otTraceStateValue = "rv:$aboveThreshold",
             flags = traceFlagsFactory.default
         )
-        val result = ProbabilitySampler(ratio).shouldSample(
+        val result = ProbabilitySampler(ratio, sdkErrorHandler).shouldSample(
             context = context,
             traceId = traceId,
             name = "span",
@@ -133,7 +135,7 @@ internal class ProbabilitySamplerTest {
             otTraceStateValue = "rv:garbage",
             flags = traceFlagsFactory.default
         )
-        val result = ProbabilitySampler(0.5).shouldSample(
+        val result = ProbabilitySampler(0.5, sdkErrorHandler).shouldSample(
             context = context,
             traceId = traceId,
             name = "span",
@@ -152,7 +154,7 @@ internal class ProbabilitySamplerTest {
             otTraceStateValue = "th:123",
             flags = traceFlagsFactory.default
         )
-        val result = ProbabilitySampler(0.5).shouldSample(
+        val result = ProbabilitySampler(0.5, sdkErrorHandler).shouldSample(
             context = context,
             traceId = traceId,
             name = "span",
@@ -171,7 +173,7 @@ internal class ProbabilitySamplerTest {
             otTraceStateValue = "rv:a0000000000000;th:c", // rv < th
             flags = TraceFlagsImpl(isSampled = true, traceFlagsFactory.default.isRandom),
         )
-        val result = ProbabilitySampler(0.5).shouldSample(
+        val result = ProbabilitySampler(0.5, sdkErrorHandler).shouldSample(
             context = context,
             traceId = traceId,
             name = "span",

--- a/sdk-common/api/jvm/sdk-common.api
+++ b/sdk-common/api/jvm/sdk-common.api
@@ -45,7 +45,7 @@ public abstract class io/opentelemetry/kotlin/export/ShutdownState {
 }
 
 public final class io/opentelemetry/kotlin/export/TelemetryExceptionHandlerKt {
-	public static final fun telemetryExceptionHandler (Ljava/lang/String;)Lkotlinx/coroutines/CoroutineExceptionHandler;
+	public static final fun telemetryExceptionHandler (Ljava/lang/String;Lio/opentelemetry/kotlin/error/SdkErrorHandler;)Lkotlinx/coroutines/CoroutineExceptionHandler;
 }
 
 public final class io/opentelemetry/kotlin/export/TimeoutOperationKt {

--- a/sdk-common/src/commonMain/kotlin/io/opentelemetry/kotlin/export/TelemetryExceptionHandler.kt
+++ b/sdk-common/src/commonMain/kotlin/io/opentelemetry/kotlin/export/TelemetryExceptionHandler.kt
@@ -1,6 +1,8 @@
 package io.opentelemetry.kotlin.export
 
-import io.opentelemetry.kotlin.platformLog
+import io.opentelemetry.kotlin.error.SdkError
+import io.opentelemetry.kotlin.error.SdkErrorHandler
+import io.opentelemetry.kotlin.error.SdkErrorSeverity
 import kotlinx.coroutines.CoroutineExceptionHandler
 
 /**
@@ -14,7 +16,13 @@ import kotlinx.coroutines.CoroutineExceptionHandler
  * [kotlinx.coroutines.CancellationException] is never routed here by the framework, so normal
  * cancellation (e.g. on shutdown) is unaffected.
  */
-public fun telemetryExceptionHandler(context: String): CoroutineExceptionHandler =
+public fun telemetryExceptionHandler(context: String, sdkErrorHandler: SdkErrorHandler): CoroutineExceptionHandler =
     CoroutineExceptionHandler { _, throwable ->
-        platformLog("$context coroutine failed: ${throwable.message}")
+        sdkErrorHandler.onError(
+            SdkError.UserCodeError(
+                cause = throwable,
+                message = "$context coroutine failed",
+                severity = SdkErrorSeverity.WARNING,
+            )
+        )
     }

--- a/sdk-common/src/commonTest/kotlin/io/opentelemetry/kotlin/export/TelemetryExceptionHandlerTest.kt
+++ b/sdk-common/src/commonTest/kotlin/io/opentelemetry/kotlin/export/TelemetryExceptionHandlerTest.kt
@@ -1,0 +1,27 @@
+package io.opentelemetry.kotlin.export
+
+import io.opentelemetry.kotlin.error.FakeSdkErrorHandler
+import io.opentelemetry.kotlin.error.SdkErrorSeverity
+import kotlin.coroutines.EmptyCoroutineContext
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+internal class TelemetryExceptionHandlerTest {
+
+    @Test
+    fun testCoroutineFailureReportsUserCodeError() {
+        val handler = FakeSdkErrorHandler()
+        val cause = IllegalStateException("boom")
+
+        telemetryExceptionHandler("Test context", handler)
+            .handleException(EmptyCoroutineContext, cause)
+
+        assertEquals(1, handler.userCodeErrors.size)
+        val error = handler.userCodeErrors.single()
+        assertEquals("Test context coroutine failed", error.message)
+        assertEquals(SdkErrorSeverity.WARNING, error.severity)
+        assertIs<IllegalStateException>(error.cause)
+        assertEquals("boom", error.cause.message)
+    }
+}


### PR DESCRIPTION
## Goal

Replace SDK error-reporting calls to `platformLog()` with `sdkErrorHandler.onError(...)`, so errors are routed through the configurable handler introduced in #710.

`PlatformLogger` implementations and `Stdout*Exporter` classes are intentionally unchanged because direct platform output is part of their responsibility.

This covers:

* Export-related paths in `sdk-common`, `exporters-core`, `exporters-otlp`, and `exporters-persistence`
* Provider and processor API misuse
* Invalid scope detachment
* B3 and TraceParent propagation failures
* `ProbabilitySampler` compatibility warnings

Errors are classified according to their origin:

* `UserCodeError` when user-supplied code throws, including exporters, processors, batch exports, OTLP HTTP failures, and persistence failures
* `ApiMisuse` when the API is misused, including empty names, invalid scope operations, invalid configuration, malformed propagation input, and compatibility warnings

Reported errors use `WARNING` severity where appropriate.

Closes #711.
Uses the configurable SdkErrorHandler introduced in #710.

## API change

The public `telemetryExceptionHandler` signature now accepts an `SdkErrorHandler`:

```kotlin
// Before
telemetryExceptionHandler(context: String)

// After
telemetryExceptionHandler(
    context: String,
    sdkErrorHandler: SdkErrorHandler,
)
```

The corresponding `sdk-common.api` dump has been updated.

## Testing

* Verified that only intentionally retained `platformLog()` usages remain:

  ```text
  rg "platformLog\(" --glob "!**/PlatformLogger*"
  ```

  Result: 0 matches.

* Targeted migration tests pass for:

  * `exporters-core`
  * `sdk-common`
  * `exporters-otlp`
  * `implementation`

* Full `./gradlew build` was not run to completion on Windows because of pre-existing `Stdout*Exporter` CRLF failures. CI pending after PR creation.

## Questions for reviewers

* Is migrating all SDK error-reporting `platformLog()` calls the intended scope for #711?
* Export and persistence failures are currently classified as `UserCodeError`. Should some of them be classified as `SdkCodeError` instead?
* How should malformed propagation input be classified?
* Is the public `telemetryExceptionHandler` signature change acceptable?
* Should the change be split given the current diff size?