### PR TITLE
Create config model layer

### DIFF
--- a/config-model/README.md
+++ b/config-model/README.md
@@ -1,0 +1,15 @@
+# config-model
+
+This module contains the intermediate configuration model that every configuration mechanism
+targets: the programmatic DSL, environment variables, and declarative (YAML) configuration.
+
+Every field in the model is nullable, where `null` means *unset*. Models can be merged using the
+following precedence rules:
+
+```
+SDK defaults  <  (envars or declarative config file)  <  DSL
+```
+
+Envars are ignored if a declarative config file is present.
+
+https://opentelemetry.io/docs/specs/otel/configuration/

--- a/config-model/build.gradle.kts
+++ b/config-model/build.gradle.kts
@@ -1,0 +1,28 @@
+plugins {
+    kotlin("multiplatform")
+    id("com.android.kotlin.multiplatform.library")
+    id("io.opentelemetry.kotlin.build-logic")
+    id("signing")
+    id("com.vanniktech.maven.publish")
+    id("org.jetbrains.kotlinx.kover")
+}
+
+kotlin {
+    sourceSets {
+        val commonMain by getting {
+            dependencies {
+                api(project(":api"))
+            }
+        }
+        val commonTest by getting {
+            dependencies {
+                implementation(libs.kotlin.test)
+            }
+        }
+        val jvmTest by getting {
+            dependencies {
+                implementation(libs.kotlin.test)
+            }
+        }
+    }
+}

--- a/config-model/gradle.properties
+++ b/config-model/gradle.properties
@@ -1,0 +1,1 @@
+io.opentelemetry.kotlin.containsPublicApi=false

--- a/config-model/src/commonMain/kotlin/io/opentelemetry/kotlin/config/model/ConfigModel.kt
+++ b/config-model/src/commonMain/kotlin/io/opentelemetry/kotlin/config/model/ConfigModel.kt
@@ -1,0 +1,17 @@
+package io.opentelemetry.kotlin.config.model
+
+import io.opentelemetry.kotlin.ExperimentalApi
+
+/**
+ * Configuration supplied by one mechanism, which can be combined with configuration from another.
+ */
+@ExperimentalApi
+interface ConfigModel<T : ConfigModel<T>> {
+
+    /**
+     * Returns a copy of this model where every value configured in [higher] wins. Values left unset
+     * in [higher] keep whatever this model had, so a higher-precedence layer refines rather than
+     * replaces the layer below it.
+     */
+    fun mergeWith(higher: T): T
+}

--- a/config-model/src/commonMain/kotlin/io/opentelemetry/kotlin/config/model/ConfigResolver.kt
+++ b/config-model/src/commonMain/kotlin/io/opentelemetry/kotlin/config/model/ConfigResolver.kt
@@ -1,0 +1,26 @@
+package io.opentelemetry.kotlin.config.model
+
+import io.opentelemetry.kotlin.ExperimentalApi
+
+/**
+ * Resolves the configuration supplied by each mechanism into the single model the SDK is
+ * initialized with.
+ */
+@ExperimentalApi
+interface ConfigResolver {
+
+    /**
+     * Resolves the supplied layers, where `null` means the mechanism supplied no configuration.
+     *
+     * Precedence is `SDK defaults < (envars or declarative config file) < DSL`. [envars] are
+     * ignored entirely when [declarativeFile] is present.
+     *
+     * Anything left unset in the result was configured by no mechanism, and is left to the default
+     * the SDK being initialized already applies.
+     */
+    fun resolve(
+        envars: OpenTelemetryConfigModel?,
+        declarativeFile: OpenTelemetryConfigModel?,
+        dsl: OpenTelemetryConfigModel?,
+    ): OpenTelemetryConfigModel
+}

