### PR TITLE
Lock on span model properties

### DIFF
--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/model/SpanModel.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/model/SpanModel.kt
@@ -65,14 +65,14 @@ internal class SpanModel(
     override var spanContext: SpanContext
         get() = lock.read { spanContextImpl }
         set(value) = lock.write {
-            if (isRecording()) {
+            if (isRecordingInternal()) {
                 spanContextImpl = value
             }
         }
 
     override fun setName(name: String) {
         lock.write {
-            if (isRecording()) {
+            if (isRecordingInternal()) {
                 nameImpl = name
             }
         }
@@ -80,7 +80,7 @@ internal class SpanModel(
 
     override fun setStatus(status: StatusData) {
         lock.write {
-            if (isRecording() && statusImpl !is StatusData.Ok) {
+            if (isRecordingInternal() && statusImpl !is StatusData.Ok) {
                 statusImpl = status
             }
         }
@@ -99,7 +99,7 @@ internal class SpanModel(
         lock.write {
             if (state == State.STARTED) {
                 state = State.ENDING
-                endTimestamp = timestamp
+                endTimestampImpl = timestamp
                 sdkErrorHandler.guard {
                     processor?.onEnding(ReadWriteSpanImpl(this))
                 }
@@ -111,7 +111,12 @@ internal class SpanModel(
         }
     }
 
-    override fun isRecording(): Boolean = state != State.ENDED
+    override fun isRecording(): Boolean = lock.read { isRecordingInternal() }
+
+    /**
+     * Reads [state] without acquiring [lock]. Callers must already hold [lock].
+     */
+    private fun isRecordingInternal(): Boolean = state != State.ENDED
 
     private val eventsList = mutableListOf<SpanEventData>()
 
@@ -146,7 +151,7 @@ internal class SpanModel(
         attributes: (AttributesMutator.() -> Unit)?
     ) {
         lock.write {
-            if (isRecording()) {
+            if (isRecordingInternal()) {
                 if (linksList.size < spanLimitConfig.linkCountLimit) {
                     val link = buildSpanLink(spanContext, attributes, spanLimitConfig)
                     linksList.add(link)
@@ -163,7 +168,7 @@ internal class SpanModel(
         attributes: (AttributesMutator.() -> Unit)?
     ) {
         lock.write {
-            if (isRecording()) {
+            if (isRecordingInternal()) {
                 if (eventsList.size < spanLimitConfig.eventCountLimit) {
                     val container = AttributesModel(
                         attributeLimit = spanLimitConfig.attributeCountPerEventLimit,
@@ -181,29 +186,38 @@ internal class SpanModel(
         }
     }
 
-    override fun toSpanData(): SpanData = SpanDataImpl(
-        name,
-        status,
-        parent,
-        spanContext,
-        spanKind,
-        startTimestamp,
-        endTimestamp,
-        attributes,
-        events,
-        droppedEventsCount,
-        links,
-        droppedLinksCount,
-        resource,
-        instrumentationScopeInfo,
-        hasEnded,
-        droppedAttributesCount
-    )
+    /**
+     * Takes the snapshot under a single read lock so that the returned [SpanData] is internally
+     * consistent.
+     */
+    override fun toSpanData(): SpanData = lock.read {
+        SpanDataImpl(
+            nameImpl,
+            statusImpl,
+            parent,
+            spanContextImpl,
+            spanKind,
+            startTimestamp,
+            endTimestampImpl,
+            attrs.attributes,
+            eventsList.toList(),
+            droppedEventsCountImpl,
+            linksList.toList(),
+            droppedLinksCountImpl,
+            resource,
+            instrumentationScopeInfo,
+            state == State.ENDED,
+            attrs.droppedAttributesCount + initialDroppedAttributesCount
+        )
+    }
 
-    override var endTimestamp: Long? = null
+    private var endTimestampImpl: Long? = null
+
+    override val endTimestamp: Long?
+        get() = lock.read { endTimestampImpl }
 
     override val hasEnded: Boolean
-        get() = state == State.ENDED
+        get() = lock.read { state == State.ENDED }
 
     private val attrs by lazy {
         AttributesModel(
@@ -225,7 +239,7 @@ internal class SpanModel(
 
     override fun setBooleanAttribute(key: String, value: Boolean) {
         lock.write {
-            if (isRecording()) {
+            if (isRecordingInternal()) {
                 attrs.setBooleanAttribute(key, value)
             }
         }
@@ -233,7 +247,7 @@ internal class SpanModel(
 
     override fun setStringAttribute(key: String, value: String) {
         lock.write {
-            if (isRecording()) {
+            if (isRecordingInternal()) {
                 attrs.setStringAttribute(key, value)
             }
         }
@@ -241,7 +255,7 @@ internal class SpanModel(
 
     override fun setLongAttribute(key: String, value: Long) {
         lock.write {
-            if (isRecording()) {
+            if (isRecordingInternal()) {
                 attrs.setLongAttribute(key, value)
             }
         }
@@ -249,7 +263,7 @@ internal class SpanModel(
 
     override fun setDoubleAttribute(key: String, value: Double) {
         lock.write {
-            if (isRecording()) {
+            if (isRecordingInternal()) {
                 attrs.setDoubleAttribute(key, value)
             }
         }
@@ -260,7 +274,7 @@ internal class SpanModel(
         value: List<Boolean>
     ) {
         lock.write {
-            if (isRecording()) {
+            if (isRecordingInternal()) {
                 attrs.setBooleanListAttribute(key, value)
             }
         }
@@ -271,7 +285,7 @@ internal class SpanModel(
         value: List<String>
     ) {
         lock.write {
-            if (isRecording()) {
+            if (isRecordingInternal()) {
                 attrs.setStringListAttribute(key, value)
             }
         }
@@ -282,7 +296,7 @@ internal class SpanModel(
         value: List<Long>
     ) {
         lock.write {
-            if (isRecording()) {
+            if (isRecordingInternal()) {
                 attrs.setLongListAttribute(key, value)
             }
         }
@@ -293,7 +307,7 @@ internal class SpanModel(
         value: List<Double>
     ) {
         lock.write {
-            if (isRecording()) {
+            if (isRecordingInternal()) {
                 attrs.setDoubleListAttribute(key, value)
             }
         }
@@ -301,7 +315,7 @@ internal class SpanModel(
 
     override fun setByteArrayAttribute(key: String, value: ByteArray) {
         lock.write {
-            if (isRecording()) {
+            if (isRecordingInternal()) {
                 attrs.setByteArrayAttribute(key, value)
             }
         }
@@ -309,7 +323,7 @@ internal class SpanModel(
 
     override fun setAnyValueAttribute(key: String, value: AnyValue) {
         lock.write {
-            if (isRecording()) {
+            if (isRecordingInternal()) {
                 attrs.setAnyValueAttribute(key, value)
             }
         }


### PR DESCRIPTION
## Goal

Closes #801 by ensuring that when checking whether a span is recording, or accessing its timestamp, the lock is acquired so the state is guaranteed to be consistent. Additionally, `toSpanData()` is synchronized behind a single lock rather than multiple locks taken on individual accessors.
