### PR TITLE
feat: configure span limits from environment variables

### DIFF
--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/config/envar/EnvVarConstants.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/config/envar/EnvVarConstants.kt
@@ -15,4 +15,23 @@ internal object EnvVarConstants {
 
         override val envVars = listOf(ATTR_COUNT_LIMIT, ATTR_VALUE_LENGTH_LIMIT)
     }
+
+    internal object SpanLimits : EnvVarLimits {
+        private val ATTR_COUNT_LIMIT = envVarName("OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT")
+        private val ATTR_VALUE_LENGTH_LIMIT =
+            envVarName("OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT")
+        private val EVENT_COUNT_LIMIT = envVarName("OTEL_SPAN_EVENT_COUNT_LIMIT")
+        private val LINK_COUNT_LIMIT = envVarName("OTEL_SPAN_LINK_COUNT_LIMIT")
+        private val EVENT_ATTR_COUNT_LIMIT = envVarName("OTEL_EVENT_ATTRIBUTE_COUNT_LIMIT")
+        private val LINK_ATTR_COUNT_LIMIT = envVarName("OTEL_LINK_ATTRIBUTE_COUNT_LIMIT")
+
+        override val envVars = listOf(
+            ATTR_COUNT_LIMIT,
+            ATTR_VALUE_LENGTH_LIMIT,
+            EVENT_COUNT_LIMIT,
+            LINK_COUNT_LIMIT,
+            EVENT_ATTR_COUNT_LIMIT,
+            LINK_ATTR_COUNT_LIMIT,
+        )
+    }
 }

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/config/envar/OpenTelemetryEnvVarConfigProcessorImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/config/envar/OpenTelemetryEnvVarConfigProcessorImpl.kt
@@ -2,20 +2,27 @@ package io.opentelemetry.kotlin.config.envar
 
 import io.opentelemetry.kotlin.config.envar.logging.LogLimitEnvVarConfigProcessor
 import io.opentelemetry.kotlin.config.envar.model.EnvironmentConfiguration
+import io.opentelemetry.kotlin.config.envar.tracing.SpanLimitEnvVarConfigProcessor
 import io.opentelemetry.kotlin.init.config.LoggingConfig
+import io.opentelemetry.kotlin.init.config.TracingConfig
 
 /**
  * Retrieves environment configuration and initiates library configuration based on that
  */
 internal class OpenTelemetryEnvVarConfigProcessorImpl(
     private val loggingConfig: LoggingConfig,
-    private val logLimitProcessor: LogLimitEnvVarConfigProcessor
+    private val logLimitProcessor: LogLimitEnvVarConfigProcessor,
+    private val tracingConfig: TracingConfig,
+    private val spanLimitProcessor: SpanLimitEnvVarConfigProcessor,
 ) : OpenTelemetryEnvVarConfigProcessor {
     override fun process(): EnvironmentConfiguration {
         return EnvironmentConfiguration(
             logLimitConfig = logLimitProcessor.configure(
                 defaultValue = loggingConfig.logLimits
-            ) { envVar -> getEnvVarValue(envVar) }
+            ) { envVar -> getEnvVarValue(envVar) },
+            spanLimitConfig = spanLimitProcessor.configure(
+                defaultValue = tracingConfig.spanLimits
+            ) { envVar -> getEnvVarValue(envVar) },
         )
     }
 }

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/config/envar/OpenTelemetryEnvVarConfigProcessorImplEntrypoint.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/config/envar/OpenTelemetryEnvVarConfigProcessorImplEntrypoint.kt
@@ -3,6 +3,7 @@ package io.opentelemetry.kotlin.config.envar
 import io.opentelemetry.kotlin.Clock
 import io.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.kotlin.config.envar.logging.LogLimitEnvVarConfigProcessorImpl
+import io.opentelemetry.kotlin.config.envar.tracing.SpanLimitEnvVarConfigProcessorImpl
 import io.opentelemetry.kotlin.init.OpenTelemetryConfigDsl
 import io.opentelemetry.kotlin.init.OpenTelemetryConfigImpl
 
@@ -30,8 +31,13 @@ internal fun createOpenTelemetryEnvVarConfigProcessorImpl(
     val logLimitProcessor = LogLimitEnvVarConfigProcessorImpl(
         envVars = EnvVarConstants.LogLimits.envVars
     )
+    val spanLimitProcessor = SpanLimitEnvVarConfigProcessorImpl(
+        envVars = EnvVarConstants.SpanLimits.envVars
+    )
     return OpenTelemetryEnvVarConfigProcessorImpl(
         loggingConfig = cfg.generateLoggingConfig(),
-        logLimitProcessor = logLimitProcessor
+        logLimitProcessor = logLimitProcessor,
+        tracingConfig = cfg.generateTracingConfig(),
+        spanLimitProcessor = spanLimitProcessor,
     )
 }

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/config/envar/model/EnvironmentConfiguration.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/config/envar/model/EnvironmentConfiguration.kt
@@ -1,7 +1,9 @@
 package io.opentelemetry.kotlin.config.envar.model
 
 import io.opentelemetry.kotlin.init.config.LogLimitConfig
