### PR TITLE
Make scalars on config DSL nullable

### DIFF
--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/init/CompatAttributeLimitsConfig.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/init/CompatAttributeLimitsConfig.kt
@@ -1,19 +1,6 @@
 package io.opentelemetry.kotlin.init
 
 internal class CompatAttributeLimitsConfig : AttributeLimitsConfigDsl {
-
-    internal var attributeCountLimitSet = false
-    internal var attributeValueLengthLimitSet = false
-
-    override var attributeCountLimit: Int = DEFAULT_ATTR_LIMIT
-        set(value) {
-            field = value
-            attributeCountLimitSet = true
-        }
-
-    override var attributeValueLengthLimit: Int = DEFAULT_ATTR_VALUE_LENGTH_LIMIT
-        set(value) {
-            field = value
-            attributeValueLengthLimitSet = true
-        }
+    override var attributeCountLimit: Int? = null
+    override var attributeValueLengthLimit: Int? = null
 }

--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/init/CompatLogLimitsConfig.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/init/CompatLogLimitsConfig.kt
@@ -6,19 +6,15 @@ import io.opentelemetry.kotlin.aliases.OtelJavaLogLimits
 @ExperimentalApi
 internal class CompatLogLimitsConfig : LogLimitsConfigDsl {
 
-    private val builder = OtelJavaLogLimits.builder()
+    override var attributeCountLimit: Int? = null
+    override var attributeValueLengthLimit: Int? = null
 
-    override var attributeCountLimit: Int = DEFAULT_ATTR_LIMIT
-        set(value) {
-            field = value
-            builder.setMaxNumberOfAttributes(value)
-        }
-
-    override var attributeValueLengthLimit: Int = DEFAULT_ATTR_VALUE_LENGTH_LIMIT
-        set(value) {
-            field = value
-            builder.setMaxAttributeValueLength(value)
-        }
-
-    fun build(): OtelJavaLogLimits = builder.build()
+    /**
+     * Only the limits that were configured are set, so anything left unset falls back to the Java
+     * SDK's own default.
+     */
+    fun build(): OtelJavaLogLimits = OtelJavaLogLimits.builder().apply {
+        attributeCountLimit?.let(::setMaxNumberOfAttributes)
+        attributeValueLengthLimit?.let(::setMaxAttributeValueLength)
+    }.build()
 }

