### PR TITLE
Optimize allocations for samplers

### DIFF
--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/tracing/sampling/SamplerAdapter.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/tracing/sampling/SamplerAdapter.kt
@@ -6,6 +6,7 @@ import io.opentelemetry.kotlin.aliases.OtelJavaSamplingDecision
 import io.opentelemetry.kotlin.aliases.OtelJavaTraceState
 import io.opentelemetry.kotlin.attributes.AttributeContainer
 import io.opentelemetry.kotlin.attributes.CompatAttributesModel
+import io.opentelemetry.kotlin.attributes.EmptyAttributeContainer
 import io.opentelemetry.kotlin.context.Context
 import io.opentelemetry.kotlin.context.toOtelJavaContext
 import io.opentelemetry.kotlin.tracing.SpanKind
@@ -42,9 +43,13 @@ internal class SamplerAdapter(
             OtelJavaSamplingDecision.RECORD_ONLY -> SamplingResult.Decision.RECORD_ONLY
             else -> SamplingResult.Decision.RECORD_AND_SAMPLE
         }
+        val resultAttributes: AttributeContainer = when {
+            result.attributes.isEmpty -> EmptyAttributeContainer
+            else -> CompatAttributesModel(result.attributes.toBuilder())
+        }
         return object : SamplingResult {
             override val decision = decision
-            override val attributes = CompatAttributesModel(result.attributes.toBuilder())
+            override val attributes: AttributeContainer = resultAttributes
             override val traceState: TraceState = TraceStateAdapter(
                 result.getUpdatedTraceState(OtelJavaTraceState.getDefault()),
             )

--- a/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/tracing/sampling/SamplerAdapterTest.kt
+++ b/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/tracing/sampling/SamplerAdapterTest.kt
@@ -1,0 +1,70 @@
+package io.opentelemetry.kotlin.tracing.sampling
+
+import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.aliases.OtelJavaAttributes
+import io.opentelemetry.kotlin.aliases.OtelJavaContext
+import io.opentelemetry.kotlin.aliases.OtelJavaLinkData
+import io.opentelemetry.kotlin.aliases.OtelJavaSampler
+import io.opentelemetry.kotlin.aliases.OtelJavaSamplingDecision
+import io.opentelemetry.kotlin.aliases.OtelJavaSamplingResult
+import io.opentelemetry.kotlin.aliases.OtelJavaSpanKind
+import io.opentelemetry.kotlin.attributes.CompatAttributesModel
+import io.opentelemetry.kotlin.attributes.EmptyAttributeContainer
+import io.opentelemetry.kotlin.context.FakeContext
+import io.opentelemetry.kotlin.tracing.SpanKind
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertSame
+
+@OptIn(ExperimentalApi::class)
+internal class SamplerAdapterTest {
+
+    @Test
+    fun `empty java attributes yield the shared empty container`() {
+        val adapter = SamplerAdapter(javaSampler(OtelJavaAttributes.empty()))
+
+        val first = adapter.sample()
+        val second = adapter.sample()
+
+        assertEquals(SamplingResult.Decision.RECORD_AND_SAMPLE, first.decision)
+        assertSame(EmptyAttributeContainer, first.attributes)
+        assertSame(first.attributes, second.attributes)
+    }
+
+    @Test
+    fun `non-empty java attributes are surfaced`() {
+        val javaAttributes = OtelJavaAttributes.builder().put("key", "value").build()
+        val adapter = SamplerAdapter(javaSampler(javaAttributes))
+
+        val result = adapter.sample()
+
+        assertIs<CompatAttributesModel>(result.attributes)
+        assertEquals(mapOf("key" to "value"), result.attributes.attributes)
+    }
+
+    private fun SamplerAdapter.sample(): SamplingResult = shouldSample(
+        context = FakeContext(),
+        traceId = "000000000000000000ffffffffffffff",
+        name = "span",
+        spanKind = SpanKind.INTERNAL,
+        attributes = CompatAttributesModel(),
+        links = emptyList(),
+    )
+
+    private fun javaSampler(samplerAttributes: OtelJavaAttributes) = object : OtelJavaSampler {
+        override fun shouldSample(
+            parentContext: OtelJavaContext,
+            traceId: String,
+            name: String,
+            spanKind: OtelJavaSpanKind,
+            attributes: OtelJavaAttributes,
+            parentLinks: List<OtelJavaLinkData>,
+        ): OtelJavaSamplingResult = OtelJavaSamplingResult.create(
+            OtelJavaSamplingDecision.RECORD_AND_SAMPLE,
+            samplerAttributes,
+        )
+
+        override fun getDescription(): String = "FakeOtelJavaSampler"
+    }
+}

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/config/TracingConfig.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/config/TracingConfig.kt
@@ -43,11 +43,11 @@ internal class TracingConfig(
      */
     val samplerFactory: (SpanFactory) -> Sampler = { _ ->
         ParentBasedSampler(
-            root = AlwaysOnSampler(),
-            remoteParentSampled = AlwaysOnSampler(),
-            remoteParentNotSampled = AlwaysOffSampler(),
-            localParentSampled = AlwaysOnSampler(),
-            localParentNotSampled = AlwaysOffSampler(),
+            root = AlwaysOnSampler,
+            remoteParentSampled = AlwaysOnSampler,
+            remoteParentNotSampled = AlwaysOffSampler,
+            localParentSampled = AlwaysOnSampler,
+            localParentNotSampled = AlwaysOffSampler,
         )
     },
 

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/TracerImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/TracerImpl.kt
@@ -35,7 +35,7 @@ internal class TracerImpl(
     private val resource: Resource,
     private val spanLimitConfig: SpanLimitConfig,
     private val shutdownState: ShutdownState,
-    private val sampler: Sampler = AlwaysOnSampler(),
+    private val sampler: Sampler = AlwaysOnSampler,
     private val sdkErrorHandler: SdkErrorHandler,
 ) : Tracer {
 

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/sampling/AlwaysOffSampler.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/sampling/AlwaysOffSampler.kt
@@ -1,13 +1,13 @@
 package io.opentelemetry.kotlin.tracing.sampling
 
 import io.opentelemetry.kotlin.attributes.AttributeContainer
-import io.opentelemetry.kotlin.attributes.AttributesModel
+import io.opentelemetry.kotlin.attributes.EmptyAttributeContainer
 import io.opentelemetry.kotlin.context.Context
 import io.opentelemetry.kotlin.tracing.SpanKind
 import io.opentelemetry.kotlin.tracing.model.SpanLink
 import io.opentelemetry.kotlin.tracing.sampling.SamplingResult.Decision
 
-internal class AlwaysOffSampler : Sampler {
+internal object AlwaysOffSampler : Sampler {
 
     override val description: String = "AlwaysOffSampler"
 
@@ -22,7 +22,7 @@ internal class AlwaysOffSampler : Sampler {
         val parentTraceState = context.extractSpan().spanContext.traceState
         return SamplingResultImpl(
             decision = Decision.DROP,
-            attributes = AttributesModel(),
+            attributes = EmptyAttributeContainer,
             traceState = parentTraceState,
         )
     }

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/sampling/AlwaysOnSampler.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/sampling/AlwaysOnSampler.kt
@@ -1,13 +1,13 @@
 package io.opentelemetry.kotlin.tracing.sampling
 
 import io.opentelemetry.kotlin.attributes.AttributeContainer
-import io.opentelemetry.kotlin.attributes.AttributesModel
+import io.opentelemetry.kotlin.attributes.EmptyAttributeContainer
 import io.opentelemetry.kotlin.context.Context
 import io.opentelemetry.kotlin.tracing.SpanKind
 import io.opentelemetry.kotlin.tracing.model.SpanLink
 import io.opentelemetry.kotlin.tracing.sampling.SamplingResult.Decision
 
-internal class AlwaysOnSampler : Sampler {
+internal object AlwaysOnSampler : Sampler {
 
     override val description: String = "AlwaysOnSampler"
 
@@ -22,7 +22,7 @@ internal class AlwaysOnSampler : Sampler {
         val parentTraceState = context.extractSpan().spanContext.traceState
         return SamplingResultImpl(
             decision = Decision.RECORD_AND_SAMPLE,
-            attributes = AttributesModel(),
+            attributes = EmptyAttributeContainer,
             traceState = parentTraceState,
         )
     }

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/sampling/BuiltInSamplerApi.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/sampling/BuiltInSamplerApi.kt
@@ -12,7 +12,7 @@ import io.opentelemetry.kotlin.init.SamplerConfigDsl
  * https://opentelemetry.io/docs/specs/otel/trace/sdk/#alwayson
  */
 @ExperimentalApi
-public fun SamplerConfigDsl.alwaysOn(): Sampler = AlwaysOnSampler()
+public fun SamplerConfigDsl.alwaysOn(): Sampler = AlwaysOnSampler
 
 /**
  * Configures sampling so that spans are never recorded and sampled.
@@ -20,7 +20,7 @@ public fun SamplerConfigDsl.alwaysOn(): Sampler = AlwaysOnSampler()
  * https://opentelemetry.io/docs/specs/otel/trace/sdk/#alwaysoff
  */
 @ExperimentalApi
-public fun SamplerConfigDsl.alwaysOff(): Sampler = AlwaysOffSampler()
+public fun SamplerConfigDsl.alwaysOff(): Sampler = AlwaysOffSampler
 
 /**
  * Configures sampling so that spans are always recorded, even if the delegate sampler
@@ -67,7 +67,7 @@ public fun SamplerConfigDsl.composite(block: SamplerConfigDsl.() -> ComposableSa
  * https://opentelemetry.io/docs/specs/otel/trace/sdk/#composablealwayson
  */
 @ExperimentalApi
-public fun SamplerConfigDsl.composableAlwaysOn(): ComposableSampler = ComposableAlwaysOnSampler()
+public fun SamplerConfigDsl.composableAlwaysOn(): ComposableSampler = ComposableAlwaysOnSampler
 
 /**
  * A [ComposableSampler] that never samples.
@@ -75,7 +75,7 @@ public fun SamplerConfigDsl.composableAlwaysOn(): ComposableSampler = Composable
  * https://opentelemetry.io/docs/specs/otel/trace/sdk/#composablealwaysoff
  */
 @ExperimentalApi
-public fun SamplerConfigDsl.composableAlwaysOff(): ComposableSampler = ComposableAlwaysOffSampler()
+public fun SamplerConfigDsl.composableAlwaysOff(): ComposableSampler = ComposableAlwaysOffSampler
 
 /**
  * A [ComposableSampler] that samples spans with the given probability [ratio].
@@ -85,7 +85,7 @@ public fun SamplerConfigDsl.composableAlwaysOff(): ComposableSampler = Composabl
 @ExperimentalApi
 public fun SamplerConfigDsl.composableProbability(ratio: Double): ComposableSampler =
     if (ratio == 0.0) {
-        ComposableAlwaysOffSampler()
+        ComposableAlwaysOffSampler
     } else {
         ComposableProbabilitySampler(ratio)
     }

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/sampling/ComposableAlwaysOffSampler.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/sampling/ComposableAlwaysOffSampler.kt
@@ -10,7 +10,12 @@ import io.opentelemetry.kotlin.tracing.model.SpanLink
  *
  * https://opentelemetry.io/docs/specs/otel/trace/sdk/#composablealwaysoff
  */
-internal class ComposableAlwaysOffSampler : ComposableSampler {
+internal object ComposableAlwaysOffSampler : ComposableSampler {
+
+    private val intent = SamplingIntentImpl(
+        threshold = null,
+        adjustedCountReliable = false
+    )
 
     override fun getSamplingIntent(
         context: Context,
@@ -18,10 +23,7 @@ internal class ComposableAlwaysOffSampler : ComposableSampler {
         spanKind: SpanKind,
         attributes: AttributeContainer,
         links: List<SpanLink>
-    ): SamplingIntent = SamplingIntentImpl(
-        threshold = null,
-        adjustedCountReliable = false
-    )
+    ): SamplingIntent = intent
 
     override val description: String
         get() = "ComposableAlwaysOffSampler"

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/sampling/ComposableAlwaysOnSampler.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/sampling/ComposableAlwaysOnSampler.kt
@@ -13,7 +13,12 @@ import io.opentelemetry.kotlin.tracing.model.SpanLink
  *
  * https://opentelemetry.io/docs/specs/otel/trace/sdk/#composablealwayson
  */
-internal class ComposableAlwaysOnSampler : ComposableSampler {
+internal object ComposableAlwaysOnSampler : ComposableSampler {
+
+    private val intent = SamplingIntentImpl(
+        threshold = 0,
+        adjustedCountReliable = true
+    )
 
     override fun getSamplingIntent(
         context: Context,
@@ -21,10 +26,7 @@ internal class ComposableAlwaysOnSampler : ComposableSampler {
         spanKind: SpanKind,
         attributes: AttributeContainer,
         links: List<SpanLink>
-    ): SamplingIntent = SamplingIntentImpl(
-        threshold = 0,
-        adjustedCountReliable = true
-    )
+    ): SamplingIntent = intent
 
     override val description: String
         get() = "ComposableAlwaysOnSampler"

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/sampling/ComposableParentThresholdSampler.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/sampling/ComposableParentThresholdSampler.kt
@@ -26,11 +26,18 @@ internal class ComposableParentThresholdSampler(private val root: ComposableSamp
         return when {
             !parent.isValid -> root.getSamplingIntent(context, name, spanKind, attributes, links)
             parentThreshold != null -> SamplingIntentImpl(threshold = parentThreshold, adjustedCountReliable = true)
-            parent.traceFlags.isSampled -> SamplingIntentImpl(threshold = 0, adjustedCountReliable = false)
-            else -> SamplingIntentImpl(threshold = null, adjustedCountReliable = false)
+            parent.traceFlags.isSampled -> SAMPLED_PARENT_WITHOUT_THRESHOLD
+            else -> NOT_SAMPLED
         }
     }
 
     override val description: String
         get() = "ComposableParentThresholdSampler{root:${root.description}}"
+
+    private companion object {
+        private val SAMPLED_PARENT_WITHOUT_THRESHOLD =
+            SamplingIntentImpl(threshold = 0, adjustedCountReliable = false)
+        private val NOT_SAMPLED =
+            SamplingIntentImpl(threshold = null, adjustedCountReliable = false)
+    }
 }

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/sampling/ComposableProbabilitySampler.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/sampling/ComposableProbabilitySampler.kt
@@ -17,7 +17,10 @@ internal class ComposableProbabilitySampler(private val ratio: Double) : Composa
         validateRatio(ratio)
     }
 
-    private val threshold: Long = thresholdFromRatio(ratio)
+    private val intent = SamplingIntentImpl(
+        threshold = thresholdFromRatio(ratio),
+        adjustedCountReliable = true
+    )
 
     override fun getSamplingIntent(
         context: Context,
@@ -25,10 +28,7 @@ internal class ComposableProbabilitySampler(private val ratio: Double) : Composa
         spanKind: SpanKind,
         attributes: AttributeContainer,
         links: List<SpanLink>
-    ): SamplingIntent = SamplingIntentImpl(
-        threshold = threshold,
-        adjustedCountReliable = true
-    )
+    ): SamplingIntent = intent
 
     override val description: String
         get() = "ComposableProbabilitySampler{$ratio}"

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/sampling/ComposableRuleBasedSampler.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/sampling/ComposableRuleBasedSampler.kt
@@ -23,7 +23,7 @@ internal data class SamplingRule(
 internal class ComposableRuleBasedSampler(rules: List<SamplingRule>) : ComposableSampler {
 
     private val rules: List<SamplingRule> = rules.toList()
-    private val noMatch = ComposableAlwaysOffSampler()
+    private val noMatch = ComposableAlwaysOffSampler
 
     override fun getSamplingIntent(
         context: Context,

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/sampling/CompositeSampler.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/sampling/CompositeSampler.kt
@@ -1,7 +1,7 @@
 package io.opentelemetry.kotlin.tracing.sampling
 
 import io.opentelemetry.kotlin.attributes.AttributeContainer
-import io.opentelemetry.kotlin.attributes.AttributesModel
+import io.opentelemetry.kotlin.attributes.EmptyAttributeContainer
 import io.opentelemetry.kotlin.context.Context
 import io.opentelemetry.kotlin.tracing.SpanKind
 import io.opentelemetry.kotlin.tracing.model.SpanLink
@@ -67,9 +67,9 @@ internal class CompositeSampler(
             traceState.put(KnownTraceState.OT, derivedOtelTraceState.encode())
         }
         val attr = if (sampled) {
-            intent.attributesProvider?.invoke() ?: AttributesModel()
+            intent.attributesProvider?.invoke() ?: EmptyAttributeContainer
         } else {
-            AttributesModel()
+            EmptyAttributeContainer
         }
 
         return SamplingResultImpl(decision, attr, derivedTraceState)

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/sampling/ProbabilitySampler.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/sampling/ProbabilitySampler.kt
@@ -1,7 +1,7 @@
 package io.opentelemetry.kotlin.tracing.sampling
 
 import io.opentelemetry.kotlin.attributes.AttributeContainer
-import io.opentelemetry.kotlin.attributes.AttributesModel
+import io.opentelemetry.kotlin.attributes.EmptyAttributeContainer
 import io.opentelemetry.kotlin.context.Context
 import io.opentelemetry.kotlin.platformLog
 import io.opentelemetry.kotlin.tracing.SpanKind
@@ -70,7 +70,7 @@ internal class ProbabilitySampler(ratio: Double) : Sampler {
 
         return SamplingResultImpl(
             decision = decision,
-            attributes = AttributesModel(),
+            attributes = EmptyAttributeContainer,
             traceState = traceState.put(KnownTraceState.OT, otelTraceState.encode()),
         )
     }

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/TracerRandomTraceIdFlagTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/TracerRandomTraceIdFlagTest.kt
@@ -111,7 +111,7 @@ internal class TracerRandomTraceIdFlagTest {
 
     private fun buildTracer(
         idGenerator: IdGenerator,
-        sampler: Sampler = AlwaysOnSampler(),
+        sampler: Sampler = AlwaysOnSampler,
     ): TracerImpl {
         val spanContextFactory = SpanContextFactoryImpl(idGenerator, traceFlagsFactory, traceStateFactory)
         return TracerImpl(

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/TracerSamplerTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/TracerSamplerTest.kt
@@ -51,7 +51,7 @@ internal class TracerSamplerTest {
     }
 
     private fun buildTracer(
-        sampler: Sampler = AlwaysOnSampler(),
+        sampler: Sampler = AlwaysOnSampler,
         limitsCfg: SpanLimitConfig = fakeSpanLimitsConfig
     ) = TracerImpl(
         clock = clock,

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/sampling/BuiltInSamplersTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/sampling/BuiltInSamplersTest.kt
@@ -76,14 +76,14 @@ internal class BuiltInSamplersTest {
 
     @Test
     fun testAlwaysOnRecordsAndSamplesSpan() {
-        val span = buildTracer(AlwaysOnSampler()).startSpan("span")
+        val span = buildTracer(AlwaysOnSampler).startSpan("span")
         assertTrue(span.isRecording())
         assertTrue(span.spanContext.traceFlags.isSampled)
     }
 
     @Test
     fun testAlwaysOffDropsSpan() {
-        val span = buildTracer(AlwaysOffSampler()).startSpan("span")
+        val span = buildTracer(AlwaysOffSampler).startSpan("span")
         assertFalse(span.isRecording())
         assertFalse(span.spanContext.traceFlags.isSampled)
     }

--- a/sdk-common/api/jvm/sdk-common.api
+++ b/sdk-common/api/jvm/sdk-common.api
@@ -2,6 +2,11 @@ public final class io/opentelemetry/kotlin/attributes/AttributeContainerExtKt {
 	public static final fun setAttributes (Lio/opentelemetry/kotlin/attributes/AttributesMutator;Lio/opentelemetry/kotlin/attributes/AttributeContainer;)V
 }
 
+public final class io/opentelemetry/kotlin/attributes/EmptyAttributeContainer : io/opentelemetry/kotlin/attributes/AttributeContainer {
+	public static final field INSTANCE Lio/opentelemetry/kotlin/attributes/EmptyAttributeContainer;
+	public fun getAttributes ()Ljava/util/Map;
+}
+
 public final class io/opentelemetry/kotlin/attributes/ExceptionAttributesExtKt {
 	public static final fun setExceptionAttributes (Lio/opentelemetry/kotlin/attributes/AttributesMutator;Ljava/lang/Throwable;)V
 }

--- a/sdk-common/src/commonMain/kotlin/io/opentelemetry/kotlin/attributes/EmptyAttributeContainer.kt
+++ b/sdk-common/src/commonMain/kotlin/io/opentelemetry/kotlin/attributes/EmptyAttributeContainer.kt
@@ -1,0 +1,11 @@
+package io.opentelemetry.kotlin.attributes
+
+/**
+ * A canonical immutable [AttributeContainer] that holds no attributes.
+ *
+ * SDK components that never contribute attributes should return this rather than allocating an
+ * empty container per call.
+ */
+public object EmptyAttributeContainer : AttributeContainer {
+    override val attributes: Map<String, Any> = emptyMap()
+}


### PR DESCRIPTION
## Goal

The built-in samplers were constructing a new AttributeContainer every time, when most of them just supply an empty map. Additionally, always on/off samplers can be implemented using just one object, rather than creating a new instance for each piece of telemetry.

Closes #807
Closes #795