--- a/config-model/src/commonMain/kotlin/io/opentelemetry/kotlin/config/model/ConfigResolverImpl.kt
+++ b/config-model/src/commonMain/kotlin/io/opentelemetry/kotlin/config/model/ConfigResolverImpl.kt
@@ -1,0 +1,16 @@
+package io.opentelemetry.kotlin.config.model
+
+import io.opentelemetry.kotlin.ExperimentalApi
+
+@ExperimentalApi
+class ConfigResolverImpl : ConfigResolver {
+
+    override fun resolve(
+        envars: OpenTelemetryConfigModel?,
+        declarativeFile: OpenTelemetryConfigModel?,
+        dsl: OpenTelemetryConfigModel?,
+    ): OpenTelemetryConfigModel {
+        val layers = listOfNotNull(declarativeFile ?: envars, dsl)
+        return mergeConfigModels(layers)
+    }
+}

--- a/config-model/src/commonMain/kotlin/io/opentelemetry/kotlin/config/model/ModelMerge.kt
+++ b/config-model/src/commonMain/kotlin/io/opentelemetry/kotlin/config/model/ModelMerge.kt
@@ -1,0 +1,12 @@
+package io.opentelemetry.kotlin.config.model
+
+/**
+ * Merges two optional nodes, where [higher] comes from the higher-precedence layer.
+ *
+ * A `null` node means the layer said nothing about it, so the other layer's node is used as-is.
+ */
+internal fun <T : ConfigModel<T>> mergeNode(lower: T?, higher: T?): T? = when {
+    lower == null -> higher
+    higher == null -> lower
+    else -> lower.mergeWith(higher)
+}

--- a/config-model/src/commonMain/kotlin/io/opentelemetry/kotlin/config/model/OpenTelemetryConfigModel.kt
+++ b/config-model/src/commonMain/kotlin/io/opentelemetry/kotlin/config/model/OpenTelemetryConfigModel.kt
@@ -1,0 +1,25 @@
+package io.opentelemetry.kotlin.config.model
+
+import io.opentelemetry.kotlin.ExperimentalApi
+
+/**
+ * Configuration for the SDK, as supplied by one configuration mechanism.
+ *
+ * https://opentelemetry.io/docs/specs/otel/configuration/
+ */
+@ExperimentalApi
+data class OpenTelemetryConfigModel(
+    val tracerProvider: TracerProviderConfigModel? = null,
+) : ConfigModel<OpenTelemetryConfigModel> {
+
+    override fun mergeWith(higher: OpenTelemetryConfigModel): OpenTelemetryConfigModel = copy(
+        tracerProvider = mergeNode(tracerProvider, higher.tracerProvider),
+    )
+}
+
+/**
+ * Combines [layers] into a single model, where each layer takes precedence over the ones before it.
+ */
+@ExperimentalApi
+fun mergeConfigModels(layers: List<OpenTelemetryConfigModel>): OpenTelemetryConfigModel =
+    layers.fold(OpenTelemetryConfigModel()) { merged, layer -> merged.mergeWith(layer) }