+import io.opentelemetry.kotlin.init.config.SpanLimitConfig
 
 internal data class EnvironmentConfiguration(
-    val logLimitConfig: LogLimitConfig
+    val logLimitConfig: LogLimitConfig,
+    val spanLimitConfig: SpanLimitConfig,
 )

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/config/envar/tracing/SpanLimitEnvVarConfigProcessor.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/config/envar/tracing/SpanLimitEnvVarConfigProcessor.kt
@@ -1,0 +1,6 @@
+package io.opentelemetry.kotlin.config.envar.tracing
+
+import io.opentelemetry.kotlin.config.envar.processor.EnvVarConfigProcessor
+import io.opentelemetry.kotlin.init.config.SpanLimitConfig
+
+internal abstract class SpanLimitEnvVarConfigProcessor : EnvVarConfigProcessor<SpanLimitConfig, Int>()

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/config/envar/tracing/SpanLimitEnvVarConfigProcessorImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/config/envar/tracing/SpanLimitEnvVarConfigProcessorImpl.kt
@@ -1,0 +1,32 @@
+package io.opentelemetry.kotlin.config.envar.tracing
+
+import io.opentelemetry.kotlin.config.envar.model.EnvVarName
+import io.opentelemetry.kotlin.config.envar.model.EnvVarName.Companion.envVarName
+import io.opentelemetry.kotlin.config.envar.model.EnvironmentVariable
+import io.opentelemetry.kotlin.init.config.SpanLimitConfig
+
+internal class SpanLimitEnvVarConfigProcessorImpl(
+    override val envVars: List<EnvVarName>
+) : SpanLimitEnvVarConfigProcessor() {
+    override fun parse(rawValue: String?): Int? = rawValue?.toIntOrNull()?.takeIf { it >= 0 }
+
+    override fun process(
+        entries: Map<EnvVarName, EnvironmentVariable<Int>>,
+        defaultValue: SpanLimitConfig
+    ): SpanLimitConfig {
+        return SpanLimitConfig(
+            attributeCountLimit = entries[envVarName("OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT")]?.value
+                ?: defaultValue.attributeCountLimit,
+            attributeValueLengthLimit = entries[envVarName("OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT")]?.value
+                ?: defaultValue.attributeValueLengthLimit,
+            linkCountLimit = entries[envVarName("OTEL_SPAN_LINK_COUNT_LIMIT")]?.value
+                ?: defaultValue.linkCountLimit,
+            eventCountLimit = entries[envVarName("OTEL_SPAN_EVENT_COUNT_LIMIT")]?.value
+                ?: defaultValue.eventCountLimit,
+            attributeCountPerEventLimit = entries[envVarName("OTEL_EVENT_ATTRIBUTE_COUNT_LIMIT")]?.value
+                ?: defaultValue.attributeCountPerEventLimit,
+            attributeCountPerLinkLimit = entries[envVarName("OTEL_LINK_ATTRIBUTE_COUNT_LIMIT")]?.value
+                ?: defaultValue.attributeCountPerLinkLimit,
+        )
+    }
+}

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/config/envar/FakeSpanLimitEnvVarConfigProcessor.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/config/envar/FakeSpanLimitEnvVarConfigProcessor.kt
@@ -1,0 +1,17 @@
+package io.opentelemetry.kotlin.config.envar
+
+import io.opentelemetry.kotlin.config.envar.model.EnvVarName
+import io.opentelemetry.kotlin.config.envar.model.EnvironmentVariable
+import io.opentelemetry.kotlin.config.envar.tracing.SpanLimitEnvVarConfigProcessor
+import io.opentelemetry.kotlin.init.config.SpanLimitConfig
+
+internal class FakeSpanLimitEnvVarConfigProcessor : SpanLimitEnvVarConfigProcessor() {
+    override val envVars: List<EnvVarName> = emptyList()
+
+    override fun parse(rawValue: String?): Int? = null
+
+    override fun process(
+        entries: Map<EnvVarName, EnvironmentVariable<Int>>,
+        defaultValue: SpanLimitConfig
+    ): SpanLimitConfig = defaultValue
+}

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/config/envar/OpenTelemetryEnvVarConfigProcessorImplTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/config/envar/OpenTelemetryEnvVarConfigProcessorImplTest.kt
@@ -17,9 +17,12 @@ internal class OpenTelemetryEnvVarConfigProcessorImplTest {
             export { FakeLogRecordProcessor() }
         }
         val logLimitProcessor = FakeLogLimitEnvVarConfigProcessor()
