### PR TITLE
fix: remove risky cast on ReadWriteSpanAdapter

### DIFF
--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/tracing/model/ReadWriteSpanAdapter.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/tracing/model/ReadWriteSpanAdapter.kt
@@ -8,6 +8,7 @@ import io.opentelemetry.kotlin.attributes.CompatAttributesModel
 import io.opentelemetry.kotlin.attributes.setFlattenedAnyValueAttribute
 import io.opentelemetry.kotlin.tracing.SpanContext
 import io.opentelemetry.kotlin.tracing.StatusData
+import io.opentelemetry.kotlin.tracing.ext.toOtelJavaSpanContext
 import io.opentelemetry.kotlin.tracing.ext.toOtelJavaStatusData
 import java.util.concurrent.TimeUnit
 
@@ -49,7 +50,7 @@ internal class ReadWriteSpanAdapter(
         if (attributes != null) {
             attributes(container)
         }
-        val ctx = (spanContext as SpanContextAdapter).impl
+        val ctx = spanContext.toOtelJavaSpanContext()
         impl.addLink(ctx, container.otelJavaAttributes())
     }
 


### PR DESCRIPTION
## Goal

Closes #783 by replacing the unchecked `spanContext as SpanContextAdapter` cast in
`ReadWriteSpanAdapter.addLink` with `toOtelJavaSpanContext()`, so a `SpanContext` supplied by a
custom `SpanProcessor` can no longer throw `ClassCastException` out of a public API method.

## Testing

Relied on existing test coverage.
