### PR TITLE
Supply traceId as bytes to Sampler

### DIFF
--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/tracing/sampling/OtelJavaSamplerAdapter.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/tracing/sampling/OtelJavaSamplerAdapter.kt
@@ -9,6 +9,7 @@ import io.opentelemetry.kotlin.aliases.OtelJavaSamplingResult
 import io.opentelemetry.kotlin.aliases.OtelJavaSpanKind
 import io.opentelemetry.kotlin.attributes.CompatAttributesModel
 import io.opentelemetry.kotlin.context.toOtelKotlinContext
+import io.opentelemetry.kotlin.factory.hexToByteArray
 import io.opentelemetry.kotlin.tracing.ext.toOtelKotlinSpanKind
 import io.opentelemetry.kotlin.tracing.sampling.SamplingResult.Decision.DROP
 import io.opentelemetry.kotlin.tracing.sampling.SamplingResult.Decision.RECORD_AND_SAMPLE
@@ -27,7 +28,7 @@ internal class OtelJavaSamplerAdapter(private val delegate: Sampler) : OtelJavaS
         val ctx = parentContext.toOtelKotlinContext()
         val kind = spanKind.toOtelKotlinSpanKind()
         val attrs = CompatAttributesModel(attributes.toBuilder())
-        val result = delegate.shouldSample(ctx, traceId, name, kind, attrs, emptyList())
+        val result = delegate.shouldSample(ctx, traceId.hexToByteArray(), name, kind, attrs, emptyList())
 
         val decision = when (result.decision) {
             DROP -> OtelJavaSamplingDecision.DROP

--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/tracing/sampling/SamplerAdapter.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/tracing/sampling/SamplerAdapter.kt
@@ -8,6 +8,7 @@ import io.opentelemetry.kotlin.attributes.AttributeContainer
 import io.opentelemetry.kotlin.attributes.CompatAttributesModel
 import io.opentelemetry.kotlin.context.Context
 import io.opentelemetry.kotlin.context.toOtelJavaContext
+import io.opentelemetry.kotlin.factory.toHexString
 import io.opentelemetry.kotlin.tracing.SpanKind
 import io.opentelemetry.kotlin.tracing.TraceState
 import io.opentelemetry.kotlin.tracing.ext.toOtelJavaSpanKind
@@ -22,7 +23,7 @@ internal class SamplerAdapter(
 
     override fun shouldSample(
         context: Context,
-        traceId: String,
+        traceIdBytes: ByteArray,
         name: String,
         spanKind: SpanKind,
         attributes: AttributeContainer,
@@ -30,7 +31,7 @@ internal class SamplerAdapter(
     ): SamplingResult {
         val result = impl.shouldSample(
             context.toOtelJavaContext(),
-            traceId,
+            traceIdBytes.toHexString(),
             name,
             spanKind.toOtelJavaSpanKind(),
             (attributes as? CompatAttributesModel)?.otelJavaAttributes()

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/TracerImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/TracerImpl.kt
@@ -12,7 +12,6 @@ import io.opentelemetry.kotlin.factory.ContextFactory
 import io.opentelemetry.kotlin.factory.IdGenerator
 import io.opentelemetry.kotlin.factory.SpanContextFactory
 import io.opentelemetry.kotlin.factory.TraceFlagsFactory
-import io.opentelemetry.kotlin.factory.toHexString
 import io.opentelemetry.kotlin.init.config.SpanLimitConfig
 import io.opentelemetry.kotlin.resource.Resource
 import io.opentelemetry.kotlin.tracing.export.SpanProcessor
@@ -82,7 +81,7 @@ internal class TracerImpl(
 
             val result = sampler.shouldSample(
                 context = ctx,
-                traceId = traceIdBytes.toHexString(),
+                traceIdBytes = traceIdBytes,
                 name = name,
                 spanKind = spanKind,
                 attributes = collector.attributes,

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/sampling/AlwaysOffSampler.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/sampling/AlwaysOffSampler.kt
@@ -13,7 +13,7 @@ internal class AlwaysOffSampler : Sampler {
 
     override fun shouldSample(
         context: Context,
-        traceId: String,
+        traceIdBytes: ByteArray,
         name: String,
         spanKind: SpanKind,
         attributes: AttributeContainer,

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/sampling/AlwaysOnSampler.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/sampling/AlwaysOnSampler.kt
@@ -13,7 +13,7 @@ internal class AlwaysOnSampler : Sampler {
 
     override fun shouldSample(
         context: Context,
-        traceId: String,
+        traceIdBytes: ByteArray,
         name: String,
         spanKind: SpanKind,
         attributes: AttributeContainer,

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/sampling/AlwaysRecordSampler.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/sampling/AlwaysRecordSampler.kt
@@ -15,13 +15,13 @@ internal class AlwaysRecordSampler(
 
     override fun shouldSample(
         context: Context,
-        traceId: String,
+        traceIdBytes: ByteArray,
         name: String,
         spanKind: SpanKind,
         attributes: AttributeContainer,
         links: List<SpanLink>,
     ): SamplingResult {
-        val delegate = root.shouldSample(context, traceId, name, spanKind, attributes, links)
+        val delegate = root.shouldSample(context, traceIdBytes, name, spanKind, attributes, links)
         if (delegate.decision == DROP) {
             return SamplingResultImpl(
                 decision = RECORD_ONLY,

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/sampling/CompositeSampler.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/sampling/CompositeSampler.kt
@@ -20,7 +20,7 @@ internal class CompositeSampler(
 
     override fun shouldSample(
         context: Context,
-        traceId: String,
+        traceIdBytes: ByteArray,
         name: String,
         spanKind: SpanKind,
         attributes: AttributeContainer,
@@ -36,7 +36,7 @@ internal class CompositeSampler(
         val adjustableThreshold = intentThreshold != null && intent.adjustedCountReliable
         val sampled = intentThreshold?.let {
             val randomVal = if (adjustableThreshold) {
-                otelTraceState.rv ?: randomnessFromTraceId(traceId)
+                otelTraceState.rv ?: randomnessFromTraceIdBytes(traceIdBytes)
             } else {
                 // Use last 56 bits of random number
                 random.nextLong() and 0x00FFFFFFFFFFFFFFL

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/sampling/ParentBasedSampler.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/sampling/ParentBasedSampler.kt
@@ -24,7 +24,7 @@ internal class ParentBasedSampler(
 
     override fun shouldSample(
         context: Context,
-        traceId: String,
+        traceIdBytes: ByteArray,
         name: String,
         spanKind: SpanKind,
         attributes: AttributeContainer,
@@ -38,6 +38,6 @@ internal class ParentBasedSampler(
             parent.traceFlags.isSampled -> localParentSampled
             else -> localParentNotSampled
         }
-        return delegate.shouldSample(context, traceId, name, spanKind, attributes, links)
+        return delegate.shouldSample(context, traceIdBytes, name, spanKind, attributes, links)
     }
 }

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/sampling/ProbabilitySampler.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/sampling/ProbabilitySampler.kt
@@ -30,7 +30,7 @@ internal class ProbabilitySampler(ratio: Double) : Sampler {
 
     override fun shouldSample(
         context: Context,
-        traceId: String,
+        traceIdBytes: ByteArray,
         name: String,
         spanKind: SpanKind,
         attributes: AttributeContainer,
@@ -48,7 +48,7 @@ internal class ProbabilitySampler(ratio: Double) : Sampler {
                 compatibilityWarningLogged = true
                 platformLog(COMPATIBILITY_WARNING)
             }
-            randomnessFromTraceId(traceId)
+            randomnessFromTraceIdBytes(traceIdBytes)
         }
 
         val incomingTh = otelTraceState.th

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/sampling/SamplingRandomness.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/sampling/SamplingRandomness.kt
@@ -1,36 +1,31 @@
 package io.opentelemetry.kotlin.tracing.sampling
 
-import io.opentelemetry.kotlin.factory.isValidHex
+/** Length in bytes of a trace ID. */
+private const val TRACE_ID_BYTES = 16
 
-/** Length in characters of a hex-encoded trace ID (16 bytes). */
-private const val TRACE_ID_LENGTH = 32
+/** Index of the first of the 7 least-significant bytes that supply the 56-bit randomness value. */
+private const val RANDOMNESS_OFFSET = 9
 
 /**
- * Derives the 56-bit randomness value (R) from the least-significant 7 bytes of a hex-encoded
- * trace ID, per W3C Trace Context Level 2.
+ * Derives the 56-bit randomness value (R) from the least-significant 7 bytes of a trace ID,
+ * per W3C Trace Context Level 2.
  *
- * Returns `0` if [traceId] is not a well-formed hex-encoded trace ID. A third-party SpanContext
+ * Returns `0` if [traceIdBytes] is not a well-formed trace ID. A third-party SpanContext
  * implementation can supply a malformed trace ID, and sampling must not throw in that case.
  *
  * https://opentelemetry.io/docs/specs/otel/trace/tracestate-probability-sampling/#randomness-value-r
  * https://www.w3.org/TR/trace-context-2/#randomness-of-trace-id
  */
-internal fun randomnessFromTraceId(traceId: String): Long {
-    if (traceId.length != TRACE_ID_LENGTH || !traceId.isValidHex()) {
+internal fun randomnessFromTraceIdBytes(traceIdBytes: ByteArray): Long {
+    if (traceIdBytes.size != TRACE_ID_BYTES) {
         return 0L
     }
-    return (byteFromBase16(traceId[18], traceId[19]) shl 48) or
-        (byteFromBase16(traceId[20], traceId[21]) shl 40) or
-        (byteFromBase16(traceId[22], traceId[23]) shl 32) or
-        (byteFromBase16(traceId[24], traceId[25]) shl 24) or
-        (byteFromBase16(traceId[26], traceId[27]) shl 16) or
-        (byteFromBase16(traceId[28], traceId[29]) shl 8) or
-        byteFromBase16(traceId[30], traceId[31])
+    var result = 0L
+    for (i in RANDOMNESS_OFFSET until TRACE_ID_BYTES) {
+        result = (result shl 8) or (traceIdBytes[i].toLong() and 0xFF)
+    }
+    return result
 }
-
-/** Parses a single byte (two hex characters) into its numeric value. */
-internal fun byteFromBase16(first: Char, second: Char): Long =
-    ((first.digitToInt(16) shl 4) or second.digitToInt(16)).toLong()
 
 private const val MAX_THRESHOLD: Long = 1L shl 56
 

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/factory/HexConversionsTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/factory/HexConversionsTest.kt
@@ -47,8 +47,36 @@ internal class HexConversionsTest {
     }
 
     @Test
+    fun hexToByteArrayNonAsciiCharacterReturnsEmptyByteArray() {
+        assertContentEquals(ByteArray(0), "0é".hexToByteArray())
+        assertContentEquals(ByteArray(0), "😀".hexToByteArray())
+    }
+
+    @Test
     fun toHexStringByteArrayDefaultValueProducesAllZeroString() {
         val bytes = 8
         assertEquals("0".repeat(bytes * 2), ByteArray(bytes).toHexString())
+    }
+
+    @Test
+    fun toHexStringPadsBytesBelow0x10() {
+        assertEquals("00010f", byteArrayOf(0x00, 0x01, 0x0f).toHexString())
+    }
+
+    @Test
+    fun toHexStringEncodesByteExtremes() {
+        assertEquals("00ff", byteArrayOf(0x00, 0xff.toByte()).toHexString())
+    }
+
+    @Test
+    fun toHexStringEncodesFullTraceIdWidth() {
+        val traceId = ByteArray(16) { (it * 0x11).toByte() }
+        assertEquals("00112233445566778899aabbccddeeff", traceId.toHexString())
+    }
+
+    @Test
+    fun hexRoundTripsForEveryByteValue() {
+        val allBytes = ByteArray(256) { it.toByte() }
+        assertContentEquals(allBytes, allBytes.toHexString().hexToByteArray())
     }
 }

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/init/TracerProviderConfigImplTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/init/TracerProviderConfigImplTest.kt
@@ -13,6 +13,7 @@ import io.opentelemetry.kotlin.factory.SpanContextFactoryImpl
 import io.opentelemetry.kotlin.factory.SpanFactoryImpl
 import io.opentelemetry.kotlin.factory.TraceFlagsFactoryImpl
 import io.opentelemetry.kotlin.factory.TraceStateFactoryImpl
+import io.opentelemetry.kotlin.factory.hexToByteArray
 import io.opentelemetry.kotlin.sdkDefaultAttributes
 import io.opentelemetry.kotlin.sdkDefaultSchemaUrl
 import io.opentelemetry.kotlin.semconv.ServiceAttributes
@@ -273,7 +274,7 @@ internal class TracerProviderConfigImplTest {
 
     private fun Sampler.decisionFor(context: Context): Decision = shouldSample(
         context = context,
-        traceId = "12345678901234567890123456789012",
+        traceIdBytes = "12345678901234567890123456789012".hexToByteArray(),
         name = "span",
         spanKind = SpanKind.INTERNAL,
         attributes = AttributesModel(),

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/sampling/BuiltInCompositeSamplerTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/sampling/BuiltInCompositeSamplerTest.kt
@@ -10,6 +10,7 @@ import io.opentelemetry.kotlin.factory.SpanContextFactoryImpl
 import io.opentelemetry.kotlin.factory.SpanFactoryImpl
 import io.opentelemetry.kotlin.factory.TraceFlagsFactoryImpl
 import io.opentelemetry.kotlin.factory.TraceStateFactoryImpl
+import io.opentelemetry.kotlin.factory.hexToByteArray
 import io.opentelemetry.kotlin.init.SamplerConfigDsl
 import io.opentelemetry.kotlin.tracing.NonRecordingSpan
 import io.opentelemetry.kotlin.tracing.SpanKind
@@ -60,7 +61,8 @@ internal class BuiltInCompositeSamplerTest {
     private fun Sampler.sample(
         context: Context = contextFactory.root(),
         traceId: String = this@BuiltInCompositeSamplerTest.traceId,
-    ): SamplingResult = shouldSample(context, traceId, "span", SpanKind.INTERNAL, AttributesModel(), emptyList())
+    ): SamplingResult =
+        shouldSample(context, traceId.hexToByteArray(), "span", SpanKind.INTERNAL, AttributesModel(), emptyList())
 
     private fun ComposableSampler.intent(context: Context = contextFactory.root()): SamplingIntent =
         getSamplingIntent(context, "span", SpanKind.INTERNAL, AttributesModel(), emptyList())

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/sampling/BuiltInSamplersTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/sampling/BuiltInSamplersTest.kt
@@ -13,6 +13,7 @@ import io.opentelemetry.kotlin.factory.SpanContextFactoryImpl
 import io.opentelemetry.kotlin.factory.SpanFactoryImpl
 import io.opentelemetry.kotlin.factory.TraceFlagsFactoryImpl
 import io.opentelemetry.kotlin.factory.TraceStateFactoryImpl
+import io.opentelemetry.kotlin.factory.hexToByteArray
 import io.opentelemetry.kotlin.init.SamplerConfigDsl
 import io.opentelemetry.kotlin.resource.FakeResource
 import io.opentelemetry.kotlin.tracing.FakeTraceState
@@ -150,7 +151,7 @@ internal class BuiltInSamplersTest {
         val fakeSampler = FakeSampler(SamplingResult.Decision.DROP)
         val result = samplerDsl.alwaysRecord(root = fakeSampler).shouldSample(
             context = contextFactory.root(),
-            traceId = "000000000000000000ffffffffffffff",
+            traceIdBytes = "000000000000000000ffffffffffffff".hexToByteArray(),
             name = "span",
             spanKind = SpanKind.INTERNAL,
             attributes = AttributesModel(),
@@ -164,7 +165,7 @@ internal class BuiltInSamplersTest {
         val fakeSampler = FakeSampler(SamplingResult.Decision.RECORD_ONLY)
         val result = samplerDsl.alwaysRecord(root = fakeSampler).shouldSample(
             context = contextFactory.root(),
-            traceId = "000000000000000000ffffffffffffff",
+            traceIdBytes = "000000000000000000ffffffffffffff".hexToByteArray(),
             name = "span",
             spanKind = SpanKind.INTERNAL,
             attributes = AttributesModel(),
@@ -178,7 +179,7 @@ internal class BuiltInSamplersTest {
         val fakeSampler = FakeSampler(SamplingResult.Decision.RECORD_AND_SAMPLE)
         val result = samplerDsl.alwaysRecord(root = fakeSampler).shouldSample(
             context = contextFactory.root(),
-            traceId = "000000000000000000ffffffffffffff",
+            traceIdBytes = "000000000000000000ffffffffffffff".hexToByteArray(),
             name = "span",
             spanKind = SpanKind.INTERNAL,
             attributes = AttributesModel(),
@@ -197,7 +198,7 @@ internal class BuiltInSamplersTest {
         )
         val result = samplerDsl.alwaysRecord(root = fakeSampler).shouldSample(
             context = contextFactory.root(),
-            traceId = "000000000000000000ffffffffffffff",
+            traceIdBytes = "000000000000000000ffffffffffffff".hexToByteArray(),
             name = "span",
             spanKind = SpanKind.INTERNAL,
             attributes = AttributesModel(),

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/sampling/ComposableRuleBasedSamplerTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/sampling/ComposableRuleBasedSamplerTest.kt
@@ -10,6 +10,7 @@ import io.opentelemetry.kotlin.factory.SpanContextFactoryImpl
 import io.opentelemetry.kotlin.factory.SpanFactoryImpl
 import io.opentelemetry.kotlin.factory.TraceFlagsFactoryImpl
 import io.opentelemetry.kotlin.factory.TraceStateFactoryImpl
+import io.opentelemetry.kotlin.factory.hexToByteArray
 import io.opentelemetry.kotlin.init.SamplerConfigDsl
 import io.opentelemetry.kotlin.tracing.NonRecordingSpan
 import io.opentelemetry.kotlin.tracing.SpanKind
@@ -95,7 +96,7 @@ internal class ComposableRuleBasedSamplerTest {
             }
         }.shouldSample(
             context = contextFactory.root(),
-            traceId = traceId,
+            traceIdBytes = traceId.hexToByteArray(),
             name = "span",
             spanKind = SpanKind.INTERNAL,
             attributes = AttributesModel(),
@@ -114,7 +115,7 @@ internal class ComposableRuleBasedSamplerTest {
             }
         }.shouldSample(
             context = contextFactory.root(),
-            traceId = traceId,
+            traceIdBytes = traceId.hexToByteArray(),
             name = "span",
             spanKind = SpanKind.INTERNAL,
             attributes = AttributesModel(),
@@ -219,7 +220,7 @@ internal class ComposableRuleBasedSamplerTest {
             }
         }.shouldSample(
             context = contextWithParent(sampled = true, isRemote = true, otValue = "th:8"),
-            traceId = traceId,
+            traceIdBytes = traceId.hexToByteArray(),
             name = "span",
             spanKind = SpanKind.INTERNAL,
             attributes = AttributesModel(),

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/sampling/ProbabilitySamplerTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/sampling/ProbabilitySamplerTest.kt
@@ -43,7 +43,7 @@ internal class ProbabilitySamplerTest {
     fun testRecordsAndSamplesSpan() {
         val result = ProbabilitySampler(0.5).shouldSample(
             context = contextFactory.root(),
-            traceId = "000000000000000000ffffffffffffff",
+            traceIdBytes = "000000000000000000ffffffffffffff".hexToByteArray(),
             name = "span",
             spanKind = SpanKind.INTERNAL,
             attributes = AttributesModel(),
@@ -56,7 +56,7 @@ internal class ProbabilitySamplerTest {
     fun testDropsSpan() {
         val result = ProbabilitySampler(0.5).shouldSample(
             context = contextFactory.root(),
-            traceId = "ffffffffffffffffff00000000000000",
+            traceIdBytes = "ffffffffffffffffff00000000000000".hexToByteArray(),
             name = "span",
             spanKind = SpanKind.INTERNAL,
             attributes = AttributesModel(),
@@ -70,7 +70,7 @@ internal class ProbabilitySamplerTest {
         val ratio = 1.0 / (1L shl 56).toDouble()
         val result = ProbabilitySampler(ratio).shouldSample(
             context = contextFactory.root(),
-            traceId = "000000000000000000ffffffffffffff",
+            traceIdBytes = "000000000000000000ffffffffffffff".hexToByteArray(),
             name = "span",
             spanKind = SpanKind.INTERNAL,
             attributes = AttributesModel(),
@@ -84,7 +84,7 @@ internal class ProbabilitySamplerTest {
         val ratio = 1.0 / (1L shl 56).toDouble()
         val result = ProbabilitySampler(ratio).shouldSample(
             context = contextFactory.root(),
-            traceId = "000000000000000000fffffffffffffe",
+            traceIdBytes = "000000000000000000fffffffffffffe".hexToByteArray(),
             name = "span",
             spanKind = SpanKind.INTERNAL,
             attributes = AttributesModel(),
@@ -116,7 +116,7 @@ internal class ProbabilitySamplerTest {
         )
         val result = ProbabilitySampler(ratio).shouldSample(
             context = context,
-            traceId = traceId,
+            traceIdBytes = traceId.hexToByteArray(),
             name = "span",
             spanKind = SpanKind.INTERNAL,
             attributes = AttributesModel(),
@@ -135,7 +135,7 @@ internal class ProbabilitySamplerTest {
         )
         val result = ProbabilitySampler(0.5).shouldSample(
             context = context,
-            traceId = traceId,
+            traceIdBytes = traceId.hexToByteArray(),
             name = "span",
             spanKind = SpanKind.INTERNAL,
             attributes = AttributesModel(),
@@ -154,7 +154,7 @@ internal class ProbabilitySamplerTest {
         )
         val result = ProbabilitySampler(0.5).shouldSample(
             context = context,
-            traceId = traceId,
+            traceIdBytes = traceId.hexToByteArray(),
             name = "span",
             spanKind = SpanKind.INTERNAL,
             attributes = AttributesModel(),
@@ -173,7 +173,7 @@ internal class ProbabilitySamplerTest {
         )
         val result = ProbabilitySampler(0.5).shouldSample(
             context = context,
-            traceId = traceId,
+            traceIdBytes = traceId.hexToByteArray(),
             name = "span",
             spanKind = SpanKind.INTERNAL,
             attributes = AttributesModel(),

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/sampling/SamplingRandomnessTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/sampling/SamplingRandomnessTest.kt
@@ -1,5 +1,6 @@
 package io.opentelemetry.kotlin.tracing.sampling
 
+import io.opentelemetry.kotlin.factory.hexToByteArray
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -7,50 +8,46 @@ internal class SamplingRandomnessTest {
 
     @Test
     fun testRandomnessUsesLeastSignificant7Bytes() {
-        // chars 18..31 of the trace ID supply the 56-bit randomness value
-        assertEquals(0x23456789abcdefL, randomnessFromTraceId("0123456789abcdef0123456789abcdef"))
-    }
-
-    @Test
-    fun testRandomnessMaxValue() {
-        assertEquals(0x00FFFFFFFFFFFFFFL, randomnessFromTraceId("ffffffffffffffffffffffffffffffff"))
-    }
-
-    @Test
-    fun testRandomnessZeroValue() {
-        assertEquals(0L, randomnessFromTraceId("00000000000000000000000000000000"))
-    }
-
-    @Test
-    fun testRandomnessAcceptsUppercaseHex() {
+        // bytes 9..15 of the trace ID supply the 56-bit randomness value
         assertEquals(
-            randomnessFromTraceId("0123456789abcdef0123456789abcdef"),
-            randomnessFromTraceId("0123456789ABCDEF0123456789ABCDEF"),
+            0x23456789abcdefL,
+            randomnessFromTraceIdBytes("0123456789abcdef0123456789abcdef".hexToByteArray()),
         )
     }
 
     @Test
+    fun testRandomnessMaxValue() {
+        assertEquals(
+            0x00FFFFFFFFFFFFFFL,
+            randomnessFromTraceIdBytes("ffffffffffffffffffffffffffffffff".hexToByteArray()),
+        )
+    }
+
+    @Test
+    fun testRandomnessZeroValue() {
+        assertEquals(0L, randomnessFromTraceIdBytes(ByteArray(16)))
+    }
+
+    @Test
+    fun testRandomnessIgnoresMostSignificant9Bytes() {
+        val leadingZeros = ByteArray(16).also { it.fill(0x11, fromIndex = 9) }
+        val leadingOnes = ByteArray(16) { 0xFF.toByte() }.also { it.fill(0x11, fromIndex = 9) }
+        assertEquals(0x11111111111111L, randomnessFromTraceIdBytes(leadingZeros))
+        assertEquals(0x11111111111111L, randomnessFromTraceIdBytes(leadingOnes))
+    }
+
+    @Test
     fun testRandomnessZeroForTooShortTraceId() {
-        assertEquals(0L, randomnessFromTraceId("0123456789abcdef"))
+        assertEquals(0L, randomnessFromTraceIdBytes(ByteArray(8)))
     }
 
     @Test
     fun testRandomnessZeroForEmptyTraceId() {
-        assertEquals(0L, randomnessFromTraceId(""))
+        assertEquals(0L, randomnessFromTraceIdBytes(ByteArray(0)))
     }
 
     @Test
     fun testRandomnessZeroForTooLongTraceId() {
-        assertEquals(0L, randomnessFromTraceId("0123456789abcdef0123456789abcdef0"))
-    }
-
-    @Test
-    fun testRandomnessZeroForNonHexCharInRandomnessWindow() {
-        assertEquals(0L, randomnessFromTraceId("0123456789abcdef0123456789abcdeg"))
-    }
-
-    @Test
-    fun testRandomnessZeroForNonHexCharOutsideRandomnessWindow() {
-        assertEquals(0L, randomnessFromTraceId("g123456789abcdef0123456789abcdef"))
+        assertEquals(0L, randomnessFromTraceIdBytes(ByteArray(17)))
     }
 }

--- a/sdk-api/api/jvm/sdk-api.api
+++ b/sdk-api/api/jvm/sdk-api.api
@@ -378,7 +378,7 @@ public abstract interface class io/opentelemetry/kotlin/tracing/sampling/Composa
 
 public abstract interface class io/opentelemetry/kotlin/tracing/sampling/Sampler {
 	public abstract fun getDescription ()Ljava/lang/String;
-	public abstract fun shouldSample (Lio/opentelemetry/kotlin/context/Context;Ljava/lang/String;Ljava/lang/String;Lio/opentelemetry/kotlin/tracing/SpanKind;Lio/opentelemetry/kotlin/attributes/AttributeContainer;Ljava/util/List;)Lio/opentelemetry/kotlin/tracing/sampling/SamplingResult;
+	public abstract fun shouldSample (Lio/opentelemetry/kotlin/context/Context;[BLjava/lang/String;Lio/opentelemetry/kotlin/tracing/SpanKind;Lio/opentelemetry/kotlin/attributes/AttributeContainer;Ljava/util/List;)Lio/opentelemetry/kotlin/tracing/sampling/SamplingResult;
 }
 
 public abstract interface class io/opentelemetry/kotlin/tracing/sampling/SamplingIntent {

--- a/sdk-api/src/commonMain/kotlin/io/opentelemetry/kotlin/factory/IdGenerator.kt
+++ b/sdk-api/src/commonMain/kotlin/io/opentelemetry/kotlin/factory/IdGenerator.kt
@@ -34,17 +34,33 @@ public interface IdGenerator {
         get() = false
 }
 
+/** Lowercase hex digits, indexed by nibble value. */
+private val HEX_DIGITS = "0123456789abcdef".toCharArray()
+
+/** ASCII code point -> nibble value, or -1 if the character is not a hex digit. */
+private val HEX_VALUES = IntArray(128) { -1 }.apply {
+    for (i in 0..9) {
+        this['0'.code + i] = i
+    }
+    for (i in 0..5) {
+        this['a'.code + i] = 10 + i
+        this['A'.code + i] = 10 + i
+    }
+}
+
 /**
  * Encodes Span/Trace ID bytes as a hex string.
  */
 @ExperimentalApi
 public fun ByteArray.toHexString(): String {
-    val result = StringBuilder(size * 2)
+    val chars = CharArray(size * 2)
+    var index = 0
     for (b in this) {
         val i = b.toInt() and 0xFF
-        result.append(i.toString(16).padStart(2, '0'))
+        chars[index++] = HEX_DIGITS[i shr 4]
+        chars[index++] = HEX_DIGITS[i and 0x0F]
     }
-    return result.toString()
+    return chars.concatToString()
 }
 
 /**
@@ -52,14 +68,27 @@ public fun ByteArray.toHexString(): String {
  * A string that is not in the expected format return an empty [ByteArray]
  */
 @ExperimentalApi
-public fun String.hexToByteArray(): ByteArray =
-    runCatching {
-        require(length % 2 == 0)
-        val out = ByteArray(length / 2)
-        for (i in out.indices) {
-            val hi = this[i * 2].digitToInt(16)
-            val lo = this[i * 2 + 1].digitToInt(16)
-            out[i] = ((hi shl 4) or lo).toByte()
+public fun String.hexToByteArray(): ByteArray {
+    if (length % 2 != 0) {
+        return ByteArray(0)
+    }
+    val out = ByteArray(length / 2)
+    for (i in out.indices) {
+        val hi = nibbleAt(i * 2)
+        val lo = nibbleAt(i * 2 + 1)
+        if (hi < 0 || lo < 0) {
+            return ByteArray(0)
         }
-        out
-    }.getOrDefault(ByteArray(0))
+        out[i] = ((hi shl 4) or lo).toByte()
+    }
+    return out
+}
+
+/** Returns the nibble value of the hex digit at [index], or -1 if it isn't one. */
+private fun String.nibbleAt(index: Int): Int {
+    val code = this[index].code
+    if (code >= HEX_VALUES.size) {
+        return -1
+    }
+    return HEX_VALUES[code]
+}

--- a/sdk-api/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/sampling/Sampler.kt
+++ b/sdk-api/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/sampling/Sampler.kt
@@ -19,7 +19,7 @@ public interface Sampler {
      * Returns whether the span should be sampled or not.
      *
      * @param context A context containing the parent span
-     * @param traceId The traceId of the span to be created
+     * @param traceIdBytes The 16-byte traceId of the span to be created
      * @param name The name of the span to be created
      * @param spanKind The spanKind of the span to be created
      * @param attributes The initial set of attributes of the span to be created
@@ -27,7 +27,7 @@ public interface Sampler {
      */
     public fun shouldSample(
         context: Context,
-        traceId: String,
+        traceIdBytes: ByteArray,
         name: String,
         spanKind: SpanKind,
         attributes: AttributeContainer,

--- a/test-fakes/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/sampling/FakeSampler.kt
+++ b/test-fakes/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/sampling/FakeSampler.kt
@@ -24,7 +24,7 @@ class FakeSampler(
 
     override fun shouldSample(
         context: Context,
-        traceId: String,
+        traceIdBytes: ByteArray,
         name: String,
         spanKind: SpanKind,
         attributes: AttributeContainer,


### PR DESCRIPTION
## Goal

`Sampler` in the spec doesn't specify [how `traceId` should be supplied](https://opentelemetry.io/docs/specs/otel/trace/sdk/#sampling), so I've switched the type from `String` to `ByteArray` as I believe this better fits the intent, and avoids needing to encode then decode a hex string in the implementation module.

I've additionally optimized the hex encoding so that fewer strings are allocated for each traceId/spanId hex string.

Closes #794

## Testing

Added unit tests & relied on existing coverage.
