### PR TITLE
Mark Logging API as stable

### DIFF
--- a/api/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/Logger.kt
+++ b/api/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/Logger.kt
@@ -10,7 +10,6 @@ import io.opentelemetry.kotlin.context.Context
  *
  * https://opentelemetry.io/docs/specs/otel/logs/api/#logger
  */
-@ExperimentalApi
 @ThreadSafe
 public interface Logger {
 
@@ -25,6 +24,7 @@ public interface Logger {
      * @param eventName The event name of the log record (optional)
      * @return true if a log record should be emitted
      */
+    @OptIn(ExperimentalApi::class)
     public fun enabled(
         context: Context? = null,
         severityNumber: SeverityNumber? = null,
@@ -46,6 +46,7 @@ public interface Logger {
      * - [exception] - an optional exception to associate with the log record
      * - [attributes] - additional attributes to associate with the log
      */
+    @OptIn(ExperimentalApi::class)
     public fun emit(
         body: Any? = null,
         eventName: String? = null,

--- a/api/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/LoggerProvider.kt
+++ b/api/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/LoggerProvider.kt
@@ -1,6 +1,5 @@
 package io.opentelemetry.kotlin.logging
 
-import io.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.kotlin.ThreadSafe
 import io.opentelemetry.kotlin.attributes.AttributesMutator
 
@@ -9,7 +8,6 @@ import io.opentelemetry.kotlin.attributes.AttributesMutator
  *
  * https://opentelemetry.io/docs/specs/otel/logs/api/#loggerprovider
  */
-@ExperimentalApi
 @ThreadSafe
 public interface LoggerProvider {
 

--- a/api/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/SeverityNumber.kt
+++ b/api/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/SeverityNumber.kt
@@ -1,13 +1,10 @@
 package io.opentelemetry.kotlin.logging
 
-import io.opentelemetry.kotlin.ExperimentalApi
-
 /**
  * Represents all possible severities of a log message.
  *
  * https://opentelemetry.io/docs/specs/otel/logs/data-model/#field-severitynumber
  */
-@ExperimentalApi
 public enum class SeverityNumber(public val severityNumber: Int) {
     UNKNOWN(0),
     TRACE(1),


### PR DESCRIPTION
## Goal

Removes the `ExperimentalApi` annotations and therefore marks the Logging API (Logger.kt, LoggerProvider.kt, SeverityNumber.kt within the api module) as stable, as discussed in the SIG. Closes #652