### PR TITLE
Fix potential key collision in providers

### DIFF
--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/logging/LoggerProviderAdapter.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/logging/LoggerProviderAdapter.kt
@@ -1,14 +1,16 @@
 package io.opentelemetry.kotlin.logging
 
 import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.InstrumentationScopeInfo
 import io.opentelemetry.kotlin.aliases.OtelJavaLoggerProvider
 import io.opentelemetry.kotlin.attributes.AttributesMutator
+import io.opentelemetry.kotlin.scope.scopeCacheKey
 import java.util.concurrent.ConcurrentHashMap
 
 @ExperimentalApi
 internal class LoggerProviderAdapter(private val impl: OtelJavaLoggerProvider) : LoggerProvider {
 
-    private val map = ConcurrentHashMap<String, LoggerAdapter>()
+    private val map = ConcurrentHashMap<InstrumentationScopeInfo, LoggerAdapter>()
 
     override fun getLogger(
         name: String,
@@ -16,8 +18,7 @@ internal class LoggerProviderAdapter(private val impl: OtelJavaLoggerProvider) :
         schemaUrl: String?,
         attributes: (AttributesMutator.() -> Unit)?
     ): Logger {
-        val key = name.plus(version).plus(schemaUrl)
-        return map.getOrPut(key) {
+        return map.getOrPut(scopeCacheKey(name, version, schemaUrl)) {
             val builder = impl.loggerBuilder(name)
 
             if (schemaUrl != null) {

--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/metrics/MeterProviderAdapter.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/metrics/MeterProviderAdapter.kt
@@ -1,9 +1,11 @@
 package io.opentelemetry.kotlin.metrics
 
 import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.InstrumentationScopeInfo
 import io.opentelemetry.kotlin.ThreadSafe
 import io.opentelemetry.kotlin.aliases.OtelJavaMeterProvider
 import io.opentelemetry.kotlin.attributes.AttributesMutator
+import io.opentelemetry.kotlin.scope.scopeCacheKey
 import java.util.concurrent.ConcurrentHashMap
 
 @ThreadSafe
@@ -12,7 +14,7 @@ internal class MeterProviderAdapter(
     private val impl: OtelJavaMeterProvider
 ) : MeterProvider {
 
-    private val map = ConcurrentHashMap<String, MeterAdapter>()
+    private val map = ConcurrentHashMap<InstrumentationScopeInfo, MeterAdapter>()
 
     override fun getMeter(
         name: String,
@@ -20,8 +22,7 @@ internal class MeterProviderAdapter(
         schemaUrl: String?,
         attributes: (AttributesMutator.() -> Unit)?,
     ): Meter {
-        val key = name.plus(version).plus(schemaUrl)
-        return map.getOrPut(key) {
+        return map.getOrPut(scopeCacheKey(name, version, schemaUrl)) {
             val builder = impl.meterBuilder(name)
             schemaUrl?.let(builder::setSchemaUrl)
             version?.let(builder::setInstrumentationVersion)

--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/scope/InstrumentationScopeInfoExt.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/scope/InstrumentationScopeInfoExt.kt
@@ -21,3 +21,15 @@ internal fun OtelJavaInstrumentationScopeInfo.toOtelKotlinInstrumentationScopeIn
         schemaUrl = schemaUrl,
         attributes = attributes.convertToMap()
     )
+
+/**
+ * Builds the cache key used by the provider adapters to dedupe tracers/loggers/meters.
+ *
+ * Scope attributes are deliberately excluded because opentelemetry-java doesn't currently support
+ * them.
+ */
+internal fun scopeCacheKey(
+    name: String,
+    version: String?,
+    schemaUrl: String?
+): InstrumentationScopeInfo = InstrumentationScopeInfoImpl(name, version, schemaUrl, emptyMap())

--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/tracing/TracerProviderAdapter.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/tracing/TracerProviderAdapter.kt
@@ -2,9 +2,11 @@ package io.opentelemetry.kotlin.tracing
 
 import io.opentelemetry.kotlin.Clock
 import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.InstrumentationScopeInfo
 import io.opentelemetry.kotlin.aliases.OtelJavaTracerProvider
 import io.opentelemetry.kotlin.attributes.AttributesMutator
 import io.opentelemetry.kotlin.init.CompatSpanLimitsConfig
+import io.opentelemetry.kotlin.scope.scopeCacheKey
 import java.util.concurrent.ConcurrentHashMap
 
 @ExperimentalApi
@@ -14,7 +16,7 @@ internal class TracerProviderAdapter(
     private val spanLimitsConfig: CompatSpanLimitsConfig,
 ) : TracerProvider {
 
-    private val map = ConcurrentHashMap<String, TracerAdapter>()
+    private val map = ConcurrentHashMap<InstrumentationScopeInfo, TracerAdapter>()
 
     override fun getTracer(
         name: String,
@@ -22,9 +24,7 @@ internal class TracerProviderAdapter(
         schemaUrl: String?,
         attributes: (AttributesMutator.() -> Unit)?
     ): Tracer {
-        val key = name.plus(version).plus(schemaUrl)
-
-        return map.getOrPut(key) {
+        return map.getOrPut(scopeCacheKey(name, version, schemaUrl)) {
             val tracerBuilder = tracerProvider.tracerBuilder(name)
 
             schemaUrl?.let(tracerBuilder::setSchemaUrl)

--- a/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/logging/LoggerProviderAdapterTest.kt
+++ b/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/logging/LoggerProviderAdapterTest.kt
@@ -1,0 +1,24 @@
+package io.opentelemetry.kotlin.logging
+
+import io.opentelemetry.kotlin.aliases.OtelJavaSdkLoggerProvider
+import kotlin.test.Test
+import kotlin.test.assertNotSame
+
+internal class LoggerProviderAdapterTest {
+
+    private val adapter = LoggerProviderAdapter(OtelJavaSdkLoggerProvider.builder().build())
+
+    @Test
+    fun testScopePropertyBoundaryCollision() {
+        val first = adapter.getLogger(name = "ab", version = "c")
+        val second = adapter.getLogger(name = "a", version = "bc")
+        assertNotSame(first, second)
+    }
+
+    @Test
+    fun testNullScopePropertyCollision() {
+        val first = adapter.getLogger(name = "name")
+        val second = adapter.getLogger(name = "name", version = "null")
+        assertNotSame(first, second)
+    }
+}

--- a/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/metrics/MeterProviderAdapterTest.kt
+++ b/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/metrics/MeterProviderAdapterTest.kt
@@ -4,6 +4,7 @@ import io.opentelemetry.kotlin.aliases.OtelJavaSdkMeterProvider
 import kotlin.test.Test
 import kotlin.test.assertNotEquals
 import kotlin.test.assertNotNull
+import kotlin.test.assertNotSame
 import kotlin.test.assertSame
 
 internal class MeterProviderAdapterTest {
@@ -40,5 +41,19 @@ internal class MeterProviderAdapterTest {
         val third = adapter.getMeter(name = "name", schemaUrl = "https://example.com/bar")
         assertSame(first, second)
         assertNotEquals(first, third)
+    }
+
+    @Test
+    fun testScopePropertyBoundaryCollision() {
+        val first = adapter.getMeter(name = "ab", version = "c")
+        val second = adapter.getMeter(name = "a", version = "bc")
+        assertNotSame(first, second)
+    }
+
+    @Test
+    fun testNullScopePropertyCollision() {
+        val first = adapter.getMeter(name = "name")
+        val second = adapter.getMeter(name = "name", version = "null")
+        assertNotSame(first, second)
     }
 }

--- a/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/tracing/TracerProviderAdapterTest.kt
+++ b/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/tracing/TracerProviderAdapterTest.kt
@@ -1,0 +1,30 @@
+package io.opentelemetry.kotlin.tracing
+
+import io.opentelemetry.kotlin.aliases.OtelJavaSdkTracerProvider
+import io.opentelemetry.kotlin.clock.FakeClock
+import io.opentelemetry.kotlin.init.CompatSpanLimitsConfig
+import kotlin.test.Test
+import kotlin.test.assertNotSame
+
+internal class TracerProviderAdapterTest {
+
+    private val adapter = TracerProviderAdapter(
+        OtelJavaSdkTracerProvider.builder().build(),
+        FakeClock(),
+        CompatSpanLimitsConfig()
+    )
+
+    @Test
+    fun testScopePropertyBoundaryCollision() {
+        val first = adapter.getTracer(name = "ab", version = "c")
+        val second = adapter.getTracer(name = "a", version = "bc")
+        assertNotSame(first, second)
+    }
+
+    @Test
+    fun testNullScopePropertyCollision() {
+        val first = adapter.getTracer(name = "name")
+        val second = adapter.getTracer(name = "name", version = "null")
+        assertNotSame(first, second)
+    }
+}


### PR DESCRIPTION
## Goal

Closes #802 where the `TracerProvider` (and other providers) in compat could theoretically collide keys.