+        val spanLimitProcessor = FakeSpanLimitEnvVarConfigProcessor()
         val configProcessor = OpenTelemetryEnvVarConfigProcessorImpl(
             loggingConfig = cfg.generateLoggingConfig(),
-            logLimitProcessor = logLimitProcessor
+            logLimitProcessor = logLimitProcessor,
+            tracingConfig = cfg.generateTracingConfig(),
+            spanLimitProcessor = spanLimitProcessor,
         )
 
         // when
@@ -33,6 +36,30 @@ internal class OpenTelemetryEnvVarConfigProcessorImplTest {
         assertEquals(
             expected = 128,
             actual = environmentConfiguration.logLimitConfig.attributeCountLimit
+        )
+        assertEquals(
+            expected = Int.MAX_VALUE,
+            actual = environmentConfiguration.spanLimitConfig.attributeValueLengthLimit
+        )
+        assertEquals(
+            expected = 128,
+            actual = environmentConfiguration.spanLimitConfig.attributeCountLimit
+        )
+        assertEquals(
+            expected = 128,
+            actual = environmentConfiguration.spanLimitConfig.eventCountLimit
+        )
+        assertEquals(
+            expected = 128,
+            actual = environmentConfiguration.spanLimitConfig.linkCountLimit
+        )
+        assertEquals(
+            expected = 128,
+            actual = environmentConfiguration.spanLimitConfig.attributeCountPerEventLimit
+        )
+        assertEquals(
+            expected = 128,
+            actual = environmentConfiguration.spanLimitConfig.attributeCountPerLinkLimit
         )
     }
 }

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/config/envar/model/EnvironmentConfigurationTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/config/envar/model/EnvironmentConfigurationTest.kt
@@ -15,15 +15,23 @@ internal class EnvironmentConfigurationTest {
         otelConfig.loggerProvider {
             export { FakeLogRecordProcessor() }
         }
-        val defaultValue = otelConfig.generateLoggingConfig().logLimits
+        val defaultLogLimits = otelConfig.generateLoggingConfig().logLimits
+        val defaultSpanLimits = otelConfig.generateTracingConfig().spanLimits
 
         // when
         val config = EnvironmentConfiguration(
-            logLimitConfig = defaultValue
+            logLimitConfig = defaultLogLimits,
+            spanLimitConfig = defaultSpanLimits,
         )
 
         // then
         assertEquals(Int.MAX_VALUE, config.logLimitConfig.attributeValueLengthLimit)
         assertEquals(128, config.logLimitConfig.attributeCountLimit)
+        assertEquals(Int.MAX_VALUE, config.spanLimitConfig.attributeValueLengthLimit)
+        assertEquals(128, config.spanLimitConfig.attributeCountLimit)
+        assertEquals(128, config.spanLimitConfig.eventCountLimit)
+        assertEquals(128, config.spanLimitConfig.linkCountLimit)
+        assertEquals(128, config.spanLimitConfig.attributeCountPerEventLimit)
+        assertEquals(128, config.spanLimitConfig.attributeCountPerLinkLimit)
     }
 }

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/config/envar/tracing/SpanLimitEnvVarConfigProcessorImplTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/config/envar/tracing/SpanLimitEnvVarConfigProcessorImplTest.kt
@@ -1,0 +1,124 @@
+package io.opentelemetry.kotlin.config.envar.tracing
+
+import io.opentelemetry.kotlin.clock.FakeClock
+import io.opentelemetry.kotlin.config.envar.EnvVarConstants
+import io.opentelemetry.kotlin.init.OpenTelemetryConfigImpl
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+internal class SpanLimitEnvVarConfigProcessorImplTest {
+
+    @Test
+    fun `should configure all span limit environment variables`() {
+        val processor = SpanLimitEnvVarConfigProcessorImpl(
+            envVars = EnvVarConstants.SpanLimits.envVars
+        )
+        val defaultValue = OpenTelemetryConfigImpl(FakeClock()).generateTracingConfig().spanLimits
+
+        val config = processor.configure(defaultValue = defaultValue) {
+            getFakeEnvVarValue(it)
+        }
+
+        assertEquals(1, config.attributeCountLimit)
+        assertEquals(2, config.attributeValueLengthLimit)
+        assertEquals(3, config.eventCountLimit)
+        assertEquals(4, config.linkCountLimit)
+        assertEquals(5, config.attributeCountPerEventLimit)
+        assertEquals(6, config.attributeCountPerLinkLimit)
+    }
+
+    @Test
+    fun `should preserve defaults when environment variables are unavailable`() {
+        val processor = SpanLimitEnvVarConfigProcessorImpl(
+            envVars = EnvVarConstants.SpanLimits.envVars
+        )
+        val defaultValue = OpenTelemetryConfigImpl(FakeClock()).generateTracingConfig().spanLimits
+
+        val config = processor.configure(defaultValue = defaultValue) { null }
+
+        assertEquals(128, config.attributeCountLimit)
+        assertEquals(Int.MAX_VALUE, config.attributeValueLengthLimit)
+        assertEquals(128, config.eventCountLimit)
+        assertEquals(128, config.linkCountLimit)
+        assertEquals(128, config.attributeCountPerEventLimit)
+        assertEquals(128, config.attributeCountPerLinkLimit)
+    }
+
+    @Test
+    fun `should preserve defaults for invalid environment variables`() {
+        val processor = SpanLimitEnvVarConfigProcessorImpl(
+            envVars = EnvVarConstants.SpanLimits.envVars
+        )
+        val defaultValue = OpenTelemetryConfigImpl(FakeClock()).generateTracingConfig().spanLimits
+
+        val config = processor.configure(defaultValue = defaultValue) {
+            getInvalidEnvVarValue(it)
+        }
+
+        assertEquals(128, config.attributeCountLimit)
+        assertEquals(Int.MAX_VALUE, config.attributeValueLengthLimit)
+        assertEquals(128, config.eventCountLimit)
+        assertEquals(128, config.linkCountLimit)
+        assertEquals(128, config.attributeCountPerEventLimit)
+        assertEquals(128, config.attributeCountPerLinkLimit)
+    }
+
+    @Test
+    fun `should preserve configured values for unset environment variables`() {
+        val processor = SpanLimitEnvVarConfigProcessorImpl(
+            envVars = EnvVarConstants.SpanLimits.envVars
+        )
+        val otelConfig = OpenTelemetryConfigImpl(FakeClock()).apply {
+            tracerProvider {
+                spanLimits {
+                    attributeCountLimit = 10
+                    attributeValueLengthLimit = 20
+                    eventCountLimit = 30
+                    linkCountLimit = 40
+                    attributeCountPerEventLimit = 50
+                    attributeCountPerLinkLimit = 60
+                }
+            }
+        }
+        val defaultValue = otelConfig.generateTracingConfig().spanLimits
+
+        val config = processor.configure(defaultValue = defaultValue) {
+            if (it == "OTEL_SPAN_EVENT_COUNT_LIMIT") {
+                "3"
+            } else {
+                null
+            }
+        }
+
+        assertEquals(10, config.attributeCountLimit)
+        assertEquals(20, config.attributeValueLengthLimit)
+        assertEquals(3, config.eventCountLimit)
+        assertEquals(40, config.linkCountLimit)
+        assertEquals(50, config.attributeCountPerEventLimit)
+        assertEquals(60, config.attributeCountPerLinkLimit)
+    }
+
+    private fun getFakeEnvVarValue(envVar: String): String {
+        return when (envVar) {
+            "OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT" -> "1"
+            "OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT" -> "2"
+            "OTEL_SPAN_EVENT_COUNT_LIMIT" -> "3"
+            "OTEL_SPAN_LINK_COUNT_LIMIT" -> "4"
+            "OTEL_EVENT_ATTRIBUTE_COUNT_LIMIT" -> "5"
+            "OTEL_LINK_ATTRIBUTE_COUNT_LIMIT" -> "6"
+            else -> "-1"
+        }
+    }
+
+    private fun getInvalidEnvVarValue(envVar: String): String {
+        return when (envVar) {
+            "OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT" -> "-1"
+            "OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT" -> ""
+            "OTEL_SPAN_EVENT_COUNT_LIMIT" -> "invalid"
+            "OTEL_SPAN_LINK_COUNT_LIMIT" -> "2147483648"
+            "OTEL_EVENT_ATTRIBUTE_COUNT_LIMIT" -> "-5"
+            "OTEL_LINK_ATTRIBUTE_COUNT_LIMIT" -> "1.5"
+            else -> "0"
+        }
+    }
+}


### PR DESCRIPTION
## Goal

Configure all six standard span-limit environment variables. Unset or invalid values keep the configured defaults.

Fixes #449

## Testing

- `./gradlew :implementation:jvmTest`
- Detekt for the changed common and JVM source sets
- `./gradlew :implementation:apiCheck`