### PR TITLE
Implement ComposableAnnotatingSampler

### DIFF
--- a/implementation/api/jvm/implementation.api
+++ b/implementation/api/jvm/implementation.api
@@ -9,6 +9,7 @@ public final class io/opentelemetry/kotlin/tracing/sampling/BuiltInSamplerApiKt 
 	public static final fun alwaysRecord (Lio/opentelemetry/kotlin/init/SamplerConfigDsl;Lio/opentelemetry/kotlin/tracing/sampling/Sampler;)Lio/opentelemetry/kotlin/tracing/sampling/Sampler;
 	public static final fun composableAlwaysOff (Lio/opentelemetry/kotlin/init/SamplerConfigDsl;)Lio/opentelemetry/kotlin/tracing/sampling/ComposableSampler;
 	public static final fun composableAlwaysOn (Lio/opentelemetry/kotlin/init/SamplerConfigDsl;)Lio/opentelemetry/kotlin/tracing/sampling/ComposableSampler;
+	public static final fun composableAnnotating (Lio/opentelemetry/kotlin/init/SamplerConfigDsl;Lio/opentelemetry/kotlin/tracing/sampling/ComposableSampler;Lkotlin/jvm/functions/Function1;)Lio/opentelemetry/kotlin/tracing/sampling/ComposableSampler;
 	public static final fun composableParentThreshold (Lio/opentelemetry/kotlin/init/SamplerConfigDsl;Lio/opentelemetry/kotlin/tracing/sampling/ComposableSampler;)Lio/opentelemetry/kotlin/tracing/sampling/ComposableSampler;
 	public static final fun composableProbability (Lio/opentelemetry/kotlin/init/SamplerConfigDsl;D)Lio/opentelemetry/kotlin/tracing/sampling/ComposableSampler;
 	public static final fun composite (Lio/opentelemetry/kotlin/init/SamplerConfigDsl;Lkotlin/jvm/functions/Function1;)Lio/opentelemetry/kotlin/tracing/sampling/Sampler;

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/sampling/BuiltInSamplerApi.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/sampling/BuiltInSamplerApi.kt
@@ -1,6 +1,7 @@
 package io.opentelemetry.kotlin.tracing.sampling
 
 import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.attributes.AttributesMutator
 import io.opentelemetry.kotlin.init.SamplerConfigDsl
 
 /**
@@ -96,3 +97,15 @@ public fun SamplerConfigDsl.composableProbability(ratio: Double): ComposableSamp
 @ExperimentalApi
 public fun SamplerConfigDsl.composableParentThreshold(root: ComposableSampler): ComposableSampler =
     ComposableParentThresholdSampler(root)
+
+/**
+ * A [ComposableSampler] that leaves the sampling decision to [delegate] but adds attributes to
+ * spans that are sampled.
+ *
+ * https://opentelemetry.io/docs/specs/otel/trace/sdk/#composableannotating
+ */
+@ExperimentalApi
+public fun SamplerConfigDsl.composableAnnotating(
+    delegate: ComposableSampler,
+    attributes: AttributesMutator.() -> Unit,
+): ComposableSampler = ComposableAnnotatingSampler(delegate, attributes)

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/sampling/ComposableAnnotatingSampler.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/sampling/ComposableAnnotatingSampler.kt
@@ -1,0 +1,58 @@
+package io.opentelemetry.kotlin.tracing.sampling
+
+import io.opentelemetry.kotlin.attributes.AttributeContainer
+import io.opentelemetry.kotlin.attributes.AttributesModel
+import io.opentelemetry.kotlin.attributes.AttributesMutator
+import io.opentelemetry.kotlin.attributes.setAttributes
+import io.opentelemetry.kotlin.context.Context
+import io.opentelemetry.kotlin.tracing.SpanKind
+import io.opentelemetry.kotlin.tracing.model.SpanLink
+
+/**
+ * A [ComposableSampler] that delegates the sampling decision to [delegate], adding [annotations]
+ * to the span if it ends up being sampled.
+ *
+ * https://opentelemetry.io/docs/specs/otel/trace/sdk/#composableannotating
+ */
+internal class ComposableAnnotatingSampler(
+    private val delegate: ComposableSampler,
+    attributes: AttributesMutator.() -> Unit,
+) : ComposableSampler {
+
+    private val annotations: AttributesModel = AttributesModel().apply(attributes)
+
+    override fun getSamplingIntent(
+        context: Context,
+        name: String,
+        spanKind: SpanKind,
+        attributes: AttributeContainer,
+        links: List<SpanLink>
+    ): SamplingIntent {
+        val intent = delegate.getSamplingIntent(context, name, spanKind, attributes, links)
+        val delegateAttributes = intent.attributesProvider
+
+        return SamplingIntentImpl(
+            threshold = intent.threshold,
+            adjustedCountReliable = intent.adjustedCountReliable,
+            attributesProvider = if (delegateAttributes == null) {
+                { annotations }
+            } else {
+                { merge(delegateAttributes()) }
+            },
+            traceStateProvider = intent.traceStateProvider,
+        )
+    }
+
+    /**
+     * Combines the delegate's attributes with [annotations], which are applied last so that they
+     * win on key collision.
+     */
+    private fun merge(delegateAttributes: AttributeContainer): AttributeContainer =
+        AttributesModel().apply {
+            setAttributes(delegateAttributes.attributes)
+            setAttributes(annotations.attributes)
+        }
+
+    override val description: String
+        get() = "ComposableAnnotatingSampler{delegate:${delegate.description}}"
+}

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/sampling/BuiltInCompositeSamplerTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/sampling/BuiltInCompositeSamplerTest.kt
@@ -1,6 +1,7 @@
 package io.opentelemetry.kotlin.tracing.sampling
 
 import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.attributes.AttributeContainer
 import io.opentelemetry.kotlin.attributes.AttributesModel
 import io.opentelemetry.kotlin.context.Context
 import io.opentelemetry.kotlin.factory.ContextFactoryImpl