--- a/config-model/src/commonMain/kotlin/io/opentelemetry/kotlin/config/model/SpanLimitsConfigModel.kt
+++ b/config-model/src/commonMain/kotlin/io/opentelemetry/kotlin/config/model/SpanLimitsConfigModel.kt
@@ -1,0 +1,53 @@
+package io.opentelemetry.kotlin.config.model
+
+import io.opentelemetry.kotlin.ExperimentalApi
+
+/**
+ * Limits on span data capture. A `null` limit is left to whatever default the SDK being configured
+ * already applies.
+ *
+ * https://opentelemetry.io/docs/specs/otel/trace/sdk/#span-limits
+ */
+@ExperimentalApi
+data class SpanLimitsConfigModel(
+
+    /**
+     * Maximum number of attributes that may be recorded on a span.
+     */
+    val attributeCountLimit: Int? = null,
+
+    /**
+     * Maximum length of a recorded attribute value.
+     */
+    val attributeValueLengthLimit: Int? = null,
+
+    /**
+     * Maximum number of links that may be recorded on a span.
+     */
+    val linkCountLimit: Int? = null,
+
+    /**
+     * Maximum number of events that may be recorded on a span.
+     */
+    val eventCountLimit: Int? = null,
+
+    /**
+     * Maximum number of attributes that may be recorded on a single event.
+     */
+    val attributeCountPerEventLimit: Int? = null,
+
+    /**
+     * Maximum number of attributes that may be recorded on a single link.
+     */
+    val attributeCountPerLinkLimit: Int? = null,
+) : ConfigModel<SpanLimitsConfigModel> {
+
+    override fun mergeWith(higher: SpanLimitsConfigModel): SpanLimitsConfigModel = copy(
+        attributeCountLimit = higher.attributeCountLimit ?: attributeCountLimit,
+        attributeValueLengthLimit = higher.attributeValueLengthLimit ?: attributeValueLengthLimit,
+        linkCountLimit = higher.linkCountLimit ?: linkCountLimit,
+        eventCountLimit = higher.eventCountLimit ?: eventCountLimit,
+        attributeCountPerEventLimit = higher.attributeCountPerEventLimit ?: attributeCountPerEventLimit,
+        attributeCountPerLinkLimit = higher.attributeCountPerLinkLimit ?: attributeCountPerLinkLimit,
+    )
+}

--- a/config-model/src/commonMain/kotlin/io/opentelemetry/kotlin/config/model/TracerProviderConfigModel.kt
+++ b/config-model/src/commonMain/kotlin/io/opentelemetry/kotlin/config/model/TracerProviderConfigModel.kt
@@ -1,0 +1,22 @@
+package io.opentelemetry.kotlin.config.model
+
+import io.opentelemetry.kotlin.ExperimentalApi
+
+/**
+ * Configuration for tracing.
+ *
+ * https://opentelemetry.io/docs/specs/otel/trace/sdk/#tracer-provider
+ */
+@ExperimentalApi
+data class TracerProviderConfigModel(
+
+    /**
+     * Limits on span data capture.
+     */
+    val spanLimits: SpanLimitsConfigModel? = null,
+) : ConfigModel<TracerProviderConfigModel> {
+
+    override fun mergeWith(higher: TracerProviderConfigModel): TracerProviderConfigModel = copy(
+        spanLimits = mergeNode(spanLimits, higher.spanLimits),
+    )
+}

