### PR TITLE
Guard call to enabled() in processors

### DIFF
--- a/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/CompositeLogRecordProcessor.kt
+++ b/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/CompositeLogRecordProcessor.kt
@@ -42,7 +42,17 @@ internal class CompositeLogRecordProcessor(
     ): Boolean {
         // returns true if _any_ of the processors are enabled.
         return lock.read {
-            processors.any { it.enabled(context, instrumentationScopeInfo, severityNumber, eventName) }
+            var enabled = false
+            batchExportOperation(
+                processors,
+                sdkErrorHandler
+            ) {
+                if (it.enabled(context, instrumentationScopeInfo, severityNumber, eventName)) {
+                    enabled = true
+                }
+                OperationResultCode.Success
+            }
+            enabled
         }
     }
 }

--- a/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/export/CompositeLogRecordProcessorTest.kt
+++ b/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/export/CompositeLogRecordProcessorTest.kt
@@ -3,6 +3,7 @@ package io.opentelemetry.kotlin.logging.export
 import io.opentelemetry.kotlin.FakeInstrumentationScopeInfo
 import io.opentelemetry.kotlin.context.FakeContext
 import io.opentelemetry.kotlin.error.FakeSdkErrorHandler
+import io.opentelemetry.kotlin.error.SdkErrorSeverity
 import io.opentelemetry.kotlin.export.OperationResultCode
 import io.opentelemetry.kotlin.export.OperationResultCode.Failure
 import io.opentelemetry.kotlin.export.OperationResultCode.Success
@@ -219,5 +220,17 @@ internal class CompositeLogRecordProcessorTest {
         val second = FakeLogRecordProcessor(enabledResult = { true })
         val processor = CompositeLogRecordProcessor(listOf(first, second), errorHandler)
         assertTrue(processor.enabled(fakeContext, scopeInfo, null, null))
+    }
+
+    @Test
+    fun testEnabledOneProcessorThrows() {
+        val first = FakeLogRecordProcessor(enabledResult = { throw IllegalStateException("boom") })
+        val second = FakeLogRecordProcessor(enabledResult = { true })
+        val processor = CompositeLogRecordProcessor(listOf(first, second), errorHandler)
+
+        assertTrue(processor.enabled(fakeContext, scopeInfo, null, null))
+
+        assertEquals(1, errorHandler.userCodeErrors.size)
+        assertEquals(SdkErrorSeverity.WARNING, errorHandler.userCodeErrors.single().severity)
     }
 }

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/LoggerProviderConfigImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/LoggerProviderConfigImpl.kt
@@ -7,6 +7,7 @@ import io.opentelemetry.kotlin.init.config.LoggingConfig
 import io.opentelemetry.kotlin.logging.LoggerConfigImpl
 import io.opentelemetry.kotlin.logging.LoggerConfigurator
 import io.opentelemetry.kotlin.logging.export.LogRecordProcessor
+import io.opentelemetry.kotlin.logging.export.compositeLogRecordProcessor
 import io.opentelemetry.kotlin.platformLog
 import io.opentelemetry.kotlin.resource.Resource
 
@@ -28,7 +29,8 @@ internal class LoggerProviderConfigImpl(
             platformLog("export() should only be called once.")
             return
         }