@@ -13,10 +14,13 @@ import io.opentelemetry.kotlin.init.SamplerConfigDsl
 import io.opentelemetry.kotlin.tracing.NonRecordingSpan
 import io.opentelemetry.kotlin.tracing.SpanKind
 import io.opentelemetry.kotlin.tracing.TraceFlagsImpl
+import io.opentelemetry.kotlin.tracing.TraceState
+import io.opentelemetry.kotlin.tracing.model.SpanLink
 import kotlin.random.Random
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
+import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 @OptIn(ExperimentalApi::class)
@@ -53,16 +57,30 @@ internal class BuiltInCompositeSamplerTest {
         return contextFactory.root().storeSpan(parentSpan)
     }
 
+    private fun Sampler.sample(
+        context: Context = contextFactory.root(),
+        traceId: String = this@BuiltInCompositeSamplerTest.traceId,
+    ): SamplingResult = shouldSample(context, traceId, "span", SpanKind.INTERNAL, AttributesModel(), emptyList())
+
+    private fun ComposableSampler.intent(context: Context = contextFactory.root()): SamplingIntent =
+        getSamplingIntent(context, "span", SpanKind.INTERNAL, AttributesModel(), emptyList())
+
+    private fun fakeComposableSampler(intent: SamplingIntent): ComposableSampler =
+        object : ComposableSampler {
+            override fun getSamplingIntent(
+                context: Context,
+                name: String,
+                spanKind: SpanKind,
+                attributes: AttributeContainer,
+                links: List<SpanLink>
+            ) = intent
+
+            override val description = "Fake"
+        }
+
     @Test
     fun `always samples when delegate is composableAlwaysOn`() {
-        val result = samplerDsl.composite { composableAlwaysOn() }.shouldSample(
-            context = contextFactory.root(),
-            traceId = traceId,
-            name = "span",
-            spanKind = SpanKind.INTERNAL,
-            attributes = AttributesModel(),
-            links = emptyList(),
-        )
+        val result = samplerDsl.composite { composableAlwaysOn() }.sample()
         assertEquals(SamplingResult.Decision.RECORD_AND_SAMPLE, result.decision)
         assertEquals("th:0", result.traceState.get("ot"))
         assertTrue(result.attributes.attributes.isEmpty())
@@ -70,14 +88,7 @@ internal class BuiltInCompositeSamplerTest {
 
     @Test
     fun `never samples when delegate is composableAlwaysOff`() {
-        val result = samplerDsl.composite { composableAlwaysOff() }.shouldSample(
-            context = contextFactory.root(),
-            traceId = traceId,
-            name = "span",
-            spanKind = SpanKind.INTERNAL,
-            attributes = AttributesModel(),
-            links = emptyList(),
-        )
+        val result = samplerDsl.composite { composableAlwaysOff() }.sample()
         assertEquals(SamplingResult.Decision.DROP, result.decision)
         assertNull(result.traceState.get("ot"))
         assertTrue(result.attributes.attributes.isEmpty())
@@ -85,81 +96,43 @@ internal class BuiltInCompositeSamplerTest {
 
     @Test
     fun `composableProbability with ratio 0 behaves like composableAlwaysOff`() {
-        val result = samplerDsl.composite { composableProbability(0.0) }.shouldSample(
-            context = contextFactory.root(),
-            traceId = traceId,
-            name = "span",
-            spanKind = SpanKind.INTERNAL,
-            attributes = AttributesModel(),
-            links = emptyList(),
-        )
+        val result = samplerDsl.composite { composableProbability(0.0) }.sample()
         assertEquals(SamplingResult.Decision.DROP, result.decision)
     }
 
     @Test
     fun `composableProbability reports adjustedCountReliable true per spec`() {
-        val intent = samplerDsl.composableProbability(0.5).getSamplingIntent(
-            context = contextFactory.root(),
-            name = "span",
-            spanKind = SpanKind.INTERNAL,
-            attributes = AttributesModel(),
-            links = emptyList(),
-        )
-        assertTrue(intent.adjustedCountReliable)
+        assertTrue(samplerDsl.composableProbability(0.5).intent().adjustedCountReliable)
     }
 
     @Test
     fun `always samples when delegate is composableProbability at ratio 1 and publishes threshold`() {
-        val result = samplerDsl.composite { composableProbability(1.0) }.shouldSample(
-            context = contextFactory.root(),
-            traceId = traceId,
-            name = "span",
-            spanKind = SpanKind.INTERNAL,
-            attributes = AttributesModel(),
-            links = emptyList(),
-        )
+        val result = samplerDsl.composite { composableProbability(1.0) }.sample()
         assertEquals(SamplingResult.Decision.RECORD_AND_SAMPLE, result.decision)
         assertEquals("th:0", result.traceState.get("ot"))
     }
 
     @Test
     fun `samples using trace id derived randomness when delegate is composableProbability`() {
-        val result = samplerDsl.composite { composableProbability(0.5) }.shouldSample(
-            context = contextFactory.root(),
-            traceId = "000000000000000000ffffffffffffff",
-            name = "span",
-            spanKind = SpanKind.INTERNAL,
-            attributes = AttributesModel(),
-            links = emptyList(),
-        )
+        val result = samplerDsl.composite { composableProbability(0.5) }
+            .sample(traceId = "000000000000000000ffffffffffffff")
         assertEquals(SamplingResult.Decision.RECORD_AND_SAMPLE, result.decision)
         assertEquals("th:8", result.traceState.get("ot"))
     }
 
     @Test
     fun `drops using trace id derived randomness when delegate is composableProbability`() {
-        val result = samplerDsl.composite { composableProbability(0.5) }.shouldSample(
-            context = contextFactory.root(),
-            traceId = "ffffffffffffffffff00000000000000",
-            name = "span",
-            spanKind = SpanKind.INTERNAL,
-            attributes = AttributesModel(),
-            links = emptyList(),
-        )
+        val result = samplerDsl.composite { composableProbability(0.5) }
+            .sample(traceId = "ffffffffffffffffff00000000000000")
         assertEquals(SamplingResult.Decision.DROP, result.decision)
         assertNull(result.traceState.get("ot"))
     }
 
     @Test
     fun `rewrites stale parent threshold when delegate is composableProbability`() {
-        val context = contextWithParent(sampled = true, isRemote = true, otValue = "th:123")
-        val result = samplerDsl.composite { composableProbability(0.5) }.shouldSample(
-            context = context,
+        val result = samplerDsl.composite { composableProbability(0.5) }.sample(
+            context = contextWithParent(sampled = true, isRemote = true, otValue = "th:123"),
             traceId = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-            name = "span",
-            spanKind = SpanKind.INTERNAL,
-            attributes = AttributesModel(),
-            links = emptyList(),
         )
         assertEquals("th:8", result.traceState.get("ot"))
     }
@@ -175,86 +148,94 @@ internal class BuiltInCompositeSamplerTest {
             SamplingResult.Decision.DROP
         }
 
-        val unreliableDelegate = object : ComposableSampler {
-            override fun getSamplingIntent(
-                context: Context,
-                name: String,
-                spanKind: SpanKind,
-                attributes: io.opentelemetry.kotlin.attributes.AttributeContainer,
-                links: List<io.opentelemetry.kotlin.tracing.model.SpanLink>
-            ) = SamplingIntentImpl(threshold = threshold, adjustedCountReliable = false)
-
-            override val description = "Unreliable"
-        }
-
-        val sampler = CompositeSampler(unreliableDelegate, random = Random(seed))
-        val result = sampler.shouldSample(
-            context = contextFactory.root(),
-            traceId = traceId,
-            name = "span",
-            spanKind = SpanKind.INTERNAL,
-            attributes = AttributesModel(),
-            links = emptyList(),
+        val unreliableDelegate = fakeComposableSampler(
+            SamplingIntentImpl(threshold = threshold, adjustedCountReliable = false)
         )
+        val result = CompositeSampler(unreliableDelegate, random = Random(seed)).sample()
+
         assertEquals(expectedDecision, result.decision)
         assertNull(result.traceState.get("ot"))
     }
 
     @Test
     fun `delegates to root when delegate is composableParentThreshold and there is no valid parent`() {
-        val result = samplerDsl.composite { composableParentThreshold(root = composableAlwaysOn()) }.shouldSample(
-            context = contextFactory.root(),
-            traceId = traceId,
-            name = "span",
-            spanKind = SpanKind.INTERNAL,
-            attributes = AttributesModel(),
-            links = emptyList(),
-        )
+        val result = samplerDsl.composite { composableParentThreshold(root = composableAlwaysOn()) }.sample()
         assertEquals(SamplingResult.Decision.RECORD_AND_SAMPLE, result.decision)
     }
 
     @Test
     fun `propagates parent threshold when delegate is composableParentThreshold`() {
-        val context = contextWithParent(sampled = true, isRemote = true, otValue = "th:8")
-        val result = samplerDsl.composite { composableParentThreshold(root = composableAlwaysOff()) }.shouldSample(
-            context = context,
-            traceId = traceId,
-            name = "span",
-            spanKind = SpanKind.INTERNAL,
-            attributes = AttributesModel(),
-            links = emptyList(),
-        )
+        val result = samplerDsl.composite { composableParentThreshold(root = composableAlwaysOff()) }
+            .sample(context = contextWithParent(sampled = true, isRemote = true, otValue = "th:8"))
         assertEquals(SamplingResult.Decision.RECORD_AND_SAMPLE, result.decision)
         assertEquals("th:8", result.traceState.get("ot"))
     }
 
     @Test
     fun `does not publish threshold when parent sampled without a threshold via composableParentThreshold`() {
-        val context = contextWithParent(sampled = true, isRemote = true)
-        val result = samplerDsl.composite { composableParentThreshold(root = composableAlwaysOff()) }.shouldSample(
-            context = context,
-            traceId = traceId,
-            name = "span",
-            spanKind = SpanKind.INTERNAL,
-            attributes = AttributesModel(),
-            links = emptyList(),
-        )
+        val result = samplerDsl.composite { composableParentThreshold(root = composableAlwaysOff()) }
+            .sample(context = contextWithParent(sampled = true, isRemote = true))
         assertEquals(SamplingResult.Decision.RECORD_AND_SAMPLE, result.decision)
         assertNull(result.traceState.get("ot"))
     }
 
     @Test
     fun `drops when parent not sampled without a threshold via composableParentThreshold`() {
-        val context = contextWithParent(sampled = false, isRemote = true)
-        val result = samplerDsl.composite { composableParentThreshold(root = composableAlwaysOn()) }.shouldSample(
-            context = context,
-            traceId = traceId,
-            name = "span",
-            spanKind = SpanKind.INTERNAL,
-            attributes = AttributesModel(),
-            links = emptyList(),
-        )
+        val result = samplerDsl.composite { composableParentThreshold(root = composableAlwaysOn()) }
+            .sample(context = contextWithParent(sampled = false, isRemote = true))
         assertEquals(SamplingResult.Decision.DROP, result.decision)
         assertNull(result.traceState.get("ot"))
+    }
+
+    @Test
+    fun `annotates sampled spans via composableAnnotating`() {
+        val annotating = samplerDsl.composableAnnotating(samplerDsl.composableProbability(0.5)) {
+            setStringAttribute("sampling.rule", "half")
+            setLongAttribute("sampling.priority", 1)
+        }
+        val result = samplerDsl.composite { annotating }.sample()
+
+        assertEquals(SamplingResult.Decision.RECORD_AND_SAMPLE, result.decision)
+        assertEquals("th:8", result.traceState.get("ot"))
+        assertEquals(mapOf("sampling.rule" to "half", "sampling.priority" to 1L), result.attributes.attributes)
+        assertTrue(annotating.intent().adjustedCountReliable)
+    }
+
+    @Test
+    fun `does not annotate dropped spans via composableAnnotating`() {
+        val result = samplerDsl.composite {
+            composableAnnotating(composableAlwaysOff()) { setStringAttribute("sampling.rule", "off") }
+        }.sample()
+        assertEquals(SamplingResult.Decision.DROP, result.decision)
+        assertTrue(result.attributes.attributes.isEmpty())
+    }
+
+    @Test
+    fun `merges delegate attributes via composableAnnotating`() {
+        val traceStateProvider: (TraceState, SamplingResult.Decision) -> TraceState =
+            { traceState, _ -> traceState.put("vendor", "value") }
+        val delegate = fakeComposableSampler(
+            SamplingIntentImpl(
+                threshold = 0,
+                adjustedCountReliable = true,
+                attributesProvider = {
+                    AttributesModel().apply {
+                        setStringAttribute("sampling.rule", "from-delegate")
+                        setStringAttribute("delegate.only", "kept")
+                    }
+                },
+                traceStateProvider = traceStateProvider,
+            )
+        )
+        val annotating = ComposableAnnotatingSampler(delegate) {
+            setStringAttribute("sampling.rule", "from-annotation")
+        }
+        val result = CompositeSampler(annotating).sample()
+
+        assertEquals(
+            mapOf("sampling.rule" to "from-annotation", "delegate.only" to "kept"),
+            result.attributes.attributes,
+        )
+        assertSame(traceStateProvider, annotating.intent().traceStateProvider)
     }
 }


### PR DESCRIPTION
## Goal

Implements a `ComposableAnnotatingSampler` which partially resolves #735. This delegates to another sampler but allows attributes to be added to sampled spans.