--- a/config-model/src/commonTest/kotlin/io/opentelemetry/kotlin/config/model/ConfigResolverImplTest.kt
+++ b/config-model/src/commonTest/kotlin/io/opentelemetry/kotlin/config/model/ConfigResolverImplTest.kt
@@ -1,0 +1,114 @@
+package io.opentelemetry.kotlin.config.model
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+internal class ConfigResolverImplTest {
+
+    private val resolver = ConfigResolverImpl()
+
+    @Test
+    fun leavesEverythingUnsetWhenNoLayerConfiguresAnything() {
+        val resolved = resolver.resolve(envars = null, declarativeFile = null, dsl = null)
+
+        assertEquals(OpenTelemetryConfigModel(), resolved)
+        assertNull(resolved.tracerProvider)
+    }
+
+    @Test
+    fun leavesUnmentionedLimitsUnset() {
+        val limits = resolveSpanLimits(dsl = configWithSpanLimits(SpanLimitsConfigModel(linkCountLimit = 5)))
+
+        assertEquals(5, limits?.linkCountLimit)
+        assertNull(limits?.eventCountLimit)
+    }
+
+    @Test
+    fun eachLayerAloneIsApplied() {
+        val limits = SpanLimitsConfigModel(linkCountLimit = 5)
+
+        assertEquals(limits, resolveSpanLimits(envars = configWithSpanLimits(limits)))
+        assertEquals(limits, resolveSpanLimits(declarativeFile = configWithSpanLimits(limits)))
+        assertEquals(limits, resolveSpanLimits(dsl = configWithSpanLimits(limits)))
+    }
+
+    @Test
+    fun dslOverridesEnvars() {
+        val limits = resolveSpanLimits(
+            envars = configWithSpanLimits(SpanLimitsConfigModel(linkCountLimit = 5, eventCountLimit = 6)),
+            dsl = configWithSpanLimits(SpanLimitsConfigModel(linkCountLimit = 50)),
+        )
+
+        assertEquals(50, limits?.linkCountLimit)
+        assertEquals(6, limits?.eventCountLimit)
+    }
+
+    @Test
+    fun dslOverridesDeclarativeFile() {
+        val limits = resolveSpanLimits(
+            declarativeFile = configWithSpanLimits(
+                SpanLimitsConfigModel(linkCountLimit = 5, eventCountLimit = 6),
+            ),
+            dsl = configWithSpanLimits(SpanLimitsConfigModel(linkCountLimit = 50)),
+        )
+
+        assertEquals(50, limits?.linkCountLimit)
+        assertEquals(6, limits?.eventCountLimit)
+    }
+
+    /**
+     * The envars are dropped wholesale rather than merged beneath the file, so a field the file
+     * leaves unset stays unset and does not fall through to the envar value.
+     */
+    @Test
+    fun declarativeFileReplacesEnvarsRatherThanMergingWithThem() {
+        val limits = resolveSpanLimits(
+            envars = configWithSpanLimits(
+                SpanLimitsConfigModel(linkCountLimit = 5, eventCountLimit = 6),
+            ),
+            declarativeFile = configWithSpanLimits(SpanLimitsConfigModel(linkCountLimit = 50)),
+        )
+
+        assertEquals(50, limits?.linkCountLimit)
+        assertNull(limits?.eventCountLimit)
+    }
+
+    @Test
+    fun emptyDeclarativeFileStillReplacesEnvars() {
+        val resolved = resolver.resolve(
+            envars = configWithSpanLimits(SpanLimitsConfigModel(linkCountLimit = 5)),
+            declarativeFile = OpenTelemetryConfigModel(),
+            dsl = null,
+        )
+
+        assertEquals(OpenTelemetryConfigModel(), resolved)
+    }
+
+    @Test
+    fun dslWinsOverBothLowerLayers() {
+        val limits = resolveSpanLimits(
+            envars = configWithSpanLimits(SpanLimitsConfigModel(linkCountLimit = 5)),
+            declarativeFile = configWithSpanLimits(SpanLimitsConfigModel(linkCountLimit = 50)),
+            dsl = configWithSpanLimits(SpanLimitsConfigModel(linkCountLimit = 500)),
+        )
+
+        assertEquals(500, limits?.linkCountLimit)
+    }
+
+    @Test
+    fun preservesAValueOfZero() {
+        val limits = resolveSpanLimits(dsl = configWithSpanLimits(SpanLimitsConfigModel(linkCountLimit = 0)))
+
+        assertEquals(0, limits?.linkCountLimit)
+    }
+
+    private fun resolveSpanLimits(
+        envars: OpenTelemetryConfigModel? = null,
+        declarativeFile: OpenTelemetryConfigModel? = null,
+        dsl: OpenTelemetryConfigModel? = null,
+    ) = resolver.resolve(envars, declarativeFile, dsl).tracerProvider?.spanLimits
+
+    private fun configWithSpanLimits(spanLimits: SpanLimitsConfigModel) =
+        OpenTelemetryConfigModel(tracerProvider = TracerProviderConfigModel(spanLimits = spanLimits))
+}

