### PR TITLE
Guard SdkErrorHandler

### DIFF
--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/init/CompatOpenTelemetryConfig.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/init/CompatOpenTelemetryConfig.kt
@@ -6,6 +6,7 @@ import io.opentelemetry.kotlin.aliases.OtelJavaResource
 import io.opentelemetry.kotlin.attributes.AttributesMutator
 import io.opentelemetry.kotlin.attributes.CompatAttributesModel
 import io.opentelemetry.kotlin.attributes.setAttributes
+import io.opentelemetry.kotlin.error.GuardedSdkErrorHandler
 import io.opentelemetry.kotlin.error.NoopSdkErrorHandler
 import io.opentelemetry.kotlin.error.SdkErrorHandler
 import io.opentelemetry.kotlin.factory.CompatIdGenerator
@@ -23,7 +24,7 @@ internal class CompatOpenTelemetryConfig(
 ) : OpenTelemetryConfigDsl {
 
     @Volatile private var configuredErrorHandler: SdkErrorHandler = NoopSdkErrorHandler
-    private val sdkErrorHandler = SdkErrorHandler { configuredErrorHandler.onError(it) }
+    private val sdkErrorHandler = GuardedSdkErrorHandler { configuredErrorHandler.onError(it) }
 
     internal val tracerProviderConfig = CompatTracerProviderConfig(clock, sdkErrorHandler)
     internal val loggerProviderConfig = CompatLoggerProviderConfig(clock, sdkErrorHandler)

--- a/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/init/CompatErrorHandlerConfigTest.kt
+++ b/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/init/CompatErrorHandlerConfigTest.kt
@@ -40,6 +40,14 @@ internal class CompatErrorHandlerConfigTest {
         captured.onError(sdkError())
     }
 
+    @Test
+    fun `a handler that throws does not terminate the process`() {
+        val captured = captureExportErrorHandler {
+            errorHandler { throw IllegalStateException("handler boom") }
+        }
+        captured.onError(sdkError())
+    }
+
     /**
      * Builds a compat config, capturing the [SdkErrorHandler] handed to the `export` block. When
      * [configureHandlerFirst] is false the handler is configured after that block has already run.

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/OpenTelemetryConfigImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/OpenTelemetryConfigImpl.kt
@@ -1,6 +1,7 @@
 package io.opentelemetry.kotlin.init
 
 import io.opentelemetry.kotlin.Clock
+import io.opentelemetry.kotlin.error.GuardedSdkErrorHandler
 import io.opentelemetry.kotlin.error.NoopSdkErrorHandler
 import io.opentelemetry.kotlin.error.SdkErrorHandler
 import io.opentelemetry.kotlin.factory.IdGenerator
@@ -19,7 +20,7 @@ internal class OpenTelemetryConfigImpl(
      * The handler is configured after the sub-configs below have been created, so they receive a
      * forwarder that resolves the configured handler on each report instead.
      */
-    private val sdkErrorHandler = SdkErrorHandler { configuredErrorHandler.onError(it) }
+    private val sdkErrorHandler = GuardedSdkErrorHandler { configuredErrorHandler.onError(it) }
 
     internal val tracingConfig: TracerProviderConfigImpl = TracerProviderConfigImpl(clock, sdkErrorHandler)
     internal val loggingConfig: LoggerProviderConfigImpl = LoggerProviderConfigImpl(clock, sdkErrorHandler)

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/CreateOpenTelemetryErrorHandlerTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/CreateOpenTelemetryErrorHandlerTest.kt
@@ -61,6 +61,17 @@ internal class CreateOpenTelemetryErrorHandlerTest {
         assertFalse(handler.hasErrors())
     }
 
+    @Test
+    fun `a handler that throws does not escape the SDK`() = runTest {
+        val api = createOpenTelemetry {
+            errorHandler { throw IllegalStateException("handler boom") }
+            tracerProvider {
+                export { throwingProcessor() }
+            }
+        }
+        assertEquals(OperationResultCode.Failure, tracerCloseable(api).shutdown())
+    }
+
     private fun throwingProcessor() = FakeSpanProcessor(
         shutdownCode = { throw IllegalStateException("boom") }
     )

--- a/sdk-common/api/jvm/sdk-common.api
+++ b/sdk-common/api/jvm/sdk-common.api
@@ -10,6 +10,11 @@ public final class io/opentelemetry/kotlin/config/ValidationKt {
 	public static final fun validateOrUseDefault (Lio/opentelemetry/kotlin/error/SdkErrorHandler;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 }
 
+public final class io/opentelemetry/kotlin/error/GuardedSdkErrorHandler : io/opentelemetry/kotlin/error/SdkErrorHandler {
+	public fun <init> (Lio/opentelemetry/kotlin/error/SdkErrorHandler;)V
+	public fun onError (Lio/opentelemetry/kotlin/error/SdkError;)V
+}
+
 public final class io/opentelemetry/kotlin/export/BatchExportOperationKt {
 	public static final fun batchExportOperation (Ljava/util/List;Lio/opentelemetry/kotlin/error/SdkErrorHandler;Lkotlin/jvm/functions/Function1;)Lio/opentelemetry/kotlin/export/OperationResultCode;
 	public static final fun batchExportOperationSuspend (Ljava/util/List;Lio/opentelemetry/kotlin/error/SdkErrorHandler;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;

--- a/sdk-common/src/commonMain/kotlin/io/opentelemetry/kotlin/error/GuardedSdkErrorHandler.kt
+++ b/sdk-common/src/commonMain/kotlin/io/opentelemetry/kotlin/error/GuardedSdkErrorHandler.kt
@@ -1,0 +1,17 @@
+package io.opentelemetry.kotlin.error
+
+/**
+ * Decorates an [SdkErrorHandler] so that a throwing implementation cannot destabilize the SDK.
+ */
+public class GuardedSdkErrorHandler(
+    private val delegate: SdkErrorHandler,
+) : SdkErrorHandler {
+
+    override fun onError(error: SdkError) {
+        try {
+            delegate.onError(error)
+        } catch (ignored: Throwable) {
+            // swallow
+        }
+    }
+}

--- a/sdk-common/src/commonTest/kotlin/io/opentelemetry/kotlin/error/GuardedSdkErrorHandlerTest.kt
+++ b/sdk-common/src/commonTest/kotlin/io/opentelemetry/kotlin/error/GuardedSdkErrorHandlerTest.kt
@@ -1,0 +1,43 @@
+package io.opentelemetry.kotlin.error
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertSame
+
+internal class GuardedSdkErrorHandlerTest {
+
+    @Test
+    fun forwardsReportsToTheDelegate() {
+        val delegate = FakeSdkErrorHandler()
+        val error = sdkError("first")
+
+        GuardedSdkErrorHandler(delegate).onError(error)
+
+        assertSame(error, delegate.errors.single())
+    }
+
+    @Test
+    fun swallowsThrowablesFromTheDelegate() {
+        val handler = GuardedSdkErrorHandler { throw IllegalStateException("boom") }
+
+        handler.onError(sdkError("first"))
+    }
+
+    @Test
+    fun keepsForwardingAfterTheDelegateThrows() {
+        val delegate = FakeSdkErrorHandler()
+        val handler = GuardedSdkErrorHandler {
+            delegate.onError(it)
+            if (delegate.errors.size == 1) {
+                error("boom")
+            }
+        }
+
+        handler.onError(sdkError("first"))
+        handler.onError(sdkError("second"))
+
+        assertEquals(listOf("first", "second"), delegate.apiMisuses.map(SdkError.ApiMisuse::api))
+    }
+
+    private fun sdkError(api: String) = SdkError.ApiMisuse(api, "boom", SdkErrorSeverity.WARNING)
+}


### PR DESCRIPTION
## Goal

Adds a guard around `SdkErrorHandler` so that when implementations throw, the SDK won't terminate the process.
