### PR TITLE
Rethrow from wrapOperation

### DIFF
--- a/api-ext/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/SpanExt.kt
+++ b/api-ext/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/SpanExt.kt
@@ -20,7 +20,8 @@ public fun Span.addLink(span: Span, attributes: AttributesMutator.() -> Unit = {
  * status - generally this will be [StatusData.Ok] unless the operation fails.
  *
  * If an exception is thrown it will be added to the span as an event and the status will be
- * set to [StatusData.Error] with a description of the throwable's message, if any.
+ * set to [StatusData.Error] with a description of the throwable's message, if any. The span is
+ * ended and the exception is then rethrown so the caller can react to it.
  */
 @ExperimentalApi
 public fun Span.wrapOperation(action: () -> StatusData) {
@@ -33,6 +34,7 @@ public fun Span.wrapOperation(action: () -> StatusData) {
             exc.exceptionType()?.let { setStringAttribute("exception.type", it) }
         }
         setStatus(StatusData.Error(exc.message))
+        throw exc
     } finally {
         end()
     }

--- a/api-ext/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/SpanExtTest.kt
+++ b/api-ext/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/SpanExtTest.kt
@@ -3,8 +3,10 @@ package io.opentelemetry.kotlin.tracing
 import io.opentelemetry.kotlin.exceptionType
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
+import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 internal class SpanExtTest {
@@ -68,9 +70,12 @@ internal class SpanExtTest {
         val errMessage = "Whoops"
         val exc = IllegalStateException(errMessage)
 
-        span.wrapOperation {
-            throw exc
+        val thrown = assertFailsWith<IllegalStateException> {
+            span.wrapOperation {
+                throw exc
+            }
         }
+        assertSame(exc, thrown)
 
         assertFalse(span.isRecording())
         assertTrue(span.status is StatusData.Error)


### PR DESCRIPTION
## Goal

Fixes #793 - wrapOperation didn't rethrow the exception it caught, which unexpectedly swallows throwables from user-supplied code.