--- a/config-model/src/commonTest/kotlin/io/opentelemetry/kotlin/config/model/ModelMergeTest.kt
+++ b/config-model/src/commonTest/kotlin/io/opentelemetry/kotlin/config/model/ModelMergeTest.kt
@@ -1,0 +1,36 @@
+package io.opentelemetry.kotlin.config.model
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+internal class ModelMergeTest {
+
+    @Test
+    fun usesHigherWhenLowerIsUnset() {
+        assertEquals(Node(2), mergeNode(null, Node(2)))
+    }
+
+    @Test
+    fun usesLowerWhenHigherIsUnset() {
+        assertEquals(Node(1), mergeNode(Node(1), null))
+    }
+
+    @Test
+    fun staysUnsetWhenNeitherLayerConfiguredIt() {
+        assertNull(mergeNode<Node>(null, null))
+    }
+
+    @Test
+    fun combinesWhenBothLayersConfiguredIt() {
+        assertEquals(Node(3), mergeNode(Node(1), Node(2)))
+    }
+
+    /**
+     * Sums on merge, so a merge performed when only one layer supplied a node shows up as a wrong
+     * value rather than silently passing.
+     */
+    private data class Node(val value: Int) : ConfigModel<Node> {
+        override fun mergeWith(higher: Node) = Node(value + higher.value)
+    }
+}

--- a/config-model/src/commonTest/kotlin/io/opentelemetry/kotlin/config/model/OpenTelemetryConfigModelTest.kt
+++ b/config-model/src/commonTest/kotlin/io/opentelemetry/kotlin/config/model/OpenTelemetryConfigModelTest.kt
@@ -1,0 +1,96 @@
+package io.opentelemetry.kotlin.config.model
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+internal class OpenTelemetryConfigModelTest {
+
+    @Test
+    fun everyFieldStartsUnset() {
+        assertNull(OpenTelemetryConfigModel().tracerProvider)
+    }
+
+    @Test
+    fun mergingEmptyModelChangesNothing() {
+        val populated = OpenTelemetryConfigModel(
+            tracerProvider = TracerProviderConfigModel(spanLimits = SpanLimitsConfigModel(linkCountLimit = 3)),
+        )
+
+        assertEquals(populated, populated.mergeWith(OpenTelemetryConfigModel()))
+    }
+
+    @Test
+    fun mergingIntoEmptyModelAdoptsEverything() {
+        val populated = OpenTelemetryConfigModel(
+            tracerProvider = TracerProviderConfigModel(spanLimits = SpanLimitsConfigModel(linkCountLimit = 3)),
+        )
+
+        assertEquals(populated, OpenTelemetryConfigModel().mergeWith(populated))
+    }
+
+    @Test
+    fun staysUnsetWhenNoLayerConfiguresAnything() {
+        assertEquals(
+            OpenTelemetryConfigModel(),
+            OpenTelemetryConfigModel().mergeWith(OpenTelemetryConfigModel()),
+        )
+    }
+
+    @Test
+    fun mergeRecursesIntoNestedBlocks() {
+        val merged = OpenTelemetryConfigModel(
+            tracerProvider = TracerProviderConfigModel(
+                spanLimits = SpanLimitsConfigModel(attributeCountLimit = 1, eventCountLimit = 4),
+            ),
+        ).mergeWith(
+            OpenTelemetryConfigModel(
+                tracerProvider = TracerProviderConfigModel(spanLimits = SpanLimitsConfigModel(eventCountLimit = 99)),
+            ),
+        )
+
+        assertEquals(1, merged.tracerProvider?.spanLimits?.attributeCountLimit)
+        assertEquals(99, merged.tracerProvider?.spanLimits?.eventCountLimit)
+    }
+
+    @Test
+    fun foldAppliesLayersInPrecedenceOrder() {
+        val envLayer = configWithSpanLimits(
+            SpanLimitsConfigModel(attributeCountLimit = 1, attributeValueLengthLimit = 2, linkCountLimit = 3),
+        )
+        val fileLayer = configWithSpanLimits(
+            SpanLimitsConfigModel(attributeCountLimit = 10, linkCountLimit = 30),
+        )
+        val dslLayer = configWithSpanLimits(SpanLimitsConfigModel(attributeCountLimit = 100))
+
+        val merged = mergeConfigModels(listOf(envLayer, fileLayer, dslLayer))
+
+        val limits = merged.tracerProvider?.spanLimits
+        assertEquals(100, limits?.attributeCountLimit)
+        assertEquals(30, limits?.linkCountLimit)
+        assertEquals(2, limits?.attributeValueLengthLimit)
+    }
+
+    @Test
+    fun foldOfNoLayersIsEmpty() {
+        assertEquals(OpenTelemetryConfigModel(), mergeConfigModels(emptyList()))
+    }
+
+    @Test
+    fun foldOfSingleLayerReturnsThatLayer() {
+        val layer = configWithSpanLimits(SpanLimitsConfigModel(linkCountLimit = 3))
+
+        assertEquals(layer, mergeConfigModels(listOf(layer)))
+    }
+
+    @Test
+    fun foldIgnoresLayersThatConfiguredNothing() {
+        val layer = configWithSpanLimits(SpanLimitsConfigModel(linkCountLimit = 3))
+        val layers = listOf(OpenTelemetryConfigModel(), layer, OpenTelemetryConfigModel())
+
+        assertEquals(layer, mergeConfigModels(layers))
+    }
+
+    private fun configWithSpanLimits(spanLimits: SpanLimitsConfigModel) =
+        OpenTelemetryConfigModel(tracerProvider = TracerProviderConfigModel(spanLimits = spanLimits))
+}

