### PR TITLE
Clarify schemaUrl behavior if merged

### DIFF
--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/OpenTelemetryImplEntrypoint.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/OpenTelemetryImplEntrypoint.kt
@@ -32,7 +32,7 @@ public fun createOpenTelemetry(
     val cfg = OpenTelemetryConfigImpl(clock).apply(config)
     val idGenerator = cfg.resolveIdGenerator()
 
-    val resourceFactory = ResourceFactoryImpl()
+    val resourceFactory = ResourceFactoryImpl(cfg.sdkErrorHandler)
     val traceFlags = TraceFlagsFactoryImpl()
     val traceState = TraceStateFactoryImpl()
     val spanContext = SpanContextFactoryImpl(idGenerator, traceFlags, traceState)

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/factory/ResourceFactoryImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/factory/ResourceFactoryImpl.kt
@@ -3,15 +3,19 @@ package io.opentelemetry.kotlin.factory
 import io.opentelemetry.kotlin.attributes.AttributesModel
 import io.opentelemetry.kotlin.attributes.AttributesMutator
 import io.opentelemetry.kotlin.attributes.NO_ATTRIBUTE_LIMIT
+import io.opentelemetry.kotlin.error.SdkErrorHandler
 import io.opentelemetry.kotlin.resource.Resource
 import io.opentelemetry.kotlin.resource.ResourceImpl
 
-internal class ResourceFactoryImpl : ResourceFactory {
+internal class ResourceFactoryImpl(
+    private val sdkErrorHandler: SdkErrorHandler,
+) : ResourceFactory {
 
-    override val empty: Resource = ResourceImpl(AttributesModel(attributeLimit = NO_ATTRIBUTE_LIMIT), null)
+    override val empty: Resource =
+        ResourceImpl(AttributesModel(attributeLimit = NO_ATTRIBUTE_LIMIT), null, sdkErrorHandler)
 
     override fun create(schemaUrl: String?, attributes: AttributesMutator.() -> Unit): Resource {
         val attrs = AttributesModel(attributeLimit = NO_ATTRIBUTE_LIMIT).apply { attributes() }
-        return ResourceImpl(attrs, schemaUrl)
+        return ResourceImpl(attrs, schemaUrl, sdkErrorHandler)
     }
 }

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/LoggerProviderConfigImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/LoggerProviderConfigImpl.kt
@@ -45,7 +45,7 @@ internal class LoggerProviderConfigImpl(
     ): LoggingConfig = LoggingConfig(
         processor = processor,
         logLimits = generateLogLimitsConfig(globalLimits),
-        resource = base.merge(resourceConfigImpl.generateResource()),
+        resource = base.merge(resourceConfigImpl.generateResource(sdkErrorHandler)),
         sdkErrorHandler = sdkErrorHandler,
         loggerConfigurator = loggerConfigurator,
     )

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/MeterProviderConfigImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/MeterProviderConfigImpl.kt
@@ -10,7 +10,7 @@ internal class MeterProviderConfigImpl(
 ) : MeterProviderConfigDsl, ResourceConfigDsl by resourceConfigImpl {
 
     fun generateMetricsConfig(base: Resource): MetricsConfig = MetricsConfig(
-        resource = base.merge(resourceConfigImpl.generateResource()),
+        resource = base.merge(resourceConfigImpl.generateResource(sdkErrorHandler)),
         sdkErrorHandler = sdkErrorHandler,
     )
 }

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/OpenTelemetryConfigImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/OpenTelemetryConfigImpl.kt
@@ -19,7 +19,7 @@ internal class OpenTelemetryConfigImpl(
      * The handler is configured after the sub-configs below have been created, so they receive a
      * forwarder that resolves the configured handler on each report instead.
      */
-    private val sdkErrorHandler = SdkErrorHandler { configuredErrorHandler.onError(it) }
+    internal val sdkErrorHandler = SdkErrorHandler { configuredErrorHandler.onError(it) }
 
     internal val tracingConfig: TracerProviderConfigImpl = TracerProviderConfigImpl(clock, sdkErrorHandler)
     internal val loggingConfig: LoggerProviderConfigImpl = LoggerProviderConfigImpl(clock, sdkErrorHandler)
@@ -64,14 +64,17 @@ internal class OpenTelemetryConfigImpl(
 
     internal fun resolveIdGenerator(): IdGenerator = customIdGenerator?.invoke() ?: IdGeneratorImpl()
 
-    private val defaultResource by lazy(::sdkDefaultResource)
+    private val defaultResource by lazy { sdkDefaultResource(sdkErrorHandler) }
+
+    private fun generateBaseResource() =
+        defaultResource.merge(globalResourceConfig.generateResource(sdkErrorHandler))
 
     internal fun generateTracingConfig() =
-        tracingConfig.generateTracingConfig(defaultResource.merge(globalResourceConfig.generateResource()), globalAttributeLimits)
+        tracingConfig.generateTracingConfig(generateBaseResource(), globalAttributeLimits)
 
     internal fun generateLoggingConfig() =
-        loggingConfig.generateLoggingConfig(defaultResource.merge(globalResourceConfig.generateResource()), globalAttributeLimits)
+        loggingConfig.generateLoggingConfig(generateBaseResource(), globalAttributeLimits)
 
     internal fun generateMetricsConfig() =
-        metricsConfig.generateMetricsConfig(defaultResource.merge(globalResourceConfig.generateResource()))
+        metricsConfig.generateMetricsConfig(generateBaseResource())
 }

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/ResourceConfigImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/ResourceConfigImpl.kt
@@ -5,12 +5,13 @@ import io.opentelemetry.kotlin.attributes.AttributesModel
 import io.opentelemetry.kotlin.attributes.AttributesMutator
 import io.opentelemetry.kotlin.attributes.NO_ATTRIBUTE_LIMIT
 import io.opentelemetry.kotlin.attributes.setAttributes
+import io.opentelemetry.kotlin.error.SdkErrorHandler
 import io.opentelemetry.kotlin.resource.Resource
 import io.opentelemetry.kotlin.resource.ResourceImpl
 import io.opentelemetry.kotlin.semconv.ServiceAttributes
 import io.opentelemetry.kotlin.semconv.TelemetryAttributes
 
-internal fun sdkDefaultResource(): Resource = ResourceImpl(
+internal fun sdkDefaultResource(sdkErrorHandler: SdkErrorHandler): Resource = ResourceImpl(
     container = AttributesModel(
         attributeLimit = NO_ATTRIBUTE_LIMIT,
         attrs = mutableMapOf(
@@ -21,6 +22,7 @@ internal fun sdkDefaultResource(): Resource = ResourceImpl(
         ),
     ),
     schemaUrl = null,
+    sdkErrorHandler = sdkErrorHandler,
 )
 
 internal class ResourceConfigImpl : ResourceConfigDsl {
@@ -49,12 +51,13 @@ internal class ResourceConfigImpl : ResourceConfigDsl {
         }
     }
 
-    internal fun generateResource(): Resource {
+    internal fun generateResource(sdkErrorHandler: SdkErrorHandler): Resource {
         val attrs = resourceAttrs.attributes.toMutableMap()
         serviceNameOverride?.let { attrs[ServiceAttributes.SERVICE_NAME] = it }
         return ResourceImpl(
             schemaUrl = schemaUrl,
-            container = AttributesModel(attributeLimit = NO_ATTRIBUTE_LIMIT, attrs = attrs)
+            container = AttributesModel(attributeLimit = NO_ATTRIBUTE_LIMIT, attrs = attrs),
+            sdkErrorHandler = sdkErrorHandler,
         )
     }
 }

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/TracerProviderConfigImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/TracerProviderConfigImpl.kt
@@ -51,7 +51,7 @@ internal class TracerProviderConfigImpl(
     fun generateTracingConfig(base: Resource, globalLimits: AttributeLimitsConfigImpl? = null): TracingConfig = TracingConfig(
         processor = processor,
         spanLimits = generateSpanLimitsConfig(globalLimits),
-        resource = base.merge(resourceConfigImpl.generateResource()),
+        resource = base.merge(resourceConfigImpl.generateResource(sdkErrorHandler)),
         sdkErrorHandler = sdkErrorHandler,
         samplerFactory = { spanFactory -> SamplerConfigImpl(spanFactory).samplerAction() },
         tracerConfigurator = tracerConfigurator,

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/resource/ResourceImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/resource/ResourceImpl.kt
@@ -3,10 +3,14 @@ package io.opentelemetry.kotlin.resource
 import io.opentelemetry.kotlin.attributes.AttributeContainer
 import io.opentelemetry.kotlin.attributes.AttributesModel
 import io.opentelemetry.kotlin.attributes.NO_ATTRIBUTE_LIMIT
+import io.opentelemetry.kotlin.error.SdkError
+import io.opentelemetry.kotlin.error.SdkErrorHandler
+import io.opentelemetry.kotlin.error.SdkErrorSeverity
 
 internal class ResourceImpl(
     container: AttributeContainer,
     override val schemaUrl: String?,
+    private val sdkErrorHandler: SdkErrorHandler,
 ) : Resource {
 
     override val attributes: Map<String, Any> = container.attributes
@@ -15,17 +19,46 @@ internal class ResourceImpl(
         val impl = MutableResourceImpl(attributes.toMutableMap(), schemaUrl)
         impl.apply(action)
         val container = AttributesModel(attributeLimit = NO_ATTRIBUTE_LIMIT, attrs = impl.attributes)
-        return ResourceImpl(container, impl.schemaUrl)
+        return ResourceImpl(container, impl.schemaUrl, sdkErrorHandler)
     }
 
     override fun merge(other: Resource): Resource {
         val mergedAttrs = (attributes + other.attributes).toMutableMap()
-        val mergedSchema = when {
-            schemaUrl == null -> other.schemaUrl
-            other.schemaUrl == null -> schemaUrl
-            schemaUrl == other.schemaUrl -> schemaUrl
-            else -> other.schemaUrl
-        }
-        return ResourceImpl(AttributesModel(attributeLimit = NO_ATTRIBUTE_LIMIT, attrs = mergedAttrs), mergedSchema)
+        val mergedSchema = mergeSchemaUrls(sdkErrorHandler, schemaUrl, other.schemaUrl)
+        return ResourceImpl(
+            AttributesModel(attributeLimit = NO_ATTRIBUTE_LIMIT, attrs = mergedAttrs),
+            mergedSchema,
+            sdkErrorHandler,
+        )
     }
+}
+
+/**
+ * Resolves the schema URL of a merged resource, as described in the OTel specification.
+ *
+ * Merging two resources whose schema URLs are both non-null and different is a merging error, so
+ * this reports an [SdkError.ApiMisuse] and returns null.
+ *
+ * https://opentelemetry.io/docs/specs/otel/resource/sdk/#merge
+ */
+private fun mergeSchemaUrls(
+    sdkErrorHandler: SdkErrorHandler,
+    schemaUrl: String?,
+    otherSchemaUrl: String?,
+): String? {
+    if (schemaUrl == null) {
+        return otherSchemaUrl
+    }
+    if (otherSchemaUrl == null || schemaUrl == otherSchemaUrl) {
+        return schemaUrl
+    }
+    sdkErrorHandler.onError(
+        SdkError.ApiMisuse(
+            "Resource.merge",
+            "Cannot merge resources with conflicting schema URLs ($schemaUrl and " +
+                "$otherSchemaUrl). The merged resource will have no schema URL.",
+            SdkErrorSeverity.WARNING,
+        )
+    )
+    return null
 }

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/CreateOpenTelemetryErrorHandlerTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/CreateOpenTelemetryErrorHandlerTest.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 @OptIn(ExperimentalApi::class)
@@ -58,6 +59,36 @@ internal class CreateOpenTelemetryErrorHandlerTest {
 
         // the throwing processor must not surface as an exception to the caller
         assertEquals(OperationResultCode.Failure, tracerCloseable(api).shutdown())
+        assertFalse(handler.hasErrors())
+    }
+
+    @Test
+    fun `merging resources with conflicting schema urls reports an api misuse`() {
+        val handler = FakeSdkErrorHandler()
+        val api = createOpenTelemetry {
+            errorHandler(handler)
+        } as OpenTelemetrySdk
+
+        val merged = api.resource.create(schemaUrl = "https://example.com/base") {}
+            .merge(api.resource.create(schemaUrl = "https://example.com/other") {})
+
+        assertNull(merged.schemaUrl)
+        val error = handler.apiMisuses.single()
+        assertEquals("Resource.merge", error.api)
+        assertEquals(SdkErrorSeverity.WARNING, error.severity)
+    }
+
+    @Test
+    fun `merging resources with matching schema urls reports nothing`() {
+        val handler = FakeSdkErrorHandler()
+        val api = createOpenTelemetry {
+            errorHandler(handler)
+        } as OpenTelemetrySdk
+
+        val merged = api.resource.create(schemaUrl = "https://example.com/schema") {}
+            .merge(api.resource.create(schemaUrl = "https://example.com/schema") {})
+
+        assertEquals("https://example.com/schema", merged.schemaUrl)
         assertFalse(handler.hasErrors())
     }
 

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/factory/ResourceFactoryImplTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/factory/ResourceFactoryImplTest.kt
@@ -1,6 +1,7 @@
 package io.opentelemetry.kotlin.factory
 
 import io.opentelemetry.kotlin.attributes.DEFAULT_ATTRIBUTE_LIMIT
+import io.opentelemetry.kotlin.error.NoopSdkErrorHandler
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotSame
@@ -9,7 +10,7 @@ import kotlin.test.assertTrue
 
 internal class ResourceFactoryImplTest {
 
-    private val factory = ResourceFactoryImpl()
+    private val factory = ResourceFactoryImpl(NoopSdkErrorHandler)
 
     @Test
     fun testEmptyHasNoAttributes() {
@@ -23,7 +24,7 @@ internal class ResourceFactoryImplTest {
 
     @Test
     fun testEmptyReturnsSameInstance() {
-        assertNotSame(factory.empty, ResourceFactoryImpl().empty)
+        assertNotSame(factory.empty, ResourceFactoryImpl(NoopSdkErrorHandler).empty)
     }
 
     @Test

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/init/LoggerProviderConfigImplTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/init/LoggerProviderConfigImplTest.kt
@@ -21,7 +21,7 @@ import kotlin.test.assertSame
 internal class LoggerProviderConfigImplTest {
 
     private val clock = FakeClock()
-    private val base = sdkDefaultResource()
+    private val base = sdkDefaultResource(NoopSdkErrorHandler)
 
     @Test
     fun testDefaultLoggingConfig() {

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/init/MeterProviderConfigImplTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/init/MeterProviderConfigImplTest.kt
@@ -12,7 +12,7 @@ import kotlin.test.assertNull
 
 internal class MeterProviderConfigImplTest {
 
-    private val base = sdkDefaultResource()
+    private val base = sdkDefaultResource(NoopSdkErrorHandler)
 
     @Test
     fun testDefaultMetricsConfig() {

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/init/TracerProviderConfigImplTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/init/TracerProviderConfigImplTest.kt
@@ -39,7 +39,7 @@ import kotlin.test.assertSame
 internal class TracerProviderConfigImplTest {
 
     private val clock = FakeClock()
-    private val base = sdkDefaultResource()
+    private val base = sdkDefaultResource(NoopSdkErrorHandler)
 
     private val traceFlagsFactory = TraceFlagsFactoryImpl()
     private val traceStateFactory = TraceStateFactoryImpl()

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/LoggerProviderImplTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/LoggerProviderImplTest.kt
@@ -27,7 +27,7 @@ internal class LoggerProviderImplTest {
     private val loggingConfig = LoggingConfig(
         null,
         LogLimitConfig(100, 100),
-        ResourceImpl(AttributesModel(), null),
+        ResourceImpl(AttributesModel(), null, NoopSdkErrorHandler),
         NoopSdkErrorHandler,
         loggerConfigurator,
     )

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/metrics/MeterProviderImplTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/metrics/MeterProviderImplTest.kt
@@ -17,7 +17,7 @@ import kotlin.test.assertSame
 internal class MeterProviderImplTest {
 
     private val metricsConfig = MetricsConfig(
-        resource = ResourceImpl(AttributesModel(), null),
+        resource = ResourceImpl(AttributesModel(), null, NoopSdkErrorHandler),
         sdkErrorHandler = NoopSdkErrorHandler,
     )
     private lateinit var impl: MeterProviderImpl

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/resource/ResourceImplTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/resource/ResourceImplTest.kt
@@ -2,17 +2,23 @@ package io.opentelemetry.kotlin.resource
 
 import io.opentelemetry.kotlin.attributes.AttributesModel
 import io.opentelemetry.kotlin.attributes.DEFAULT_ATTRIBUTE_LIMIT
+import io.opentelemetry.kotlin.error.FakeSdkErrorHandler
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 internal class ResourceImplTest {
 
+    private val errorHandler = FakeSdkErrorHandler()
+
+    private fun resource(schemaUrl: String?, vararg attrs: Pair<String, Any>) =
+        ResourceImpl(AttributesModel(attrs = mutableMapOf(*attrs)), schemaUrl, errorHandler)
+
     @Test
     fun testResourceImpl() {
-        val attrs =
-            AttributesModel(attrs = mutableMapOf("key" to "value"))
-        val resource = ResourceImpl(attrs, "https://example.com/schema")
+        val resource = resource("https://example.com/schema", "key" to "value")
         val another = resource.asNewResource {
             attributes["foo"] = "value"
             schemaUrl = "https://example.com/another"
@@ -30,9 +36,7 @@ internal class ResourceImplTest {
 
     @Test
     fun testEmptyResource() {
-        val attrs =
-            AttributesModel(attrs = mutableMapOf("key" to "value"))
-        val resource = ResourceImpl(attrs, "https://example.com/schema")
+        val resource = resource("https://example.com/schema", "key" to "value")
         val another = resource.asNewResource {
             attributes.clear()
             schemaUrl = null
@@ -43,8 +47,7 @@ internal class ResourceImplTest {
 
     @Test
     fun testDefensiveCopy() {
-        val container = AttributesModel(attrs = mutableMapOf())
-        val resource = ResourceImpl(container, null)
+        val resource = resource(null)
         lateinit var attrs: MutableMap<String, Any>
         val another = resource.asNewResource {
             attrs = attributes
@@ -56,18 +59,16 @@ internal class ResourceImplTest {
     @Test
     fun testNewResourceNoAttributeLimit() {
         val count = DEFAULT_ATTRIBUTE_LIMIT + 3
-        val attrs = (0 until count).associate { "key$it" to "value$it" }
-        val container = AttributesModel(attrs = attrs.toMutableMap())
-        val resource = ResourceImpl(container, "https://example.com/schema")
+        val attrs = (0 until count).map { "key$it" to "value$it" as Any }
+        val resource = resource("https://example.com/schema", *attrs.toTypedArray())
         assertEquals(count, resource.attributes.size)
     }
 
     @Test
     fun testMutateResourceNoAttributeLimit() {
         val count = DEFAULT_ATTRIBUTE_LIMIT + 3
-        val attrs = (0 until count).associate { "key$it" to "value$it" }
-        val container = AttributesModel(attrs = attrs.toMutableMap())
-        val resource = ResourceImpl(container, "https://example.com/schema")
+        val attrs = (0 until count).map { "key$it" to "value$it" as Any }
+        val resource = resource("https://example.com/schema", *attrs.toTypedArray())
         val mutated = resource.asNewResource {
             attributes["extraKey"] = "extraValue"
         }
@@ -77,62 +78,71 @@ internal class ResourceImplTest {
 
     @Test
     fun testMergeNonOverlapping() {
-        val base = ResourceImpl(AttributesModel(attrs = mutableMapOf("a" to "1")), "https://example.com/base")
-        val other = ResourceImpl(AttributesModel(attrs = mutableMapOf("b" to "2")), "https://example.com/other")
+        val base = resource("https://example.com/schema", "a" to "1")
+        val other = resource("https://example.com/schema", "b" to "2")
         val merged = base.merge(other)
         assertEquals("1", merged.attributes["a"])
         assertEquals("2", merged.attributes["b"])
+        assertFalse(errorHandler.hasErrors())
     }
 
     @Test
     fun testMergeOtherWinsOnConflict() {
-        val base = ResourceImpl(AttributesModel(attrs = mutableMapOf("key" to "base")), null)
-        val other = ResourceImpl(AttributesModel(attrs = mutableMapOf("key" to "other")), null)
+        val base = resource(null, "key" to "base")
+        val other = resource(null, "key" to "other")
         val merged = base.merge(other)
         assertEquals("other", merged.attributes["key"])
+        assertFalse(errorHandler.hasErrors())
     }
 
     @Test
     fun testMergeSchemaUrlBothNull() {
-        val base = ResourceImpl(AttributesModel(), null)
-        val other = ResourceImpl(AttributesModel(), null)
-        assertNull(base.merge(other).schemaUrl)
+        assertNull(resource(null).merge(resource(null)).schemaUrl)
+        assertFalse(errorHandler.hasErrors())
     }
 
     @Test
     fun testMergeSchemaUrlBaseNull() {
-        val base = ResourceImpl(AttributesModel(), null)
-        val other = ResourceImpl(AttributesModel(), "https://example.com/other")
-        assertEquals("https://example.com/other", base.merge(other).schemaUrl)
+        val merged = resource(null).merge(resource("https://example.com/other"))
+        assertEquals("https://example.com/other", merged.schemaUrl)
+        assertFalse(errorHandler.hasErrors())
     }
 
     @Test
     fun testMergeSchemaUrlOtherNull() {
-        val base = ResourceImpl(AttributesModel(), "https://example.com/base")
-        val other = ResourceImpl(AttributesModel(), null)
-        assertEquals("https://example.com/base", base.merge(other).schemaUrl)
+        val merged = resource("https://example.com/base").merge(resource(null))
+        assertEquals("https://example.com/base", merged.schemaUrl)
+        assertFalse(errorHandler.hasErrors())
     }
 
     @Test
     fun testMergeSchemaUrlSame() {
-        val base = ResourceImpl(AttributesModel(), "https://example.com/schema")
-        val other = ResourceImpl(AttributesModel(), "https://example.com/schema")
-        assertEquals("https://example.com/schema", base.merge(other).schemaUrl)
+        val merged = resource("https://example.com/schema").merge(resource("https://example.com/schema"))
+        assertEquals("https://example.com/schema", merged.schemaUrl)
+        assertFalse(errorHandler.hasErrors())
     }
 
     @Test
-    fun testMergeSchemaUrlDifferentOtherWins() {
-        val base = ResourceImpl(AttributesModel(), "https://example.com/base")
-        val other = ResourceImpl(AttributesModel(), "https://example.com/other")
-        assertEquals("https://example.com/other", base.merge(other).schemaUrl)
+    fun testMergeConflictingSchemaUrlsDropsSchemaAndReportsError() {
+        val base = resource("https://example.com/base", "a" to "1")
+        val other = resource("https://example.com/other", "b" to "2")
+        val merged = base.merge(other)
+
+        assertNull(merged.schemaUrl)
+        assertEquals("1", merged.attributes["a"])
+        assertEquals("2", merged.attributes["b"])
+
+        val error = errorHandler.apiMisuses.single()
+        assertEquals("Resource.merge", error.api)
+        assertTrue(error.message.contains("https://example.com/base"))
+        assertTrue(error.message.contains("https://example.com/other"))
     }
 
     @Test
     fun testMergeNoAttributeLimit() {
-        val baseAttrs = (0 until DEFAULT_ATTRIBUTE_LIMIT).associate { "base$it" to "v$it" }
-        val otherAttrs = mapOf("extra" to "value")
-        val base = ResourceImpl(AttributesModel(attrs = baseAttrs.toMutableMap()), null)
-        val other = ResourceImpl(AttributesModel(attrs = otherAttrs.toMutableMap()), null)
+        val baseAttrs = (0 until DEFAULT_ATTRIBUTE_LIMIT).map { "base$it" to "v$it" as Any }
+        val base = resource(null, *baseAttrs.toTypedArray())
+        val other = resource(null, "extra" to "value")
         val merged = base.merge(other)
         assertEquals(DEFAULT_ATTRIBUTE_LIMIT + 1, merged.attributes.size)
         assertEquals("value", merged.attributes["extra"])

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/TracerProviderImplTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/TracerProviderImplTest.kt
@@ -27,7 +27,7 @@ internal class TracerProviderImplTest {
     private val tracingConfig = TracingConfig(
         null,
         fakeSpanLimitsConfig,
-        ResourceImpl(AttributesModel(), null),
+        ResourceImpl(AttributesModel(), null, NoopSdkErrorHandler),
         NoopSdkErrorHandler,
     )
 

--- a/sdk-api/src/commonMain/kotlin/io/opentelemetry/kotlin/resource/Resource.kt
+++ b/sdk-api/src/commonMain/kotlin/io/opentelemetry/kotlin/resource/Resource.kt
@@ -25,7 +25,12 @@ public interface Resource : AttributeContainer {
 
     /**
      * Merges this resource with [other], returning a new [Resource].
-     * Properties on [other] take precedence in the event of a conflict when merging.
+     * Attributes on [other] take precedence in the event of a conflict when merging.
+     *
+     * The [schemaUrl] of the merged resource is whichever of the two is non-null, or the shared
+     * value if both are equal. Merging resources whose schema URLs are both non-null and different
+     * is a merging error, which the specification leaves undefined; opentelemetry-kotlin SDK
+     * produces a resource with no [schemaUrl].
      *
      * https://opentelemetry.io/docs/specs/otel/resource/sdk/#merge
      */


### PR DESCRIPTION
## Goal

Closes #737 by documenting the behavior for if two resource objects have a schemaUrl mismatch. The behavior I've chosen is to avoid specifying a schemaUrl, as otherwise the SDK is being misleading.