### PR TITLE
Parse the YAML config

### DIFF
--- a/buildSrc/src/main/kotlin/io/opentelemetry/kotlin/config/schema/ConfigModelGenerator.kt
+++ b/buildSrc/src/main/kotlin/io/opentelemetry/kotlin/config/schema/ConfigModelGenerator.kt
@@ -25,7 +25,7 @@ import com.squareup.kotlinpoet.TypeSpec
  * `opentelemetry-configuration` JSON schema.
  *
  * The schema is passed in as the nested [Map]/[List] structure produced by Groovy's `JsonSlurper`.
- * Every generated type is `internal` and annotated with kotlinx.serialization annotations.
+ * Every generated type is public and annotated with kotlinx.serialization annotations.
  */
 internal class ConfigModelGenerator(private val packageName: String) {
 
@@ -62,7 +62,7 @@ internal class ConfigModelGenerator(private val packageName: String) {
 
         val constructor = FunSpec.constructorBuilder()
         val typeBuilder = TypeSpec.classBuilder(name)
-            .addModifiers(KModifier.DATA, KModifier.INTERNAL)
+            .addModifiers(KModifier.DATA)
             .addAnnotation(serializable)
             .deriveKDoc(def)
 
@@ -85,7 +85,7 @@ internal class ConfigModelGenerator(private val packageName: String) {
 
             constructor.addParameter(param)
             typeBuilder.addProperty(
-                PropertySpec.builder(kotlinName, type, KModifier.INTERNAL)
+                PropertySpec.builder(kotlinName, type)
                     .initializer(kotlinName)
                     .deriveKDoc(propSchema)
                     .build()
@@ -97,7 +97,6 @@ internal class ConfigModelGenerator(private val packageName: String) {
 
     private fun buildEnum(name: String, def: Map<String, Any?>): FileSpec {
         val builder = TypeSpec.enumBuilder(name)
-            .addModifiers(KModifier.INTERNAL)
             .addAnnotation(serializable)
             .deriveKDoc(def)
 
@@ -116,7 +115,6 @@ internal class ConfigModelGenerator(private val packageName: String) {
 
     private fun buildMapTypeAlias(name: String, def: Map<String, Any?>): FileSpec {
         val alias = TypeAliasSpec.builder(name, MAP.parameterizedBy(STRING, contextualAnyNullable))
-            .addModifiers(KModifier.INTERNAL)
             .deriveKDoc(def)
             .build()
         return FileSpec.builder(packageName, name).addFileComment(HEADER).addTypeAlias(alias)
@@ -125,7 +123,6 @@ internal class ConfigModelGenerator(private val packageName: String) {
 
     private fun buildMarkerClass(name: String, def: Map<String, Any?>): FileSpec {
         val marker = TypeSpec.classBuilder(name)
-            .addModifiers(KModifier.INTERNAL)
             .addAnnotation(serializable)
             .deriveKDoc(def)
             .build()

--- a/config-schema/build.gradle.kts
+++ b/config-schema/build.gradle.kts
@@ -22,7 +22,7 @@ kotlin {
     sourceSets {
         val commonMain by getting {
             dependencies {
-                implementation(libs.kotlin.serialization)
+                api(libs.kotlin.serialization)
             }
         }
     }

--- a/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/Aggregation.kt
+++ b/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/Aggregation.kt
@@ -5,38 +5,38 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal data class Aggregation(
+public data class Aggregation(
   /**
    * Configures the stream to use the instrument kind to select an aggregation and advisory parameters to influence aggregation configuration parameters. See https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#default-aggregation for details.
    * If omitted, ignore.
    */
-  internal val default: DefaultAggregation? = null,
+  public val default: DefaultAggregation? = null,
   /**
    * Configures the stream to ignore/drop all instrument measurements. See https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#drop-aggregation for details.
    * If omitted, ignore.
    */
-  internal val drop: DropAggregation? = null,
+  public val drop: DropAggregation? = null,
   /**
    * Configures the stream to collect data for the histogram metric point using a set of explicit boundary values for histogram bucketing. See https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#explicit-bucket-histogram-aggregation for details
    * If omitted, ignore.
    */
   @SerialName("explicit_bucket_histogram")
-  internal val explicitBucketHistogram: ExplicitBucketHistogramAggregation? = null,
+  public val explicitBucketHistogram: ExplicitBucketHistogramAggregation? = null,
   /**
    * Configures the stream to collect data for the exponential histogram metric point, which uses a base-2 exponential formula to determine bucket boundaries and an integer scale parameter to control resolution. See https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#base2-exponential-bucket-histogram-aggregation for details.
    * If omitted, ignore.
    */
   @SerialName("base2_exponential_bucket_histogram")
-  internal val base2ExponentialBucketHistogram: Base2ExponentialBucketHistogramAggregation? = null,
+  public val base2ExponentialBucketHistogram: Base2ExponentialBucketHistogramAggregation? = null,
   /**
    * Configures the stream to collect data using the last measurement. See https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#last-value-aggregation for details.
    * If omitted, ignore.
    */
   @SerialName("last_value")
-  internal val lastValue: LastValueAggregation? = null,
+  public val lastValue: LastValueAggregation? = null,
   /**
    * Configures the stream to collect the arithmetic sum of measurement values. See https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#sum-aggregation for details.
    * If omitted, ignore.
    */
-  internal val sum: SumAggregation? = null,
+  public val sum: SumAggregation? = null,
 )

--- a/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/AlwaysOffSampler.kt
+++ b/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/AlwaysOffSampler.kt
@@ -4,4 +4,4 @@ package io.opentelemetry.kotlin.config.schema.model
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal class AlwaysOffSampler
+public class AlwaysOffSampler

--- a/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/AlwaysOnSampler.kt
+++ b/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/AlwaysOnSampler.kt
@@ -4,4 +4,4 @@ package io.opentelemetry.kotlin.config.schema.model
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal class AlwaysOnSampler
+public class AlwaysOnSampler

--- a/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/AttributeLimits.kt
+++ b/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/AttributeLimits.kt
@@ -6,19 +6,19 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal data class AttributeLimits(
+public data class AttributeLimits(
   /**
    * Configure max attribute value size. 
    * Value must be non-negative.
    * If omitted or null, there is no limit.
    */
   @SerialName("attribute_value_length_limit")
-  internal val attributeValueLengthLimit: Long? = null,
+  public val attributeValueLengthLimit: Long? = null,
   /**
    * Configure max attribute count. 
    * Value must be non-negative.
    * If omitted or null, 128 is used.
    */
   @SerialName("attribute_count_limit")
-  internal val attributeCountLimit: Long? = null,
+  public val attributeCountLimit: Long? = null,
 )

--- a/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/AttributeNameValue.kt
+++ b/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/AttributeNameValue.kt
@@ -7,18 +7,18 @@ import kotlinx.serialization.Contextual
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal data class AttributeNameValue(
+public data class AttributeNameValue(
   /**
    * The attribute name.
    * Property is required and must be non-null.
    */
-  internal val name: String,
+  public val name: String,
   /**
    * The attribute value.
    * The type of value must match .type.
    * Property must be present, but if null the entry is ignored.
    */
-  internal val `value`: @Contextual Any? = null,
+  public val `value`: @Contextual Any? = null,
   /**
    * The attribute type.
    * Values include:
@@ -32,5 +32,5 @@ internal data class AttributeNameValue(
    * * string_array: String array attribute value.
    * If omitted, string is used.
    */
-  internal val type: AttributeType? = null,
+  public val type: AttributeType? = null,
 )

--- a/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/AttributeType.kt
+++ b/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/AttributeType.kt
@@ -5,7 +5,7 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal enum class AttributeType {
+public enum class AttributeType {
   @SerialName("string")
   STRING,
   @SerialName("bool")

--- a/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/B3MultiPropagator.kt
+++ b/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/B3MultiPropagator.kt
@@ -4,4 +4,4 @@ package io.opentelemetry.kotlin.config.schema.model
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal class B3MultiPropagator
+public class B3MultiPropagator

--- a/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/B3Propagator.kt
+++ b/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/B3Propagator.kt
@@ -4,4 +4,4 @@ package io.opentelemetry.kotlin.config.schema.model
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal class B3Propagator
+public class B3Propagator

--- a/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/BaggagePropagator.kt
+++ b/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/BaggagePropagator.kt
@@ -4,4 +4,4 @@ package io.opentelemetry.kotlin.config.schema.model
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal class BaggagePropagator
+public class BaggagePropagator

--- a/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/Base2ExponentialBucketHistogramAggregation.kt
+++ b/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/Base2ExponentialBucketHistogramAggregation.kt
@@ -7,23 +7,23 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal data class Base2ExponentialBucketHistogramAggregation(
+public data class Base2ExponentialBucketHistogramAggregation(
   /**
    * Configure the max scale factor.
    * If omitted or null, 20 is used.
    */
   @SerialName("max_scale")
-  internal val maxScale: Long? = null,
+  public val maxScale: Long? = null,
   /**
    * Configure the maximum number of buckets in each of the positive and negative ranges, not counting the special zero bucket.
    * If omitted or null, 160 is used.
    */
   @SerialName("max_size")
-  internal val maxSize: Long? = null,
+  public val maxSize: Long? = null,
   /**
    * Configure whether or not to record min and max.
    * If omitted or null, true is used.
    */
   @SerialName("record_min_max")
-  internal val recordMinMax: Boolean? = null,
+  public val recordMinMax: Boolean? = null,
 )

--- a/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/BatchLogRecordProcessor.kt
+++ b/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/BatchLogRecordProcessor.kt
@@ -6,36 +6,36 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal data class BatchLogRecordProcessor(
+public data class BatchLogRecordProcessor(
   /**
    * Configure delay interval (in milliseconds) between two consecutive exports. 
    * Value must be non-negative.
    * If omitted or null, 1000 is used.
    */
   @SerialName("schedule_delay")
-  internal val scheduleDelay: Long? = null,
+  public val scheduleDelay: Long? = null,
   /**
    * Configure maximum allowed time (in milliseconds) to export data. 
    * Value must be non-negative. A value of 0 indicates no limit (infinity).
    * If omitted or null, 30000 is used.
    */
   @SerialName("export_timeout")
-  internal val exportTimeout: Long? = null,
+  public val exportTimeout: Long? = null,
   /**
    * Configure maximum queue size. Value must be positive.
    * If omitted or null, 2048 is used.
    */
   @SerialName("max_queue_size")
-  internal val maxQueueSize: Long? = null,
+  public val maxQueueSize: Long? = null,
   /**
    * Configure maximum batch size. Value must be positive.
    * If omitted or null, 512 is used.
    */
   @SerialName("max_export_batch_size")
-  internal val maxExportBatchSize: Long? = null,
+  public val maxExportBatchSize: Long? = null,
   /**
    * Configure exporter.
    * Property is required and must be non-null.
    */
-  internal val exporter: LogRecordExporter,
+  public val exporter: LogRecordExporter,
 )

--- a/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/BatchSpanProcessor.kt
+++ b/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/BatchSpanProcessor.kt
@@ -6,36 +6,36 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal data class BatchSpanProcessor(
+public data class BatchSpanProcessor(
   /**
    * Configure delay interval (in milliseconds) between two consecutive exports. 
    * Value must be non-negative.
    * If omitted or null, 5000 is used.
    */
   @SerialName("schedule_delay")
-  internal val scheduleDelay: Long? = null,
+  public val scheduleDelay: Long? = null,
   /**
    * Configure maximum allowed time (in milliseconds) to export data. 
    * Value must be non-negative. A value of 0 indicates no limit (infinity).
    * If omitted or null, 30000 is used.
    */
   @SerialName("export_timeout")
-  internal val exportTimeout: Long? = null,
+  public val exportTimeout: Long? = null,
   /**
    * Configure maximum queue size. Value must be positive.
    * If omitted or null, 2048 is used.
    */
   @SerialName("max_queue_size")
-  internal val maxQueueSize: Long? = null,
+  public val maxQueueSize: Long? = null,
   /**
    * Configure maximum batch size. Value must be positive.
    * If omitted or null, 512 is used.
    */
   @SerialName("max_export_batch_size")
-  internal val maxExportBatchSize: Long? = null,
+  public val maxExportBatchSize: Long? = null,
   /**
    * Configure exporter.
    * Property is required and must be non-null.
    */
-  internal val exporter: SpanExporter,
+  public val exporter: SpanExporter,
 )

--- a/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/CardinalityLimits.kt
+++ b/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/CardinalityLimits.kt
@@ -6,50 +6,50 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal data class CardinalityLimits(
+public data class CardinalityLimits(
   /**
    * Configure default cardinality limit for all instrument types.
    * Instrument-specific cardinality limits take priority.
    * If omitted or null, 2000 is used.
    */
-  internal val default: Long? = null,
+  public val default: Long? = null,
   /**
    * Configure default cardinality limit for counter instruments.
    * If omitted or null, the value from .default is used.
    */
-  internal val counter: Long? = null,
+  public val counter: Long? = null,
   /**
    * Configure default cardinality limit for gauge instruments.
    * If omitted or null, the value from .default is used.
    */
-  internal val gauge: Long? = null,
+  public val gauge: Long? = null,
   /**
    * Configure default cardinality limit for histogram instruments.
    * If omitted or null, the value from .default is used.
    */
-  internal val histogram: Long? = null,
+  public val histogram: Long? = null,
   /**
    * Configure default cardinality limit for observable_counter instruments.
    * If omitted or null, the value from .default is used.
    */
   @SerialName("observable_counter")
-  internal val observableCounter: Long? = null,
+  public val observableCounter: Long? = null,
   /**
    * Configure default cardinality limit for observable_gauge instruments.
    * If omitted or null, the value from .default is used.
    */
   @SerialName("observable_gauge")
-  internal val observableGauge: Long? = null,
+  public val observableGauge: Long? = null,
   /**
    * Configure default cardinality limit for observable_up_down_counter instruments.
    * If omitted or null, the value from .default is used.
    */
   @SerialName("observable_up_down_counter")
-  internal val observableUpDownCounter: Long? = null,
+  public val observableUpDownCounter: Long? = null,
   /**
    * Configure default cardinality limit for up_down_counter instruments.
    * If omitted or null, the value from .default is used.
    */
   @SerialName("up_down_counter")
-  internal val upDownCounter: Long? = null,
+  public val upDownCounter: Long? = null,
 )

--- a/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/ConsoleExporter.kt
+++ b/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/ConsoleExporter.kt
@@ -4,4 +4,4 @@ package io.opentelemetry.kotlin.config.schema.model
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal class ConsoleExporter
+public class ConsoleExporter

--- a/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/ConsoleMetricExporter.kt
+++ b/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/ConsoleMetricExporter.kt
@@ -5,7 +5,7 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal data class ConsoleMetricExporter(
+public data class ConsoleMetricExporter(
   /**
    * Configure temporality preference.
    * Values include:
@@ -15,7 +15,7 @@ internal data class ConsoleMetricExporter(
    * If omitted, cumulative is used.
    */
   @SerialName("temporality_preference")
-  internal val temporalityPreference: ExporterTemporalityPreference? = null,
+  public val temporalityPreference: ExporterTemporalityPreference? = null,
   /**
    * Configure default histogram aggregation.
    * Values include:
@@ -24,5 +24,5 @@ internal data class ConsoleMetricExporter(
    * If omitted, explicit_bucket_histogram is used.
    */
   @SerialName("default_histogram_aggregation")
-  internal val defaultHistogramAggregation: ExporterDefaultHistogramAggregation? = null,
+  public val defaultHistogramAggregation: ExporterDefaultHistogramAggregation? = null,
 )

--- a/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/DefaultAggregation.kt
+++ b/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/DefaultAggregation.kt
@@ -4,4 +4,4 @@ package io.opentelemetry.kotlin.config.schema.model
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal class DefaultAggregation
+public class DefaultAggregation

--- a/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/Distribution.kt
+++ b/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/Distribution.kt
@@ -6,4 +6,4 @@ import kotlin.String
 import kotlin.collections.Map
 import kotlinx.serialization.Contextual
 
-internal typealias Distribution = Map<String, @Contextual Any?>
+public typealias Distribution = Map<String, @Contextual Any?>

--- a/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/DropAggregation.kt
+++ b/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/DropAggregation.kt
@@ -4,4 +4,4 @@ package io.opentelemetry.kotlin.config.schema.model
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal class DropAggregation
+public class DropAggregation

--- a/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/ExemplarFilter.kt
+++ b/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/ExemplarFilter.kt
@@ -5,7 +5,7 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal enum class ExemplarFilter {
+public enum class ExemplarFilter {
   @SerialName("always_on")
   ALWAYS_ON,
   @SerialName("always_off")

--- a/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/ExperimentalCodeInstrumentation.kt
+++ b/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/ExperimentalCodeInstrumentation.kt
@@ -4,7 +4,7 @@ package io.opentelemetry.kotlin.config.schema.model
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal data class ExperimentalCodeInstrumentation(
+public data class ExperimentalCodeInstrumentation(
   /**
    * Configure code semantic convention version and migration behavior.
    *
@@ -13,5 +13,5 @@ internal data class ExperimentalCodeInstrumentation(
    * See code semantic conventions: https://opentelemetry.io/docs/specs/semconv/registry/attributes/code/
    * If omitted, uses the general stability_opt_in_list setting, or instrumentations continue emitting their default semantic convention version if not set.
    */
-  internal val semconv: ExperimentalSemconvConfig? = null,
+  public val semconv: ExperimentalSemconvConfig? = null,
 )

--- a/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/ExperimentalComposableAlwaysOffSampler.kt
+++ b/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/ExperimentalComposableAlwaysOffSampler.kt
@@ -4,4 +4,4 @@ package io.opentelemetry.kotlin.config.schema.model
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal class ExperimentalComposableAlwaysOffSampler
+public class ExperimentalComposableAlwaysOffSampler

--- a/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/ExperimentalComposableAlwaysOnSampler.kt
+++ b/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/ExperimentalComposableAlwaysOnSampler.kt
@@ -4,4 +4,4 @@ package io.opentelemetry.kotlin.config.schema.model
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal class ExperimentalComposableAlwaysOnSampler
+public class ExperimentalComposableAlwaysOnSampler

--- a/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/ExperimentalComposableParentThresholdSampler.kt
+++ b/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/ExperimentalComposableParentThresholdSampler.kt
@@ -4,10 +4,10 @@ package io.opentelemetry.kotlin.config.schema.model
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal data class ExperimentalComposableParentThresholdSampler(
+public data class ExperimentalComposableParentThresholdSampler(
   /**
    * Sampler to use when there is no parent.
    * Property is required and must be non-null.
    */
-  internal val root: ExperimentalComposableSampler,
+  public val root: ExperimentalComposableSampler,
 )

--- a/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/ExperimentalComposableProbabilitySampler.kt
+++ b/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/ExperimentalComposableProbabilitySampler.kt
@@ -5,10 +5,10 @@ import kotlin.Double
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal data class ExperimentalComposableProbabilitySampler(
+public data class ExperimentalComposableProbabilitySampler(
   /**
    * Configure ratio.
    * If omitted or null, 1.0 is used.
    */
-  internal val ratio: Double? = null,
+  public val ratio: Double? = null,
 )

--- a/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/ExperimentalComposableRuleBasedSampler.kt
+++ b/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/ExperimentalComposableRuleBasedSampler.kt
@@ -5,7 +5,7 @@ import kotlin.collections.List
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal data class ExperimentalComposableRuleBasedSampler(
+public data class ExperimentalComposableRuleBasedSampler(
   /**
    * The rules for the sampler, matched in order.
    * Each rule can have multiple match conditions. All conditions must match for the rule to match.
@@ -13,5 +13,5 @@ internal data class ExperimentalComposableRuleBasedSampler(
    * If no rules match, the span is not sampled.
    * If omitted, no span is sampled.
    */
-  internal val rules: List<ExperimentalComposableRuleBasedSamplerRule>? = null,
+  public val rules: List<ExperimentalComposableRuleBasedSamplerRule>? = null,
 )

--- a/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/ExperimentalComposableRuleBasedSamplerRule.kt
+++ b/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/ExperimentalComposableRuleBasedSamplerRule.kt
@@ -10,7 +10,7 @@ import kotlinx.serialization.Serializable
  * If no conditions are specified, the rule matches all spans that reach it.
  */
 @Serializable
-internal data class ExperimentalComposableRuleBasedSamplerRule(
+public data class ExperimentalComposableRuleBasedSamplerRule(
   /**
    * Values to match against a single attribute. Non-string attributes are matched using their string representation:
    * for example, a value of "404" would match the http.response.status_code 404. For array attributes, if any
@@ -18,7 +18,7 @@ internal data class ExperimentalComposableRuleBasedSamplerRule(
    * If omitted, ignore.
    */
   @SerialName("attribute_values")
-  internal val attributeValues: ExperimentalComposableRuleBasedSamplerRuleAttributeValues? = null,
+  public val attributeValues: ExperimentalComposableRuleBasedSamplerRuleAttributeValues? = null,
   /**
    * Patterns to match against a single attribute. Non-string attributes are matched using their string representation:
    * for example, a pattern of "4*" would match any http.response.status_code in 400-499. For array attributes, if any
@@ -26,8 +26,7 @@ internal data class ExperimentalComposableRuleBasedSamplerRule(
    * If omitted, ignore.
    */
   @SerialName("attribute_patterns")
-  internal val attributePatterns:
-      ExperimentalComposableRuleBasedSamplerRuleAttributePatterns? = null,
+  public val attributePatterns: ExperimentalComposableRuleBasedSamplerRuleAttributePatterns? = null,
   /**
    * The span kinds to match. If the span's kind matches any of these, it matches.
    * Values include:
@@ -39,7 +38,7 @@ internal data class ExperimentalComposableRuleBasedSamplerRule(
    * If omitted, ignore.
    */
   @SerialName("span_kinds")
-  internal val spanKinds: List<SpanKind>? = null,
+  public val spanKinds: List<SpanKind>? = null,
   /**
    * The parent span types to match.
    * Values include:
@@ -48,10 +47,10 @@ internal data class ExperimentalComposableRuleBasedSamplerRule(
    * * remote: remote, a remote parent.
    * If omitted, ignore.
    */
-  internal val parent: List<ExperimentalSpanParent>? = null,
+  public val parent: List<ExperimentalSpanParent>? = null,
   /**
    * The sampler to use for matching spans.
    * Property is required and must be non-null.
    */
-  internal val sampler: ExperimentalComposableSampler,
+  public val sampler: ExperimentalComposableSampler,
 )

--- a/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/ExperimentalComposableRuleBasedSamplerRuleAttributePatterns.kt
+++ b/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/ExperimentalComposableRuleBasedSamplerRuleAttributePatterns.kt
@@ -6,12 +6,12 @@ import kotlin.collections.List
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal data class ExperimentalComposableRuleBasedSamplerRuleAttributePatterns(
+public data class ExperimentalComposableRuleBasedSamplerRuleAttributePatterns(
   /**
    * The attribute key to match against.
    * Property is required and must be non-null.
    */
-  internal val key: String,
+  public val key: String,
   /**
    * Configure list of value patterns to include.
    * Matching is case-sensitive. Values are evaluated to match as follows:
@@ -19,7 +19,7 @@ internal data class ExperimentalComposableRuleBasedSamplerRuleAttributePatterns(
    *  * If the value matches the wildcard pattern, where '?' matches any single character and '*' matches any number of characters including none.
    * If omitted, all values are included.
    */
-  internal val included: List<String>? = null,
+  public val included: List<String>? = null,
   /**
    * Configure list of value patterns to exclude. Applies after .included (i.e. excluded has higher priority than included).
    * Matching is case-sensitive. Values are evaluated to match as follows:
@@ -27,5 +27,5 @@ internal data class ExperimentalComposableRuleBasedSamplerRuleAttributePatterns(
    *  * If the value matches the wildcard pattern, where '?' matches any single character and '*' matches any number of characters including none.
    * If omitted, .included attributes are included.
    */
-  internal val excluded: List<String>? = null,
+  public val excluded: List<String>? = null,
 )

--- a/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/ExperimentalComposableRuleBasedSamplerRuleAttributeValues.kt
+++ b/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/ExperimentalComposableRuleBasedSamplerRuleAttributeValues.kt
@@ -6,15 +6,15 @@ import kotlin.collections.List
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal data class ExperimentalComposableRuleBasedSamplerRuleAttributeValues(
+public data class ExperimentalComposableRuleBasedSamplerRuleAttributeValues(
   /**
    * The attribute key to match against.
    * Property is required and must be non-null.
    */
-  internal val key: String,
+  public val key: String,
   /**
    * The attribute values to match against. If the attribute's value matches any of these, it matches.
    * Property is required and must be non-null.
    */
-  internal val values: List<String>,
+  public val values: List<String>,
 )

--- a/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/ExperimentalComposableSampler.kt
+++ b/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/ExperimentalComposableSampler.kt
@@ -5,34 +5,34 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal data class ExperimentalComposableSampler(
+public data class ExperimentalComposableSampler(
   /**
    * Configure sampler to be always_off.
    * If omitted, ignore.
    */
   @SerialName("always_off")
-  internal val alwaysOff: ExperimentalComposableAlwaysOffSampler? = null,
+  public val alwaysOff: ExperimentalComposableAlwaysOffSampler? = null,
   /**
    * Configure sampler to be always_on.
    * If omitted, ignore.
    */
   @SerialName("always_on")
-  internal val alwaysOn: ExperimentalComposableAlwaysOnSampler? = null,
+  public val alwaysOn: ExperimentalComposableAlwaysOnSampler? = null,
   /**
    * Configure sampler to be parent_threshold.
    * If omitted, ignore.
    */
   @SerialName("parent_threshold")
-  internal val parentThreshold: ExperimentalComposableParentThresholdSampler? = null,
+  public val parentThreshold: ExperimentalComposableParentThresholdSampler? = null,
   /**
    * Configure sampler to be probability.
    * If omitted, ignore.
    */
-  internal val probability: ExperimentalComposableProbabilitySampler? = null,
+  public val probability: ExperimentalComposableProbabilitySampler? = null,
   /**
    * Configure sampler to be rule_based.
    * If omitted, ignore.
    */
   @SerialName("rule_based")
-  internal val ruleBased: ExperimentalComposableRuleBasedSampler? = null,
+  public val ruleBased: ExperimentalComposableRuleBasedSampler? = null,
 )

--- a/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/ExperimentalContainerResourceDetector.kt
+++ b/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/ExperimentalContainerResourceDetector.kt
@@ -4,4 +4,4 @@ package io.opentelemetry.kotlin.config.schema.model
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal class ExperimentalContainerResourceDetector
+public class ExperimentalContainerResourceDetector

--- a/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/ExperimentalDbInstrumentation.kt
+++ b/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/ExperimentalDbInstrumentation.kt
@@ -4,7 +4,7 @@ package io.opentelemetry.kotlin.config.schema.model
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal data class ExperimentalDbInstrumentation(
+public data class ExperimentalDbInstrumentation(
   /**
    * Configure database semantic convention version and migration behavior.
    *
@@ -13,5 +13,5 @@ internal data class ExperimentalDbInstrumentation(
    * See database migration: https://opentelemetry.io/docs/specs/semconv/database/
    * If omitted, uses the general stability_opt_in_list setting, or instrumentations continue emitting their default semantic convention version if not set.
    */
-  internal val semconv: ExperimentalSemconvConfig? = null,
+  public val semconv: ExperimentalSemconvConfig? = null,
 )

--- a/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/ExperimentalEventToSpanEventBridgeLogRecordProcessor.kt
+++ b/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/ExperimentalEventToSpanEventBridgeLogRecordProcessor.kt
@@ -4,4 +4,4 @@ package io.opentelemetry.kotlin.config.schema.model
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal class ExperimentalEventToSpanEventBridgeLogRecordProcessor
+public class ExperimentalEventToSpanEventBridgeLogRecordProcessor

--- a/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/ExperimentalGenAiInstrumentation.kt
+++ b/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/ExperimentalGenAiInstrumentation.kt
@@ -4,7 +4,7 @@ package io.opentelemetry.kotlin.config.schema.model
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal data class ExperimentalGenAiInstrumentation(
+public data class ExperimentalGenAiInstrumentation(
   /**
    * Configure GenAI semantic convention version and migration behavior.
    *
@@ -13,5 +13,5 @@ internal data class ExperimentalGenAiInstrumentation(
    * See GenAI semantic conventions: https://opentelemetry.io/docs/specs/semconv/gen-ai/
    * If omitted, uses the general stability_opt_in_list setting, or instrumentations continue emitting their default semantic convention version if not set.
    */
-  internal val semconv: ExperimentalSemconvConfig? = null,
+  public val semconv: ExperimentalSemconvConfig? = null,
 )

--- a/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/ExperimentalGeneralInstrumentation.kt
+++ b/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/ExperimentalGeneralInstrumentation.kt
@@ -6,49 +6,49 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal data class ExperimentalGeneralInstrumentation(
+public data class ExperimentalGeneralInstrumentation(
   /**
    * Configure instrumentations following the http semantic conventions.
    * See http semantic conventions: https://opentelemetry.io/docs/specs/semconv/http/
    * If omitted, defaults as described in ExperimentalHttpInstrumentation are used.
    */
-  internal val http: ExperimentalHttpInstrumentation? = null,
+  public val http: ExperimentalHttpInstrumentation? = null,
   /**
    * Configure instrumentations following the code semantic conventions.
    * See code semantic conventions: https://opentelemetry.io/docs/specs/semconv/registry/attributes/code/
    * If omitted, defaults as described in ExperimentalCodeInstrumentation are used.
    */
-  internal val code: ExperimentalCodeInstrumentation? = null,
+  public val code: ExperimentalCodeInstrumentation? = null,
   /**
    * Configure instrumentations following the database semantic conventions.
    * See database semantic conventions: https://opentelemetry.io/docs/specs/semconv/database/
    * If omitted, defaults as described in ExperimentalDbInstrumentation are used.
    */
-  internal val db: ExperimentalDbInstrumentation? = null,
+  public val db: ExperimentalDbInstrumentation? = null,
   /**
    * Configure instrumentations following the GenAI semantic conventions.
    * See GenAI semantic conventions: https://opentelemetry.io/docs/specs/semconv/gen-ai/
    * If omitted, defaults as described in ExperimentalGenAiInstrumentation are used.
    */
   @SerialName("gen_ai")
-  internal val genAi: ExperimentalGenAiInstrumentation? = null,
+  public val genAi: ExperimentalGenAiInstrumentation? = null,
   /**
    * Configure instrumentations following the messaging semantic conventions.
    * See messaging semantic conventions: https://opentelemetry.io/docs/specs/semconv/messaging/
    * If omitted, defaults as described in ExperimentalMessagingInstrumentation are used.
    */
-  internal val messaging: ExperimentalMessagingInstrumentation? = null,
+  public val messaging: ExperimentalMessagingInstrumentation? = null,
   /**
    * Configure instrumentations following the RPC semantic conventions.
    * See RPC semantic conventions: https://opentelemetry.io/docs/specs/semconv/rpc/
    * If omitted, defaults as described in ExperimentalRpcInstrumentation are used.
    */
-  internal val rpc: ExperimentalRpcInstrumentation? = null,
+  public val rpc: ExperimentalRpcInstrumentation? = null,
   /**
    * Configure general sanitization options.
    * If omitted, defaults as described in ExperimentalSanitization are used.
    */
-  internal val sanitization: ExperimentalSanitization? = null,
+  public val sanitization: ExperimentalSanitization? = null,
   /**
    * Configure semantic convention stability opt-in as a comma-separated list.
    * This property follows the format and semantics of the OTEL_SEMCONV_STABILITY_OPT_IN environment variable.
@@ -80,5 +80,5 @@ internal data class ExperimentalGeneralInstrumentation(
    * If omitted or null, no opt-in is configured and instrumentations continue emitting their default semantic convention version.
    */
   @SerialName("stability_opt_in_list")
-  internal val stabilityOptInList: String? = null,
+  public val stabilityOptInList: String? = null,
 )

--- a/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/ExperimentalHostResourceDetector.kt
+++ b/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/ExperimentalHostResourceDetector.kt
@@ -4,4 +4,4 @@ package io.opentelemetry.kotlin.config.schema.model
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal class ExperimentalHostResourceDetector
+public class ExperimentalHostResourceDetector

--- a/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/ExperimentalHttpClientInstrumentation.kt
+++ b/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/ExperimentalHttpClientInstrumentation.kt
@@ -7,19 +7,19 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal data class ExperimentalHttpClientInstrumentation(
+public data class ExperimentalHttpClientInstrumentation(
   /**
    * Configure headers to capture for outbound http requests.
    * If omitted, no outbound request headers are captured.
    */
   @SerialName("request_captured_headers")
-  internal val requestCapturedHeaders: List<String>? = null,
+  public val requestCapturedHeaders: List<String>? = null,
   /**
    * Configure headers to capture for inbound http responses.
    * If omitted, no inbound response headers are captured.
    */
   @SerialName("response_captured_headers")
-  internal val responseCapturedHeaders: List<String>? = null,
+  public val responseCapturedHeaders: List<String>? = null,
   /**
    * Override the default list of known HTTP methods.
    * Known methods are case-sensitive.
@@ -27,5 +27,5 @@ internal data class ExperimentalHttpClientInstrumentation(
    * If omitted, HTTP methods GET, HEAD, POST, PUT, DELETE, CONNECT, OPTIONS, TRACE, PATCH are known.
    */
   @SerialName("known_methods")
-  internal val knownMethods: List<String>? = null,
+  public val knownMethods: List<String>? = null,
 )

--- a/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/ExperimentalHttpInstrumentation.kt
+++ b/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/ExperimentalHttpInstrumentation.kt
@@ -4,7 +4,7 @@ package io.opentelemetry.kotlin.config.schema.model
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal data class ExperimentalHttpInstrumentation(
+public data class ExperimentalHttpInstrumentation(
   /**
    * Configure HTTP semantic convention version and migration behavior.
    *
@@ -13,15 +13,15 @@ internal data class ExperimentalHttpInstrumentation(
    * See HTTP migration: https://opentelemetry.io/docs/specs/semconv/non-normative/http-migration/
    * If omitted, uses the general stability_opt_in_list setting, or instrumentations continue emitting their default semantic convention version if not set.
    */
-  internal val semconv: ExperimentalSemconvConfig? = null,
+  public val semconv: ExperimentalSemconvConfig? = null,
   /**
    * Configure instrumentations following the http client semantic conventions.
    * If omitted, defaults as described in ExperimentalHttpClientInstrumentation are used.
    */
-  internal val client: ExperimentalHttpClientInstrumentation? = null,
+  public val client: ExperimentalHttpClientInstrumentation? = null,
   /**
    * Configure instrumentations following the http server semantic conventions.
    * If omitted, defaults as described in ExperimentalHttpServerInstrumentation are used.
    */
-  internal val server: ExperimentalHttpServerInstrumentation? = null,
+  public val server: ExperimentalHttpServerInstrumentation? = null,
 )

--- a/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/ExperimentalHttpServerInstrumentation.kt
+++ b/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/ExperimentalHttpServerInstrumentation.kt
@@ -7,19 +7,19 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal data class ExperimentalHttpServerInstrumentation(
+public data class ExperimentalHttpServerInstrumentation(
   /**
    * Configure headers to capture for inbound http requests.
    * If omitted, no request headers are captured.
    */
   @SerialName("request_captured_headers")
-  internal val requestCapturedHeaders: List<String>? = null,
+  public val requestCapturedHeaders: List<String>? = null,
   /**
    * Configure headers to capture for outbound http responses.
    * If omitted, no response headers are captures.
    */
   @SerialName("response_captured_headers")
-  internal val responseCapturedHeaders: List<String>? = null,
+  public val responseCapturedHeaders: List<String>? = null,
   /**
    * Override the default list of known HTTP methods.
    * Known methods are case-sensitive.
@@ -27,5 +27,5 @@ internal data class ExperimentalHttpServerInstrumentation(
    * If omitted, HTTP methods GET, HEAD, POST, PUT, DELETE, CONNECT, OPTIONS, TRACE, PATCH are known.
    */
   @SerialName("known_methods")
-  internal val knownMethods: List<String>? = null,
+  public val knownMethods: List<String>? = null,
 )

--- a/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/ExperimentalInstrumentation.kt
+++ b/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/ExperimentalInstrumentation.kt
@@ -4,76 +4,76 @@ package io.opentelemetry.kotlin.config.schema.model
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal data class ExperimentalInstrumentation(
+public data class ExperimentalInstrumentation(
   /**
    * Configure general SemConv options that may apply to multiple languages and instrumentations.
    * Instrumenation may merge general config options with the language specific configuration at .instrumentation.<language>.
    * If omitted, default values as described in ExperimentalGeneralInstrumentation are used.
    */
-  internal val general: ExperimentalGeneralInstrumentation? = null,
+  public val general: ExperimentalGeneralInstrumentation? = null,
   /**
    * Configure C++ language-specific instrumentation libraries.
    * If omitted, instrumentation defaults are used.
    */
-  internal val cpp: ExperimentalLanguageSpecificInstrumentation? = null,
+  public val cpp: ExperimentalLanguageSpecificInstrumentation? = null,
   /**
    * Configure .NET language-specific instrumentation libraries.
    * Each entry's key identifies a particular instrumentation library. The corresponding value configures it.
    * If omitted, instrumentation defaults are used.
    */
-  internal val dotnet: ExperimentalLanguageSpecificInstrumentation? = null,
+  public val dotnet: ExperimentalLanguageSpecificInstrumentation? = null,
   /**
    * Configure Erlang language-specific instrumentation libraries.
    * Each entry's key identifies a particular instrumentation library. The corresponding value configures it.
    * If omitted, instrumentation defaults are used.
    */
-  internal val erlang: ExperimentalLanguageSpecificInstrumentation? = null,
+  public val erlang: ExperimentalLanguageSpecificInstrumentation? = null,
   /**
    * Configure Go language-specific instrumentation libraries.
    * Each entry's key identifies a particular instrumentation library. The corresponding value configures it.
    * If omitted, instrumentation defaults are used.
    */
-  internal val go: ExperimentalLanguageSpecificInstrumentation? = null,
+  public val go: ExperimentalLanguageSpecificInstrumentation? = null,
   /**
    * Configure Java language-specific instrumentation libraries.
    * Each entry's key identifies a particular instrumentation library. The corresponding value configures it.
    * If omitted, instrumentation defaults are used.
    */
-  internal val java: ExperimentalLanguageSpecificInstrumentation? = null,
+  public val java: ExperimentalLanguageSpecificInstrumentation? = null,
   /**
    * Configure JavaScript language-specific instrumentation libraries.
    * Each entry's key identifies a particular instrumentation library. The corresponding value configures it.
    * If omitted, instrumentation defaults are used.
    */
-  internal val js: ExperimentalLanguageSpecificInstrumentation? = null,
+  public val js: ExperimentalLanguageSpecificInstrumentation? = null,
   /**
    * Configure PHP language-specific instrumentation libraries.
    * Each entry's key identifies a particular instrumentation library. The corresponding value configures it.
    * If omitted, instrumentation defaults are used.
    */
-  internal val php: ExperimentalLanguageSpecificInstrumentation? = null,
+  public val php: ExperimentalLanguageSpecificInstrumentation? = null,
   /**
    * Configure Python language-specific instrumentation libraries.
    * Each entry's key identifies a particular instrumentation library. The corresponding value configures it.
    * If omitted, instrumentation defaults are used.
    */
-  internal val python: ExperimentalLanguageSpecificInstrumentation? = null,
+  public val python: ExperimentalLanguageSpecificInstrumentation? = null,
   /**
    * Configure Ruby language-specific instrumentation libraries.
    * Each entry's key identifies a particular instrumentation library. The corresponding value configures it.
    * If omitted, instrumentation defaults are used.
    */
-  internal val ruby: ExperimentalLanguageSpecificInstrumentation? = null,
+  public val ruby: ExperimentalLanguageSpecificInstrumentation? = null,
   /**
    * Configure Rust language-specific instrumentation libraries.
    * Each entry's key identifies a particular instrumentation library. The corresponding value configures it.
    * If omitted, instrumentation defaults are used.
    */
-  internal val rust: ExperimentalLanguageSpecificInstrumentation? = null,
+  public val rust: ExperimentalLanguageSpecificInstrumentation? = null,
   /**
    * Configure Swift language-specific instrumentation libraries.
    * Each entry's key identifies a particular instrumentation library. The corresponding value configures it.
    * If omitted, instrumentation defaults are used.
    */
-  internal val swift: ExperimentalLanguageSpecificInstrumentation? = null,
+  public val swift: ExperimentalLanguageSpecificInstrumentation? = null,
 )

--- a/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/ExperimentalJaegerRemoteSampler.kt
+++ b/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/ExperimentalJaegerRemoteSampler.kt
@@ -7,21 +7,21 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal data class ExperimentalJaegerRemoteSampler(
+public data class ExperimentalJaegerRemoteSampler(
   /**
    * Configure the endpoint of the jaeger remote sampling service.
    * Property is required and must be non-null.
    */
-  internal val endpoint: String,
+  public val endpoint: String,
   /**
    * Configure the polling interval (in milliseconds) to fetch from the remote sampling service.
    * If omitted or null, 60000 is used.
    */
-  internal val interval: Long? = null,
+  public val interval: Long? = null,
   /**
    * Configure the initial sampler used before first configuration is fetched.
    * Property is required and must be non-null.
    */
   @SerialName("initial_sampler")
-  internal val initialSampler: Sampler,
+  public val initialSampler: Sampler,
 )

--- a/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/ExperimentalLanguageSpecificInstrumentation.kt
+++ b/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/ExperimentalLanguageSpecificInstrumentation.kt
@@ -6,4 +6,4 @@ import kotlin.String
 import kotlin.collections.Map
 import kotlinx.serialization.Contextual
 
-internal typealias ExperimentalLanguageSpecificInstrumentation = Map<String, @Contextual Any?>
+public typealias ExperimentalLanguageSpecificInstrumentation = Map<String, @Contextual Any?>

--- a/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/ExperimentalLoggerConfig.kt
+++ b/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/ExperimentalLoggerConfig.kt
@@ -6,12 +6,12 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal data class ExperimentalLoggerConfig(
+public data class ExperimentalLoggerConfig(
   /**
    * Configure if the logger is enabled or not.
    * If omitted or null, true is used.
    */
-  internal val enabled: Boolean? = null,
+  public val enabled: Boolean? = null,
   /**
    * Configure severity filtering.
    * Log records with an non-zero (i.e. unspecified) severity number which is less than minimum_severity are not processed.
@@ -43,12 +43,12 @@ internal data class ExperimentalLoggerConfig(
    * If omitted, severity filtering is not applied.
    */
   @SerialName("minimum_severity")
-  internal val minimumSeverity: SeverityNumber? = null,
+  public val minimumSeverity: SeverityNumber? = null,
   /**
    * Configure trace based filtering.
    * If true, log records associated with unsampled trace contexts traces are not processed. If false, or if a log record is not associated with a trace context, trace based filtering is not applied.
    * If omitted or null, trace based filtering is not applied.
    */
   @SerialName("trace_based")
-  internal val traceBased: Boolean? = null,
+  public val traceBased: Boolean? = null,
 )

--- a/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/ExperimentalLoggerConfigurator.kt
+++ b/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/ExperimentalLoggerConfigurator.kt
@@ -6,16 +6,16 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal data class ExperimentalLoggerConfigurator(
+public data class ExperimentalLoggerConfigurator(
   /**
    * Configure the default logger config used there is no matching entry in .logger_configurator/development.loggers.
    * If omitted, unmatched .loggers use default values as described in ExperimentalLoggerConfig.
    */
   @SerialName("default_config")
-  internal val defaultConfig: ExperimentalLoggerConfig? = null,
+  public val defaultConfig: ExperimentalLoggerConfig? = null,
   /**
    * Configure loggers.
    * If omitted, all loggers use .default_config.
    */
-  internal val loggers: List<ExperimentalLoggerMatcherAndConfig>? = null,
+  public val loggers: List<ExperimentalLoggerMatcherAndConfig>? = null,
 )

--- a/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/ExperimentalLoggerMatcherAndConfig.kt
+++ b/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/ExperimentalLoggerMatcherAndConfig.kt
@@ -5,7 +5,7 @@ import kotlin.String
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal data class ExperimentalLoggerMatcherAndConfig(
+public data class ExperimentalLoggerMatcherAndConfig(
   /**
    * Configure logger names to match. Matching is case-sensitive, evaluated as follows:
    *
@@ -13,10 +13,10 @@ internal data class ExperimentalLoggerMatcherAndConfig(
    *  * If the logger name matches the wildcard pattern, where '?' matches any single character and '*' matches any number of characters including none.
    * Property is required and must be non-null.
    */
-  internal val name: String,
+  public val name: String,
   /**
    * The logger config.
    * Property is required and must be non-null.
    */
-  internal val config: ExperimentalLoggerConfig,
+  public val config: ExperimentalLoggerConfig,
 )

--- a/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/ExperimentalMessagingInstrumentation.kt
+++ b/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/ExperimentalMessagingInstrumentation.kt
@@ -4,7 +4,7 @@ package io.opentelemetry.kotlin.config.schema.model
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal data class ExperimentalMessagingInstrumentation(
+public data class ExperimentalMessagingInstrumentation(
   /**
    * Configure messaging semantic convention version and migration behavior.
    *
@@ -13,5 +13,5 @@ internal data class ExperimentalMessagingInstrumentation(
    * See messaging semantic conventions: https://opentelemetry.io/docs/specs/semconv/messaging/
    * If omitted, uses the general stability_opt_in_list setting, or instrumentations continue emitting their default semantic convention version if not set.
    */
-  internal val semconv: ExperimentalSemconvConfig? = null,
+  public val semconv: ExperimentalSemconvConfig? = null,
 )

--- a/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/ExperimentalMeterConfig.kt
+++ b/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/ExperimentalMeterConfig.kt
@@ -5,10 +5,10 @@ import kotlin.Boolean
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal data class ExperimentalMeterConfig(
+public data class ExperimentalMeterConfig(
   /**
    * Configure if the meter is enabled or not.
    * If omitted, true is used.
    */
-  internal val enabled: Boolean? = null,
+  public val enabled: Boolean? = null,
 )

--- a/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/ExperimentalMeterConfigurator.kt
+++ b/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/ExperimentalMeterConfigurator.kt
@@ -6,16 +6,16 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal data class ExperimentalMeterConfigurator(
+public data class ExperimentalMeterConfigurator(
   /**
    * Configure the default meter config used there is no matching entry in .meter_configurator/development.meters.
    * If omitted, unmatched .meters use default values as described in ExperimentalMeterConfig.
    */
   @SerialName("default_config")
-  internal val defaultConfig: ExperimentalMeterConfig? = null,
+  public val defaultConfig: ExperimentalMeterConfig? = null,
   /**
    * Configure meters.
    * If omitted, all meters used .default_config.
    */
-  internal val meters: List<ExperimentalMeterMatcherAndConfig>? = null,
+  public val meters: List<ExperimentalMeterMatcherAndConfig>? = null,
 )

--- a/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/ExperimentalMeterMatcherAndConfig.kt
+++ b/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/ExperimentalMeterMatcherAndConfig.kt
@@ -5,7 +5,7 @@ import kotlin.String
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal data class ExperimentalMeterMatcherAndConfig(
+public data class ExperimentalMeterMatcherAndConfig(
   /**
    * Configure meter names to match. Matching is case-sensitive, evaluated as follows:
    *
@@ -13,10 +13,10 @@ internal data class ExperimentalMeterMatcherAndConfig(
    *  * If the meter name matches the wildcard pattern, where '?' matches any single character and '*' matches any number of characters including none.
    * Property is required and must be non-null.
    */
-  internal val name: String,
+  public val name: String,
   /**
    * The meter config.
    * Property is required and must be non-null.
    */
-  internal val config: ExperimentalMeterConfig,
+  public val config: ExperimentalMeterConfig,
 )

--- a/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/ExperimentalOtlpFileExporter.kt
+++ b/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/ExperimentalOtlpFileExporter.kt
@@ -6,12 +6,12 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal data class ExperimentalOtlpFileExporter(
+public data class ExperimentalOtlpFileExporter(
   /**
    * Configure output stream. 
    * Values include stdout, or scheme+destination. For example: file:///path/to/file.jsonl.
    * If omitted or null, stdout is used.
    */
   @SerialName("output_stream")
-  internal val outputStream: String? = null,
+  public val outputStream: String? = null,
 )

--- a/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/ExperimentalOtlpFileMetricExporter.kt
+++ b/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/ExperimentalOtlpFileMetricExporter.kt
@@ -6,14 +6,14 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal data class ExperimentalOtlpFileMetricExporter(
+public data class ExperimentalOtlpFileMetricExporter(
   /**
    * Configure output stream. 
    * Values include stdout, or scheme+destination. For example: file:///path/to/file.jsonl.
    * If omitted or null, stdout is used.
    */
   @SerialName("output_stream")
-  internal val outputStream: String? = null,
+  public val outputStream: String? = null,
   /**
    * Configure temporality preference.
    * Values include:
@@ -23,7 +23,7 @@ internal data class ExperimentalOtlpFileMetricExporter(
    * If omitted, cumulative is used.
    */
   @SerialName("temporality_preference")
-  internal val temporalityPreference: ExporterTemporalityPreference? = null,
+  public val temporalityPreference: ExporterTemporalityPreference? = null,
   /**
    * Configure default histogram aggregation.
    * Values include:
@@ -32,5 +32,5 @@ internal data class ExperimentalOtlpFileMetricExporter(
    * If omitted, explicit_bucket_histogram is used.
    */
   @SerialName("default_histogram_aggregation")
-  internal val defaultHistogramAggregation: ExporterDefaultHistogramAggregation? = null,
+  public val defaultHistogramAggregation: ExporterDefaultHistogramAggregation? = null,
 )

--- a/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/ExperimentalProbabilitySampler.kt
+++ b/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/ExperimentalProbabilitySampler.kt
@@ -5,10 +5,10 @@ import kotlin.Double
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal data class ExperimentalProbabilitySampler(
+public data class ExperimentalProbabilitySampler(
   /**
    * Configure ratio.
    * If omitted or null, 1.0 is used.
    */
-  internal val ratio: Double? = null,
+  public val ratio: Double? = null,
 )

--- a/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/ExperimentalProcessResourceDetector.kt
+++ b/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/ExperimentalProcessResourceDetector.kt
@@ -4,4 +4,4 @@ package io.opentelemetry.kotlin.config.schema.model
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal class ExperimentalProcessResourceDetector
+public class ExperimentalProcessResourceDetector

--- a/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/ExperimentalPrometheusMetricExporter.kt
+++ b/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/ExperimentalPrometheusMetricExporter.kt
@@ -8,35 +8,35 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal data class ExperimentalPrometheusMetricExporter(
+public data class ExperimentalPrometheusMetricExporter(
   /**
    * Configure host.
    * If omitted or null, localhost is used.
    */
-  internal val host: String? = null,
+  public val host: String? = null,
   /**
    * Configure port.
    * If omitted or null, 9464 is used.
    */
-  internal val port: Long? = null,
+  public val port: Long? = null,
   /**
    * Configure Prometheus Exporter to produce metrics with scope labels.
    * If omitted or null, true is used.
    */
   @SerialName("scope_info_enabled")
-  internal val scopeInfoEnabled: Boolean? = null,
+  public val scopeInfoEnabled: Boolean? = null,
   /**
    * Configure Prometheus Exporter to produce metrics with a target info metric for the resource.
    * If omitted or null, true is used.
    */
   @SerialName("target_info_enabled/development")
-  internal val targetInfoEnabledDevelopment: Boolean? = null,
+  public val targetInfoEnabledDevelopment: Boolean? = null,
   /**
    * Configure Prometheus Exporter to add resource attributes as metrics attributes, where the resource attribute keys match the patterns.
    * If omitted, no resource attributes are added.
    */
   @SerialName("resource_constant_labels")
-  internal val resourceConstantLabels: IncludeExclude? = null,
+  public val resourceConstantLabels: IncludeExclude? = null,
   /**
    * Configure how metric names are translated to Prometheus metric names.
    * Values include:
@@ -47,5 +47,5 @@ internal data class ExperimentalPrometheusMetricExporter(
    * If omitted, underscore_escaping_with_suffixes is used.
    */
   @SerialName("translation_strategy")
-  internal val translationStrategy: ExperimentalPrometheusTranslationStrategy? = null,
+  public val translationStrategy: ExperimentalPrometheusTranslationStrategy? = null,
 )

--- a/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/ExperimentalPrometheusTranslationStrategy.kt
+++ b/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/ExperimentalPrometheusTranslationStrategy.kt
@@ -5,7 +5,7 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal enum class ExperimentalPrometheusTranslationStrategy {
+public enum class ExperimentalPrometheusTranslationStrategy {
   @SerialName("underscore_escaping_with_suffixes")
   UNDERSCORE_ESCAPING_WITH_SUFFIXES,
   @SerialName("underscore_escaping_without_suffixes/development")

--- a/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/ExperimentalResourceDetection.kt
+++ b/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/ExperimentalResourceDetection.kt
@@ -5,16 +5,16 @@ import kotlin.collections.List
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal data class ExperimentalResourceDetection(
+public data class ExperimentalResourceDetection(
   /**
    * Configure attributes provided by resource detectors.
    * If omitted, all attributes from resource detectors are added.
    */
-  internal val attributes: IncludeExclude? = null,
+  public val attributes: IncludeExclude? = null,
   /**
    * Configure resource detectors.
    * Resource detector names are dependent on the SDK language ecosystem. Please consult documentation for each respective language. 
    * If omitted, no resource detectors are enabled.
    */
-  internal val detectors: List<ExperimentalResourceDetector>? = null,
+  public val detectors: List<ExperimentalResourceDetector>? = null,
 )

--- a/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/ExperimentalResourceDetector.kt
+++ b/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/ExperimentalResourceDetector.kt
@@ -4,25 +4,25 @@ package io.opentelemetry.kotlin.config.schema.model
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal data class ExperimentalResourceDetector(
+public data class ExperimentalResourceDetector(
   /**
    * Enable the container resource detector, which populates container.* attributes.
    * If omitted, ignore.
    */
-  internal val container: ExperimentalContainerResourceDetector? = null,
+  public val container: ExperimentalContainerResourceDetector? = null,
   /**
    * Enable the host resource detector, which populates host.* and os.* attributes.
    * If omitted, ignore.
    */
-  internal val host: ExperimentalHostResourceDetector? = null,
+  public val host: ExperimentalHostResourceDetector? = null,
   /**
    * Enable the process resource detector, which populates process.* attributes.
    * If omitted, ignore.
    */
-  internal val process: ExperimentalProcessResourceDetector? = null,
+  public val process: ExperimentalProcessResourceDetector? = null,
   /**
    * Enable the service detector, which populates service.name based on the OTEL_SERVICE_NAME environment variable and service.instance.id.
    * If omitted, ignore.
    */
-  internal val service: ExperimentalServiceResourceDetector? = null,
+  public val service: ExperimentalServiceResourceDetector? = null,
 )

--- a/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/ExperimentalRpcInstrumentation.kt
+++ b/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/ExperimentalRpcInstrumentation.kt
@@ -4,7 +4,7 @@ package io.opentelemetry.kotlin.config.schema.model
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal data class ExperimentalRpcInstrumentation(
+public data class ExperimentalRpcInstrumentation(
   /**
    * Configure RPC semantic convention version and migration behavior.
    *
@@ -13,5 +13,5 @@ internal data class ExperimentalRpcInstrumentation(
    * See RPC semantic conventions: https://opentelemetry.io/docs/specs/semconv/rpc/
    * If omitted, uses the general stability_opt_in_list setting, or instrumentations continue emitting their default semantic convention version if not set.
    */
-  internal val semconv: ExperimentalSemconvConfig? = null,
+  public val semconv: ExperimentalSemconvConfig? = null,
 )

--- a/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/ExperimentalSanitization.kt
+++ b/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/ExperimentalSanitization.kt
@@ -4,10 +4,10 @@ package io.opentelemetry.kotlin.config.schema.model
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal data class ExperimentalSanitization(
+public data class ExperimentalSanitization(
   /**
    * Configure URL sanitization options.
    * If omitted, defaults as described in ExperimentalUrlSanitization are used.
    */
-  internal val url: ExperimentalUrlSanitization? = null,
+  public val url: ExperimentalUrlSanitization? = null,
 )

--- a/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/ExperimentalSemconvConfig.kt
+++ b/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/ExperimentalSemconvConfig.kt
@@ -7,17 +7,17 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal data class ExperimentalSemconvConfig(
+public data class ExperimentalSemconvConfig(
   /**
    * The target semantic convention version for this domain (e.g., 1).
    * If omitted or null, the latest stable version is used, or if no stable version is available and .experimental is true then the latest experimental version is used.
    */
-  internal val version: Long? = null,
+  public val version: Long? = null,
   /**
    * Use latest experimental semantic conventions (before stable is available or to enable experimental features on top of stable conventions).
    * If omitted or null, false is used.
    */
-  internal val experimental: Boolean? = null,
+  public val experimental: Boolean? = null,
   /**
    * When true, also emit the previous major version alongside the target version.
    * For version=1, the previous version refers to the pre-stable conventions that the instrumentation emitted before the first stable semantic convention version was defined.
@@ -26,5 +26,5 @@ internal data class ExperimentalSemconvConfig(
    * If omitted or null, false is used.
    */
   @SerialName("dual_emit")
-  internal val dualEmit: Boolean? = null,
+  public val dualEmit: Boolean? = null,
 )

--- a/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/ExperimentalServiceResourceDetector.kt
+++ b/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/ExperimentalServiceResourceDetector.kt
@@ -4,4 +4,4 @@ package io.opentelemetry.kotlin.config.schema.model
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal class ExperimentalServiceResourceDetector
+public class ExperimentalServiceResourceDetector

--- a/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/ExperimentalSpanParent.kt
+++ b/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/ExperimentalSpanParent.kt
@@ -5,7 +5,7 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal enum class ExperimentalSpanParent {
+public enum class ExperimentalSpanParent {
   @SerialName("none")
   NONE,
   @SerialName("remote")

--- a/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/ExperimentalTracerConfig.kt
+++ b/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/ExperimentalTracerConfig.kt
@@ -5,10 +5,10 @@ import kotlin.Boolean
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal data class ExperimentalTracerConfig(
+public data class ExperimentalTracerConfig(
   /**
    * Configure if the tracer is enabled or not.
    * If omitted, true is used.
    */
-  internal val enabled: Boolean? = null,
+  public val enabled: Boolean? = null,
 )

--- a/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/ExperimentalTracerConfigurator.kt
+++ b/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/ExperimentalTracerConfigurator.kt
@@ -6,16 +6,16 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal data class ExperimentalTracerConfigurator(
+public data class ExperimentalTracerConfigurator(
   /**
    * Configure the default tracer config used there is no matching entry in .tracer_configurator/development.tracers.
    * If omitted, unmatched .tracers use default values as described in ExperimentalTracerConfig.
    */
   @SerialName("default_config")
-  internal val defaultConfig: ExperimentalTracerConfig? = null,
+  public val defaultConfig: ExperimentalTracerConfig? = null,
   /**
    * Configure tracers.
    * If omitted, all tracers use .default_config.
    */
-  internal val tracers: List<ExperimentalTracerMatcherAndConfig>? = null,
+  public val tracers: List<ExperimentalTracerMatcherAndConfig>? = null,
 )

--- a/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/ExperimentalTracerMatcherAndConfig.kt
+++ b/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/ExperimentalTracerMatcherAndConfig.kt
@@ -5,7 +5,7 @@ import kotlin.String
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal data class ExperimentalTracerMatcherAndConfig(
+public data class ExperimentalTracerMatcherAndConfig(
   /**
    * Configure tracer names to match. Matching is case-sensitive, evaluated as follows:
    *
@@ -13,10 +13,10 @@ internal data class ExperimentalTracerMatcherAndConfig(
    *  * If the tracer name matches the wildcard pattern, where '?' matches any single character and '*' matches any number of characters including none.
    * Property is required and must be non-null.
    */
-  internal val name: String,
+  public val name: String,
   /**
    * The tracer config.
    * Property is required and must be non-null.
    */
-  internal val config: ExperimentalTracerConfig,
+  public val config: ExperimentalTracerConfig,
 )

--- a/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/ExperimentalUrlSanitization.kt
+++ b/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/ExperimentalUrlSanitization.kt
@@ -7,7 +7,7 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal data class ExperimentalUrlSanitization(
+public data class ExperimentalUrlSanitization(
   /**
    * List of query parameter names whose values should be redacted from URLs.
    * Query parameter names are case-sensitive.
@@ -16,5 +16,5 @@ internal data class ExperimentalUrlSanitization(
    * If omitted, the default sensitive query parameter list as defined by the url semantic conventions (https://github.com/open-telemetry/semantic-conventions/blob/main/docs/registry/attributes/url.md) is used.
    */
   @SerialName("sensitive_query_parameters")
-  internal val sensitiveQueryParameters: List<String>? = null,
+  public val sensitiveQueryParameters: List<String>? = null,
 )

--- a/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/ExplicitBucketHistogramAggregation.kt
+++ b/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/ExplicitBucketHistogramAggregation.kt
@@ -8,16 +8,16 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal data class ExplicitBucketHistogramAggregation(
+public data class ExplicitBucketHistogramAggregation(
   /**
    * Configure bucket boundaries.
    * If omitted, [0, 5, 10, 25, 50, 75, 100, 250, 500, 750, 1000, 2500, 5000, 7500, 10000] is used.
    */
-  internal val boundaries: List<Double>? = null,
+  public val boundaries: List<Double>? = null,
   /**
    * Configure record min and max.
    * If omitted or null, true is used.
    */
   @SerialName("record_min_max")
-  internal val recordMinMax: Boolean? = null,
+  public val recordMinMax: Boolean? = null,
 )

--- a/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/ExporterDefaultHistogramAggregation.kt
+++ b/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/ExporterDefaultHistogramAggregation.kt
@@ -5,7 +5,7 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal enum class ExporterDefaultHistogramAggregation {
+public enum class ExporterDefaultHistogramAggregation {
   @SerialName("explicit_bucket_histogram")
   EXPLICIT_BUCKET_HISTOGRAM,
   @SerialName("base2_exponential_bucket_histogram")

--- a/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/ExporterTemporalityPreference.kt
+++ b/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/ExporterTemporalityPreference.kt
@@ -5,7 +5,7 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal enum class ExporterTemporalityPreference {
+public enum class ExporterTemporalityPreference {
   @SerialName("cumulative")
   CUMULATIVE,
   @SerialName("delta")

--- a/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/GrpcTls.kt
+++ b/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/GrpcTls.kt
@@ -7,32 +7,32 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal data class GrpcTls(
+public data class GrpcTls(
   /**
    * Configure certificate used to verify a server's TLS credentials. 
    * Absolute path to certificate file in PEM format.
    * If omitted or null, system default certificate verification is used for secure connections.
    */
   @SerialName("ca_file")
-  internal val caFile: String? = null,
+  public val caFile: String? = null,
   /**
    * Configure mTLS private client key. 
    * Absolute path to client key file in PEM format. If set, .client_certificate must also be set.
    * If omitted or null, mTLS is not used.
    */
   @SerialName("key_file")
-  internal val keyFile: String? = null,
+  public val keyFile: String? = null,
   /**
    * Configure mTLS client certificate. 
    * Absolute path to client certificate file in PEM format. If set, .client_key must also be set.
    * If omitted or null, mTLS is not used.
    */
   @SerialName("cert_file")
-  internal val certFile: String? = null,
+  public val certFile: String? = null,
   /**
    * Configure client transport security for the exporter's connection. 
    * Only applicable when .endpoint is provided without http or https scheme. Implementations may choose to ignore .insecure.
    * If omitted or null, false is used.
    */
-  internal val insecure: Boolean? = null,
+  public val insecure: Boolean? = null,
 )

--- a/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/HttpTls.kt
+++ b/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/HttpTls.kt
@@ -6,26 +6,26 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal data class HttpTls(
+public data class HttpTls(
   /**
    * Configure certificate used to verify a server's TLS credentials. 
    * Absolute path to certificate file in PEM format.
    * If omitted or null, system default certificate verification is used for secure connections.
    */
   @SerialName("ca_file")
-  internal val caFile: String? = null,
+  public val caFile: String? = null,
   /**
    * Configure mTLS private client key. 
    * Absolute path to client key file in PEM format. If set, .client_certificate must also be set.
    * If omitted or null, mTLS is not used.
    */
   @SerialName("key_file")
-  internal val keyFile: String? = null,
+  public val keyFile: String? = null,
   /**
    * Configure mTLS client certificate. 
    * Absolute path to client certificate file in PEM format. If set, .client_key must also be set.
    * If omitted or null, mTLS is not used.
    */
   @SerialName("cert_file")
-  internal val certFile: String? = null,
+  public val certFile: String? = null,
 )

--- a/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/IdGenerator.kt
+++ b/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/IdGenerator.kt
@@ -4,10 +4,10 @@ package io.opentelemetry.kotlin.config.schema.model
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal data class IdGenerator(
+public data class IdGenerator(
   /**
    * Configure the ID generator to randomly generate TraceIds and SpanIds (spec default).
    * If omitted, ignore.
    */
-  internal val random: RandomIdGenerator? = null,
+  public val random: RandomIdGenerator? = null,
 )

--- a/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/IncludeExclude.kt
+++ b/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/IncludeExclude.kt
@@ -6,7 +6,7 @@ import kotlin.collections.List
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal data class IncludeExclude(
+public data class IncludeExclude(
   /**
    * Configure list of value patterns to include.
    * Matching is case-sensitive. Values are evaluated to match as follows:
@@ -14,7 +14,7 @@ internal data class IncludeExclude(
    *  * If the value matches the wildcard pattern, where '?' matches any single character and '*' matches any number of characters including none.
    * If omitted, all values are included.
    */
-  internal val included: List<String>? = null,
+  public val included: List<String>? = null,
   /**
    * Configure list of value patterns to exclude. Applies after .included (i.e. excluded has higher priority than included).
    * Matching is case-sensitive. Values are evaluated to match as follows:
@@ -22,5 +22,5 @@ internal data class IncludeExclude(
    *  * If the value matches the wildcard pattern, where '?' matches any single character and '*' matches any number of characters including none.
    * If omitted, .included attributes are included.
    */
-  internal val excluded: List<String>? = null,
+  public val excluded: List<String>? = null,
 )

--- a/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/InstrumentType.kt
+++ b/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/InstrumentType.kt
@@ -5,7 +5,7 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal enum class InstrumentType {
+public enum class InstrumentType {
   @SerialName("counter")
   COUNTER,
   @SerialName("gauge")

--- a/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/LastValueAggregation.kt
+++ b/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/LastValueAggregation.kt
@@ -4,4 +4,4 @@ package io.opentelemetry.kotlin.config.schema.model
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal class LastValueAggregation
+public class LastValueAggregation

--- a/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/LogRecordExporter.kt
+++ b/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/LogRecordExporter.kt
@@ -5,28 +5,28 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal data class LogRecordExporter(
+public data class LogRecordExporter(
   /**
    * Configure exporter to be OTLP with HTTP transport.
    * If omitted, ignore.
    */
   @SerialName("otlp_http")
-  internal val otlpHttp: OtlpHttpExporter? = null,
+  public val otlpHttp: OtlpHttpExporter? = null,
   /**
    * Configure exporter to be OTLP with gRPC transport.
    * If omitted, ignore.
    */
   @SerialName("otlp_grpc")
-  internal val otlpGrpc: OtlpGrpcExporter? = null,
+  public val otlpGrpc: OtlpGrpcExporter? = null,
   /**
    * Configure exporter to be OTLP with file transport.
    * If omitted, ignore.
    */
   @SerialName("otlp_file/development")
-  internal val otlpFileDevelopment: ExperimentalOtlpFileExporter? = null,
+  public val otlpFileDevelopment: ExperimentalOtlpFileExporter? = null,
   /**
    * Configure exporter to be console.
    * If omitted, ignore.
    */
-  internal val console: ConsoleExporter? = null,
+  public val console: ConsoleExporter? = null,
 )

--- a/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/LogRecordLimits.kt
+++ b/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/LogRecordLimits.kt
@@ -6,19 +6,19 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal data class LogRecordLimits(
+public data class LogRecordLimits(
   /**
    * Configure max attribute value size. Overrides .attribute_limits.attribute_value_length_limit. 
    * Value must be non-negative.
    * If omitted or null, there is no limit.
    */
   @SerialName("attribute_value_length_limit")
-  internal val attributeValueLengthLimit: Long? = null,
+  public val attributeValueLengthLimit: Long? = null,
   /**
    * Configure max attribute count. Overrides .attribute_limits.attribute_count_limit. 
    * Value must be non-negative.
    * If omitted or null, 128 is used.
    */
   @SerialName("attribute_count_limit")
-  internal val attributeCountLimit: Long? = null,
+  public val attributeCountLimit: Long? = null,
 )

--- a/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/LogRecordProcessor.kt
+++ b/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/LogRecordProcessor.kt
@@ -5,22 +5,22 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal data class LogRecordProcessor(
+public data class LogRecordProcessor(
   /**
    * Configure a batch log record processor.
    * If omitted, ignore.
    */
-  internal val batch: BatchLogRecordProcessor? = null,
+  public val batch: BatchLogRecordProcessor? = null,
   /**
    * Configure a simple log record processor.
    * If omitted, ignore.
    */
-  internal val simple: SimpleLogRecordProcessor? = null,
+  public val simple: SimpleLogRecordProcessor? = null,
   /**
    * Configure an event to span event bridge log record processor.
    * If omitted, ignore.
    */
   @SerialName("event_to_span_event_bridge/development")
-  internal val eventToSpanEventBridgeDevelopment:
+  public val eventToSpanEventBridgeDevelopment:
       ExperimentalEventToSpanEventBridgeLogRecordProcessor? = null,
 )

--- a/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/LoggerProvider.kt
+++ b/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/LoggerProvider.kt
@@ -6,21 +6,21 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal data class LoggerProvider(
+public data class LoggerProvider(
   /**
    * Configure log record processors.
    * Property is required and must be non-null.
    */
-  internal val processors: List<LogRecordProcessor>,
+  public val processors: List<LogRecordProcessor>,
   /**
    * Configure log record limits. See also attribute_limits.
    * If omitted, default values as described in LogRecordLimits are used.
    */
-  internal val limits: LogRecordLimits? = null,
+  public val limits: LogRecordLimits? = null,
   /**
    * Configure loggers.
    * If omitted, all loggers use default values as described in ExperimentalLoggerConfig.
    */
   @SerialName("logger_configurator/development")
-  internal val loggerConfiguratorDevelopment: ExperimentalLoggerConfigurator? = null,
+  public val loggerConfiguratorDevelopment: ExperimentalLoggerConfigurator? = null,
 )

--- a/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/MeterProvider.kt
+++ b/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/MeterProvider.kt
@@ -6,18 +6,18 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal data class MeterProvider(
+public data class MeterProvider(
   /**
    * Configure metric readers.
    * Property is required and must be non-null.
    */
-  internal val readers: List<MetricReader>,
+  public val readers: List<MetricReader>,
   /**
    * Configure views. 
    * Each view has a selector which determines the instrument(s) it applies to, and a configuration for the resulting stream(s).
    * If omitted, no views are registered.
    */
-  internal val views: List<View>? = null,
+  public val views: List<View>? = null,
   /**
    * Configure the exemplar filter.
    * Values include:
@@ -27,11 +27,11 @@ internal data class MeterProvider(
    * If omitted, trace_based is used.
    */
   @SerialName("exemplar_filter")
-  internal val exemplarFilter: ExemplarFilter? = null,
+  public val exemplarFilter: ExemplarFilter? = null,
   /**
    * Configure meters.
    * If omitted, all meters use default values as described in ExperimentalMeterConfig.
    */
   @SerialName("meter_configurator/development")
-  internal val meterConfiguratorDevelopment: ExperimentalMeterConfigurator? = null,
+  public val meterConfiguratorDevelopment: ExperimentalMeterConfigurator? = null,
 )

--- a/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/MetricProducer.kt
+++ b/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/MetricProducer.kt
@@ -4,10 +4,10 @@ package io.opentelemetry.kotlin.config.schema.model
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal data class MetricProducer(
+public data class MetricProducer(
   /**
    * Configure metric producer to be opencensus.
    * If omitted, ignore.
    */
-  internal val opencensus: OpenCensusMetricProducer? = null,
+  public val opencensus: OpenCensusMetricProducer? = null,
 )

--- a/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/MetricReader.kt
+++ b/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/MetricReader.kt
@@ -4,15 +4,15 @@ package io.opentelemetry.kotlin.config.schema.model
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal data class MetricReader(
+public data class MetricReader(
   /**
    * Configure a periodic metric reader.
    * If omitted, ignore.
    */
-  internal val periodic: PeriodicMetricReader? = null,
+  public val periodic: PeriodicMetricReader? = null,
   /**
    * Configure a pull based metric reader.
    * If omitted, ignore.
    */
-  internal val pull: PullMetricReader? = null,
+  public val pull: PullMetricReader? = null,
 )

--- a/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/NameStringValuePair.kt
+++ b/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/NameStringValuePair.kt
@@ -5,15 +5,15 @@ import kotlin.String
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal data class NameStringValuePair(
+public data class NameStringValuePair(
   /**
    * The name of the pair.
    * Property is required and must be non-null.
    */
-  internal val name: String,
+  public val name: String,
   /**
    * The value of the pair.
    * Property must be present, but if null the behavior is dependent on usage context.
    */
-  internal val `value`: String? = null,
+  public val `value`: String? = null,
 )

--- a/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/OpenCensusMetricProducer.kt
+++ b/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/OpenCensusMetricProducer.kt
@@ -4,4 +4,4 @@ package io.opentelemetry.kotlin.config.schema.model
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal class OpenCensusMetricProducer
+public class OpenCensusMetricProducer

--- a/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/OpenTelemetryConfiguration.kt
+++ b/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/OpenTelemetryConfiguration.kt
@@ -7,7 +7,7 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal data class OpenTelemetryConfiguration(
+public data class OpenTelemetryConfiguration(
   /**
    * The file format version.
    * Represented as a string including the semver major, minor version numbers (and optionally the meta tag). For example: "0.4", "1.0-rc.2", "1.0" (after stable release).
@@ -16,12 +16,12 @@ internal data class OpenTelemetryConfiguration(
    * Property is required and must be non-null.
    */
   @SerialName("file_format")
-  internal val fileFormat: String,
+  public val fileFormat: String,
   /**
    * Configure if the SDK is disabled or not.
    * If omitted or null, false is used.
    */
-  internal val disabled: Boolean? = null,
+  public val disabled: Boolean? = null,
   /**
    * Configure the log level of the internal logger used by the SDK.
    * Values include:
@@ -52,47 +52,47 @@ internal data class OpenTelemetryConfiguration(
    * If omitted, INFO is used.
    */
   @SerialName("log_level")
-  internal val logLevel: SeverityNumber? = null,
+  public val logLevel: SeverityNumber? = null,
   /**
    * Configure general attribute limits. See also tracer_provider.limits, logger_provider.limits.
    * If omitted, default values as described in AttributeLimits are used.
    */
   @SerialName("attribute_limits")
-  internal val attributeLimits: AttributeLimits? = null,
+  public val attributeLimits: AttributeLimits? = null,
   /**
    * Configure logger provider.
    * If omitted, a noop logger provider is used.
    */
   @SerialName("logger_provider")
-  internal val loggerProvider: LoggerProvider? = null,
+  public val loggerProvider: LoggerProvider? = null,
   /**
    * Configure meter provider.
    * If omitted, a noop meter provider is used.
    */
   @SerialName("meter_provider")
-  internal val meterProvider: MeterProvider? = null,
+  public val meterProvider: MeterProvider? = null,
   /**
    * Configure text map context propagators.
    * If omitted, a noop propagator is used.
    */
-  internal val propagator: Propagator? = null,
+  public val propagator: Propagator? = null,
   /**
    * Configure tracer provider.
    * If omitted, a noop tracer provider is used.
    */
   @SerialName("tracer_provider")
-  internal val tracerProvider: TracerProvider? = null,
+  public val tracerProvider: TracerProvider? = null,
   /**
    * Configure resource for all signals.
    * If omitted, the default resource is used.
    */
-  internal val resource: Resource? = null,
+  public val resource: Resource? = null,
   /**
    * Configure instrumentation.
    * If omitted, instrumentation defaults are used.
    */
   @SerialName("instrumentation/development")
-  internal val instrumentationDevelopment: ExperimentalInstrumentation? = null,
+  public val instrumentationDevelopment: ExperimentalInstrumentation? = null,
   /**
    * Defines configuration parameters specific to a particular OpenTelemetry distribution or vendor.
    * This section provides a standardized location for distribution-specific settings
@@ -100,5 +100,5 @@ internal data class OpenTelemetryConfiguration(
    * It allows vendors to expose their own extensions and general configuration options.
    * If omitted, distribution defaults are used.
    */
-  internal val distribution: Distribution? = null,
+  public val distribution: Distribution? = null,
 )

--- a/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/OtlpGrpcExporter.kt
+++ b/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/OtlpGrpcExporter.kt
@@ -8,40 +8,40 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal data class OtlpGrpcExporter(
+public data class OtlpGrpcExporter(
   /**
    * Configure endpoint.
    * If omitted or null, http://localhost:4317 is used.
    */
-  internal val endpoint: String? = null,
+  public val endpoint: String? = null,
   /**
    * Configure TLS settings for the exporter.
    * If omitted, system default TLS settings are used.
    */
-  internal val tls: GrpcTls? = null,
+  public val tls: GrpcTls? = null,
   /**
    * Configure headers. Entries have higher priority than entries from .headers_list.
    * If an entry's .value is null, the entry is ignored.
    * If omitted, no headers are added.
    */
-  internal val headers: List<NameStringValuePair>? = null,
+  public val headers: List<NameStringValuePair>? = null,
   /**
    * Configure headers. Entries have lower priority than entries from .headers.
    * The value is a list of comma separated key-value pairs matching the format of OTEL_EXPORTER_OTLP_HEADERS. See https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md#configuration-options for details.
    * If omitted or null, no headers are added.
    */
   @SerialName("headers_list")
-  internal val headersList: String? = null,
+  public val headersList: String? = null,
   /**
    * Configure compression.
    * Known values include: gzip, none. Implementations may support other compression algorithms.
    * If omitted or null, none is used.
    */
-  internal val compression: String? = null,
+  public val compression: String? = null,
   /**
    * Configure max time (in milliseconds) to wait for each export.
    * Value must be non-negative. A value of 0 indicates no limit (infinity).
    * If omitted or null, 10000 is used.
    */
-  internal val timeout: Long? = null,
+  public val timeout: Long? = null,
 )

--- a/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/OtlpGrpcMetricExporter.kt
+++ b/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/OtlpGrpcMetricExporter.kt
@@ -8,42 +8,42 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal data class OtlpGrpcMetricExporter(
+public data class OtlpGrpcMetricExporter(
   /**
    * Configure endpoint.
    * If omitted or null, http://localhost:4317 is used.
    */
-  internal val endpoint: String? = null,
+  public val endpoint: String? = null,
   /**
    * Configure TLS settings for the exporter.
    * If omitted, system default TLS settings are used.
    */
-  internal val tls: GrpcTls? = null,
+  public val tls: GrpcTls? = null,
   /**
    * Configure headers. Entries have higher priority than entries from .headers_list.
    * If an entry's .value is null, the entry is ignored.
    * If omitted, no headers are added.
    */
-  internal val headers: List<NameStringValuePair>? = null,
+  public val headers: List<NameStringValuePair>? = null,
   /**
    * Configure headers. Entries have lower priority than entries from .headers.
    * The value is a list of comma separated key-value pairs matching the format of OTEL_EXPORTER_OTLP_HEADERS. See https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md#configuration-options for details.
    * If omitted or null, no headers are added.
    */
   @SerialName("headers_list")
-  internal val headersList: String? = null,
+  public val headersList: String? = null,
   /**
    * Configure compression.
    * Known values include: gzip, none. Implementations may support other compression algorithms.
    * If omitted or null, none is used.
    */
-  internal val compression: String? = null,
+  public val compression: String? = null,
   /**
    * Configure max time (in milliseconds) to wait for each export.
    * Value must be non-negative. A value of 0 indicates no limit (infinity).
    * If omitted or null, 10000 is used.
    */
-  internal val timeout: Long? = null,
+  public val timeout: Long? = null,
   /**
    * Configure temporality preference.
    * Values include:
@@ -53,7 +53,7 @@ internal data class OtlpGrpcMetricExporter(
    * If omitted, cumulative is used.
    */
   @SerialName("temporality_preference")
-  internal val temporalityPreference: ExporterTemporalityPreference? = null,
+  public val temporalityPreference: ExporterTemporalityPreference? = null,
   /**
    * Configure default histogram aggregation.
    * Values include:
@@ -62,5 +62,5 @@ internal data class OtlpGrpcMetricExporter(
    * If omitted, explicit_bucket_histogram is used.
    */
   @SerialName("default_histogram_aggregation")
-  internal val defaultHistogramAggregation: ExporterDefaultHistogramAggregation? = null,
+  public val defaultHistogramAggregation: ExporterDefaultHistogramAggregation? = null,
 )

--- a/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/OtlpHttpEncoding.kt
+++ b/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/OtlpHttpEncoding.kt
@@ -5,7 +5,7 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal enum class OtlpHttpEncoding {
+public enum class OtlpHttpEncoding {
   @SerialName("protobuf")
   PROTOBUF,
   @SerialName("json")

--- a/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/OtlpHttpExporter.kt
+++ b/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/OtlpHttpExporter.kt
@@ -8,42 +8,42 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal data class OtlpHttpExporter(
+public data class OtlpHttpExporter(
   /**
    * Configure endpoint, including the signal specific path.
    * If omitted or null, the http://localhost:4318/v1/{signal} (where signal is 'traces', 'logs', or 'metrics') is used.
    */
-  internal val endpoint: String? = null,
+  public val endpoint: String? = null,
   /**
    * Configure TLS settings for the exporter.
    * If omitted, system default TLS settings are used.
    */
-  internal val tls: HttpTls? = null,
+  public val tls: HttpTls? = null,
   /**
    * Configure headers. Entries have higher priority than entries from .headers_list.
    * If an entry's .value is null, the entry is ignored.
    * If omitted, no headers are added.
    */
-  internal val headers: List<NameStringValuePair>? = null,
+  public val headers: List<NameStringValuePair>? = null,
   /**
    * Configure headers. Entries have lower priority than entries from .headers.
    * The value is a list of comma separated key-value pairs matching the format of OTEL_EXPORTER_OTLP_HEADERS. See https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md#configuration-options for details.
    * If omitted or null, no headers are added.
    */
   @SerialName("headers_list")
-  internal val headersList: String? = null,
+  public val headersList: String? = null,
   /**
    * Configure compression.
    * Known values include: gzip, none. Implementations may support other compression algorithms.
    * If omitted or null, none is used.
    */
-  internal val compression: String? = null,
+  public val compression: String? = null,
   /**
    * Configure max time (in milliseconds) to wait for each export.
    * Value must be non-negative. A value of 0 indicates no limit (infinity).
    * If omitted or null, 10000 is used.
    */
-  internal val timeout: Long? = null,
+  public val timeout: Long? = null,
   /**
    * Configure the encoding used for messages. 
    * Implementations may not support json.
@@ -52,5 +52,5 @@ internal data class OtlpHttpExporter(
    * * protobuf: Protobuf binary encoding.
    * If omitted, protobuf is used.
    */
-  internal val encoding: OtlpHttpEncoding? = null,
+  public val encoding: OtlpHttpEncoding? = null,
 )

--- a/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/OtlpHttpMetricExporter.kt
+++ b/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/OtlpHttpMetricExporter.kt
@@ -8,42 +8,42 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal data class OtlpHttpMetricExporter(
+public data class OtlpHttpMetricExporter(
   /**
    * Configure endpoint.
    * If omitted or null, http://localhost:4318/v1/metrics is used.
    */
-  internal val endpoint: String? = null,
+  public val endpoint: String? = null,
   /**
    * Configure TLS settings for the exporter.
    * If omitted, system default TLS settings are used.
    */
-  internal val tls: HttpTls? = null,
+  public val tls: HttpTls? = null,
   /**
    * Configure headers. Entries have higher priority than entries from .headers_list.
    * If an entry's .value is null, the entry is ignored.
    * If omitted, no headers are added.
    */
-  internal val headers: List<NameStringValuePair>? = null,
+  public val headers: List<NameStringValuePair>? = null,
   /**
    * Configure headers. Entries have lower priority than entries from .headers.
    * The value is a list of comma separated key-value pairs matching the format of OTEL_EXPORTER_OTLP_HEADERS. See https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md#configuration-options for details.
    * If omitted or null, no headers are added.
    */
   @SerialName("headers_list")
-  internal val headersList: String? = null,
+  public val headersList: String? = null,
   /**
    * Configure compression.
    * Known values include: gzip, none. Implementations may support other compression algorithms.
    * If omitted or null, none is used.
    */
-  internal val compression: String? = null,
+  public val compression: String? = null,
   /**
    * Configure max time (in milliseconds) to wait for each export.
    * Value must be non-negative. A value of 0 indicates no limit (infinity).
    * If omitted or null, 10000 is used.
    */
-  internal val timeout: Long? = null,
+  public val timeout: Long? = null,
   /**
    * Configure the encoding used for messages. 
    * Implementations may not support json.
@@ -52,7 +52,7 @@ internal data class OtlpHttpMetricExporter(
    * * protobuf: Protobuf binary encoding.
    * If omitted, protobuf is used.
    */
-  internal val encoding: OtlpHttpEncoding? = null,
+  public val encoding: OtlpHttpEncoding? = null,
   /**
    * Configure temporality preference.
    * Values include:
@@ -62,7 +62,7 @@ internal data class OtlpHttpMetricExporter(
    * If omitted, cumulative is used.
    */
   @SerialName("temporality_preference")
-  internal val temporalityPreference: ExporterTemporalityPreference? = null,
+  public val temporalityPreference: ExporterTemporalityPreference? = null,
   /**
    * Configure default histogram aggregation.
    * Values include:
@@ -71,5 +71,5 @@ internal data class OtlpHttpMetricExporter(
    * If omitted, explicit_bucket_histogram is used.
    */
   @SerialName("default_histogram_aggregation")
-  internal val defaultHistogramAggregation: ExporterDefaultHistogramAggregation? = null,
+  public val defaultHistogramAggregation: ExporterDefaultHistogramAggregation? = null,
 )

--- a/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/ParentBasedSampler.kt
+++ b/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/ParentBasedSampler.kt
@@ -5,34 +5,34 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal data class ParentBasedSampler(
+public data class ParentBasedSampler(
   /**
    * Configure root sampler.
    * If omitted, always_on is used.
    */
-  internal val root: Sampler? = null,
+  public val root: Sampler? = null,
   /**
    * Configure remote_parent_sampled sampler.
    * If omitted, always_on is used.
    */
   @SerialName("remote_parent_sampled")
-  internal val remoteParentSampled: Sampler? = null,
+  public val remoteParentSampled: Sampler? = null,
   /**
    * Configure remote_parent_not_sampled sampler.
    * If omitted, always_off is used.
    */
   @SerialName("remote_parent_not_sampled")
-  internal val remoteParentNotSampled: Sampler? = null,
+  public val remoteParentNotSampled: Sampler? = null,
   /**
    * Configure local_parent_sampled sampler.
    * If omitted, always_on is used.
    */
   @SerialName("local_parent_sampled")
-  internal val localParentSampled: Sampler? = null,
+  public val localParentSampled: Sampler? = null,
   /**
    * Configure local_parent_not_sampled sampler.
    * If omitted, always_off is used.
    */
   @SerialName("local_parent_not_sampled")
-  internal val localParentNotSampled: Sampler? = null,
+  public val localParentNotSampled: Sampler? = null,
 )

--- a/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/PeriodicMetricReader.kt
+++ b/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/PeriodicMetricReader.kt
@@ -7,39 +7,39 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal data class PeriodicMetricReader(
+public data class PeriodicMetricReader(
   /**
    * Configure delay interval (in milliseconds) between start of two consecutive exports. 
    * Value must be non-negative.
    * If omitted or null, 60000 is used.
    */
-  internal val interval: Long? = null,
+  public val interval: Long? = null,
   /**
    * Configure maximum allowed time (in milliseconds) to export data. 
    * Value must be non-negative. A value of 0 indicates no limit (infinity).
    * If omitted or null, 30000 is used.
    */
-  internal val timeout: Long? = null,
+  public val timeout: Long? = null,
   /**
    * Configure maximum export batch size.
    * If omitted or null, no limit is used.
    */
   @SerialName("max_export_batch_size/development")
-  internal val maxExportBatchSizeDevelopment: Long? = null,
+  public val maxExportBatchSizeDevelopment: Long? = null,
   /**
    * Configure exporter.
    * Property is required and must be non-null.
    */
-  internal val exporter: PushMetricExporter,
+  public val exporter: PushMetricExporter,
   /**
    * Configure metric producers.
    * If omitted, no metric producers are added.
    */
-  internal val producers: List<MetricProducer>? = null,
+  public val producers: List<MetricProducer>? = null,
   /**
    * Configure cardinality limits.
    * If omitted, default values as described in CardinalityLimits are used.
    */
   @SerialName("cardinality_limits")
-  internal val cardinalityLimits: CardinalityLimits? = null,
+  public val cardinalityLimits: CardinalityLimits? = null,
 )

--- a/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/Propagator.kt
+++ b/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/Propagator.kt
@@ -7,13 +7,13 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal data class Propagator(
+public data class Propagator(
   /**
    * Configure the propagators in the composite text map propagator. Entries from .composite_list are appended to the list here with duplicates filtered out.
    * Built-in propagator keys include: tracecontext, baggage, b3, b3multi. Known third party keys include: xray.
    * If omitted, and .composite_list is omitted or null, a noop propagator is used.
    */
-  internal val composite: List<TextMapPropagator>? = null,
+  public val composite: List<TextMapPropagator>? = null,
   /**
    * Configure the propagators in the composite text map propagator. Entries are appended to .composite with duplicates filtered out.
    * The value is a comma separated list of propagator identifiers matching the format of OTEL_PROPAGATORS. See https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/sdk-environment-variables.md#general-sdk-configuration for details.
@@ -21,5 +21,5 @@ internal data class Propagator(
    * If omitted or null, and .composite is omitted or null, a noop propagator is used.
    */
   @SerialName("composite_list")
-  internal val compositeList: String? = null,
+  public val compositeList: String? = null,
 )

--- a/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/PullMetricExporter.kt
+++ b/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/PullMetricExporter.kt
@@ -5,11 +5,11 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal data class PullMetricExporter(
+public data class PullMetricExporter(
   /**
    * Configure exporter to be prometheus.
    * If omitted, ignore.
    */
   @SerialName("prometheus/development")
-  internal val prometheusDevelopment: ExperimentalPrometheusMetricExporter? = null,
+  public val prometheusDevelopment: ExperimentalPrometheusMetricExporter? = null,
 )

--- a/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/PullMetricReader.kt
+++ b/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/PullMetricReader.kt
@@ -6,21 +6,21 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal data class PullMetricReader(
+public data class PullMetricReader(
   /**
    * Configure exporter.
    * Property is required and must be non-null.
    */
-  internal val exporter: PullMetricExporter,
+  public val exporter: PullMetricExporter,
   /**
    * Configure metric producers.
    * If omitted, no metric producers are added.
    */
-  internal val producers: List<MetricProducer>? = null,
+  public val producers: List<MetricProducer>? = null,
   /**
    * Configure cardinality limits.
    * If omitted, default values as described in CardinalityLimits are used.
    */
   @SerialName("cardinality_limits")
-  internal val cardinalityLimits: CardinalityLimits? = null,
+  public val cardinalityLimits: CardinalityLimits? = null,
 )

--- a/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/PushMetricExporter.kt
+++ b/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/PushMetricExporter.kt
@@ -5,28 +5,28 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal data class PushMetricExporter(
+public data class PushMetricExporter(
   /**
    * Configure exporter to be OTLP with HTTP transport.
    * If omitted, ignore.
    */
   @SerialName("otlp_http")
-  internal val otlpHttp: OtlpHttpMetricExporter? = null,
+  public val otlpHttp: OtlpHttpMetricExporter? = null,
   /**
    * Configure exporter to be OTLP with gRPC transport.
    * If omitted, ignore.
    */
   @SerialName("otlp_grpc")
-  internal val otlpGrpc: OtlpGrpcMetricExporter? = null,
+  public val otlpGrpc: OtlpGrpcMetricExporter? = null,
   /**
    * Configure exporter to be OTLP with file transport.
    * If omitted, ignore.
    */
   @SerialName("otlp_file/development")
-  internal val otlpFileDevelopment: ExperimentalOtlpFileMetricExporter? = null,
+  public val otlpFileDevelopment: ExperimentalOtlpFileMetricExporter? = null,
   /**
    * Configure exporter to be console.
    * If omitted, ignore.
    */
-  internal val console: ConsoleMetricExporter? = null,
+  public val console: ConsoleMetricExporter? = null,
 )

--- a/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/RandomIdGenerator.kt
+++ b/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/RandomIdGenerator.kt
@@ -4,4 +4,4 @@ package io.opentelemetry.kotlin.config.schema.model
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal class RandomIdGenerator
+public class RandomIdGenerator

--- a/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/Resource.kt
+++ b/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/Resource.kt
@@ -7,29 +7,29 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal data class Resource(
+public data class Resource(
   /**
    * Configure resource attributes. Entries have higher priority than entries from .resource.attributes_list.
    * If omitted, no resource attributes are added.
    */
-  internal val attributes: List<AttributeNameValue>? = null,
+  public val attributes: List<AttributeNameValue>? = null,
   /**
    * Configure resource detection.
    * If omitted, resource detection is disabled.
    */
   @SerialName("detection/development")
-  internal val detectionDevelopment: ExperimentalResourceDetection? = null,
+  public val detectionDevelopment: ExperimentalResourceDetection? = null,
   /**
    * Configure resource schema URL.
    * If omitted or null, no schema URL is used.
    */
   @SerialName("schema_url")
-  internal val schemaUrl: String? = null,
+  public val schemaUrl: String? = null,
   /**
    * Configure resource attributes. Entries have lower priority than entries from .resource.attributes.
    * The value is a list of comma separated key-value pairs matching the format of OTEL_RESOURCE_ATTRIBUTES. See https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/sdk-environment-variables.md#general-sdk-configuration for details.
    * If omitted or null, no resource attributes are added.
    */
   @SerialName("attributes_list")
-  internal val attributesList: String? = null,
+  public val attributesList: String? = null,
 )

--- a/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/Sampler.kt
+++ b/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/Sampler.kt
@@ -5,47 +5,47 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal data class Sampler(
+public data class Sampler(
   /**
    * Configure sampler to be always_off.
    * If omitted, ignore.
    */
   @SerialName("always_off")
-  internal val alwaysOff: AlwaysOffSampler? = null,
+  public val alwaysOff: AlwaysOffSampler? = null,
   /**
    * Configure sampler to be always_on.
    * If omitted, ignore.
    */
   @SerialName("always_on")
-  internal val alwaysOn: AlwaysOnSampler? = null,
+  public val alwaysOn: AlwaysOnSampler? = null,
   /**
    * Configure sampler to be composite.
    * If omitted, ignore.
    */
   @SerialName("composite/development")
-  internal val compositeDevelopment: ExperimentalComposableSampler? = null,
+  public val compositeDevelopment: ExperimentalComposableSampler? = null,
   /**
    * Configure sampler to be jaeger_remote.
    * If omitted, ignore.
    */
   @SerialName("jaeger_remote/development")
-  internal val jaegerRemoteDevelopment: ExperimentalJaegerRemoteSampler? = null,
+  public val jaegerRemoteDevelopment: ExperimentalJaegerRemoteSampler? = null,
   /**
    * Configure sampler to be parent_based.
    * If omitted, ignore.
    */
   @SerialName("parent_based")
-  internal val parentBased: ParentBasedSampler? = null,
+  public val parentBased: ParentBasedSampler? = null,
   /**
    * Configure sampler to be probability.
    * If omitted, ignore.
    */
   @SerialName("probability/development")
-  internal val probabilityDevelopment: ExperimentalProbabilitySampler? = null,
+  public val probabilityDevelopment: ExperimentalProbabilitySampler? = null,
   /**
    * Configure sampler to be trace_id_ratio_based.
    * If omitted, ignore.
    */
   @SerialName("trace_id_ratio_based")
-  internal val traceIdRatioBased: TraceIdRatioBasedSampler? = null,
+  public val traceIdRatioBased: TraceIdRatioBasedSampler? = null,
 )

--- a/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/SeverityNumber.kt
+++ b/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/SeverityNumber.kt
@@ -5,7 +5,7 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal enum class SeverityNumber {
+public enum class SeverityNumber {
   @SerialName("trace")
   TRACE,
   @SerialName("trace2")

--- a/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/SimpleLogRecordProcessor.kt
+++ b/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/SimpleLogRecordProcessor.kt
@@ -4,10 +4,10 @@ package io.opentelemetry.kotlin.config.schema.model
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal data class SimpleLogRecordProcessor(
+public data class SimpleLogRecordProcessor(
   /**
    * Configure exporter.
    * Property is required and must be non-null.
    */
-  internal val exporter: LogRecordExporter,
+  public val exporter: LogRecordExporter,
 )

--- a/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/SimpleSpanProcessor.kt
+++ b/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/SimpleSpanProcessor.kt
@@ -4,10 +4,10 @@ package io.opentelemetry.kotlin.config.schema.model
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal data class SimpleSpanProcessor(
+public data class SimpleSpanProcessor(
   /**
    * Configure exporter.
    * Property is required and must be non-null.
    */
-  internal val exporter: SpanExporter,
+  public val exporter: SpanExporter,
 )

--- a/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/SpanExporter.kt
+++ b/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/SpanExporter.kt
@@ -5,28 +5,28 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal data class SpanExporter(
+public data class SpanExporter(
   /**
    * Configure exporter to be OTLP with HTTP transport.
    * If omitted, ignore.
    */
   @SerialName("otlp_http")
-  internal val otlpHttp: OtlpHttpExporter? = null,
+  public val otlpHttp: OtlpHttpExporter? = null,
   /**
    * Configure exporter to be OTLP with gRPC transport.
    * If omitted, ignore.
    */
   @SerialName("otlp_grpc")
-  internal val otlpGrpc: OtlpGrpcExporter? = null,
+  public val otlpGrpc: OtlpGrpcExporter? = null,
   /**
    * Configure exporter to be OTLP with file transport.
    * If omitted, ignore.
    */
   @SerialName("otlp_file/development")
-  internal val otlpFileDevelopment: ExperimentalOtlpFileExporter? = null,
+  public val otlpFileDevelopment: ExperimentalOtlpFileExporter? = null,
   /**
    * Configure exporter to be console.
    * If omitted, ignore.
    */
-  internal val console: ConsoleExporter? = null,
+  public val console: ConsoleExporter? = null,
 )

--- a/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/SpanKind.kt
+++ b/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/SpanKind.kt
@@ -5,7 +5,7 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal enum class SpanKind {
+public enum class SpanKind {
   @SerialName("internal")
   INTERNAL,
   @SerialName("server")

--- a/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/SpanLimits.kt
+++ b/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/SpanLimits.kt
@@ -6,47 +6,47 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal data class SpanLimits(
+public data class SpanLimits(
   /**
    * Configure max attribute value size. Overrides .attribute_limits.attribute_value_length_limit. 
    * Value must be non-negative.
    * If omitted or null, there is no limit.
    */
   @SerialName("attribute_value_length_limit")
-  internal val attributeValueLengthLimit: Long? = null,
+  public val attributeValueLengthLimit: Long? = null,
   /**
    * Configure max attribute count. Overrides .attribute_limits.attribute_count_limit. 
    * Value must be non-negative.
    * If omitted or null, 128 is used.
    */
   @SerialName("attribute_count_limit")
-  internal val attributeCountLimit: Long? = null,
+  public val attributeCountLimit: Long? = null,
   /**
    * Configure max span event count. 
    * Value must be non-negative.
    * If omitted or null, 128 is used.
    */
   @SerialName("event_count_limit")
-  internal val eventCountLimit: Long? = null,
+  public val eventCountLimit: Long? = null,
   /**
    * Configure max span link count. 
    * Value must be non-negative.
    * If omitted or null, 128 is used.
    */
   @SerialName("link_count_limit")
-  internal val linkCountLimit: Long? = null,
+  public val linkCountLimit: Long? = null,
   /**
    * Configure max attributes per span event. 
    * Value must be non-negative.
    * If omitted or null, 128 is used.
    */
   @SerialName("event_attribute_count_limit")
-  internal val eventAttributeCountLimit: Long? = null,
+  public val eventAttributeCountLimit: Long? = null,
   /**
    * Configure max attributes per span link. 
    * Value must be non-negative.
    * If omitted or null, 128 is used.
    */
   @SerialName("link_attribute_count_limit")
-  internal val linkAttributeCountLimit: Long? = null,
+  public val linkAttributeCountLimit: Long? = null,
 )

--- a/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/SpanProcessor.kt
+++ b/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/SpanProcessor.kt
@@ -4,15 +4,15 @@ package io.opentelemetry.kotlin.config.schema.model
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal data class SpanProcessor(
+public data class SpanProcessor(
   /**
    * Configure a batch span processor.
    * If omitted, ignore.
    */
-  internal val batch: BatchSpanProcessor? = null,
+  public val batch: BatchSpanProcessor? = null,
   /**
    * Configure a simple span processor.
    * If omitted, ignore.
    */
-  internal val simple: SimpleSpanProcessor? = null,
+  public val simple: SimpleSpanProcessor? = null,
 )

--- a/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/SumAggregation.kt
+++ b/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/SumAggregation.kt
@@ -4,4 +4,4 @@ package io.opentelemetry.kotlin.config.schema.model
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal class SumAggregation
+public class SumAggregation

--- a/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/TextMapPropagator.kt
+++ b/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/TextMapPropagator.kt
@@ -4,25 +4,25 @@ package io.opentelemetry.kotlin.config.schema.model
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal data class TextMapPropagator(
+public data class TextMapPropagator(
   /**
    * Include the w3c trace context propagator.
    * If omitted, ignore.
    */
-  internal val tracecontext: TraceContextPropagator? = null,
+  public val tracecontext: TraceContextPropagator? = null,
   /**
    * Include the w3c baggage propagator.
    * If omitted, ignore.
    */
-  internal val baggage: BaggagePropagator? = null,
+  public val baggage: BaggagePropagator? = null,
   /**
    * Include the zipkin b3 propagator.
    * If omitted, ignore.
    */
-  internal val b3: B3Propagator? = null,
+  public val b3: B3Propagator? = null,
   /**
    * Include the zipkin b3 multi propagator.
    * If omitted, ignore.
    */
-  internal val b3multi: B3MultiPropagator? = null,
+  public val b3multi: B3MultiPropagator? = null,
 )

--- a/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/TraceContextPropagator.kt
+++ b/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/TraceContextPropagator.kt
@@ -4,4 +4,4 @@ package io.opentelemetry.kotlin.config.schema.model
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal class TraceContextPropagator
+public class TraceContextPropagator

--- a/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/TraceIdRatioBasedSampler.kt
+++ b/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/TraceIdRatioBasedSampler.kt
@@ -5,10 +5,10 @@ import kotlin.Double
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal data class TraceIdRatioBasedSampler(
+public data class TraceIdRatioBasedSampler(
   /**
    * Configure trace_id_ratio.
    * If omitted or null, 1.0 is used.
    */
-  internal val ratio: Double? = null,
+  public val ratio: Double? = null,
 )

--- a/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/TracerProvider.kt
+++ b/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/TracerProvider.kt
@@ -6,32 +6,32 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal data class TracerProvider(
+public data class TracerProvider(
   /**
    * Configure span processors.
    * Property is required and must be non-null.
    */
-  internal val processors: List<SpanProcessor>,
+  public val processors: List<SpanProcessor>,
   /**
    * Configure span limits. See also attribute_limits.
    * If omitted, default values as described in SpanLimits are used.
    */
-  internal val limits: SpanLimits? = null,
+  public val limits: SpanLimits? = null,
   /**
    * Configure the sampler.
    * If omitted, parent based sampler with a root of always_on is used.
    */
-  internal val sampler: Sampler? = null,
+  public val sampler: Sampler? = null,
   /**
    * Configure the trace and span ID generator.
    * If omitted, RandomIdGenerator is used.
    */
   @SerialName("id_generator")
-  internal val idGenerator: IdGenerator? = null,
+  public val idGenerator: IdGenerator? = null,
   /**
    * Configure tracers.
    * If omitted, all tracers use default values as described in ExperimentalTracerConfig.
    */
   @SerialName("tracer_configurator/development")
-  internal val tracerConfiguratorDevelopment: ExperimentalTracerConfigurator? = null,
+  public val tracerConfiguratorDevelopment: ExperimentalTracerConfigurator? = null,
 )

--- a/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/View.kt
+++ b/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/View.kt
@@ -4,16 +4,16 @@ package io.opentelemetry.kotlin.config.schema.model
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal data class View(
+public data class View(
   /**
    * Configure view selector. 
    * Selection criteria is additive as described in https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#instrument-selection-criteria.
    * Property is required and must be non-null.
    */
-  internal val selector: ViewSelector,
+  public val selector: ViewSelector,
   /**
    * Configure view stream.
    * Property is required and must be non-null.
    */
-  internal val stream: ViewStream,
+  public val stream: ViewStream,
 )

--- a/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/ViewSelector.kt
+++ b/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/ViewSelector.kt
@@ -6,13 +6,13 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal data class ViewSelector(
+public data class ViewSelector(
   /**
    * Configure instrument name selection criteria.
    * If omitted or null, all instrument names match.
    */
   @SerialName("instrument_name")
-  internal val instrumentName: String? = null,
+  public val instrumentName: String? = null,
   /**
    * Configure instrument type selection criteria.
    * Values include:
@@ -26,28 +26,28 @@ internal data class ViewSelector(
    * If omitted, all instrument types match.
    */
   @SerialName("instrument_type")
-  internal val instrumentType: InstrumentType? = null,
+  public val instrumentType: InstrumentType? = null,
   /**
    * Configure the instrument unit selection criteria.
    * If omitted or null, all instrument units match.
    */
-  internal val unit: String? = null,
+  public val unit: String? = null,
   /**
    * Configure meter name selection criteria.
    * If omitted or null, all meter names match.
    */
   @SerialName("meter_name")
-  internal val meterName: String? = null,
+  public val meterName: String? = null,
   /**
    * Configure meter version selection criteria.
    * If omitted or null, all meter versions match.
    */
   @SerialName("meter_version")
-  internal val meterVersion: String? = null,
+  public val meterVersion: String? = null,
   /**
    * Configure meter schema url selection criteria.
    * If omitted or null, all meter schema URLs match.
    */
   @SerialName("meter_schema_url")
-  internal val meterSchemaUrl: String? = null,
+  public val meterSchemaUrl: String? = null,
 )

--- a/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/ViewStream.kt
+++ b/config-schema/src/commonMain/kotlin/io/opentelemetry/kotlin/config/schema/model/ViewStream.kt
@@ -7,32 +7,32 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal data class ViewStream(
+public data class ViewStream(
   /**
    * Configure metric name of the resulting stream(s).
    * If omitted or null, the instrument's original name is used.
    */
-  internal val name: String? = null,
+  public val name: String? = null,
   /**
    * Configure metric description of the resulting stream(s).
    * If omitted or null, the instrument's origin description is used.
    */
-  internal val description: String? = null,
+  public val description: String? = null,
   /**
    * Configure aggregation of the resulting stream(s).
    * If omitted, default is used.
    */
-  internal val aggregation: Aggregation? = null,
+  public val aggregation: Aggregation? = null,
   /**
    * Configure the aggregation cardinality limit.
    * If omitted or null, the metric reader's default cardinality limit is used.
    */
   @SerialName("aggregation_cardinality_limit")
-  internal val aggregationCardinalityLimit: Long? = null,
+  public val aggregationCardinalityLimit: Long? = null,
   /**
    * Configure attribute keys retained in the resulting stream(s).
    * If omitted, all attribute keys are retained.
    */
   @SerialName("attribute_keys")
-  internal val attributeKeys: IncludeExclude? = null,
+  public val attributeKeys: IncludeExclude? = null,
 )

--- a/config/build.gradle.kts
+++ b/config/build.gradle.kts
@@ -12,12 +12,14 @@ kotlin {
         val commonMain by getting {
             dependencies {
                 implementation(project(":sdk-api"))
+                api(project(":config-schema"))
                 implementation(libs.yamlkt)
                 implementation(libs.okio)
             }
         }
         val commonTest by getting {
             dependencies {
+                implementation(project(":test-fakes"))
                 implementation(libs.kotlin.test)
                 implementation(libs.okio.fakefilesystem)
             }

--- a/config/src/commonMain/kotlin/io/opentelemetry/kotlin/config/OpenTelemetryConfigurationParser.kt
+++ b/config/src/commonMain/kotlin/io/opentelemetry/kotlin/config/OpenTelemetryConfigurationParser.kt
@@ -1,0 +1,29 @@
+package io.opentelemetry.kotlin.config
+
+import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.config.schema.model.OpenTelemetryConfiguration
+import net.mamoe.yamlkt.Yaml
+import okio.FileSystem
+import okio.Path
+
+/**
+ * Parses declarative-configuration YAML into the [OpenTelemetryConfiguration] schema model.
+ *
+ * Unlike [YamlConfigParser], which returns the raw parsed value, this maps the document onto the
+ * types generated from the `opentelemetry-configuration` JSON schema.
+ */
+@ExperimentalApi
+class OpenTelemetryConfigurationParser {
+
+    /**
+     * Parses a single YAML document from [yaml] into an [OpenTelemetryConfiguration].
+     */
+    fun parse(yaml: String): OpenTelemetryConfiguration =
+        Yaml.decodeFromString(OpenTelemetryConfiguration.serializer(), yaml)
+
+    /**
+     * Reads the file at [path] from [fileSystem] and parses it as a single YAML document.
+     */
+    fun parse(fileSystem: FileSystem, path: Path): OpenTelemetryConfiguration =
+        parse(fileSystem.read(path) { readUtf8() })
+}

--- a/config/src/commonTest/kotlin/io/opentelemetry/kotlin/config/OpenTelemetryConfigurationParserTest.kt
+++ b/config/src/commonTest/kotlin/io/opentelemetry/kotlin/config/OpenTelemetryConfigurationParserTest.kt
@@ -1,0 +1,127 @@
+package io.opentelemetry.kotlin.config
+
+import io.opentelemetry.kotlin.config.schema.model.AttributeNameValue
+import io.opentelemetry.kotlin.config.schema.model.AttributeType
+import io.opentelemetry.kotlin.config.schema.model.OpenTelemetryConfiguration
+import io.opentelemetry.kotlin.config.schema.model.Resource
+import io.opentelemetry.kotlin.config.schema.model.SeverityNumber
+import io.opentelemetry.kotlin.config.schema.model.SpanLimits
+import io.opentelemetry.kotlin.config.schema.model.TracerProvider
+import io.opentelemetry.kotlin.framework.loadTestFixture
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.MissingFieldException
+import kotlinx.serialization.SerializationException
+import okio.FileNotFoundException
+import okio.Path.Companion.toPath
+import okio.fakefilesystem.FakeFileSystem
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+@OptIn(ExperimentalSerializationApi::class)
+internal class OpenTelemetryConfigurationParserTest {
+
+    private val parser = OpenTelemetryConfigurationParser()
+
+    @Test
+    fun parsesGoldenConfigFile() {
+        val expected = OpenTelemetryConfiguration(
+            fileFormat = "1.0",
+            disabled = false,
+            logLevel = SeverityNumber.INFO,
+            resource = Resource(
+                attributes = listOf(
+                    AttributeNameValue(
+                        name = "service.name",
+                        value = "unknown_service",
+                        type = AttributeType.STRING,
+                    ),
+                ),
+                schemaUrl = "https://opentelemetry.io/schemas/1.37.0",
+                attributesList = "service.namespace=demo,service.version=1.0.0",
+            ),
+            tracerProvider = TracerProvider(
+                processors = emptyList(),
+                limits = SpanLimits(attributeCountLimit = 128, eventCountLimit = 64),
+            ),
+        )
+
+        assertEquals(expected, parser.parse(loadTestFixture(GOLDEN_FILE)))
+    }
+
+    @Test
+    fun parsesFromFileSystem() {
+        val fileSystem = FakeFileSystem()
+        val path = "config.yaml".toPath()
+        fileSystem.write(path) { writeUtf8(MINIMAL_DOCUMENT) }
+
+        assertEquals(
+            OpenTelemetryConfiguration(fileFormat = "1.0"),
+            parser.parse(fileSystem, path),
+        )
+    }
+
+    @Test
+    fun ignoresUnknownKeys() {
+        val yaml = "$MINIMAL_DOCUMENT\nnot_in_the_schema: 1"
+
+        assertEquals(OpenTelemetryConfiguration(fileFormat = "1.0"), parser.parse(yaml))
+    }
+
+    @Test
+    fun emptyDocumentFails() {
+        val documents = listOf("", "   \n\n  ", "# no configuration here\n", "disabled: false")
+
+        documents.forEach { yaml ->
+            val error = assertFailsWith<MissingFieldException>("parsing <$yaml> should fail") {
+                parser.parse(yaml)
+            }
+            assertEquals(listOf("file_format"), error.missingFields)
+        }
+    }
+
+    @Test
+    fun nullFileFormatFails() {
+        assertFailsWith<SerializationException> { parser.parse("file_format: null") }
+    }
+
+    @Test
+    fun malformedYamlFails() {
+        assertFailsWith<SerializationException> {
+            parser.parse("file_format: \"1.0\"\n  bad indent: [unclosed")
+        }
+    }
+
+    @Test
+    fun documentThatIsNotAMappingFails() {
+        assertFailsWith<SerializationException> { parser.parse("just a string") }
+    }
+
+    @Test
+    fun unknownEnumValueFails() {
+        assertFailsWith<SerializationException> {
+            parser.parse("$MINIMAL_DOCUMENT\nlog_level: nonsense")
+        }
+    }
+
+    @Test
+    fun emptyFileFails() {
+        val fileSystem = FakeFileSystem()
+        val path = "empty.yaml".toPath()
+        fileSystem.write(path) { writeUtf8("") }
+
+        assertFailsWith<MissingFieldException> { parser.parse(fileSystem, path) }
+    }
+
+    @Test
+    fun missingFileFails() {
+        assertFailsWith<FileNotFoundException> {
+            parser.parse(FakeFileSystem(), "does-not-exist.yaml".toPath())
+        }
+    }
+
+    private companion object {
+        const val GOLDEN_FILE = "minimal_config.yaml"
+        const val MINIMAL_DOCUMENT = "file_format: \"1.0\""
+    }
+}

--- a/config/src/commonTest/resources/minimal_config.yaml
+++ b/config/src/commonTest/resources/minimal_config.yaml
@@ -1,0 +1,15 @@
+file_format: "1.0"
+disabled: false
+log_level: info
+resource:
+  schema_url: "https://opentelemetry.io/schemas/1.37.0"
+  attributes_list: "service.namespace=demo,service.version=1.0.0"
+  attributes:
+    - name: service.name
+      value: unknown_service
+      type: string
+tracer_provider:
+  processors: []
+  limits:
+    attribute_count_limit: 128
+    event_count_limit: 64


### PR DESCRIPTION
## Goal

Works towards #368 by parsing a YAML file into a model class that is generated from [opentelemetry-configuration schemas](https://github.com/open-telemetry/opentelemetry-configuration). I've only asserted that some basic properties are mapped over correctly so far - future changesets will go further with these assertions.

The majority of the delta in this changeset is down to the config-schema models being made public so that they're accessible from another module.

## Testing

Added unit tests.