--- a/config-model/src/commonTest/kotlin/io/opentelemetry/kotlin/config/model/SpanLimitsConfigModelTest.kt
+++ b/config-model/src/commonTest/kotlin/io/opentelemetry/kotlin/config/model/SpanLimitsConfigModelTest.kt
@@ -1,0 +1,101 @@
+package io.opentelemetry.kotlin.config.model
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+internal class SpanLimitsConfigModelTest {
+
+    @Test
+    fun everyFieldStartsUnset() {
+        val model = SpanLimitsConfigModel()
+
+        assertNull(model.attributeCountLimit)
+        assertNull(model.attributeValueLengthLimit)
+        assertNull(model.linkCountLimit)
+        assertNull(model.eventCountLimit)
+        assertNull(model.attributeCountPerEventLimit)
+        assertNull(model.attributeCountPerLinkLimit)
+    }
+
+    @Test
+    fun keepsLowerValueWhenHigherLeavesItUnset() {
+        val merged = SpanLimitsConfigModel(attributeCountLimit = 10).mergeWith(SpanLimitsConfigModel())
+
+        assertEquals(10, merged.attributeCountLimit)
+        assertNull(merged.attributeValueLengthLimit)
+    }
+
+    @Test
+    fun adoptsHigherValueWhenLowerLeavesItUnset() {
+        val merged = SpanLimitsConfigModel().mergeWith(SpanLimitsConfigModel(attributeCountLimit = 10))
+
+        assertEquals(10, merged.attributeCountLimit)
+    }
+
+    @Test
+    fun staysUnsetWhenNeitherLayerConfiguredIt() {
+        assertEquals(SpanLimitsConfigModel(), SpanLimitsConfigModel().mergeWith(SpanLimitsConfigModel()))
+    }
+
+    @Test
+    fun treatsZeroAsAConfiguredValue() {
+        val merged = SpanLimitsConfigModel(linkCountLimit = 128).mergeWith(SpanLimitsConfigModel(linkCountLimit = 0))
+
+        assertEquals(0, merged.linkCountLimit)
+    }
+
+    @Test
+    fun refinesRatherThanReplaces() {
+        val lower = SpanLimitsConfigModel(
+            attributeCountLimit = 1,
+            attributeValueLengthLimit = 2,
+            linkCountLimit = 3,
+            eventCountLimit = 4,
+            attributeCountPerEventLimit = 5,
+            attributeCountPerLinkLimit = 6,
+        )
+
+        val merged = lower.mergeWith(SpanLimitsConfigModel(linkCountLimit = 99))
+
+        assertEquals(99, merged.linkCountLimit)
+        assertEquals(1, merged.attributeCountLimit)
+        assertEquals(2, merged.attributeValueLengthLimit)
+        assertEquals(4, merged.eventCountLimit)
+        assertEquals(5, merged.attributeCountPerEventLimit)
+        assertEquals(6, merged.attributeCountPerLinkLimit)
+    }
+
+    @Test
+    fun prefersHigherLayerForEveryField() {
+        val lower = SpanLimitsConfigModel(
+            attributeCountLimit = 1,
+            attributeValueLengthLimit = 2,
+            linkCountLimit = 3,
+            eventCountLimit = 4,
+            attributeCountPerEventLimit = 5,
+            attributeCountPerLinkLimit = 6,
+        )
+        val higher = SpanLimitsConfigModel(
+            attributeCountLimit = 10,
+            attributeValueLengthLimit = 20,
+            linkCountLimit = 30,
+            eventCountLimit = 40,
+            attributeCountPerEventLimit = 50,
+            attributeCountPerLinkLimit = 60,
+        )
+
+        assertEquals(higher, lower.mergeWith(higher))
+    }
+
+    @Test
+    fun doesNotMutateEitherLayer() {
+        val lower = SpanLimitsConfigModel(attributeCountLimit = 1)
+        val higher = SpanLimitsConfigModel(linkCountLimit = 2)
+
+        lower.mergeWith(higher)
+
+        assertEquals(SpanLimitsConfigModel(attributeCountLimit = 1), lower)
+        assertEquals(SpanLimitsConfigModel(linkCountLimit = 2), higher)
+    }
+}