-        processor = LogExportConfigImpl(clock, sdkErrorHandler).action()
+        val dsl = LogExportConfigImpl(clock, sdkErrorHandler)
+        processor = dsl.compositeLogRecordProcessor(dsl.action())
     }
 
     override fun logLimits(action: LogLimitsConfigDsl.() -> Unit) {

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/TracerProviderConfigImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/TracerProviderConfigImpl.kt
@@ -10,6 +10,7 @@ import io.opentelemetry.kotlin.resource.Resource
 import io.opentelemetry.kotlin.tracing.TracerConfigImpl
 import io.opentelemetry.kotlin.tracing.TracerConfigurator
 import io.opentelemetry.kotlin.tracing.export.SpanProcessor
+import io.opentelemetry.kotlin.tracing.export.compositeSpanProcessor
 import io.opentelemetry.kotlin.tracing.sampling.Sampler
 import io.opentelemetry.kotlin.tracing.sampling.alwaysOn
 import io.opentelemetry.kotlin.tracing.sampling.parentBased
@@ -37,7 +38,8 @@ internal class TracerProviderConfigImpl(
             platformLog("export() should only be called once.")
             return
         }
-        processor = TraceExportConfigImpl(clock, sdkErrorHandler).action()
+        val dsl = TraceExportConfigImpl(clock, sdkErrorHandler)
+        processor = dsl.compositeSpanProcessor(dsl.action())
     }
 
     override fun sampler(action: SamplerConfigDsl.() -> Sampler) {

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/BareProcessorFaultIsolationTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/BareProcessorFaultIsolationTest.kt
@@ -1,0 +1,113 @@
+package io.opentelemetry.kotlin
+
+import io.opentelemetry.kotlin.error.FakeSdkErrorHandler
+import io.opentelemetry.kotlin.error.SdkErrorSeverity
+import io.opentelemetry.kotlin.logging.export.FakeLogRecordProcessor
+import io.opentelemetry.kotlin.tracing.export.FakeSpanProcessor
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * A processor supplied to `export {}` without an explicit composite must still get the same fault
+ * isolation as one that is composited, i.e. a throw from user code is reported to the error handler
+ * rather than propagating into the instrumented application.
+ */
+@OptIn(ExperimentalApi::class)
+internal class BareProcessorFaultIsolationTest {
+
+    private val handler = FakeSdkErrorHandler()
+
+    @Test
+    fun `a bare span processor throwing in onStart does not reach the caller`() {
+        val processor = FakeSpanProcessor(startAction = { _, _ -> error("boom") })
+        val otel = otelWith(processor)
+
+        otel.tracerProvider.getTracer("test").startSpan("span")
+
+        assertEquals(1, processor.startCalls.size)
+        assertSingleUserCodeError()
+    }
+
+    @Test
+    fun `a bare span processor throwing in onEnding does not reach the caller and onEnd still fires`() {
+        val processor = FakeSpanProcessor(endingAction = { error("boom") })
+        val otel = otelWith(processor)
+
+        val span = otel.tracerProvider.getTracer("test").startSpan("span")
+        span.end()
+
+        assertEquals(1, processor.endingCalls.size)
+        assertEquals(1, processor.endCalls.size)
+        assertFalse(span.isRecording())
+        assertSingleUserCodeError()
+    }
+
+    @Test
+    fun `a bare span processor throwing in onEnd does not reach the caller`() {
+        val processor = FakeSpanProcessor(endAction = { error("boom") })
+        val otel = otelWith(processor)
+
+        otel.tracerProvider.getTracer("test").startSpan("span").end()
+
+        assertEquals(1, processor.endCalls.size)
+        assertSingleUserCodeError()
+    }
+
+    @Test
+    fun `a bare span processor that requires neither callback receives neither`() {
+        val processor = FakeSpanProcessor(startRequired = false, endRequired = false)
+        val otel = otelWith(processor)
+
+        otel.tracerProvider.getTracer("test").startSpan("span").end()
+
+        assertTrue(processor.startCalls.isEmpty())
+        assertTrue(processor.endingCalls.isEmpty())
+        assertTrue(processor.endCalls.isEmpty())
+        assertFalse(handler.hasErrors())
+    }
+
+    @Test
+    fun `a bare log record processor throwing in onEmit does not reach the caller`() {
+        val processor = FakeLogRecordProcessor(action = { _, _ -> error("boom") })
+        val otel = createOpenTelemetry {
+            errorHandler(handler)
+            loggerProvider {
+                export { processor }
+            }
+        }
+
+        otel.loggerProvider.getLogger("test").emit(body = "log")
+
+        assertEquals(1, processor.logs.size)
+        assertSingleUserCodeError()
+    }
+
+    @Test
+    fun `a bare log record processor throwing in enabled does not reach the caller`() {
+        val processor = FakeLogRecordProcessor(enabledResult = { error("boom") })
+        val otel = createOpenTelemetry {
+            errorHandler(handler)
+            loggerProvider {
+                export { processor }
+            }
+        }
+
+        assertFalse(otel.loggerProvider.getLogger("test").enabled())
+        assertSingleUserCodeError()
+    }
+
+    private fun otelWith(processor: FakeSpanProcessor) = createOpenTelemetry {
+        errorHandler(handler)
+        tracerProvider {
+            export { processor }
+        }
+    }
+
+    private fun assertSingleUserCodeError() {
+        val error = handler.userCodeErrors.single()
+        assertEquals(SdkErrorSeverity.WARNING, error.severity)
+        assertEquals("boom", error.cause.message)
+    }
+}

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/init/LoggerProviderConfigImplTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/init/LoggerProviderConfigImplTest.kt
@@ -2,21 +2,19 @@ package io.opentelemetry.kotlin.init
 
 import io.opentelemetry.kotlin.attributes.DEFAULT_ATTRIBUTE_LIMIT
 import io.opentelemetry.kotlin.clock.FakeClock
+import io.opentelemetry.kotlin.context.FakeContext
 import io.opentelemetry.kotlin.error.NoopSdkErrorHandler
 import io.opentelemetry.kotlin.logging.export.FakeLogRecordProcessor
-import io.opentelemetry.kotlin.logging.export.LogRecordProcessor
 import io.opentelemetry.kotlin.logging.export.compositeLogRecordProcessor
-import io.opentelemetry.kotlin.logging.export.simpleLogRecordProcessor
-import io.opentelemetry.kotlin.logging.export.stdoutLogRecordExporter
+import io.opentelemetry.kotlin.logging.model.FakeReadWriteLogRecord
 import io.opentelemetry.kotlin.sdkDefaultAttributes
 import io.opentelemetry.kotlin.semconv.ServiceAttributes
 import io.opentelemetry.kotlin.semconv.TelemetryAttributes
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
-import kotlin.test.assertNotSame
 import kotlin.test.assertNull
-import kotlin.test.assertSame
+import kotlin.test.assertTrue
 
 internal class LoggerProviderConfigImplTest {
 
@@ -69,22 +67,17 @@ internal class LoggerProviderConfigImplTest {
 
     @Test
     fun testDoubleExportConfigKeepsFirst() {
-        var first: LogRecordProcessor? = null
-        var second: LogRecordProcessor? = null
+        val first = FakeLogRecordProcessor()
+        val second = FakeLogRecordProcessor()
         val cfg = LoggerProviderConfigImpl(clock, NoopSdkErrorHandler).apply {
-            export {
-                simpleLogRecordProcessor(stdoutLogRecordExporter()).apply {
-                    first = this
-                }
-            }
-            export {
-                simpleLogRecordProcessor(stdoutLogRecordExporter()).apply {
-                    second = this
-                }
-            }
+            export { first }
+            export { second }
         }.generateLoggingConfig(base)
-        assertSame(first, cfg.processor)
-        assertNotSame(second, cfg.processor)
+
+        assertNotNull(cfg.processor).onEmit(FakeReadWriteLogRecord(), FakeContext())
+
+        assertEquals(1, first.logs.size)
+        assertTrue(second.logs.isEmpty())
     }
 
     @Test

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/init/TracerProviderConfigImplTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/init/TracerProviderConfigImplTest.kt
@@ -5,6 +5,7 @@ import io.opentelemetry.kotlin.attributes.AttributesModel
 import io.opentelemetry.kotlin.attributes.DEFAULT_ATTRIBUTE_LIMIT
 import io.opentelemetry.kotlin.clock.FakeClock
 import io.opentelemetry.kotlin.context.Context
+import io.opentelemetry.kotlin.context.FakeContext
 import io.opentelemetry.kotlin.error.NoopSdkErrorHandler
 import io.opentelemetry.kotlin.factory.ContextFactoryImpl
 import io.opentelemetry.kotlin.factory.FakeSpanFactory
@@ -16,11 +17,11 @@ import io.opentelemetry.kotlin.factory.TraceStateFactoryImpl
 import io.opentelemetry.kotlin.sdkDefaultAttributes
 import io.opentelemetry.kotlin.semconv.ServiceAttributes
 import io.opentelemetry.kotlin.semconv.TelemetryAttributes
+import io.opentelemetry.kotlin.tracing.FakeReadWriteSpan
 import io.opentelemetry.kotlin.tracing.NonRecordingSpan
 import io.opentelemetry.kotlin.tracing.SpanKind
 import io.opentelemetry.kotlin.tracing.TraceFlagsImpl
 import io.opentelemetry.kotlin.tracing.export.FakeSpanProcessor
-import io.opentelemetry.kotlin.tracing.export.SpanProcessor
 import io.opentelemetry.kotlin.tracing.export.compositeSpanProcessor
 import io.opentelemetry.kotlin.tracing.sampling.FakeSampler
 import io.opentelemetry.kotlin.tracing.sampling.ParentBasedSampler
@@ -32,9 +33,9 @@ import kotlin.test.assertContains
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
 import kotlin.test.assertNotNull
-import kotlin.test.assertNotSame
 import kotlin.test.assertNull
 import kotlin.test.assertSame
+import kotlin.test.assertTrue
 
 internal class TracerProviderConfigImplTest {
 
@@ -170,22 +171,17 @@ internal class TracerProviderConfigImplTest {
 
     @Test
     fun testDoubleExportConfigKeepsFirst() {
-        var first: SpanProcessor? = null
-        var second: SpanProcessor? = null
+        val first = FakeSpanProcessor()
+        val second = FakeSpanProcessor()
         val cfg = TracerProviderConfigImpl(clock, NoopSdkErrorHandler).apply {
-            export {
-                compositeSpanProcessor(FakeSpanProcessor()).apply {
-                    first = this
-                }
-            }
-            export {
-                compositeSpanProcessor(FakeSpanProcessor()).apply {
-                    second = this
-                }
-            }
+            export { first }
+            export { second }
         }.generateTracingConfig(base)
-        assertSame(first, cfg.processor)
-        assertNotSame(second, cfg.processor)
+
+        assertNotNull(cfg.processor).onStart(FakeReadWriteSpan(), FakeContext())
+
+        assertEquals(1, first.startCalls.size)
+        assertTrue(second.startCalls.isEmpty())
     }
 
     @Test


### PR DESCRIPTION
## Goal

Ensures that `enabled()` is guarded in user-submitted processors so that if it throws execution still continues. I've chosen to assume that throwing means the processor should continue as normal.