--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/init/CompatLoggerProviderConfig.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/init/CompatLoggerProviderConfig.kt
@@ -34,13 +34,10 @@ internal class CompatLoggerProviderConfig(
     internal val logLimitsConfig = CompatLogLimitsConfig()
     private var logLimitsAction: (LogLimitsConfigDsl.() -> Unit)? = null
     private var loggerConfigurator: LoggerConfigurator? = null
-    private var serviceNameOverride: String? = null
-
-    override var serviceName: String
-        get() = serviceNameOverride ?: "unknown_service"
+    override var serviceName: String? = null
         set(value) {
-            serviceNameOverride = value
-            resourceAttrs.setStringAttribute(ServiceAttributes.SERVICE_NAME, value)
+            field = value
+            value?.let { resourceAttrs.setStringAttribute(ServiceAttributes.SERVICE_NAME, it) }
         }
 
     private val resourceAttrs = CompatAttributesModel()
@@ -84,15 +81,13 @@ internal class CompatLoggerProviderConfig(
     fun build(
         clock: Clock,
         baseResource: Resource = ResourceAdapter(OtelJavaResource.builder().build()),
-        globalLimits: CompatAttributeLimitsConfig? = null,
+        globalLimits: AttributeLimitsConfigDsl? = null,
     ): LoggerProvider {
-        if (globalLimits?.attributeCountLimitSet == true) {
-            logLimitsConfig.attributeCountLimit = globalLimits.attributeCountLimit
-        }
-        if (globalLimits?.attributeValueLengthLimitSet == true) {
-            logLimitsConfig.attributeValueLengthLimit = globalLimits.attributeValueLengthLimit
-        }
         logLimitsAction?.invoke(logLimitsConfig)
+        logLimitsConfig.attributeCountLimit =
+            logLimitsConfig.attributeCountLimit ?: globalLimits?.attributeCountLimit
+        logLimitsConfig.attributeValueLengthLimit =
+            logLimitsConfig.attributeValueLengthLimit ?: globalLimits?.attributeValueLengthLimit
         builder.setLogLimits(logLimitsConfig::build)
         loggerConfigurator?.let(::applyLoggerConfigurator)
         val resource = ResourceAdapter(

--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/init/CompatMeterProviderConfig.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/init/CompatMeterProviderConfig.kt
@@ -21,10 +21,10 @@ internal class CompatMeterProviderConfig(
 ) : MeterProviderConfigDsl {
 
     private val builder: OtelJavaSdkMeterProviderBuilder = OtelJavaSdkMeterProvider.builder()
-    override var serviceName: String = "unknown_service"
+    override var serviceName: String? = null
         set(value) {
             field = value
-            resourceAttrs.setStringAttribute(ServiceAttributes.SERVICE_NAME, value)
+            value?.let { resourceAttrs.setStringAttribute(ServiceAttributes.SERVICE_NAME, it) }
         }
 
     private val resourceAttrs = CompatAttributesModel()

--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/init/CompatOpenTelemetryConfig.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/init/CompatOpenTelemetryConfig.kt
@@ -42,13 +42,10 @@ internal class CompatOpenTelemetryConfig(
 
     private val globalResourceAttrs = CompatAttributesModel()
     private var globalResourceSchemaUrl: String? = null
-    private var serviceNameOverride: String? = null
-
-    override var serviceName: String
-        get() = serviceNameOverride ?: "unknown_service"
+    override var serviceName: String? = null
         set(value) {
-            serviceNameOverride = value
-            globalResourceAttrs.setStringAttribute(ServiceAttributes.SERVICE_NAME, value)
+            field = value
+            value?.let { globalResourceAttrs.setStringAttribute(ServiceAttributes.SERVICE_NAME, it) }
         }
 
     override fun resource(schemaUrl: String?, attributes: AttributesMutator.() -> Unit) {

--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/init/CompatSpanLimitsConfig.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/init/CompatSpanLimitsConfig.kt
@@ -6,43 +6,36 @@ import io.opentelemetry.kotlin.aliases.OtelJavaSpanLimits
 @ExperimentalApi
 internal class CompatSpanLimitsConfig : SpanLimitsConfigDsl {
 
-    private val builder = OtelJavaSpanLimits.builder()
+    override var attributeCountLimit: Int? = null
+    override var attributeValueLengthLimit: Int? = null
+    override var linkCountLimit: Int? = null
+    override var eventCountLimit: Int? = null
+    override var attributeCountPerEventLimit: Int? = null
+    override var attributeCountPerLinkLimit: Int? = null
 
-    override var attributeCountLimit: Int = DEFAULT_ATTR_LIMIT
-        set(value) {
-            field = value
-            builder.setMaxNumberOfAttributes(value)
-        }
+    /**
+     * The Java SDK cannot report dropped links, events, or attributes back to us, so the adapters
+     * enforce those three limits themselves and need the default filled in here.
+     */
+    val effectiveAttributeCountLimit: Int
+        get() = attributeCountLimit ?: DEFAULT_ATTR_LIMIT
 
-    override var attributeValueLengthLimit: Int = DEFAULT_ATTR_VALUE_LENGTH_LIMIT
-        set(value) {
-            field = value
-            builder.setMaxAttributeValueLength(value)
-        }
+    val effectiveLinkCountLimit: Int
+        get() = linkCountLimit ?: DEFAULT_LINK_LIMIT
 
-    override var linkCountLimit: Int = DEFAULT_LINK_LIMIT
-        set(value) {
-            field = value
-            builder.setMaxNumberOfLinks(value)
-        }
+    val effectiveEventCountLimit: Int
+        get() = eventCountLimit ?: DEFAULT_EVENT_LIMIT
 
-    override var eventCountLimit: Int = DEFAULT_EVENT_LIMIT
-        set(value) {
-            field = value
-            builder.setMaxNumberOfEvents(value)
-        }
-
-    override var attributeCountPerEventLimit: Int = DEFAULT_ATTR_LIMIT
-        set(value) {
-            field = value
-            builder.setMaxNumberOfAttributesPerEvent(value)
-        }
-
-    override var attributeCountPerLinkLimit: Int = DEFAULT_ATTR_LIMIT
-        set(value) {
-            field = value
-            builder.setMaxNumberOfAttributesPerLink(value)
-        }
-
-    fun build(): OtelJavaSpanLimits = builder.build()
+    /**
+     * Only the limits that were configured are set, so anything left unset falls back to the Java
+     * SDK's own default.
+     */
+    fun build(): OtelJavaSpanLimits = OtelJavaSpanLimits.builder().apply {
+        attributeCountLimit?.let(::setMaxNumberOfAttributes)
+        attributeValueLengthLimit?.let(::setMaxAttributeValueLength)
+        linkCountLimit?.let(::setMaxNumberOfLinks)
+        eventCountLimit?.let(::setMaxNumberOfEvents)
+        attributeCountPerEventLimit?.let(::setMaxNumberOfAttributesPerEvent)
+        attributeCountPerLinkLimit?.let(::setMaxNumberOfAttributesPerLink)
+    }.build()
 }

--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/init/CompatTracerProviderConfig.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/init/CompatTracerProviderConfig.kt
@@ -41,16 +41,13 @@ internal class CompatTracerProviderConfig(
     internal val spanLimitsConfig = CompatSpanLimitsConfig()
     private var spanLimitsAction: (SpanLimitsConfigDsl.() -> Unit)? = null
     private var tracerConfigurator: TracerConfigurator? = null
-    private var serviceNameOverride: String? = null
-
     private val resourceAttrs = CompatAttributesModel()
     private var resourceSchemaUrl: String? = null
 
-    override var serviceName: String
-        get() = serviceNameOverride ?: "unknown_service"
+    override var serviceName: String? = null
         set(value) {
-            serviceNameOverride = value
-            resourceAttrs.setStringAttribute(ServiceAttributes.SERVICE_NAME, value)
+            field = value
+            value?.let { resourceAttrs.setStringAttribute(ServiceAttributes.SERVICE_NAME, it) }
         }
 
     override fun resource(schemaUrl: String?, attributes: AttributesMutator.() -> Unit) {
@@ -102,7 +99,7 @@ internal class CompatTracerProviderConfig(
         clock: Clock,
         idGenerator: IdGenerator,
         baseResource: Resource = ResourceAdapter(OtelJavaResource.builder().build()),
-        globalLimits: CompatAttributeLimitsConfig? = null,
+        globalLimits: AttributeLimitsConfigDsl? = null,
     ): TracerProvider {
         builder.setIdGenerator(
             when (idGenerator) {
@@ -110,13 +107,11 @@ internal class CompatTracerProviderConfig(
                 else -> OtelJavaIdGeneratorAdapter(idGenerator)
             }
         )
-        if (globalLimits?.attributeCountLimitSet == true) {
-            spanLimitsConfig.attributeCountLimit = globalLimits.attributeCountLimit
-        }
-        if (globalLimits?.attributeValueLengthLimitSet == true) {
-            spanLimitsConfig.attributeValueLengthLimit = globalLimits.attributeValueLengthLimit
-        }
         spanLimitsAction?.invoke(spanLimitsConfig)
+        spanLimitsConfig.attributeCountLimit =
+            spanLimitsConfig.attributeCountLimit ?: globalLimits?.attributeCountLimit
+        spanLimitsConfig.attributeValueLengthLimit =
+            spanLimitsConfig.attributeValueLengthLimit ?: globalLimits?.attributeValueLengthLimit
         builder.setSpanLimits(spanLimitsConfig.build())
         tracerConfigurator?.let(::applyTracerConfigurator)
         val resource = ResourceAdapter(

--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/init/DefaultLimits.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/init/DefaultLimits.kt
@@ -1,6 +1,10 @@
 package io.opentelemetry.kotlin.init
 
+/**
+ * Defaults for the limits the compat adapters enforce themselves. A limit left unset by every
+ * configuration mechanism is not passed to the Java SDK at all, so it applies its own default to
+ * everything else.
+ */
 internal const val DEFAULT_ATTR_LIMIT = 128
-internal const val DEFAULT_ATTR_VALUE_LENGTH_LIMIT = Int.MAX_VALUE
 internal const val DEFAULT_LINK_LIMIT: Int = 128
 internal const val DEFAULT_EVENT_LIMIT: Int = 128

--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/tracing/model/SpanAdapter.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/tracing/model/SpanAdapter.kt
@@ -85,7 +85,7 @@ internal class SpanAdapter(
         if (attributes != null) {
             attributes(container)
         }
-        if (linksImpl.size < spanLimitsConfig.linkCountLimit) {
+        if (linksImpl.size < spanLimitsConfig.effectiveLinkCountLimit) {
             linksImpl.add(SpanLinkCompatImpl(spanContext, container))
         }
         impl.addLink(spanContext.toOtelJavaSpanContext(), container.otelJavaAttributes())
@@ -101,7 +101,7 @@ internal class SpanAdapter(
             attributes(container)
         }
         val time = timestamp ?: clock.now()
-        if (eventsImpl.size < spanLimitsConfig.eventCountLimit) {
+        if (eventsImpl.size < spanLimitsConfig.effectiveEventCountLimit) {
             eventsImpl.add(SpanEventCompatImpl(name, time, container))
         }
         impl.addEvent(name, container.otelJavaAttributes(), time, TimeUnit.NANOSECONDS)
@@ -109,56 +109,56 @@ internal class SpanAdapter(
 
     override fun setBooleanAttribute(key: String, value: Boolean) {
         impl.setAttribute(key, value)
-        if (attrs.size < spanLimitsConfig.attributeCountLimit) {
+        if (attrs.size < spanLimitsConfig.effectiveAttributeCountLimit) {
             attrs[key] = value
         }
     }
 
     override fun setStringAttribute(key: String, value: String) {
         impl.setAttribute(key, value)
-        if (attrs.size < spanLimitsConfig.attributeCountLimit) {
+        if (attrs.size < spanLimitsConfig.effectiveAttributeCountLimit) {
             attrs[key] = value
         }
     }
 
     override fun setLongAttribute(key: String, value: Long) {
         impl.setAttribute(key, value)
-        if (attrs.size < spanLimitsConfig.attributeCountLimit) {
+        if (attrs.size < spanLimitsConfig.effectiveAttributeCountLimit) {
             attrs[key] = value
         }
     }
 
     override fun setDoubleAttribute(key: String, value: Double) {
         impl.setAttribute(key, value)
-        if (attrs.size < spanLimitsConfig.attributeCountLimit) {
+        if (attrs.size < spanLimitsConfig.effectiveAttributeCountLimit) {
             attrs[key] = value
         }
     }
 
     override fun setBooleanListAttribute(key: String, value: List<Boolean>) {
         impl.setAttribute(OtelJavaAttributeKey.booleanArrayKey(key), value)
-        if (attrs.size < spanLimitsConfig.attributeCountLimit) {
+        if (attrs.size < spanLimitsConfig.effectiveAttributeCountLimit) {
             attrs[key] = value
         }
     }
 
     override fun setStringListAttribute(key: String, value: List<String>) {
         impl.setAttribute(OtelJavaAttributeKey.stringArrayKey(key), value)
-        if (attrs.size < spanLimitsConfig.attributeCountLimit) {
+        if (attrs.size < spanLimitsConfig.effectiveAttributeCountLimit) {
             attrs[key] = value
         }
     }
 
     override fun setLongListAttribute(key: String, value: List<Long>) {
         impl.setAttribute(OtelJavaAttributeKey.longArrayKey(key), value)
-        if (attrs.size < spanLimitsConfig.attributeCountLimit) {
+        if (attrs.size < spanLimitsConfig.effectiveAttributeCountLimit) {
             attrs[key] = value
         }
     }
 
     override fun setDoubleListAttribute(key: String, value: List<Double>) {
         impl.setAttribute(OtelJavaAttributeKey.doubleArrayKey(key), value)
-        if (attrs.size < spanLimitsConfig.attributeCountLimit) {
+        if (attrs.size < spanLimitsConfig.effectiveAttributeCountLimit) {
             attrs[key] = value
         }
     }

--- a/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/init/CompatMeterProviderConfigTest.kt
+++ b/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/init/CompatMeterProviderConfigTest.kt
@@ -4,6 +4,7 @@ import io.opentelemetry.kotlin.clock.FakeClock
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
+import kotlin.test.assertNull
 import kotlin.test.assertSame
 
 internal class CompatMeterProviderConfigTest {
@@ -11,9 +12,9 @@ internal class CompatMeterProviderConfigTest {
     private val clock = FakeClock()
 
     @Test
-    fun `default service name is unknown_service`() {
+    fun `service name is unset by default`() {
         val cfg = CompatMeterProviderConfig(clock)
-        assertEquals("unknown_service", cfg.serviceName)
+        assertNull(cfg.serviceName)
     }
 
     @Test

--- a/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/init/GlobalAttributeLimitsConfigTest.kt
+++ b/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/init/GlobalAttributeLimitsConfigTest.kt
@@ -1,12 +1,13 @@
 package io.opentelemetry.kotlin.init
 
+import io.opentelemetry.kotlin.aliases.OtelJavaLogLimits
+import io.opentelemetry.kotlin.aliases.OtelJavaSpanLimits
 import io.opentelemetry.kotlin.clock.FakeClock
 import io.opentelemetry.kotlin.error.NoopSdkErrorHandler
 import io.opentelemetry.kotlin.factory.CompatIdGenerator
 import org.junit.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFalse
-import kotlin.test.assertTrue
+import kotlin.test.assertNull
 
 internal class GlobalAttributeLimitsConfigTest {
 
@@ -16,21 +17,8 @@ internal class GlobalAttributeLimitsConfigTest {
     @Test
     fun `CompatAttributeLimitsConfig default state`() {
         val cfg = CompatAttributeLimitsConfig()
-        assertFalse(cfg.attributeCountLimitSet)
-        assertFalse(cfg.attributeValueLengthLimitSet)
-        assertEquals(DEFAULT_ATTR_LIMIT, cfg.attributeCountLimit)
-        assertEquals(DEFAULT_ATTR_VALUE_LENGTH_LIMIT, cfg.attributeValueLengthLimit)
-    }
-
-    @Test
-    fun `CompatAttributeLimitsConfig sets flags on assignment`() {
-        val cfg = CompatAttributeLimitsConfig()
-        cfg.attributeCountLimit = 64
-        cfg.attributeValueLengthLimit = 256
-        assertTrue(cfg.attributeCountLimitSet)
-        assertTrue(cfg.attributeValueLengthLimitSet)
-        assertEquals(64, cfg.attributeCountLimit)
-        assertEquals(256, cfg.attributeValueLengthLimit)
+        assertNull(cfg.attributeCountLimit)
+        assertNull(cfg.attributeValueLengthLimit)
     }
 
     @Test
@@ -62,6 +50,23 @@ internal class GlobalAttributeLimitsConfigTest {
     }
 
     @Test
+    fun `a signal-specific zero is not treated as unset`() {
+        val globalLimits = CompatAttributeLimitsConfig().apply { attributeCountLimit = 64 }
+
+        val tracerConfig = CompatTracerProviderConfig(clock, NoopSdkErrorHandler).apply {
+            spanLimits { attributeCountLimit = 0 }
+        }
+        tracerConfig.build(clock, idGenerator, globalLimits = globalLimits)
+        assertEquals(0, tracerConfig.spanLimitsConfig.attributeCountLimit)
+
+        val loggerConfig = CompatLoggerProviderConfig(clock, NoopSdkErrorHandler).apply {
+            logLimits { attributeCountLimit = 0 }
+        }
+        loggerConfig.build(clock, globalLimits = globalLimits)
+        assertEquals(0, loggerConfig.logLimitsConfig.attributeCountLimit)
+    }
+
+    @Test
     fun `partial signal override - other global properties still apply`() {
         val globalLimits = CompatAttributeLimitsConfig().apply { attributeCountLimit = 64 }
 
@@ -74,15 +79,17 @@ internal class GlobalAttributeLimitsConfigTest {
     }
 
     @Test
-    fun `no global - defaults are zero (Java SDK uses its own defaults)`() {
+    fun `no global - limits stay unset so the Java SDK applies its own defaults`() {
         val tracerConfig = CompatTracerProviderConfig(clock, NoopSdkErrorHandler)
         tracerConfig.build(clock, idGenerator)
-        assertEquals(DEFAULT_ATTR_LIMIT, tracerConfig.spanLimitsConfig.attributeCountLimit)
-        assertEquals(DEFAULT_ATTR_VALUE_LENGTH_LIMIT, tracerConfig.spanLimitsConfig.attributeValueLengthLimit)
+        assertNull(tracerConfig.spanLimitsConfig.attributeCountLimit)
+        assertNull(tracerConfig.spanLimitsConfig.attributeValueLengthLimit)
+        assertEquals(OtelJavaSpanLimits.getDefault(), tracerConfig.spanLimitsConfig.build())
 
         val loggerConfig = CompatLoggerProviderConfig(clock, NoopSdkErrorHandler)
         loggerConfig.build(clock)
-        assertEquals(DEFAULT_ATTR_LIMIT, loggerConfig.logLimitsConfig.attributeCountLimit)
-        assertEquals(DEFAULT_ATTR_VALUE_LENGTH_LIMIT, loggerConfig.logLimitsConfig.attributeValueLengthLimit)
+        assertNull(loggerConfig.logLimitsConfig.attributeCountLimit)
+        assertNull(loggerConfig.logLimitsConfig.attributeValueLengthLimit)
+        assertEquals(OtelJavaLogLimits.getDefault(), loggerConfig.logLimitsConfig.build())
     }
 }

--- a/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/init/LogLimitsConfigImplTest.kt
+++ b/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/init/LogLimitsConfigImplTest.kt
@@ -1,16 +1,23 @@
 package io.opentelemetry.kotlin.init
 
+import io.opentelemetry.kotlin.aliases.OtelJavaLogLimits
 import org.junit.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 
 internal class LogLimitsConfigImplTest {
 
     @Test
     fun `test default`() {
         CompatLogLimitsConfig().apply {
-            assertEquals(DEFAULT_ATTR_LIMIT, attributeCountLimit)
-            assertEquals(DEFAULT_ATTR_VALUE_LENGTH_LIMIT, attributeValueLengthLimit)
+            assertNull(attributeCountLimit)
+            assertNull(attributeValueLengthLimit)
         }
+    }
+
+    @Test
+    fun `unset limits fall through to the Java SDK defaults`() {
+        assertEquals(OtelJavaLogLimits.getDefault(), CompatLogLimitsConfig().build())
     }
 
     @Test

--- a/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/init/SpanLimitsConfigImplTest.kt
+++ b/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/init/SpanLimitsConfigImplTest.kt
@@ -1,19 +1,47 @@
 package io.opentelemetry.kotlin.init
 
+import io.opentelemetry.kotlin.aliases.OtelJavaSpanLimits
 import org.junit.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 
 internal class SpanLimitsConfigImplTest {
 
     @Test
     fun `test default`() {
         CompatSpanLimitsConfig().apply {
-            assertEquals(DEFAULT_EVENT_LIMIT, eventCountLimit)
-            assertEquals(DEFAULT_ATTR_LIMIT, attributeCountLimit)
-            assertEquals(DEFAULT_LINK_LIMIT, linkCountLimit)
-            assertEquals(DEFAULT_ATTR_LIMIT, attributeCountPerLinkLimit)
-            assertEquals(DEFAULT_ATTR_LIMIT, attributeCountPerEventLimit)
-            assertEquals(DEFAULT_ATTR_VALUE_LENGTH_LIMIT, attributeValueLengthLimit)
+            assertNull(eventCountLimit)
+            assertNull(attributeCountLimit)
+            assertNull(linkCountLimit)
+            assertNull(attributeCountPerLinkLimit)
+            assertNull(attributeCountPerEventLimit)
+            assertNull(attributeValueLengthLimit)
+        }
+    }
+
+    @Test
+    fun `unset limits fall through to the Java SDK defaults`() {
+        assertEquals(OtelJavaSpanLimits.getDefault(), CompatSpanLimitsConfig().build())
+    }
+
+    @Test
+    fun `the limits the adapters enforce themselves resolve to a default`() {
+        CompatSpanLimitsConfig().apply {
+            assertEquals(DEFAULT_ATTR_LIMIT, effectiveAttributeCountLimit)
+            assertEquals(DEFAULT_LINK_LIMIT, effectiveLinkCountLimit)
+            assertEquals(DEFAULT_EVENT_LIMIT, effectiveEventCountLimit)
+        }
+    }
+
+    @Test
+    fun `a configured zero is not treated as unset`() {
+        CompatSpanLimitsConfig().apply {
+            attributeCountLimit = 0
+            linkCountLimit = 0
+            eventCountLimit = 0
+            assertEquals(0, effectiveAttributeCountLimit)
+            assertEquals(0, effectiveLinkCountLimit)
+            assertEquals(0, effectiveEventCountLimit)
         }
     }
 

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/AttributeLimitsConfigImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/AttributeLimitsConfigImpl.kt
@@ -1,9 +1,6 @@
 package io.opentelemetry.kotlin.init
 
-import io.opentelemetry.kotlin.attributes.DEFAULT_ATTRIBUTE_LIMIT
-import io.opentelemetry.kotlin.attributes.DEFAULT_ATTRIBUTE_VALUE_LENGTH_LIMIT
-
 internal class AttributeLimitsConfigImpl : AttributeLimitsConfigDsl {
-    override var attributeCountLimit: Int = DEFAULT_ATTRIBUTE_LIMIT
-    override var attributeValueLengthLimit: Int = DEFAULT_ATTRIBUTE_VALUE_LENGTH_LIMIT
+    override var attributeCountLimit: Int? = null
+    override var attributeValueLengthLimit: Int? = null
 }

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/ContextConfigImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/ContextConfigImpl.kt
@@ -6,8 +6,10 @@ import io.opentelemetry.kotlin.context.ImplicitContextStorage
 import io.opentelemetry.kotlin.context.ImplicitContextStorageMode
 import io.opentelemetry.kotlin.context.ThreadLocalImplicitContextStorage
 
+internal val DEFAULT_STORAGE_MODE = ImplicitContextStorageMode.GLOBAL
+
 internal class ContextConfigImpl : ContextConfigDsl {
-    override var storageMode: ImplicitContextStorageMode = ImplicitContextStorageMode.GLOBAL
+    override var storageMode: ImplicitContextStorageMode? = null
 
     private var customStorage: ((() -> Context) -> ImplicitContextStorage)? = null
 
@@ -17,7 +19,7 @@ internal class ContextConfigImpl : ContextConfigDsl {
 
     internal fun generateStorage(rootSupplier: () -> Context): ImplicitContextStorage {
         customStorage?.let { return it(rootSupplier) }
-        return when (storageMode) {
+        return when (storageMode ?: DEFAULT_STORAGE_MODE) {
             ImplicitContextStorageMode.GLOBAL -> DefaultImplicitContextStorage(rootSupplier)
             ImplicitContextStorageMode.THREAD_LOCAL -> ThreadLocalImplicitContextStorage(
                 rootSupplier

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/LogLimitsConfigImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/LogLimitsConfigImpl.kt
@@ -1,8 +1,6 @@
 package io.opentelemetry.kotlin.init
 
-import io.opentelemetry.kotlin.attributes.DEFAULT_ATTRIBUTE_LIMIT
-
 internal class LogLimitsConfigImpl : LogLimitsConfigDsl {
-    override var attributeCountLimit: Int = DEFAULT_ATTRIBUTE_LIMIT
-    override var attributeValueLengthLimit: Int = Int.MAX_VALUE
+    override var attributeCountLimit: Int? = null
+    override var attributeValueLengthLimit: Int? = null
 }

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/LoggerProviderConfigImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/LoggerProviderConfigImpl.kt
@@ -1,6 +1,8 @@
 package io.opentelemetry.kotlin.init
 
 import io.opentelemetry.kotlin.Clock
+import io.opentelemetry.kotlin.attributes.DEFAULT_ATTRIBUTE_LIMIT
+import io.opentelemetry.kotlin.attributes.DEFAULT_ATTRIBUTE_VALUE_LENGTH_LIMIT
 import io.opentelemetry.kotlin.error.SdkErrorHandler
 import io.opentelemetry.kotlin.init.config.LogLimitConfig
 import io.opentelemetry.kotlin.init.config.LoggingConfig
@@ -41,7 +43,7 @@ internal class LoggerProviderConfigImpl(
 
     fun generateLoggingConfig(
         base: Resource,
-        globalLimits: AttributeLimitsConfigImpl? = null
+        globalLimits: AttributeLimitsConfigDsl? = null
     ): LoggingConfig = LoggingConfig(
         processor = processor,
         logLimits = generateLogLimitsConfig(globalLimits),
@@ -50,16 +52,20 @@ internal class LoggerProviderConfigImpl(
         loggerConfigurator = loggerConfigurator,
     )
 
-    private fun generateLogLimitsConfig(globalLimits: AttributeLimitsConfigImpl?): LogLimitConfig {
+    /**
+     * A limit left unset by the log limits falls back to the global attribute limits, then to the
+     * default this SDK applies.
+     */
+    private fun generateLogLimitsConfig(globalLimits: AttributeLimitsConfigDsl?): LogLimitConfig {
         val impl = LogLimitsConfigImpl()
-        globalLimits?.let {
-            impl.attributeCountLimit = it.attributeCountLimit
-            impl.attributeValueLengthLimit = it.attributeValueLengthLimit
-        }
         logLimitsAction(impl)
         return LogLimitConfig(
-            attributeCountLimit = impl.attributeCountLimit,
-            attributeValueLengthLimit = impl.attributeValueLengthLimit,
+            attributeCountLimit = impl.attributeCountLimit
+                ?: globalLimits?.attributeCountLimit
+                ?: DEFAULT_ATTRIBUTE_LIMIT,
+            attributeValueLengthLimit = impl.attributeValueLengthLimit
+                ?: globalLimits?.attributeValueLengthLimit
+                ?: DEFAULT_ATTRIBUTE_VALUE_LENGTH_LIMIT,
         )
     }
 }

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/ResourceConfigImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/ResourceConfigImpl.kt
@@ -28,13 +28,8 @@ internal class ResourceConfigImpl : ResourceConfigDsl {
 
     private val resourceAttrs = AttributesModel(attributeLimit = NO_ATTRIBUTE_LIMIT)
     private var schemaUrl: String? = null
-    private var serviceNameOverride: String? = null
 
-    override var serviceName: String
-        get() = serviceNameOverride ?: "unknown_service"
-        set(value) {
-            serviceNameOverride = value
-        }
+    override var serviceName: String? = null
 
     override fun resource(
         schemaUrl: String?,
@@ -52,7 +47,7 @@ internal class ResourceConfigImpl : ResourceConfigDsl {
 
     internal fun generateResource(): Resource {
         val attrs = resourceAttrs.attributes.toMutableMap()
-        serviceNameOverride?.let { attrs[ServiceAttributes.SERVICE_NAME] = it }
+        serviceName?.let { attrs[ServiceAttributes.SERVICE_NAME] = it }
         return ResourceImpl(
             schemaUrl = schemaUrl,
             container = AttributesModel(attributeLimit = NO_ATTRIBUTE_LIMIT, attrs = attrs)

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/SpanLimitsConfigImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/SpanLimitsConfigImpl.kt
@@ -1,15 +1,10 @@
 package io.opentelemetry.kotlin.init
 
-import io.opentelemetry.kotlin.attributes.DEFAULT_ATTRIBUTE_LIMIT
-import io.opentelemetry.kotlin.attributes.DEFAULT_ATTRIBUTE_VALUE_LENGTH_LIMIT
-import io.opentelemetry.kotlin.init.config.DEFAULT_EVENT_LIMIT
-import io.opentelemetry.kotlin.init.config.DEFAULT_LINK_LIMIT
-
 internal class SpanLimitsConfigImpl : SpanLimitsConfigDsl {
-    override var attributeCountLimit: Int = DEFAULT_ATTRIBUTE_LIMIT
-    override var attributeValueLengthLimit: Int = DEFAULT_ATTRIBUTE_VALUE_LENGTH_LIMIT
-    override var linkCountLimit: Int = DEFAULT_LINK_LIMIT
-    override var eventCountLimit: Int = DEFAULT_EVENT_LIMIT
-    override var attributeCountPerEventLimit: Int = DEFAULT_ATTRIBUTE_LIMIT
-    override var attributeCountPerLinkLimit: Int = DEFAULT_ATTRIBUTE_LIMIT
+    override var attributeCountLimit: Int? = null
+    override var attributeValueLengthLimit: Int? = null
+    override var linkCountLimit: Int? = null
+    override var eventCountLimit: Int? = null
+    override var attributeCountPerEventLimit: Int? = null
+    override var attributeCountPerLinkLimit: Int? = null
 }

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/TracerProviderConfigImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/TracerProviderConfigImpl.kt
@@ -1,8 +1,12 @@
 package io.opentelemetry.kotlin.init
 
 import io.opentelemetry.kotlin.Clock
+import io.opentelemetry.kotlin.attributes.DEFAULT_ATTRIBUTE_LIMIT
+import io.opentelemetry.kotlin.attributes.DEFAULT_ATTRIBUTE_VALUE_LENGTH_LIMIT
 import io.opentelemetry.kotlin.error.SdkErrorHandler
 import io.opentelemetry.kotlin.factory.SpanFactory
+import io.opentelemetry.kotlin.init.config.DEFAULT_EVENT_LIMIT
+import io.opentelemetry.kotlin.init.config.DEFAULT_LINK_LIMIT
 import io.opentelemetry.kotlin.init.config.SpanLimitConfig
 import io.opentelemetry.kotlin.init.config.TracingConfig
 import io.opentelemetry.kotlin.platformLog
@@ -48,7 +52,7 @@ internal class TracerProviderConfigImpl(
         tracerConfigurator = configurator
     }
 
-    fun generateTracingConfig(base: Resource, globalLimits: AttributeLimitsConfigImpl? = null): TracingConfig = TracingConfig(
+    fun generateTracingConfig(base: Resource, globalLimits: AttributeLimitsConfigDsl? = null): TracingConfig = TracingConfig(
         processor = processor,
         spanLimits = generateSpanLimitsConfig(globalLimits),
         resource = base.merge(resourceConfigImpl.generateResource()),
@@ -59,20 +63,24 @@ internal class TracerProviderConfigImpl(
 
     private class SamplerConfigImpl(override val spanFactory: SpanFactory) : SamplerConfigDsl
 
-    private fun generateSpanLimitsConfig(globalLimits: AttributeLimitsConfigImpl?): SpanLimitConfig {
+    /**
+     * A limit left unset by the span limits falls back to the global attribute limits, then to the
+     * default this SDK applies. Only the attribute limits are configurable globally.
+     */
+    private fun generateSpanLimitsConfig(globalLimits: AttributeLimitsConfigDsl?): SpanLimitConfig {
         val impl = SpanLimitsConfigImpl()
-        globalLimits?.let {
-            impl.attributeCountLimit = it.attributeCountLimit
-            impl.attributeValueLengthLimit = it.attributeValueLengthLimit
-        }
         spanLimitsAction(impl)
         return SpanLimitConfig(
-            attributeCountLimit = impl.attributeCountLimit,
-            attributeValueLengthLimit = impl.attributeValueLengthLimit,
-            linkCountLimit = impl.linkCountLimit,
-            eventCountLimit = impl.eventCountLimit,
-            attributeCountPerEventLimit = impl.attributeCountPerEventLimit,
-            attributeCountPerLinkLimit = impl.attributeCountPerLinkLimit,
+            attributeCountLimit = impl.attributeCountLimit
+                ?: globalLimits?.attributeCountLimit
+                ?: DEFAULT_ATTRIBUTE_LIMIT,
+            attributeValueLengthLimit = impl.attributeValueLengthLimit
+                ?: globalLimits?.attributeValueLengthLimit
+                ?: DEFAULT_ATTRIBUTE_VALUE_LENGTH_LIMIT,
+            linkCountLimit = impl.linkCountLimit ?: DEFAULT_LINK_LIMIT,
+            eventCountLimit = impl.eventCountLimit ?: DEFAULT_EVENT_LIMIT,
+            attributeCountPerEventLimit = impl.attributeCountPerEventLimit ?: DEFAULT_ATTRIBUTE_LIMIT,
+            attributeCountPerLinkLimit = impl.attributeCountPerLinkLimit ?: DEFAULT_ATTRIBUTE_LIMIT,
         )
     }
 }

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/init/OpenTelemetryConfigImplTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/init/OpenTelemetryConfigImplTest.kt
@@ -35,7 +35,7 @@ internal class OpenTelemetryConfigImplTest {
         val cfg = OpenTelemetryConfigImpl(clock)
         assertNull(cfg.generateTracingConfig().processor)
         assertNull(cfg.generateLoggingConfig().processor)
-        assertEquals(ImplicitContextStorageMode.GLOBAL, cfg.contextConfig.storageMode)
+        assertNull(cfg.contextConfig.storageMode)
         assertSame(NoopOpenTelemetry.propagator, cfg.propagatorCfg.buildPropagator())
     }
 
@@ -67,7 +67,7 @@ internal class OpenTelemetryConfigImplTest {
             export { FakeSpanProcessor() }
         }
         cfg.context {
-            assertEquals(ImplicitContextStorageMode.GLOBAL, storageMode)
+            assertNull(storageMode)
         }
         assertNotNull(cfg.generateTracingConfig().processor)
         assertNotNull(cfg.generateLoggingConfig().processor)
@@ -132,6 +132,27 @@ internal class OpenTelemetryConfigImplTest {
             assertEquals(256, attributeValueLengthLimit)
         }
         assertEquals(64, cfg.generateLoggingConfig().logLimits.attributeCountLimit)
+    }
+
+    @Test
+    fun testSignalZeroAttrLimitBeatsGlobal() {
+        val cfg = OpenTelemetryConfigImpl(clock).apply {
+            attributeLimits {
+                attributeCountLimit = 64
+            }
+            tracerProvider {
+                spanLimits {
+                    attributeCountLimit = 0
+                }
+            }
+            loggerProvider {
+                logLimits {
+                    attributeCountLimit = 0
+                }
+            }
+        }
+        assertEquals(0, cfg.generateTracingConfig().spanLimits.attributeCountLimit)
+        assertEquals(0, cfg.generateLoggingConfig().logLimits.attributeCountLimit)
     }
 
     @Test

--- a/sdk-api/api/jvm/sdk-api.api
+++ b/sdk-api/api/jvm/sdk-api.api
@@ -117,10 +117,10 @@ public final class io/opentelemetry/kotlin/factory/ResourceFactory$DefaultImpls 
 }
 
 public abstract interface class io/opentelemetry/kotlin/init/AttributeLimitsConfigDsl {
-	public abstract fun getAttributeCountLimit ()I
-	public abstract fun getAttributeValueLengthLimit ()I
-	public abstract fun setAttributeCountLimit (I)V
-	public abstract fun setAttributeValueLengthLimit (I)V
+	public abstract fun getAttributeCountLimit ()Ljava/lang/Integer;
+	public abstract fun getAttributeValueLengthLimit ()Ljava/lang/Integer;
+	public abstract fun setAttributeCountLimit (Ljava/lang/Integer;)V
+	public abstract fun setAttributeValueLengthLimit (Ljava/lang/Integer;)V
 }
 
 public final class io/opentelemetry/kotlin/init/B3Format : java/lang/Enum {
@@ -204,14 +204,14 @@ public abstract interface class io/opentelemetry/kotlin/init/SamplerConfigDsl {
 }
 
 public abstract interface class io/opentelemetry/kotlin/init/SpanLimitsConfigDsl : io/opentelemetry/kotlin/init/AttributeLimitsConfigDsl {
-	public abstract fun getAttributeCountPerEventLimit ()I
-	public abstract fun getAttributeCountPerLinkLimit ()I
-	public abstract fun getEventCountLimit ()I
-	public abstract fun getLinkCountLimit ()I
-	public abstract fun setAttributeCountPerEventLimit (I)V
-	public abstract fun setAttributeCountPerLinkLimit (I)V
-	public abstract fun setEventCountLimit (I)V
-	public abstract fun setLinkCountLimit (I)V
+	public abstract fun getAttributeCountPerEventLimit ()Ljava/lang/Integer;
+	public abstract fun getAttributeCountPerLinkLimit ()Ljava/lang/Integer;
+	public abstract fun getEventCountLimit ()Ljava/lang/Integer;
+	public abstract fun getLinkCountLimit ()Ljava/lang/Integer;
+	public abstract fun setAttributeCountPerEventLimit (Ljava/lang/Integer;)V
+	public abstract fun setAttributeCountPerLinkLimit (Ljava/lang/Integer;)V
+	public abstract fun setEventCountLimit (Ljava/lang/Integer;)V
+	public abstract fun setLinkCountLimit (Ljava/lang/Integer;)V
 }
 
 public abstract interface class io/opentelemetry/kotlin/init/TraceExportConfigDsl {

--- a/sdk-api/src/commonMain/kotlin/io/opentelemetry/kotlin/init/AttributeLimitsConfigDsl.kt
+++ b/sdk-api/src/commonMain/kotlin/io/opentelemetry/kotlin/init/AttributeLimitsConfigDsl.kt
@@ -14,10 +14,10 @@ public interface AttributeLimitsConfigDsl {
     /**
      * The maximum number of attributes
      */
-    public var attributeCountLimit: Int
+    public var attributeCountLimit: Int?
 
     /**
      * The maximum length of an attribute value
      */
-    public var attributeValueLengthLimit: Int
+    public var attributeValueLengthLimit: Int?
 }

--- a/sdk-api/src/commonMain/kotlin/io/opentelemetry/kotlin/init/ContextConfigDsl.kt
+++ b/sdk-api/src/commonMain/kotlin/io/opentelemetry/kotlin/init/ContextConfigDsl.kt
@@ -16,7 +16,7 @@ public interface ContextConfigDsl {
      * Selects among the built-in [ImplicitContextStorage] implementations. Ignored when a custom
      * implementation is supplied via [storage].
      */
-    public var storageMode: ImplicitContextStorageMode
+    public var storageMode: ImplicitContextStorageMode?
 
     /**
      * Plugs in a custom [ImplicitContextStorage] implementation. When set, this takes precedence

--- a/sdk-api/src/commonMain/kotlin/io/opentelemetry/kotlin/init/ResourceConfigDsl.kt
+++ b/sdk-api/src/commonMain/kotlin/io/opentelemetry/kotlin/init/ResourceConfigDsl.kt
@@ -10,10 +10,10 @@ import io.opentelemetry.kotlin.attributes.AttributesMutator
 public interface ResourceConfigDsl {
 
     /**
-     * Sets the logical name of the service. Defaults to "unknown_service" if not explicitly set.
+     * Sets the logical name of the service.
      * https://opentelemetry.io/docs/specs/semconv/registry/attributes/service/#service-attributes
      */
-    public var serviceName: String
+    public var serviceName: String?
 
     /**
      * Declares a resource, including an optional schema and any attributes.

--- a/sdk-api/src/commonMain/kotlin/io/opentelemetry/kotlin/init/SpanLimitsConfigDsl.kt
+++ b/sdk-api/src/commonMain/kotlin/io/opentelemetry/kotlin/init/SpanLimitsConfigDsl.kt
@@ -12,20 +12,20 @@ public interface SpanLimitsConfigDsl : AttributeLimitsConfigDsl {
     /**
      * The maximum number of links
      */
-    public var linkCountLimit: Int
+    public var linkCountLimit: Int?
 
     /**
      * The maximum number of events
      */
-    public var eventCountLimit: Int
+    public var eventCountLimit: Int?
 
     /**
      * The maximum number of attributes per event
      */
-    public var attributeCountPerEventLimit: Int
+    public var attributeCountPerEventLimit: Int?
 
     /**
      * The maximum number of attributes per link
      */
-    public var attributeCountPerLinkLimit: Int
+    public var attributeCountPerLinkLimit: Int?
 }


### PR DESCRIPTION
## Goal

Makes the scalars on the config DSL nullable, so that they don't override default values in the SDK if already set. This is a pre-requisite refactor that will help merging config values set on the DSL with yaml/envars, which will land in future PRs.

## Testing

Updated existing tests.
