### PR TITLE
Start building instrumentation for Ktor

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@ This repo is a Kotlin Multiplatform (KMP) implementation of the [OpenTelemetry s
 | `implementation` | KMP implementation of OpenTelemetry |
 | `compat` | Facade of `api` that uses opentelemetry-java under the hood |
 | `exporters-*` | OTLP, in-memory, etc. |
+| `instrumentation/*` | Instrumentation for third-party libraries |
 | `testing` / `test-fakes` | Test utilities |
 | `semconv` | Semantic conventions |
 | `examples` | Example apps |

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -58,6 +58,8 @@ ktor-client-encoding = { module = "io.ktor:ktor-client-encoding", version.ref = 
 ktor-client-okhttp = { module = "io.ktor:ktor-client-okhttp", version.ref = "ktor" }
 ktor-client-cio = { module = "io.ktor:ktor-client-cio", version.ref = "ktor" }
 ktor-client-mock = { module = "io.ktor:ktor-client-mock", version.ref = "ktor" }
+ktor-server-core = { module = "io.ktor:ktor-server-core", version.ref = "ktor" }
+ktor-server-test-host = { module = "io.ktor:ktor-server-test-host", version.ref = "ktor" }
 okio = { module = "com.squareup.okio:okio", version.ref = "okio" }
 okio-fakefilesystem = { module = "com.squareup.okio:okio-fakefilesystem", version.ref = "okio" }
 yamlkt = { module = "net.mamoe.yamlkt:yamlkt", version.ref = "yamlkt" }

--- a/instrumentation/instrumentation-ktor-client/README.md
+++ b/instrumentation/instrumentation-ktor-client/README.md
@@ -1,0 +1,4 @@
+# instrumentation-ktor-client
+
+This module instruments the [Ktor HTTP client](https://ktor.io/docs/client-create-new-application.html).
+It records a `CLIENT` span for each outgoing request.

--- a/instrumentation/instrumentation-ktor-client/api/jvm/instrumentation-ktor-client.api
+++ b/instrumentation/instrumentation-ktor-client/api/jvm/instrumentation-ktor-client.api
@@ -1,0 +1,4 @@
+public final class io/opentelemetry/kotlin/instrumentation/ktor/client/OpenTelemetryKtorClientPluginApiKt {
+	public static final fun openTelemetryKtorClientPlugin (Lio/opentelemetry/kotlin/OpenTelemetry;)Lio/ktor/client/plugins/api/ClientPlugin;
+}
+

--- a/instrumentation/instrumentation-ktor-client/build.gradle.kts
+++ b/instrumentation/instrumentation-ktor-client/build.gradle.kts
@@ -1,0 +1,27 @@
+plugins {
+    kotlin("multiplatform")
+    id("com.android.kotlin.multiplatform.library")
+    id("io.opentelemetry.kotlin.build-logic")
+    id("signing")
+    id("com.vanniktech.maven.publish")
+    id("org.jetbrains.kotlinx.kover")
+}
+
+kotlin {
+    sourceSets {
+        val commonMain by getting {
+            dependencies {
+                api(project(":api"))
+                api(libs.ktor.client.core)
+            }
+        }
+        val commonTest by getting {
+            dependencies {
+                implementation(project(":implementation"))
+                implementation(project(":test-fakes"))
+                implementation(libs.kotlinx.coroutines.test)
+                implementation(libs.ktor.client.mock)
+            }
+        }
+    }
+}

--- a/instrumentation/instrumentation-ktor-client/src/commonMain/kotlin/io/opentelemetry/kotlin/instrumentation/ktor/client/OpenTelemetryKtorClientPluginApi.kt
+++ b/instrumentation/instrumentation-ktor-client/src/commonMain/kotlin/io/opentelemetry/kotlin/instrumentation/ktor/client/OpenTelemetryKtorClientPluginApi.kt
@@ -1,0 +1,37 @@
+package io.opentelemetry.kotlin.instrumentation.ktor.client
+
+import io.ktor.client.plugins.api.ClientPlugin
+import io.ktor.client.plugins.api.Send
+import io.ktor.client.plugins.api.createClientPlugin
+import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.OpenTelemetry
+import io.opentelemetry.kotlin.tracing.SpanKind
+
+/**
+ * Creates a Ktor client plugin that records a `CLIENT` span for each outgoing HTTP request.
+ *
+ * https://opentelemetry.io/docs/specs/semconv/http/http-spans/
+ */
+@ExperimentalApi
+public fun openTelemetryKtorClientPlugin(openTelemetry: OpenTelemetry): ClientPlugin<Unit> =
+    createClientPlugin("opentelemetry-kotlin-ktor") {
+        val tracer = openTelemetry.tracerProvider.getTracer("io.opentelemetry.kotlin.instrumentation.ktor.client")
+
+        on(Send) { request ->
+            if (tracer.enabled()) {
+                val parentContext = openTelemetry.context.implicit()
+                val span = tracer.startSpan(
+                    name = request.method.value,
+                    parentContext = parentContext,
+                    spanKind = SpanKind.CLIENT,
+                )
+                try {
+                    proceed(request)
+                } finally {
+                    span.end()
+                }
+            } else {
+                proceed(request)
+            }
+        }
+    }

--- a/instrumentation/instrumentation-ktor-client/src/commonTest/kotlin/io/opentelemetry/kotlin/instrumentation/ktor/client/OpenTelemetryKtorClientPluginTest.kt
+++ b/instrumentation/instrumentation-ktor-client/src/commonTest/kotlin/io/opentelemetry/kotlin/instrumentation/ktor/client/OpenTelemetryKtorClientPluginTest.kt
@@ -1,0 +1,66 @@
+package io.opentelemetry.kotlin.instrumentation.ktor.client
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.request.get
+import io.ktor.http.HttpStatusCode
+import io.opentelemetry.kotlin.OpenTelemetry
+import io.opentelemetry.kotlin.createOpenTelemetry
+import io.opentelemetry.kotlin.tracing.SpanKind
+import io.opentelemetry.kotlin.tracing.data.SpanData
+import io.opentelemetry.kotlin.tracing.export.FakeSpanProcessor
+import kotlinx.coroutines.test.runTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFails
+import kotlin.test.assertTrue
+
+internal class OpenTelemetryKtorClientPluginTest {
+
+    private lateinit var processor: FakeSpanProcessor
+
+    private val spans: List<SpanData>
+        get() = processor.endCalls.map { it.toSpanData() }
+
+    @BeforeTest
+    fun setUp() {
+        processor = FakeSpanProcessor()
+    }
+
+    @Test
+    fun testRequestSuccess() = runTest {
+        client(okEngine()).get("https://example.com/users")
+
+        val span = spans.single()
+        assertEquals("GET", span.name)
+        assertEquals(SpanKind.CLIENT, span.spanKind)
+    }
+
+    @Test
+    fun testRequestFail() = runTest {
+        val client = client(MockEngine { throw BoomException() })
+
+        assertFails { client.get("http://example.com/x") }
+
+        val span = spans.single()
+        assertTrue(span.hasEnded)
+    }
+
+    private fun openTelemetry(): OpenTelemetry =
+        createOpenTelemetry {
+            tracerProvider { export { processor } }
+        }
+
+    private fun client(
+        engine: MockEngine,
+        openTelemetry: OpenTelemetry = openTelemetry(),
+    ): HttpClient = HttpClient(engine) {
+        install(openTelemetryKtorClientPlugin(openTelemetry))
+    }
+
+    private fun okEngine(): MockEngine = MockEngine { respond("ok", HttpStatusCode.OK) }
+}
+
+private class BoomException : RuntimeException("boom")

--- a/instrumentation/instrumentation-ktor-server/README.md
+++ b/instrumentation/instrumentation-ktor-server/README.md
@@ -1,0 +1,6 @@
+# instrumentation-ktor-server
+
+This module instruments the [Ktor server](https://ktor.io/docs/server-create-a-new-project.html).
+It records a `SERVER` span for each inbound request.
+
+JVM and Android only, as Ktor's server engines do not support the iOS or JS targets.

--- a/instrumentation/instrumentation-ktor-server/api/jvm/instrumentation-ktor-server.api
+++ b/instrumentation/instrumentation-ktor-server/api/jvm/instrumentation-ktor-server.api
@@ -1,0 +1,4 @@
+public final class io/opentelemetry/kotlin/instrumentation/ktor/server/OpenTelemetryKtorServerPluginApiKt {
+	public static final fun openTelemetryKtorServerPlugin (Lio/opentelemetry/kotlin/OpenTelemetry;)Lio/ktor/server/application/ApplicationPlugin;
+}
+

--- a/instrumentation/instrumentation-ktor-server/build.gradle.kts
+++ b/instrumentation/instrumentation-ktor-server/build.gradle.kts
@@ -1,0 +1,26 @@
+plugins {
+    kotlin("multiplatform")
+    id("com.android.kotlin.multiplatform.library")
+    id("io.opentelemetry.kotlin.build-logic")
+    id("signing")
+    id("com.vanniktech.maven.publish")
+    id("org.jetbrains.kotlinx.kover")
+}
+
+kotlin {
+    sourceSets {
+        val jvmAndAndroidMain by getting {
+            dependencies {
+                api(project(":api"))
+                api(libs.ktor.server.core)
+            }
+        }
+        val jvmTest by getting {
+            dependencies {
+                implementation(project(":implementation"))
+                implementation(project(":test-fakes"))
+                implementation(libs.ktor.server.test.host)
+            }
+        }
+    }
+}

--- a/instrumentation/instrumentation-ktor-server/gradle.properties
+++ b/instrumentation/instrumentation-ktor-server/gradle.properties
@@ -1,0 +1,1 @@
+io.opentelemetry.kotlin.jvmAndroidModule=true

--- a/instrumentation/instrumentation-ktor-server/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/instrumentation/ktor/server/OpenTelemetryKtorServerPluginApi.kt
+++ b/instrumentation/instrumentation-ktor-server/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/instrumentation/ktor/server/OpenTelemetryKtorServerPluginApi.kt
@@ -1,0 +1,51 @@
+package io.opentelemetry.kotlin.instrumentation.ktor.server
+
+import io.ktor.server.application.ApplicationCall
+import io.ktor.server.application.ApplicationPlugin
+import io.ktor.server.application.createApplicationPlugin
+import io.ktor.server.application.hooks.CallFailed
+import io.ktor.server.application.hooks.CallSetup
+import io.ktor.server.application.hooks.ResponseSent
+import io.ktor.server.request.httpMethod
+import io.ktor.util.AttributeKey
+import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.OpenTelemetry
+import io.opentelemetry.kotlin.tracing.Span
+import io.opentelemetry.kotlin.tracing.SpanKind
+
+private val spanKey: AttributeKey<Span> =
+    AttributeKey("io.opentelemetry.kotlin.instrumentation.ktor.server.span")
+
+/**
+ * Creates a Ktor server plugin that records a `SERVER` span for each inbound HTTP request.
+ *
+ * https://opentelemetry.io/docs/specs/semconv/http/http-spans/
+ */
+@ExperimentalApi
+public fun openTelemetryKtorServerPlugin(openTelemetry: OpenTelemetry): ApplicationPlugin<Unit> =
+    createApplicationPlugin("opentelemetry-kotlin-ktor") {
+        val tracer = openTelemetry.tracerProvider.getTracer("io.opentelemetry.kotlin.instrumentation.ktor.server")
+
+        on(CallSetup) { call ->
+            if (tracer.enabled()) {
+                call.attributes.put(
+                    spanKey,
+                    tracer.startSpan(
+                        name = call.request.httpMethod.value,
+                        spanKind = SpanKind.SERVER,
+                    ),
+                )
+            }
+        }
+        on(CallFailed) { call, _ -> call.endSpan() }
+        on(ResponseSent) { call -> call.endSpan() }
+    }
+
+/**
+ * Ends the request's span at most once, by removing it as it is ended.
+ */
+private fun ApplicationCall.endSpan() {
+    val span = attributes.getOrNull(spanKey) ?: return
+    attributes.remove(spanKey)
+    span.end()
+}

--- a/instrumentation/instrumentation-ktor-server/src/jvmTest/kotlin/io/opentelemetry/kotlin/instrumentation/ktor/server/OpenTelemetryKtorServerPluginTest.kt
+++ b/instrumentation/instrumentation-ktor-server/src/jvmTest/kotlin/io/opentelemetry/kotlin/instrumentation/ktor/server/OpenTelemetryKtorServerPluginTest.kt
@@ -1,0 +1,64 @@
+package io.opentelemetry.kotlin.instrumentation.ktor.server
+
+import io.ktor.client.request.get
+import io.ktor.server.response.respondText
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.get
+import io.ktor.server.testing.ApplicationTestBuilder
+import io.ktor.server.testing.testApplication
+import io.opentelemetry.kotlin.OpenTelemetry
+import io.opentelemetry.kotlin.createOpenTelemetry
+import io.opentelemetry.kotlin.tracing.SpanKind
+import io.opentelemetry.kotlin.tracing.data.SpanData
+import io.opentelemetry.kotlin.tracing.export.FakeSpanProcessor
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+internal class OpenTelemetryKtorServerPluginTest {
+
+    private lateinit var processor: FakeSpanProcessor
+
+    private val spans: List<SpanData>
+        get() = processor.endCalls.map { it.toSpanData() }
+
+    @BeforeTest
+    fun setUp() {
+        processor = FakeSpanProcessor()
+    }
+
+    @Test
+    fun testRequestSuccess() = testApplication {
+        server { get("/users") { call.respondText("ok") } }
+
+        client.get("/users")
+
+        val span = spans.single()
+        assertEquals("GET", span.name)
+        assertEquals(SpanKind.SERVER, span.spanKind)
+    }
+
+    @Test
+    fun testRequestFail() = testApplication {
+        server { get("/x") { throw BoomException() } }
+
+        runCatching { client.get("/x") }
+
+        // single() also asserts the span was not ended, and so recorded, more than once.
+        val span = spans.single()
+        assertTrue(span.hasEnded)
+    }
+
+    private fun openTelemetry(): OpenTelemetry =
+        createOpenTelemetry {
+            tracerProvider { export { processor } }
+        }
+
+    private fun ApplicationTestBuilder.server(routes: Route.() -> Unit) {
+        install(openTelemetryKtorServerPlugin(openTelemetry()))
+        routing(routes)
+    }
+}
+
+private class BoomException : RuntimeException("boom")


### PR DESCRIPTION
## Goal

Partially addresses #66 by starting some instrumentation for [Ktor](https://ktor.io/). Currently this just creates a very simple trace for a HTTP request on both the client and the server, and adds all the boilerplate module to setup the instrumentation.

Why instrumentation? Ktor feels like a good first candidate as it's a widely used KMP library that supports all our targets, and there are already [well established semantic conventions](https://opentelemetry.io/docs/specs/semconv/http/http-spans/) for HTTP requests. I also think the project is at a point where it would be helpful to have examples of how the API can be used to write instrumentation.

I've kept this changeset to the minimum possible, but in future I envision the following improvements:

- Capture all other relevant attributes for HTTP requests
- Inject a traceparent header
- Setup the example app to use Ktor

## Testing

Added unit tests