--- a/config-model/src/commonTest/kotlin/io/opentelemetry/kotlin/config/model/TracerProviderConfigModelTest.kt
+++ b/config-model/src/commonTest/kotlin/io/opentelemetry/kotlin/config/model/TracerProviderConfigModelTest.kt
@@ -1,0 +1,44 @@
+package io.opentelemetry.kotlin.config.model
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+internal class TracerProviderConfigModelTest {
+
+    @Test
+    fun spanLimitsStartUnset() {
+        assertNull(TracerProviderConfigModel().spanLimits)
+    }
+
+    @Test
+    fun staysUnsetWhenNeitherLayerConfiguredSpanLimits() {
+        assertNull(TracerProviderConfigModel().mergeWith(TracerProviderConfigModel()).spanLimits)
+    }
+
+    @Test
+    fun adoptsSpanLimitsFromWhicheverLayerSuppliedThem() {
+        val limits = SpanLimitsConfigModel(linkCountLimit = 3)
+
+        assertEquals(
+            limits,
+            TracerProviderConfigModel().mergeWith(TracerProviderConfigModel(spanLimits = limits)).spanLimits,
+        )
+        assertEquals(
+            limits,
+            TracerProviderConfigModel(spanLimits = limits).mergeWith(TracerProviderConfigModel()).spanLimits,
+        )
+    }
+
+    @Test
+    fun mergesSpanLimitsWhenBothLayersSuppliedThem() {
+        val merged = TracerProviderConfigModel(
+            spanLimits = SpanLimitsConfigModel(attributeCountLimit = 1, linkCountLimit = 3),
+        ).mergeWith(
+            TracerProviderConfigModel(spanLimits = SpanLimitsConfigModel(linkCountLimit = 99)),
+        )
+
+        assertEquals(1, merged.spanLimits?.attributeCountLimit)
+        assertEquals(99, merged.spanLimits?.linkCountLimit)
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -23,6 +23,7 @@ include(
     ":sdk-api",
     ":sdk-common",
     ":config",
+    ":config-model",
     ":config-schema",
     ":noop",
     ":implementation",


### PR DESCRIPTION
## Goal

Begins working towards #762 by adding a `config-model` module with a model class representation of how OpenTelemetry can be configured. This is independent of the DSL (because that acts on live objects) and envar/yaml parsing, so that the concerns are separated.

Separating out this logic should make it simpler to apply precedence rules for config and also to reason about how the SDK is behaving.

## Testing

Added unit tests.
