### PR TITLE
fix: remove by lazy on SpanModel and LogRecordModel lock

### DIFF
--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/model/LogRecordModel.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/model/LogRecordModel.kt
@@ -26,9 +26,7 @@ internal class LogRecordModel(
     logLimitConfig: LogLimitConfig,
 ) : ReadWriteLogRecord {
 
-    private val lock by lazy {
-        ReentrantReadWriteLock()
-    }
+    private val lock = ReentrantReadWriteLock()
 
     override var timestamp: Long? = timestamp
         get() = lock.read {

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/model/SpanModel.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/model/SpanModel.kt
@@ -45,9 +45,7 @@ internal class SpanModel(
         ENDED
     }
 
-    private val lock by lazy {
-        ReentrantReadWriteLock()
-    }
+    private val lock = ReentrantReadWriteLock()
 
     private var state: State = State.STARTED
 


### PR DESCRIPTION
## Goal

Close #797.

Every read and mutation on `SpanModel` goes through `lock.read {}` / `lock.write {}`, so `by lazy` on the lock never actually defers anything — it just costs an extra `SynchronizedLazyImpl` per span and a volatile read per access. `LogRecordModel` had the same pattern, so it is fixed too. Both classes are `internal`, so no API change.

## Testing

JMH GC profiler on `benchmark-jvm`: `SimpleLoggingBenchmark` drops from 112 to 88 B/op — exactly one `SynchronizedLazyImpl`. `CreateSimpleSpanBenchmark` drops by the same 24 B/op. Throughput is unchanged within error bars.

`jvmTest` across all modules and detekt on the changed module pass.
