### PR TITLE
Make immutable copy when exporting log record

### DIFF
--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/logging/export/LogRecordDataExt.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/logging/export/LogRecordDataExt.kt
@@ -10,12 +10,12 @@ import io.opentelemetry.kotlin.attributes.attrsFromMap
 import io.opentelemetry.kotlin.attributes.resourceFromMap
 import io.opentelemetry.kotlin.attributes.toFlattenedBodyString
 import io.opentelemetry.kotlin.logging.OtelJavaLogRecordDataImpl
-import io.opentelemetry.kotlin.logging.model.ReadableLogRecord
+import io.opentelemetry.kotlin.logging.data.LogRecordData
 import io.opentelemetry.kotlin.logging.toOtelJavaSeverityNumber
 import io.opentelemetry.kotlin.scope.toOtelJavaInstrumentationScopeInfo
 import io.opentelemetry.kotlin.tracing.ext.toOtelJavaSpanContext
 
-internal fun ReadableLogRecord.toLogRecordData(): OtelJavaLogRecordData {
+internal fun LogRecordData.toOtelJavaLogRecordData(): OtelJavaLogRecordData {
     return OtelJavaLogRecordDataImpl(
         timestampNanos = timestamp ?: 0,
         observedTimestampNanos = observedTimestamp ?: 0,

--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/logging/export/LogRecordExporterAdapter.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/logging/export/LogRecordExporterAdapter.kt
@@ -3,7 +3,7 @@ package io.opentelemetry.kotlin.logging.export
 import io.opentelemetry.kotlin.aliases.OtelJavaLogRecordExporter
 import io.opentelemetry.kotlin.export.MutableShutdownState
 import io.opentelemetry.kotlin.export.OperationResultCode
-import io.opentelemetry.kotlin.logging.model.ReadableLogRecord
+import io.opentelemetry.kotlin.logging.data.LogRecordData
 import io.opentelemetry.kotlin.toOperationResultCode
 
 internal class LogRecordExporterAdapter(
@@ -12,9 +12,10 @@ internal class LogRecordExporterAdapter(
 
     private val shutdownState = MutableShutdownState()
 
-    override suspend fun export(telemetry: List<ReadableLogRecord>): OperationResultCode =
+    override suspend fun export(telemetry: List<LogRecordData>): OperationResultCode =
         shutdownState.ifActive {
-            impl.export(telemetry.map(ReadableLogRecord::toLogRecordData)).toOperationResultCode()
+            impl.export(telemetry.map(LogRecordData::toOtelJavaLogRecordData))
+                .toOperationResultCode()
         }
 
     override suspend fun forceFlush(): OperationResultCode = impl.flush().toOperationResultCode()

--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/logging/export/ReadWriteLogRecordAdapter.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/logging/export/ReadWriteLogRecordAdapter.kt
@@ -6,7 +6,9 @@ import io.opentelemetry.kotlin.aliases.OtelJavaReadWriteLogRecord
 import io.opentelemetry.kotlin.attributes.AnyValue
 import io.opentelemetry.kotlin.attributes.convertToMap
 import io.opentelemetry.kotlin.attributes.setFlattenedAnyValueAttribute
+import io.opentelemetry.kotlin.logging.LogRecordDataImpl
 import io.opentelemetry.kotlin.logging.SeverityNumber
+import io.opentelemetry.kotlin.logging.data.LogRecordData
 import io.opentelemetry.kotlin.logging.model.ReadWriteLogRecord
 import io.opentelemetry.kotlin.logging.toOtelKotlinSeverityNumber
 import io.opentelemetry.kotlin.resource.Resource
@@ -105,4 +107,18 @@ internal class ReadWriteLogRecordAdapter(
 
     override val instrumentationScopeInfo: InstrumentationScopeInfo
         get() = impl.instrumentationScopeInfo.toOtelKotlinInstrumentationScopeInfo()
+
+    override fun toLogRecordData(): LogRecordData = LogRecordDataImpl(
+        timestamp,
+        observedTimestamp,
+        severityNumber,
+        severityText,
+        body,
+        eventName,
+        spanContext,
+        attributes,
+        resource,
+        instrumentationScopeInfo,
+        droppedAttributesCount
+    )
 }

--- a/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/logging/export/LogRecordDataExtTest.kt
+++ b/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/logging/export/LogRecordDataExtTest.kt
@@ -2,17 +2,17 @@ package io.opentelemetry.kotlin.logging.export
 
 import io.opentelemetry.kotlin.aliases.OtelJavaSeverity
 import io.opentelemetry.kotlin.attributes.AnyValue
-import io.opentelemetry.kotlin.logging.model.FakeReadableLogRecord
+import io.opentelemetry.kotlin.logging.data.FakeLogRecordData
 import org.junit.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
 
-internal class ReadableLogRecordExtTest {
+internal class LogRecordDataExtTest {
 
     @Test
     fun testLogRecordDefaultConversions() {
-        val record = FakeReadableLogRecord()
-        val observed = record.toLogRecordData()
+        val record = FakeLogRecordData()
+        val observed = record.toOtelJavaLogRecordData()
         assertEquals(record.timestamp, observed.timestampEpochNanos)
         assertEquals(record.observedTimestamp, observed.observedTimestampEpochNanos)
         assertEquals(record.severityText, observed.severityText)
@@ -23,23 +23,23 @@ internal class ReadableLogRecordExtTest {
 
     @Test
     fun testLogRecordEventNameConversion() {
-        val record = FakeReadableLogRecord(eventName = "my_event_name")
-        val observed = record.toLogRecordData()
+        val record = FakeLogRecordData(eventName = "my_event_name")
+        val observed = record.toOtelJavaLogRecordData()
         assertEquals("my_event_name", observed.eventName)
     }
 
     @Test
     fun testLogRecordStructuredBodyConversion() {
         val structuredBody = mapOf("key" to "value")
-        val record = FakeReadableLogRecord(body = structuredBody)
-        val observed = record.toLogRecordData()
+        val record = FakeLogRecordData(body = structuredBody)
+        val observed = record.toOtelJavaLogRecordData()
         assertEquals(structuredBody.toString(), observed.bodyValue?.asString())
     }
 
     @Test
     fun testLogRecordAnyValueStringBody() {
-        val record = FakeReadableLogRecord(body = AnyValue.StringValue("hello"))
-        val observed = record.toLogRecordData()
+        val record = FakeLogRecordData(body = AnyValue.StringValue("hello"))
+        val observed = record.toOtelJavaLogRecordData()
         assertEquals("hello", observed.bodyValue?.asString())
     }
 
@@ -52,36 +52,36 @@ internal class ReadableLogRecordExtTest {
             AnyValue.BoolValue(true) to "true",
             AnyValue.DoubleValue(3.14) to "3.14"
         ).forEach { (body, expected) ->
-            val observed = FakeReadableLogRecord(body = body).toLogRecordData()
+            val observed = FakeLogRecordData(body = body).toOtelJavaLogRecordData()
             assertEquals(expected, observed.bodyValue?.asString())
         }
     }
 
     @Test
     fun testLogRecordAnyValueNullBody() {
-        val record = FakeReadableLogRecord(body = AnyValue.NullValue)
-        val observed = record.toLogRecordData()
+        val record = FakeLogRecordData(body = AnyValue.NullValue)
+        val observed = record.toOtelJavaLogRecordData()
         assertNull(observed.bodyValue?.asString())
     }
 
     @Test
     fun testLogRecordAnyValueMapBody() {
         val map = AnyValue.MapValue(mapOf("k" to AnyValue.StringValue("v")))
-        val record = FakeReadableLogRecord(body = map)
-        val observed = record.toLogRecordData()
+        val record = FakeLogRecordData(body = map)
+        val observed = record.toOtelJavaLogRecordData()
         assertEquals(map.toString(), observed.bodyValue?.asString())
     }
 
     @Test
     fun testLogRecordNullConversions() {
-        val record = FakeReadableLogRecord(
+        val record = FakeLogRecordData(
             timestamp = null,
             observedTimestamp = null,
             severityNumber = null,
             severityText = null,
             body = null,
         )
-        val observed = record.toLogRecordData()
+        val observed = record.toOtelJavaLogRecordData()
         assertEquals(0, observed.timestampEpochNanos)
         assertEquals(0, observed.observedTimestampEpochNanos)
         assertEquals(OtelJavaSeverity.UNDEFINED_SEVERITY_NUMBER, observed.severity)

--- a/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/logging/export/LogRecordExporterAdapterTest.kt
+++ b/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/logging/export/LogRecordExporterAdapterTest.kt
@@ -3,7 +3,7 @@ package io.opentelemetry.kotlin.logging.export
 import io.opentelemetry.kotlin.attributes.convertToMap
 import io.opentelemetry.kotlin.export.OperationResultCode
 import io.opentelemetry.kotlin.fakes.otel.java.FakeOtelJavaLogRecordExporter
-import io.opentelemetry.kotlin.logging.model.FakeReadableLogRecord
+import io.opentelemetry.kotlin.logging.data.FakeLogRecordData
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Test
@@ -35,7 +35,7 @@ internal class LogRecordExporterAdapterTest {
 
     @Test
     fun `test export`() = runTest {
-        val original = FakeReadableLogRecord()
+        val original = FakeLogRecordData()
         assertEquals(OperationResultCode.Success, wrapper.export(listOf(original)))
 
         val observed = impl.exports.single()
@@ -59,7 +59,7 @@ internal class LogRecordExporterAdapterTest {
     @Test
     fun `test export returns failure after shutdown`() = runTest {
         wrapper.shutdown()
-        val result = wrapper.export(listOf(FakeReadableLogRecord()))
+        val result = wrapper.export(listOf(FakeLogRecordData()))
         assertEquals(OperationResultCode.Failure, result)
         assertTrue(impl.exports.isEmpty())
     }

--- a/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/BatchLogRecordProcessorImpl.kt
+++ b/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/BatchLogRecordProcessorImpl.kt
@@ -40,7 +40,9 @@ internal class BatchLogRecordProcessorImpl(
     override fun onEmit(
         log: ReadWriteLogRecord,
         context: Context
-    ) = shutdownState.execute { processor.processTelemetry(log) }
+    ) = shutdownState.execute {
+        processor.processTelemetry(log.toLogRecordData())
+    }
 
     override fun enabled(
         context: Context,

--- a/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/CompositeLogRecordExporter.kt
+++ b/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/CompositeLogRecordExporter.kt
@@ -5,7 +5,7 @@ import io.opentelemetry.kotlin.export.CompositeTelemetryCloseable
 import io.opentelemetry.kotlin.export.OperationResultCode
 import io.opentelemetry.kotlin.export.TelemetryCloseable
 import io.opentelemetry.kotlin.export.batchExportOperationSuspend
-import io.opentelemetry.kotlin.logging.model.ReadableLogRecord
+import io.opentelemetry.kotlin.logging.data.LogRecordData
 
 internal class CompositeLogRecordExporter(
     private val exporters: List<LogRecordExporter>,
@@ -16,7 +16,7 @@ internal class CompositeLogRecordExporter(
     )
 ) : LogRecordExporter, TelemetryCloseable by telemetryCloseable {
 
-    override suspend fun export(telemetry: List<ReadableLogRecord>): OperationResultCode {
+    override suspend fun export(telemetry: List<LogRecordData>): OperationResultCode {
         return batchExportOperationSuspend(
             exporters,
             sdkErrorHandler

--- a/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/NoopLogRecordExporter.kt
+++ b/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/NoopLogRecordExporter.kt
@@ -1,10 +1,10 @@
 package io.opentelemetry.kotlin.logging.export
 
 import io.opentelemetry.kotlin.export.OperationResultCode
-import io.opentelemetry.kotlin.logging.model.ReadableLogRecord
+import io.opentelemetry.kotlin.logging.data.LogRecordData
 
 internal object NoopLogRecordExporter : LogRecordExporter {
-    override suspend fun export(telemetry: List<ReadableLogRecord>): OperationResultCode = OperationResultCode.Failure
+    override suspend fun export(telemetry: List<LogRecordData>): OperationResultCode = OperationResultCode.Failure
     override suspend fun forceFlush(): OperationResultCode = OperationResultCode.Success
     override suspend fun shutdown(): OperationResultCode = OperationResultCode.Success
 }

--- a/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/SimpleLogRecordProcessor.kt
+++ b/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/SimpleLogRecordProcessor.kt
@@ -30,9 +30,10 @@ internal class SimpleLogRecordProcessor(
         context: Context
     ) {
         shutdownState.execute {
+            val data = log.toLogRecordData()
             scope.launch {
                 lock.write {
-                    exporter.export(listOf(log))
+                    exporter.export(listOf(data))
                 }
             }
         }

--- a/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/StdoutLogRecordExporter.kt
+++ b/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/StdoutLogRecordExporter.kt
@@ -2,7 +2,7 @@ package io.opentelemetry.kotlin.logging.export
 
 import io.opentelemetry.kotlin.export.MutableShutdownState
 import io.opentelemetry.kotlin.export.OperationResultCode
-import io.opentelemetry.kotlin.logging.model.ReadableLogRecord
+import io.opentelemetry.kotlin.logging.data.LogRecordData
 import io.opentelemetry.kotlin.platformLog
 
 /**
@@ -14,7 +14,7 @@ internal class StdoutLogRecordExporter(
 
     private val shutdownState = MutableShutdownState()
 
-    override suspend fun export(telemetry: List<ReadableLogRecord>): OperationResultCode =
+    override suspend fun export(telemetry: List<LogRecordData>): OperationResultCode =
         shutdownState.ifActive {
             telemetry.forEach { logRecord ->
                 logger(formatLogRecord(logRecord))
@@ -29,7 +29,7 @@ internal class StdoutLogRecordExporter(
             OperationResultCode.Success
         }
 
-    private fun formatLogRecord(logRecord: ReadableLogRecord): String = buildString {
+    private fun formatLogRecord(logRecord: LogRecordData): String = buildString {
         append("LogRecord")
         logRecord.severityNumber?.let {
             append(" [")

--- a/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/export/BatchLogRecordProcessorImplTest.kt
+++ b/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/export/BatchLogRecordProcessorImplTest.kt
@@ -7,6 +7,7 @@ import io.opentelemetry.kotlin.error.NoopSdkErrorHandler
 import io.opentelemetry.kotlin.export.OperationResultCode
 import io.opentelemetry.kotlin.logging.model.FakeReadWriteLogRecord
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import kotlin.test.BeforeTest
@@ -32,6 +33,35 @@ internal class BatchLogRecordProcessorImplTest {
             maxExportBatchSize = 10,
             sdkErrorHandler = NoopSdkErrorHandler,
         )
+    }
+
+    @Test
+    fun testExportReceivesImmutableSnapshot() = runTest {
+        // the processor from setup() polls on a real dispatcher, so shut it down before
+        // running on virtual time - otherwise its pending timer never lets Node exit.
+        processor.shutdown()
+
+        val testProcessor = BatchLogRecordProcessorImpl(
+            exporter = exporter,
+            maxQueueSize = 100,
+            scheduleDelayMs = 1,
+            exportTimeoutMs = 1000,
+            maxExportBatchSize = 10,
+            sdkErrorHandler = NoopSdkErrorHandler,
+            dispatcher = StandardTestDispatcher(testScheduler),
+        )
+
+        val log = FakeReadWriteLogRecord(body = "my_log")
+        testProcessor.onEmit(log, FakeContext())
+        log.body = "changed"
+        assertEquals(OperationResultCode.Success, testProcessor.forceFlush())
+
+        // the queued batch retains plain data rather than the live log record
+        val export = exporter.logs.single()
+        assertFalse(export === log)
+        assertEquals("my_log", export.body)
+
+        testProcessor.shutdown()
     }
 
     @Test

--- a/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/export/CompositeLogRecordExporterTest.kt
+++ b/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/export/CompositeLogRecordExporterTest.kt
@@ -4,7 +4,7 @@ import io.opentelemetry.kotlin.error.FakeSdkErrorHandler
 import io.opentelemetry.kotlin.export.OperationResultCode
 import io.opentelemetry.kotlin.export.OperationResultCode.Failure
 import io.opentelemetry.kotlin.export.OperationResultCode.Success
-import io.opentelemetry.kotlin.logging.model.FakeReadableLogRecord
+import io.opentelemetry.kotlin.logging.data.FakeLogRecordData
 import kotlinx.coroutines.test.runTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -15,7 +15,7 @@ import kotlin.test.assertTrue
 
 internal class CompositeLogRecordExporterTest {
 
-    private val fakeTelemetry = listOf(FakeReadableLogRecord())
+    private val fakeTelemetry = listOf(FakeLogRecordData())
     private lateinit var errorHandler: FakeSdkErrorHandler
 
     @BeforeTest

--- a/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/export/SimpleLogRecordProcessorTest.kt
+++ b/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/export/SimpleLogRecordProcessorTest.kt
@@ -42,6 +42,25 @@ internal class SimpleLogRecordProcessorTest {
     }
 
     @Test
+    fun testExportReceivesImmutableSnapshot() = runTest {
+        val exporter = FakeLogRecordExporter()
+        val processor = SimpleLogRecordProcessor(
+            exporter,
+            CoroutineScope(UnconfinedTestDispatcher(testScheduler)),
+        )
+
+        val log = FakeReadWriteLogRecord(body = "my_log")
+        processor.onEmit(log, FakeContext())
+
+        // the exporter retains plain data rather than the live log record
+        val export = exporter.logs.single()
+        assertFalse(export === log)
+
+        log.body = "changed"
+        assertEquals("my_log", export.body)
+    }
+
+    @Test
     fun testOnEmitNoOpAfterShutdown() = runTest {
         val exporter = FakeLogRecordExporter()
         val processor = SimpleLogRecordProcessor(

--- a/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/export/StdoutLogRecordExporterTest.kt
+++ b/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/export/StdoutLogRecordExporterTest.kt
@@ -5,7 +5,7 @@ import io.opentelemetry.kotlin.export.FakeLogExportConfig
 import io.opentelemetry.kotlin.export.OperationResultCode
 import io.opentelemetry.kotlin.framework.loadTestFixture
 import io.opentelemetry.kotlin.logging.SeverityNumber
-import io.opentelemetry.kotlin.logging.model.FakeReadableLogRecord
+import io.opentelemetry.kotlin.logging.data.FakeLogRecordData
 import io.opentelemetry.kotlin.resource.FakeResource
 import io.opentelemetry.kotlin.tracing.FakeSpanContext
 import kotlinx.coroutines.test.runTest
@@ -21,7 +21,7 @@ internal class StdoutLogRecordExporterTest {
             output.add(it)
         }
 
-        val logRecord = FakeReadableLogRecord(
+        val logRecord = FakeLogRecordData(
             body = null,
             timestamp = null,
             observedTimestamp = null,
@@ -47,7 +47,7 @@ internal class StdoutLogRecordExporterTest {
             output.add(it)
         }
 
-        val logRecord = FakeReadableLogRecord(
+        val logRecord = FakeLogRecordData(
             timestamp = 1000000000L,
             observedTimestamp = 1000000100L,
             severityNumber = SeverityNumber.INFO,
@@ -89,7 +89,7 @@ internal class StdoutLogRecordExporterTest {
         val exporter = StdoutLogRecordExporter(output::add)
         exporter.shutdown()
 
-        val logRecord = FakeReadableLogRecord()
+        val logRecord = FakeLogRecordData()
         val result = exporter.export(listOf(logRecord))
         assertEquals(OperationResultCode.Failure, result)
         assertEquals(0, output.size)

--- a/exporters-in-memory/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/InMemoryLogRecordExporter.kt
+++ b/exporters-in-memory/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/InMemoryLogRecordExporter.kt
@@ -1,7 +1,7 @@
 package io.opentelemetry.kotlin.logging.export
 
 import io.opentelemetry.kotlin.ExperimentalApi
-import io.opentelemetry.kotlin.logging.model.ReadableLogRecord
+import io.opentelemetry.kotlin.logging.data.LogRecordData
 
 /**
  * A log record exporter that stores telemetry in memory. This is intended for development/testing
@@ -12,5 +12,5 @@ public interface InMemoryLogRecordExporter : LogRecordExporter {
     /**
      * A list of log records that have been exported.
      */
-    public val exportedLogRecords: List<ReadableLogRecord>
+    public val exportedLogRecords: List<LogRecordData>
 }

--- a/exporters-in-memory/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/InMemoryLogRecordExporterImpl.kt
+++ b/exporters-in-memory/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/InMemoryLogRecordExporterImpl.kt
@@ -2,17 +2,17 @@ package io.opentelemetry.kotlin.logging.export
 
 import io.opentelemetry.kotlin.export.MutableShutdownState
 import io.opentelemetry.kotlin.export.OperationResultCode
-import io.opentelemetry.kotlin.logging.model.ReadableLogRecord
+import io.opentelemetry.kotlin.logging.data.LogRecordData
 
 internal class InMemoryLogRecordExporterImpl : InMemoryLogRecordExporter {
 
-    private val impl = mutableListOf<ReadableLogRecord>()
+    private val impl = mutableListOf<LogRecordData>()
     private val shutdownState = MutableShutdownState()
 
-    override val exportedLogRecords: List<ReadableLogRecord>
+    override val exportedLogRecords: List<LogRecordData>
         get() = impl
 
-    override suspend fun export(telemetry: List<ReadableLogRecord>): OperationResultCode =
+    override suspend fun export(telemetry: List<LogRecordData>): OperationResultCode =
         shutdownState.ifActive {
             impl += telemetry
             OperationResultCode.Success

--- a/exporters-in-memory/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/export/InMemoryLogRecordExporterTest.kt
+++ b/exporters-in-memory/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/export/InMemoryLogRecordExporterTest.kt
@@ -1,7 +1,7 @@
 package io.opentelemetry.kotlin.logging.export
 
 import io.opentelemetry.kotlin.export.OperationResultCode
-import io.opentelemetry.kotlin.logging.model.FakeReadableLogRecord
+import io.opentelemetry.kotlin.logging.data.FakeLogRecordData
 import kotlinx.coroutines.test.runTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -10,7 +10,7 @@ import kotlin.test.assertTrue
 
 internal class InMemoryLogRecordExporterTest {
 
-    private val fakeTelemetry = listOf(FakeReadableLogRecord())
+    private val fakeTelemetry = listOf(FakeLogRecordData())
     private lateinit var exporter: InMemoryLogRecordExporter
 
     @BeforeTest

--- a/exporters-otlp/src/commonMain/kotlin/io/opentelemetry/kotlin/export/OtlpClient.kt
+++ b/exporters-otlp/src/commonMain/kotlin/io/opentelemetry/kotlin/export/OtlpClient.kt
@@ -18,9 +18,9 @@ import io.opentelemetry.kotlin.export.OtlpResponse.RetryableError
 import io.opentelemetry.kotlin.export.OtlpResponse.ServerError
 import io.opentelemetry.kotlin.export.OtlpResponse.Success
 import io.opentelemetry.kotlin.export.OtlpResponse.Unknown
+import io.opentelemetry.kotlin.logging.data.LogRecordData
 import io.opentelemetry.kotlin.logging.export.deserializeLogRecordPartialSuccess
 import io.opentelemetry.kotlin.logging.export.toProtobufByteArray
-import io.opentelemetry.kotlin.logging.model.ReadableLogRecord
 import io.opentelemetry.kotlin.platformLog
 import io.opentelemetry.kotlin.tracing.data.SpanData
 import io.opentelemetry.kotlin.tracing.export.deserializeTraceRecordPartialSuccess
@@ -36,7 +36,7 @@ internal class OtlpClient(
     private val contentType = ContentType.parse("application/x-protobuf")
     private val userAgent = "OTel-OTLP-Exporter-Kotlin/${BuildKonfig.VERSION}"
 
-    suspend fun exportLogs(telemetry: List<ReadableLogRecord>): OtlpResponse = exportTelemetry(
+    suspend fun exportLogs(telemetry: List<LogRecordData>): OtlpResponse = exportTelemetry(
         OtlpEndpoint.Logs,
         telemetry::toProtobufByteArray,
         ByteArray::deserializeLogRecordPartialSuccess

--- a/exporters-otlp/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/OtlpHttpLogRecordExporter.kt
+++ b/exporters-otlp/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/OtlpHttpLogRecordExporter.kt
@@ -3,7 +3,7 @@ package io.opentelemetry.kotlin.logging.export
 import io.opentelemetry.kotlin.export.OperationResultCode
 import io.opentelemetry.kotlin.export.OtlpClient
 import io.opentelemetry.kotlin.export.TelemetryExporter
-import io.opentelemetry.kotlin.logging.model.ReadableLogRecord
+import io.opentelemetry.kotlin.logging.data.LogRecordData
 
 internal class OtlpHttpLogRecordExporter(
     private val otlpClient: OtlpClient,
@@ -16,7 +16,7 @@ internal class OtlpHttpLogRecordExporter(
         otlpClient.exportLogs(it)
     }
 
-    override suspend fun export(telemetry: List<ReadableLogRecord>): OperationResultCode {
+    override suspend fun export(telemetry: List<LogRecordData>): OperationResultCode {
         return exporter.export(telemetry)
     }
 

--- a/exporters-otlp/src/commonTest/kotlin/io/opentelemetry/kotlin/export/OtlpClientTest.kt
+++ b/exporters-otlp/src/commonTest/kotlin/io/opentelemetry/kotlin/export/OtlpClientTest.kt
@@ -11,9 +11,9 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.http.headersOf
 import io.ktor.util.toMap
 import io.ktor.utils.io.ByteReadChannel
+import io.opentelemetry.kotlin.logging.data.FakeLogRecordData
+import io.opentelemetry.kotlin.logging.data.LogRecordData
 import io.opentelemetry.kotlin.logging.export.toProtobufByteArray
-import io.opentelemetry.kotlin.logging.model.FakeReadableLogRecord
-import io.opentelemetry.kotlin.logging.model.ReadableLogRecord
 import io.opentelemetry.kotlin.tracing.data.FakeSpanData
 import io.opentelemetry.kotlin.tracing.data.SpanData
 import io.opentelemetry.kotlin.tracing.export.toProtobufByteArray
@@ -36,7 +36,7 @@ import kotlin.time.Duration.Companion.milliseconds
 internal class OtlpClientTest {
 
     private val requestTimeoutMs = 250L
-    private val logRecords = listOf(FakeReadableLogRecord())
+    private val logRecords = listOf(FakeLogRecordData())
     private val spans = listOf(FakeSpanData())
     private val baseUrl = "http://localhost:1234"
     private val expectedUserAgent = "OTel-OTLP-Exporter-Kotlin/${BuildKonfig.VERSION}"
@@ -81,8 +81,8 @@ internal class OtlpClientTest {
     fun testExportMultiLogSuccess() = runTest {
         sendAndAssertLogRequest(
             telemetry = listOf(
-                FakeReadableLogRecord(body = "a"),
-                FakeReadableLogRecord(body = "b")
+                FakeLogRecordData(body = "a"),
+                FakeLogRecordData(body = "b")
             ),
             mockResponseStatus = HttpStatusCode.OK,
             expectedResponse = OtlpResponse.Success,
@@ -326,7 +326,7 @@ internal class OtlpClientTest {
         )
 
     private suspend fun sendAndAssertLogRequest(
-        telemetry: List<ReadableLogRecord>,
+        telemetry: List<LogRecordData>,
         mockResponseStatus: HttpStatusCode,
         expectedResponse: OtlpResponse
     ) {

--- a/exporters-otlp/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/export/OtlpHttpLogRecordExporterTest.kt
+++ b/exporters-otlp/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/export/OtlpHttpLogRecordExporterTest.kt
@@ -17,8 +17,8 @@ import io.opentelemetry.kotlin.export.OperationResultCode
 import io.opentelemetry.kotlin.export.OtlpClient
 import io.opentelemetry.kotlin.export.createDefaultHttpClient
 import io.opentelemetry.kotlin.init.LogExportConfigDsl
-import io.opentelemetry.kotlin.logging.model.FakeReadableLogRecord
-import io.opentelemetry.kotlin.logging.model.ReadableLogRecord
+import io.opentelemetry.kotlin.logging.data.FakeLogRecordData
+import io.opentelemetry.kotlin.logging.data.LogRecordData
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withTimeout
@@ -30,7 +30,7 @@ import kotlin.test.assertTrue
 
 internal class OtlpHttpLogRecordExporterTest {
 
-    private val logRecords = listOf(FakeReadableLogRecord())
+    private val logRecords = listOf(FakeLogRecordData())
     private val baseUrl = "http://localhost:1234"
 
     private lateinit var client: OtlpClient
@@ -143,7 +143,7 @@ internal class OtlpHttpLogRecordExporterTest {
         return requests
     }
 
-    private suspend fun assertTelemetryExported(telemetry: List<ReadableLogRecord>) {
+    private suspend fun assertTelemetryExported(telemetry: List<LogRecordData>) {
         val requests = waitForExportedTelemetry()
         val request = requests.single()
         val bytes = request.body.toByteArray()

--- a/exporters-persistence/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/PersistingLogRecordExporter.kt
+++ b/exporters-persistence/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/PersistingLogRecordExporter.kt
@@ -5,17 +5,17 @@ import io.opentelemetry.kotlin.export.MutableShutdownState
 import io.opentelemetry.kotlin.export.OperationResultCode
 import io.opentelemetry.kotlin.export.OperationResultCode.Success
 import io.opentelemetry.kotlin.export.TelemetryRepository
-import io.opentelemetry.kotlin.logging.model.ReadableLogRecord
+import io.opentelemetry.kotlin.logging.data.LogRecordData
 
 @ExperimentalApi
 internal class PersistingLogRecordExporter(
     private val exporter: LogRecordExporter,
-    private val repository: TelemetryRepository<ReadableLogRecord>,
+    private val repository: TelemetryRepository<LogRecordData>,
 ) : LogRecordExporter {
 
     private val shutdownState = MutableShutdownState()
 
-    override suspend fun export(telemetry: List<ReadableLogRecord>): OperationResultCode =
+    override suspend fun export(telemetry: List<LogRecordData>): OperationResultCode =
         shutdownState.ifActive {
             // if persistence failed attempt immediate export as a best-effort fallback
             repository.store(telemetry) ?: return exporter.export(telemetry)

--- a/exporters-persistence/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/PersistingLogRecordProcessor.kt
+++ b/exporters-persistence/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/PersistingLogRecordProcessor.kt
@@ -18,8 +18,8 @@ import io.opentelemetry.kotlin.export.TimeoutTelemetryCloseable
 import io.opentelemetry.kotlin.export.telemetryExceptionHandler
 import io.opentelemetry.kotlin.init.LogExportConfigDsl
 import io.opentelemetry.kotlin.logging.SeverityNumber
+import io.opentelemetry.kotlin.logging.data.LogRecordData
 import io.opentelemetry.kotlin.logging.model.ReadWriteLogRecord
-import io.opentelemetry.kotlin.logging.model.ReadableLogRecord
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -48,8 +48,8 @@ internal class PersistingLogRecordProcessor(
     fileSystem: TelemetryFileSystem,
     dsl: LogExportConfigDsl,
     config: PersistedTelemetryConfig,
-    serializer: (List<ReadableLogRecord>) -> ByteArray,
-    deserializer: (ByteArray) -> List<ReadableLogRecord>,
+    serializer: (List<LogRecordData>) -> ByteArray,
+    deserializer: (ByteArray) -> List<LogRecordData>,
     maxQueueSize: Int,
     private val scheduleDelayMs: Long,
     private val exportTimeoutMs: Long,

--- a/exporters-persistence/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/PersistingLogRecordProcessorApi.kt
+++ b/exporters-persistence/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/PersistingLogRecordProcessorApi.kt
@@ -65,7 +65,7 @@ internal fun LogExportConfigDsl.persistingLogRecordProcessorImpl(
         fileSystem = fileSystem,
         dsl = this,
         serializer = { it.toProtobufByteArray() },
-        deserializer = { it.toReadableLogRecordList() },
+        deserializer = { it.toLogRecordDataList() },
         config = PersistedTelemetryConfig(sdkErrorHandler = sdkErrorHandler),
         maxQueueSize = maxQueueSize,
         scheduleDelayMs = scheduleDelayMs,

--- a/exporters-persistence/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/export/PersistingLogRecordExporterTest.kt
+++ b/exporters-persistence/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/export/PersistingLogRecordExporterTest.kt
@@ -3,8 +3,8 @@ package io.opentelemetry.kotlin.logging.export
 import io.opentelemetry.kotlin.export.FakeTelemetryRepository
 import io.opentelemetry.kotlin.export.OperationResultCode.Failure
 import io.opentelemetry.kotlin.export.OperationResultCode.Success
-import io.opentelemetry.kotlin.logging.model.FakeReadableLogRecord
-import io.opentelemetry.kotlin.logging.model.ReadableLogRecord
+import io.opentelemetry.kotlin.logging.data.FakeLogRecordData
+import io.opentelemetry.kotlin.logging.data.LogRecordData
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -13,11 +13,11 @@ import kotlin.test.assertTrue
 
 internal class PersistingLogRecordExporterTest {
 
-    private val telemetry = listOf(FakeReadableLogRecord(body = "test"))
+    private val telemetry = listOf(FakeLogRecordData(body = "test"))
 
     @Test
     fun testStoreCalledOnExport() = runTest {
-        val repository = FakeTelemetryRepository<ReadableLogRecord>()
+        val repository = FakeTelemetryRepository<LogRecordData>()
         val exporter = PersistingLogRecordExporter(FakeLogRecordExporter(), repository)
         exporter.export(telemetry)
 
@@ -27,7 +27,7 @@ internal class PersistingLogRecordExporterTest {
 
     @Test
     fun testExportReturnsSuccessWhenStoreSucceeds() = runTest {
-        val repository = FakeTelemetryRepository<ReadableLogRecord>()
+        val repository = FakeTelemetryRepository<LogRecordData>()
         val exporter = PersistingLogRecordExporter(FakeLogRecordExporter(), repository)
 
         val result = exporter.export(telemetry)
@@ -36,7 +36,7 @@ internal class PersistingLogRecordExporterTest {
 
     @Test
     fun testDelegateNotCalledWhenStoreSucceeds() = runTest {
-        val repository = FakeTelemetryRepository<ReadableLogRecord>()
+        val repository = FakeTelemetryRepository<LogRecordData>()
         val delegate = FakeLogRecordExporter()
         val exporter = PersistingLogRecordExporter(delegate, repository)
 
@@ -46,7 +46,7 @@ internal class PersistingLogRecordExporterTest {
 
     @Test
     fun testExportStillWorksIfStoreFails() = runTest {
-        val repository = FakeTelemetryRepository<ReadableLogRecord>(storeFails = true)
+        val repository = FakeTelemetryRepository<LogRecordData>(storeFails = true)
         val delegate = FakeLogRecordExporter()
         val exporter = PersistingLogRecordExporter(delegate, repository)
 
@@ -58,7 +58,7 @@ internal class PersistingLogRecordExporterTest {
 
     @Test
     fun testFallbackExportResultPropagatedWhenStoreFails() = runTest {
-        val repository = FakeTelemetryRepository<ReadableLogRecord>(storeFails = true)
+        val repository = FakeTelemetryRepository<LogRecordData>(storeFails = true)
         val exporter = PersistingLogRecordExporter(
             FakeLogRecordExporter(action = { Failure }),
             repository,
@@ -70,14 +70,14 @@ internal class PersistingLogRecordExporterTest {
 
     @Test
     fun testForceFlushReturnsSuccess() = runTest {
-        val repository = FakeTelemetryRepository<ReadableLogRecord>()
+        val repository = FakeTelemetryRepository<LogRecordData>()
         val exporter = PersistingLogRecordExporter(FakeLogRecordExporter(), repository)
         assertEquals(Success, exporter.forceFlush())
     }
 
     @Test
     fun testShutdown() = runTest {
-        val repository = FakeTelemetryRepository<ReadableLogRecord>()
+        val repository = FakeTelemetryRepository<LogRecordData>()
         val exporter = PersistingLogRecordExporter(FakeLogRecordExporter(), repository)
 
         assertEquals(Success, exporter.export(telemetry))
@@ -94,7 +94,7 @@ internal class PersistingLogRecordExporterTest {
 
     @Test
     fun testForceFlushWorksAfterShutdown() = runTest {
-        val repository = FakeTelemetryRepository<ReadableLogRecord>()
+        val repository = FakeTelemetryRepository<LogRecordData>()
         val exporter = PersistingLogRecordExporter(FakeLogRecordExporter(), repository)
         exporter.shutdown()
         assertEquals(Success, exporter.forceFlush())

--- a/exporters-protobuf/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/ExportLogsServiceRequestCreator.kt
+++ b/exporters-protobuf/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/ExportLogsServiceRequestCreator.kt
@@ -3,15 +3,15 @@ package io.opentelemetry.kotlin.logging.export
 import io.opentelemetry.kotlin.export.conversion.toResource
 import io.opentelemetry.kotlin.export.conversion.toInstrumentationScopeInfo
 import io.opentelemetry.kotlin.export.conversion.toProtobuf
-import io.opentelemetry.kotlin.logging.model.ReadableLogRecord
+import io.opentelemetry.kotlin.logging.data.LogRecordData
 import io.opentelemetry.proto.collector.logs.v1.ExportLogsServiceRequest
 import io.opentelemetry.proto.logs.v1.ResourceLogs
 import io.opentelemetry.proto.logs.v1.ScopeLogs
 
-fun List<ReadableLogRecord>.toProtobufByteArray(): ByteArray =
+fun List<LogRecordData>.toProtobufByteArray(): ByteArray =
     ExportLogsServiceRequest.ADAPTER.encode(toExportLogsServiceRequest())
 
-fun ByteArray.toReadableLogRecordList(): List<ReadableLogRecord> {
+fun ByteArray.toLogRecordDataList(): List<LogRecordData> {
     val request = ExportLogsServiceRequest.ADAPTER.decode(this)
     return request.resource_logs.flatMap { resourceLogs ->
         val resource = resourceLogs.resource?.toResource()
@@ -20,25 +20,25 @@ fun ByteArray.toReadableLogRecordList(): List<ReadableLogRecord> {
             val scopeInfo = scopeLogs.scope?.toInstrumentationScopeInfo(scopeLogs.schema_url)
                 ?: return@flatMap emptyList()
             scopeLogs.log_records.map { logRecord ->
-                logRecord.toReadableLogRecord(resource, scopeInfo)
+                logRecord.toLogRecordData(resource, scopeInfo)
             }
         }
     }
 }
 
-internal fun List<ReadableLogRecord>.toExportLogsServiceRequest(): ExportLogsServiceRequest =
+internal fun List<LogRecordData>.toExportLogsServiceRequest(): ExportLogsServiceRequest =
     ExportLogsServiceRequest(
         resource_logs = toResourceLogs()
     )
 
-private fun List<ReadableLogRecord>.toResourceLogs(): List<ResourceLogs> = map { it.toResourceLogs() }
+private fun List<LogRecordData>.toResourceLogs(): List<ResourceLogs> = map { it.toResourceLogs() }
 
-private fun ReadableLogRecord.toResourceLogs(): ResourceLogs = ResourceLogs(
+private fun LogRecordData.toResourceLogs(): ResourceLogs = ResourceLogs(
     scope_logs = listOf(toScopeLogs()),
     resource = resource.toProtobuf()
 )
 
-private fun ReadableLogRecord.toScopeLogs(): ScopeLogs = ScopeLogs(
+private fun LogRecordData.toScopeLogs(): ScopeLogs = ScopeLogs(
     log_records = listOf(toProtobuf()),
     scope = instrumentationScopeInfo.toProtobuf(),
     schema_url = instrumentationScopeInfo.schemaUrl ?: ""

--- a/exporters-protobuf/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/LogRecordProtobufConversion.kt
+++ b/exporters-protobuf/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/LogRecordProtobufConversion.kt
@@ -9,7 +9,7 @@ import io.opentelemetry.kotlin.export.conversion.toFlagsInt
 import io.opentelemetry.kotlin.export.conversion.toMapValue
 import io.opentelemetry.kotlin.export.conversion.toNestedAnyValue
 import io.opentelemetry.kotlin.export.conversion.toProtoAnyValue
-import io.opentelemetry.kotlin.logging.model.ReadableLogRecord
+import io.opentelemetry.kotlin.logging.data.LogRecordData
 import io.opentelemetry.kotlin.logging.SeverityNumber
 import io.opentelemetry.kotlin.resource.Resource
 import io.opentelemetry.kotlin.tracing.SpanContext
@@ -43,7 +43,7 @@ import io.opentelemetry.proto.logs.v1.SeverityNumber.SEVERITY_NUMBER_WARN4
 import okio.ByteString.Companion.toByteString
 
 
-internal fun ReadableLogRecord.toProtobuf(): LogRecord = LogRecord(
+internal fun LogRecordData.toProtobuf(): LogRecord = LogRecord(
     trace_id = spanContext.traceIdBytes.toByteString(),
     span_id = spanContext.spanIdBytes.toByteString(),
     flags = spanContext.traceFlags.toFlagsInt(),
@@ -57,10 +57,10 @@ internal fun ReadableLogRecord.toProtobuf(): LogRecord = LogRecord(
     dropped_attributes_count = droppedAttributesCount,
 )
 
-internal fun LogRecord.toReadableLogRecord(
+internal fun LogRecord.toLogRecordData(
     resource: Resource,
     instrumentationScopeInfo: InstrumentationScopeInfo
-): ReadableLogRecord = DeserializedReadableLogRecord(
+): LogRecordData = DeserializedLogRecordData(
     timestamp = time_unix_nano,
     observedTimestamp = observed_time_unix_nano,
     severityNumber = severity_number.toSeverityNumber(),
@@ -160,7 +160,7 @@ private fun io.opentelemetry.proto.logs.v1.SeverityNumber.toSeverityNumber(): Se
         SEVERITY_NUMBER_FATAL4 -> SeverityNumber.FATAL4
     }
 
-private class DeserializedReadableLogRecord(
+private class DeserializedLogRecordData(
     override val timestamp: Long?,
     override val observedTimestamp: Long?,
     override val severityNumber: SeverityNumber?,
@@ -172,4 +172,4 @@ private class DeserializedReadableLogRecord(
     override val resource: Resource,
     override val instrumentationScopeInfo: InstrumentationScopeInfo,
     override val droppedAttributesCount: Int
-) : ReadableLogRecord
+) : LogRecordData

--- a/exporters-protobuf/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/export/ExportLogsServiceRequestTest.kt
+++ b/exporters-protobuf/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/export/ExportLogsServiceRequestTest.kt
@@ -2,7 +2,7 @@ package io.opentelemetry.kotlin.logging.export
 
 import io.opentelemetry.kotlin.InstrumentationScopeInfo
 import io.opentelemetry.kotlin.factory.hexToByteArray
-import io.opentelemetry.kotlin.logging.model.FakeReadableLogRecord
+import io.opentelemetry.kotlin.logging.data.FakeLogRecordData
 import io.opentelemetry.kotlin.logging.SeverityNumber
 import io.opentelemetry.kotlin.tracing.FakeSpanContext
 import io.opentelemetry.kotlin.tracing.FakeTraceFlags
@@ -14,7 +14,7 @@ import kotlin.test.assertNull
 
 class ExportLogsServiceRequestTest {
 
-    private val telemetry = FakeReadableLogRecord(
+    private val telemetry = FakeLogRecordData(
         eventName = "foo",
         spanContext = FakeSpanContext(
             traceIdBytes = "12345678901234567890123456789012".hexToByteArray(),
@@ -28,7 +28,7 @@ class ExportLogsServiceRequestTest {
     fun testProtobufToByteArray() {
         val original = listOf(telemetry)
         val byteArray = original.toProtobufByteArray()
-        val result = byteArray.toReadableLogRecordList()
+        val result = byteArray.toLogRecordDataList()
 
         assertEquals(1, result.size)
         val expected = original[0]
@@ -77,23 +77,23 @@ class ExportLogsServiceRequestTest {
         )
 
         severityLevels.forEach { severity ->
-            val record = FakeReadableLogRecord(severityNumber = severity)
+            val record = FakeLogRecordData(severityNumber = severity)
             val byteArray = listOf(record).toProtobufByteArray()
-            val result = byteArray.toReadableLogRecordList()
+            val result = byteArray.toLogRecordDataList()
             assertEquals(severity, result[0].severityNumber, "Failed for severity: $severity")
         }
     }
 
     @Test
     fun testNullRoundTrip() {
-        val record = FakeReadableLogRecord(
+        val record = FakeLogRecordData(
             severityNumber = null,
             severityText = null,
             body = null,
             eventName = null,
         )
         val byteArray = listOf(record).toProtobufByteArray()
-        val result = byteArray.toReadableLogRecordList()
+        val result = byteArray.toLogRecordDataList()
         assertNull(result[0].severityNumber)
         assertNull(result[0].severityText)
         assertNull(result[0].body)
@@ -102,14 +102,14 @@ class ExportLogsServiceRequestTest {
 
     @Test
     fun testEventNameRoundTrip() {
-        val record = FakeReadableLogRecord(eventName = "test-event")
+        val record = FakeLogRecordData(eventName = "test-event")
         val byteArray = listOf(record).toProtobufByteArray()
-        val result = byteArray.toReadableLogRecordList()
+        val result = byteArray.toLogRecordDataList()
         assertEquals("test-event", result[0].eventName)
     }
 
     private fun assertSpanContextMatches(
-        expectedContext: FakeSpanContext,
+        expectedContext: SpanContext,
         actualContext: SpanContext
     ) {
         assertEquals(expectedContext.traceId, actualContext.traceId)

--- a/exporters-protobuf/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/export/LogRecordProtobufConversionTest.kt
+++ b/exporters-protobuf/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/export/LogRecordProtobufConversionTest.kt
@@ -3,7 +3,7 @@ package io.opentelemetry.kotlin.logging.export
 import io.opentelemetry.kotlin.attributes.AnyValue
 import io.opentelemetry.kotlin.export.assertAttributesMatch
 import io.opentelemetry.kotlin.factory.toHexString
-import io.opentelemetry.kotlin.logging.model.FakeReadableLogRecord
+import io.opentelemetry.kotlin.logging.data.FakeLogRecordData
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
@@ -15,7 +15,7 @@ class LogRecordProtobufConversionTest {
 
     @Test
     fun testEmptyConversion() {
-        val obj = FakeReadableLogRecord(
+        val obj = FakeLogRecordData(
             timestamp = null,
             observedTimestamp = null,
             severityNumber = null,
@@ -46,7 +46,7 @@ class LogRecordProtobufConversionTest {
             "doubleList" to listOf(6.0, 12.0),
             "boolList" to listOf(true, false),
         )
-        val obj = FakeReadableLogRecord(attributes = attrs)
+        val obj = FakeLogRecordData(attributes = attrs)
         val protobuf = obj.toProtobuf()
         assertEquals(obj.timestamp, protobuf.time_unix_nano)
         assertEquals(obj.observedTimestamp, protobuf.observed_time_unix_nano)
@@ -60,48 +60,48 @@ class LogRecordProtobufConversionTest {
 
     @Test
     fun testDroppedAttributesCountConversion() {
-        val obj = FakeReadableLogRecord(droppedAttributesCount = 7)
+        val obj = FakeLogRecordData(droppedAttributesCount = 7)
         val protobuf = obj.toProtobuf()
         assertEquals(7, protobuf.dropped_attributes_count)
 
-        val restored = protobuf.toReadableLogRecord(obj.resource, obj.instrumentationScopeInfo)
+        val restored = protobuf.toLogRecordData(obj.resource, obj.instrumentationScopeInfo)
         assertEquals(7, restored.droppedAttributesCount)
     }
 
     @Test
     fun testAnyValueStringBodySerialisesAsString() {
-        val protobuf = FakeReadableLogRecord(body = AnyValue.StringValue("hi")).toProtobuf()
+        val protobuf = FakeLogRecordData(body = AnyValue.StringValue("hi")).toProtobuf()
         assertEquals("hi", protobuf.body?.string_value)
     }
 
     @Test
     fun testAnyValueBoolBodySerialisesAsBool() {
-        val protobuf = FakeReadableLogRecord(body = AnyValue.BoolValue(true)).toProtobuf()
+        val protobuf = FakeLogRecordData(body = AnyValue.BoolValue(true)).toProtobuf()
         assertEquals(true, protobuf.body?.bool_value)
     }
 
     @Test
     fun testAnyValueLongBodySerialisesAsInt() {
-        val protobuf = FakeReadableLogRecord(body = AnyValue.LongValue(42)).toProtobuf()
+        val protobuf = FakeLogRecordData(body = AnyValue.LongValue(42)).toProtobuf()
         assertEquals(42L, protobuf.body?.int_value)
     }
 
     @Test
     fun testAnyValueDoubleBodySerialisesAsDouble() {
-        val protobuf = FakeReadableLogRecord(body = AnyValue.DoubleValue(1.5)).toProtobuf()
+        val protobuf = FakeLogRecordData(body = AnyValue.DoubleValue(1.5)).toProtobuf()
         assertEquals(1.5, protobuf.body?.double_value)
     }
 
     @Test
     fun testAnyValueBytesBodySerialisesAsBytes() {
         val bytes = byteArrayOf(1, 2, 3)
-        val protobuf = FakeReadableLogRecord(body = AnyValue.BytesValue(bytes)).toProtobuf()
+        val protobuf = FakeLogRecordData(body = AnyValue.BytesValue(bytes)).toProtobuf()
         assertContentEquals(bytes, protobuf.body?.bytes_value?.toByteArray())
     }
 
     @Test
     fun testAnyValueNullBodySerialisesAsEmptyAnyValue() {
-        val protobuf = FakeReadableLogRecord(body = AnyValue.NullValue).toProtobuf()
+        val protobuf = FakeLogRecordData(body = AnyValue.NullValue).toProtobuf()
         val any = protobuf.body
         assertNotNull(any)
         assertNull(any.string_value)
@@ -121,7 +121,7 @@ class LogRecordProtobufConversionTest {
                 AnyValue.LongValue(1),
             )
         )
-        val protobuf = FakeReadableLogRecord(body = list).toProtobuf()
+        val protobuf = FakeLogRecordData(body = list).toProtobuf()
         val arr = protobuf.body?.array_value
         assertNotNull(arr)
         assertEquals(2, arr.values.size)
@@ -137,7 +137,7 @@ class LogRecordProtobufConversionTest {
                 "count" to AnyValue.LongValue(7),
             )
         )
-        val protobuf = FakeReadableLogRecord(body = map).toProtobuf()
+        val protobuf = FakeLogRecordData(body = map).toProtobuf()
         val kv = protobuf.body?.kvlist_value
         assertNotNull(kv)
         assertEquals(2, kv.values.size)
@@ -162,9 +162,9 @@ class LogRecordProtobufConversionTest {
                 )
             )
         )
-        val obj = FakeReadableLogRecord(body = original)
+        val obj = FakeLogRecordData(body = original)
         val protobuf = obj.toProtobuf()
-        val restored = protobuf.toReadableLogRecord(obj.resource, obj.instrumentationScopeInfo)
+        val restored = protobuf.toLogRecordData(obj.resource, obj.instrumentationScopeInfo)
         assertEquals(original, restored.body)
     }
 
@@ -173,14 +173,14 @@ class LogRecordProtobufConversionTest {
         val payload = object {
             override fun toString() = "custom-string"
         }
-        val protobuf = FakeReadableLogRecord(body = payload).toProtobuf()
+        val protobuf = FakeLogRecordData(body = payload).toProtobuf()
         assertEquals("custom-string", protobuf.body?.string_value)
     }
 
     @Test
     fun testPrimitiveBodyRoundTripsAsRawKotlinType() {
-        val obj = FakeReadableLogRecord(body = 99L)
-        val restored = obj.toProtobuf().toReadableLogRecord(obj.resource, obj.instrumentationScopeInfo)
+        val obj = FakeLogRecordData(body = 99L)
+        val restored = obj.toProtobuf().toLogRecordData(obj.resource, obj.instrumentationScopeInfo)
         assertTrue(restored.body is Long, "expected Long, got ${restored.body?.let { it::class }}")
         assertEquals(99L, restored.body)
     }

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/model/LogRecordModel.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/model/LogRecordModel.kt
@@ -5,13 +5,16 @@ import io.opentelemetry.kotlin.ReentrantReadWriteLock
 import io.opentelemetry.kotlin.attributes.AnyValue
 import io.opentelemetry.kotlin.attributes.AttributesModel
 import io.opentelemetry.kotlin.init.config.LogLimitConfig
+import io.opentelemetry.kotlin.logging.LogRecordDataImpl
 import io.opentelemetry.kotlin.logging.SeverityNumber
+import io.opentelemetry.kotlin.logging.data.LogRecordData
 import io.opentelemetry.kotlin.resource.Resource
 import io.opentelemetry.kotlin.tracing.SpanContext
 
 /**
  * The single source of truth for log record state. This is not exposed to consumers of the API - they
- * are presented with views such as [ReadableLogRecordImpl], depending on which API call they make.
+ * are presented with views such as [ReadWriteLogRecordImpl], or an immutable snapshot taken via
+ * [toLogRecordData], depending on which API call they make.
  */
 internal class LogRecordModel(
     override val resource: Resource,
@@ -187,4 +190,18 @@ internal class LogRecordModel(
             attrs.setAnyValueAttribute(key, value)
         }
     }
+
+    override fun toLogRecordData(): LogRecordData = LogRecordDataImpl(
+        timestamp,
+        observedTimestamp,
+        severityNumber,
+        severityText,
+        body,
+        eventName,
+        spanContext,
+        attributes,
+        resource,
+        instrumentationScopeInfo,
+        droppedAttributesCount
+    )
 }

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/model/ReadableLogRecordImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/model/ReadableLogRecordImpl.kt
@@ -1,7 +1,0 @@
-package io.opentelemetry.kotlin.logging.model
-/**
- * A view of [LogRecordModel] that is returned when only read operations are permissible on a log record.
- */
-internal class ReadableLogRecordImpl(
-    private val impl: ReadWriteLogRecord
-) : ReadableLogRecord by impl

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/LogRecordSnapshotTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/LogRecordSnapshotTest.kt
@@ -1,0 +1,100 @@
+package io.opentelemetry.kotlin.logging
+
+import io.opentelemetry.kotlin.InstrumentationScopeInfoImpl
+import io.opentelemetry.kotlin.clock.FakeClock
+import io.opentelemetry.kotlin.error.NoopSdkErrorHandler
+import io.opentelemetry.kotlin.export.MutableShutdownState
+import io.opentelemetry.kotlin.factory.FakeContextFactory
+import io.opentelemetry.kotlin.factory.FakeSpanContextFactory
+import io.opentelemetry.kotlin.init.config.LogLimitConfig
+import io.opentelemetry.kotlin.logging.export.FakeLogRecordProcessor
+import io.opentelemetry.kotlin.resource.FakeResource
+import io.opentelemetry.kotlin.tracing.fakeLogLimitsConfig
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNotSame
+
+internal class LogRecordSnapshotTest {
+
+    private val key = InstrumentationScopeInfoImpl("key", null, null, emptyMap())
+    private val processor = FakeLogRecordProcessor()
+    private lateinit var logger: LoggerImpl
+
+    @BeforeTest
+    fun setUp() {
+        logger = LoggerImpl(
+            clock = FakeClock(),
+            processor = processor,
+            contextFactory = FakeContextFactory(),
+            spanContextFactory = FakeSpanContextFactory(),
+            key = key,
+            resource = FakeResource(),
+            logLimitConfig = LogLimitConfig(
+                attributeCountLimit = 2,
+                attributeValueLengthLimit = fakeLogLimitsConfig.attributeValueLengthLimit
+            ),
+            shutdownState = MutableShutdownState(),
+            sdkErrorHandler = NoopSdkErrorHandler,
+        )
+    }
+
+    @Test
+    fun testSnapshotHoldsPlainData() {
+        logger.emit(
+            body = "my_log",
+            eventName = "my_event",
+            severityNumber = SeverityNumber.WARN,
+            severityText = "warning",
+        ) {
+            setStringAttribute("key", "value")
+        }
+
+        val log = processor.logs.single()
+        val data = log.toLogRecordData()
+        assertIs<LogRecordDataImpl>(data)
+
+        val emitted: Any = log
+        assertNotSame(data, emitted)
+
+        assertEquals("my_log", data.body)
+        assertEquals("my_event", data.eventName)
+        assertEquals(SeverityNumber.WARN, data.severityNumber)
+        assertEquals("warning", data.severityText)
+        assertEquals(mapOf("key" to "value"), data.attributes)
+        assertEquals(log.timestamp, data.timestamp)
+        assertEquals(log.observedTimestamp, data.observedTimestamp)
+        assertEquals(log.spanContext, data.spanContext)
+        assertEquals(log.resource, data.resource)
+        assertEquals(key, data.instrumentationScopeInfo)
+    }
+
+    @Test
+    fun testSnapshotUnaffectedByLaterMutation() {
+        logger.emit("my_log") { setStringAttribute("key", "value") }
+
+        val log = processor.logs.single()
+        val data = log.toLogRecordData()
+
+        log.body = "changed"
+        log.severityText = "changed"
+        log.setStringAttribute("other", "value")
+
+        assertEquals("my_log", data.body)
+        assertEquals(mapOf("key" to "value"), data.attributes)
+    }
+
+    @Test
+    fun testSnapshotCapturesDroppedAttributesCount() {
+        logger.emit("my_log") {
+            setStringAttribute("a", "value")
+            setStringAttribute("b", "value")
+            setStringAttribute("c", "value") // exceeds the limit of 2
+        }
+
+        val data = processor.logs.single().toLogRecordData()
+        assertEquals(2, data.attributes.size)
+        assertEquals(1, data.droppedAttributesCount)
+    }
+}

--- a/integration-test/config/detekt/baseline.xml
+++ b/integration-test/config/detekt/baseline.xml
@@ -2,7 +2,7 @@
 <SmellBaseline>
   <ManuallySuppressedIssues/>
   <CurrentIssues>
-    <ID>SpreadOperator:OtelKotlinTestRule.kt$OtelKotlinTestRule$( InMemoryLogRecordProcessor( logRecordExporter, scope, ), *config.logRecordProcessors.toTypedArray() )</ID>
+    <ID>SpreadOperator:OtelKotlinTestRule.kt$OtelKotlinTestRule$( *config.logRecordProcessors.toTypedArray(), InMemoryLogRecordProcessor( logRecordExporter, scope, ), )</ID>
     <ID>SpreadOperator:OtelKotlinTestRule.kt$OtelKotlinTestRule$( InMemorySpanProcessor( spanExporter, scope, ), *config.spanProcessors.toTypedArray() )</ID>
   </CurrentIssues>
 </SmellBaseline>

--- a/integration-test/src/commonMain/kotlin/io/opentelemetry/kotlin/framework/InMemoryLogRecordExporter.kt
+++ b/integration-test/src/commonMain/kotlin/io/opentelemetry/kotlin/framework/InMemoryLogRecordExporter.kt
@@ -1,18 +1,18 @@
 package io.opentelemetry.kotlin.framework
 
 import io.opentelemetry.kotlin.export.OperationResultCode
+import io.opentelemetry.kotlin.logging.data.LogRecordData
 import io.opentelemetry.kotlin.logging.export.LogRecordExporter
-import io.opentelemetry.kotlin.logging.model.ReadableLogRecord
 import kotlin.collections.plusAssign
 
 internal class InMemoryLogRecordExporter : LogRecordExporter {
 
-    private val impl = mutableListOf<ReadableLogRecord>()
+    private val impl = mutableListOf<LogRecordData>()
 
-    val exportedLogRecords: List<ReadableLogRecord>
+    val exportedLogRecords: List<LogRecordData>
         get() = impl
 
-    override suspend fun export(telemetry: List<ReadableLogRecord>): OperationResultCode {
+    override suspend fun export(telemetry: List<LogRecordData>): OperationResultCode {
         impl += telemetry
         return OperationResultCode.Success
     }

--- a/integration-test/src/commonMain/kotlin/io/opentelemetry/kotlin/framework/InMemoryLogRecordProcessor.kt
+++ b/integration-test/src/commonMain/kotlin/io/opentelemetry/kotlin/framework/InMemoryLogRecordProcessor.kt
@@ -13,8 +13,9 @@ internal class InMemoryLogRecordProcessor(
 ) : LogRecordProcessor {
 
     override fun onEmit(log: ReadWriteLogRecord, context: Context) {
+        val data = log.toLogRecordData()
         scope.launch {
-            exporter.export(listOf(log))
+            exporter.export(listOf(data))
         }
     }
 

--- a/integration-test/src/commonMain/kotlin/io/opentelemetry/kotlin/framework/OtelKotlinTestRule.kt
+++ b/integration-test/src/commonMain/kotlin/io/opentelemetry/kotlin/framework/OtelKotlinTestRule.kt
@@ -8,8 +8,8 @@ import io.opentelemetry.kotlin.init.LoggerProviderConfigDsl
 import io.opentelemetry.kotlin.init.TracerProviderConfigDsl
 import io.opentelemetry.kotlin.logging.Logger
 import io.opentelemetry.kotlin.logging.LoggerProvider
+import io.opentelemetry.kotlin.logging.data.LogRecordData
 import io.opentelemetry.kotlin.logging.export.compositeLogRecordProcessor
-import io.opentelemetry.kotlin.logging.model.ReadableLogRecord
 import io.opentelemetry.kotlin.tracing.Tracer
 import io.opentelemetry.kotlin.tracing.TracerProvider
 import io.opentelemetry.kotlin.tracing.data.SpanData
@@ -52,12 +52,14 @@ abstract class OtelKotlinTestRule(context: TestCoroutineScheduler) {
     protected val loggerProviderConfig: LoggerProviderConfigDsl.() -> Unit = {
         config.attributes?.let { resource(config.schemaUrl, it) }
         export {
+            // the test hook is registered last so that it snapshots the log record after
+            // any other processor has had a chance to mutate it
             compositeLogRecordProcessor(
+                *config.logRecordProcessors.toTypedArray(),
                 InMemoryLogRecordProcessor(
                     logRecordExporter,
                     scope,
                 ),
-                *config.logRecordProcessors.toTypedArray()
             )
         }
         logLimits(config.logLimits)
@@ -109,13 +111,13 @@ abstract class OtelKotlinTestRule(context: TestCoroutineScheduler) {
     fun assertLogRecords(
         expectedCount: Int,
         goldenFileName: String? = null,
-        assertions: (logs: List<ReadableLogRecord>) -> Unit = {},
+        assertions: (logs: List<LogRecordData>) -> Unit = {},
     ) {
-        val observedLogRecords: List<ReadableLogRecord> = logRecordExporter.exportedLogRecords
+        val observedLogRecords: List<LogRecordData> = logRecordExporter.exportedLogRecords
         if (observedLogRecords.size != expectedCount) {
             error("Expected $expectedCount log records, but found ${observedLogRecords.size}")
         }
-        val data = observedLogRecords.map(ReadableLogRecord::toSerializable)
+        val data = observedLogRecords.map(LogRecordData::toSerializable)
         assertions(observedLogRecords)
 
         if (goldenFileName != null) {

--- a/integration-test/src/commonMain/kotlin/io/opentelemetry/kotlin/framework/serialization/conversion/SerializableLogRecordData.kt
+++ b/integration-test/src/commonMain/kotlin/io/opentelemetry/kotlin/framework/serialization/conversion/SerializableLogRecordData.kt
@@ -1,9 +1,9 @@
 package io.opentelemetry.kotlin.framework.serialization.conversion
 
 import io.opentelemetry.kotlin.framework.serialization.SerializableLogRecordData
-import io.opentelemetry.kotlin.logging.model.ReadableLogRecord
+import io.opentelemetry.kotlin.logging.data.LogRecordData
 
-fun ReadableLogRecord.toSerializable() =
+fun LogRecordData.toSerializable() =
     SerializableLogRecordData(
         resource = resource.toSerializable(),
         instrumentationScopeInfo = instrumentationScopeInfo.toSerializable(),

--- a/integration-test/src/commonTest/kotlin/io/opentelemetry/kotlin/framework/serialization/SerializableLogRecordDataTest.kt
+++ b/integration-test/src/commonTest/kotlin/io/opentelemetry/kotlin/framework/serialization/SerializableLogRecordDataTest.kt
@@ -2,7 +2,7 @@ package io.opentelemetry.kotlin.framework.serialization
 
 import io.opentelemetry.kotlin.InstrumentationScopeInfo
 import io.opentelemetry.kotlin.framework.serialization.conversion.toSerializable
-import io.opentelemetry.kotlin.logging.model.FakeReadableLogRecord
+import io.opentelemetry.kotlin.logging.data.FakeLogRecordData
 import io.opentelemetry.kotlin.resource.Resource
 import io.opentelemetry.kotlin.tracing.SpanContext
 import io.opentelemetry.kotlin.tracing.model.hex
@@ -13,7 +13,7 @@ internal class SerializableLogRecordDataTest {
 
     @Test
     fun testConversion() {
-        val fake = FakeReadableLogRecord(eventName = "event")
+        val fake = FakeLogRecordData(eventName = "event")
         val observed = fake.toSerializable()
 
         compareResource(checkNotNull(fake.resource), checkNotNull(observed.resource))

--- a/model/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/LogRecordDataImpl.kt
+++ b/model/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/LogRecordDataImpl.kt
@@ -1,0 +1,23 @@
+package io.opentelemetry.kotlin.logging
+
+import io.opentelemetry.kotlin.InstrumentationScopeInfo
+import io.opentelemetry.kotlin.logging.data.LogRecordData
+import io.opentelemetry.kotlin.resource.Resource
+import io.opentelemetry.kotlin.tracing.SpanContext
+
+/**
+ * An immutable snapshot of a log record's state.
+ */
+class LogRecordDataImpl(
+    override val timestamp: Long?,
+    override val observedTimestamp: Long?,
+    override val severityNumber: SeverityNumber?,
+    override val severityText: String?,
+    override val body: Any?,
+    override val eventName: String?,
+    override val spanContext: SpanContext,
+    override val attributes: Map<String, Any>,
+    override val resource: Resource,
+    override val instrumentationScopeInfo: InstrumentationScopeInfo,
+    override val droppedAttributesCount: Int = 0,
+) : LogRecordData

--- a/sdk-api/api/jvm/sdk-api.api
+++ b/sdk-api/api/jvm/sdk-api.api
@@ -242,6 +242,19 @@ public abstract interface class io/opentelemetry/kotlin/logging/LoggerConfigurat
 	public abstract fun loggerConfig (Lio/opentelemetry/kotlin/InstrumentationScopeInfo;)Lio/opentelemetry/kotlin/logging/LoggerConfig;
 }
 
+public abstract interface class io/opentelemetry/kotlin/logging/data/LogRecordData : io/opentelemetry/kotlin/attributes/AttributeContainer {
+	public abstract fun getBody ()Ljava/lang/Object;
+	public abstract fun getDroppedAttributesCount ()I
+	public abstract fun getEventName ()Ljava/lang/String;
+	public abstract fun getInstrumentationScopeInfo ()Lio/opentelemetry/kotlin/InstrumentationScopeInfo;
+	public abstract fun getObservedTimestamp ()Ljava/lang/Long;
+	public abstract fun getResource ()Lio/opentelemetry/kotlin/resource/Resource;
+	public abstract fun getSeverityNumber ()Lio/opentelemetry/kotlin/logging/SeverityNumber;
+	public abstract fun getSeverityText ()Ljava/lang/String;
+	public abstract fun getSpanContext ()Lio/opentelemetry/kotlin/tracing/SpanContext;
+	public abstract fun getTimestamp ()Ljava/lang/Long;
+}
+
 public abstract interface class io/opentelemetry/kotlin/logging/export/LogRecordExporter : io/opentelemetry/kotlin/export/TelemetryCloseable {
 	public abstract fun export (Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
@@ -272,17 +285,8 @@ public abstract interface class io/opentelemetry/kotlin/logging/model/ReadWriteL
 	public abstract fun setTimestamp (Ljava/lang/Long;)V
 }
 
-public abstract interface class io/opentelemetry/kotlin/logging/model/ReadableLogRecord : io/opentelemetry/kotlin/attributes/AttributeContainer {
-	public abstract fun getBody ()Ljava/lang/Object;
-	public abstract fun getDroppedAttributesCount ()I
-	public abstract fun getEventName ()Ljava/lang/String;
-	public abstract fun getInstrumentationScopeInfo ()Lio/opentelemetry/kotlin/InstrumentationScopeInfo;
-	public abstract fun getObservedTimestamp ()Ljava/lang/Long;
-	public abstract fun getResource ()Lio/opentelemetry/kotlin/resource/Resource;
-	public abstract fun getSeverityNumber ()Lio/opentelemetry/kotlin/logging/SeverityNumber;
-	public abstract fun getSeverityText ()Ljava/lang/String;
-	public abstract fun getSpanContext ()Lio/opentelemetry/kotlin/tracing/SpanContext;
-	public abstract fun getTimestamp ()Ljava/lang/Long;
+public abstract interface class io/opentelemetry/kotlin/logging/model/ReadableLogRecord : io/opentelemetry/kotlin/logging/data/LogRecordData {
+	public abstract fun toLogRecordData ()Lio/opentelemetry/kotlin/logging/data/LogRecordData;
 }
 
 public abstract interface class io/opentelemetry/kotlin/resource/MutableResource {

--- a/sdk-api/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/data/LogRecordData.kt
+++ b/sdk-api/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/data/LogRecordData.kt
@@ -1,0 +1,69 @@
+package io.opentelemetry.kotlin.logging.data
+
+import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.InstrumentationScopeInfo
+import io.opentelemetry.kotlin.attributes.AttributeContainer
+import io.opentelemetry.kotlin.logging.SeverityNumber
+import io.opentelemetry.kotlin.resource.Resource
+import io.opentelemetry.kotlin.tracing.SpanContext
+
+/**
+ * A full representation of a log record that contains all the data needed for exporting.
+ */
+@ExperimentalApi
+public interface LogRecordData : AttributeContainer {
+
+    /**
+     * The timestamp in nanoseconds at which the event occurred.
+     */
+    public val timestamp: Long?
+
+    /**
+     * The timestamp in nanoseconds at which the event was entered into the OpenTelemetry API.
+     */
+    public val observedTimestamp: Long?
+
+    /**
+     * The severity of the log.
+     */
+    public val severityNumber: SeverityNumber?
+
+    /**
+     * A string representation of the severity at the point it was captured. This can be distinct from
+     * [SeverityNumber] - for example, when capturing logs from a 3rd party library with different severity concepts.
+     */
+    public val severityText: String?
+
+    /**
+     * Contains the body of the log message.
+     *
+     * Recommended types are [String] and [io.opentelemetry.kotlin.attributes.AnyValue]. Other
+     * types are converted via toString().
+     */
+    public val body: Any?
+
+    /**
+     * Contains the event name if this is an event, otherwise null
+     */
+    public val eventName: String?
+
+    /**
+     * The span context associated with the log record
+     */
+    public val spanContext: SpanContext
+
+    /**
+     * The resource associated with the log record
+     */
+    public val resource: Resource
+
+    /**
+     * The instrumentation scope information associated with the log record
+     */
+    public val instrumentationScopeInfo: InstrumentationScopeInfo
+
+    /**
+     * The number of attributes that were dropped because the log record's attribute limit was exceeded.
+     */
+    public val droppedAttributesCount: Int
+}

--- a/sdk-api/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/LogRecordExporter.kt
+++ b/sdk-api/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/LogRecordExporter.kt
@@ -3,7 +3,7 @@ package io.opentelemetry.kotlin.logging.export
 import io.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.kotlin.export.OperationResultCode
 import io.opentelemetry.kotlin.export.TelemetryCloseable
-import io.opentelemetry.kotlin.logging.model.ReadableLogRecord
+import io.opentelemetry.kotlin.logging.data.LogRecordData
 
 /**
  * An interface for exporting logs to an arbitrary destination.
@@ -15,5 +15,5 @@ public interface LogRecordExporter : TelemetryCloseable {
      * Exports a batch of logs. This operation is considered successful if the implementation
      * returns [OperationResultCode.Success]. If the export operation fails the batch must be dropped.
      */
-    public suspend fun export(telemetry: List<ReadableLogRecord>): OperationResultCode
+    public suspend fun export(telemetry: List<LogRecordData>): OperationResultCode
 }

--- a/sdk-api/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/model/ReadableLogRecord.kt
+++ b/sdk-api/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/model/ReadableLogRecord.kt
@@ -1,11 +1,7 @@
 package io.opentelemetry.kotlin.logging.model
 
 import io.opentelemetry.kotlin.ExperimentalApi
-import io.opentelemetry.kotlin.InstrumentationScopeInfo
-import io.opentelemetry.kotlin.attributes.AttributeContainer
-import io.opentelemetry.kotlin.logging.SeverityNumber
-import io.opentelemetry.kotlin.resource.Resource
-import io.opentelemetry.kotlin.tracing.SpanContext
+import io.opentelemetry.kotlin.logging.data.LogRecordData
 
 /**
  * A read-only representation of a log record.
@@ -13,59 +9,11 @@ import io.opentelemetry.kotlin.tracing.SpanContext
  * https://opentelemetry.io/docs/specs/otel/logs/sdk/#readablelogrecord
  */
 @ExperimentalApi
-public interface ReadableLogRecord : AttributeContainer {
+public interface ReadableLogRecord : LogRecordData {
 
     /**
-     * The timestamp in nanoseconds at which the event occurred.
+     * Return an instance of the log record at the time of invocation. The implementation provided
+     * should be immutable.
      */
-    public val timestamp: Long?
-
-    /**
-     * The timestamp in nanoseconds at which the event was entered into the OpenTelemetry API.
-     */
-    public val observedTimestamp: Long?
-
-    /**
-     * The severity of the log.
-     */
-    public val severityNumber: SeverityNumber?
-
-    /**
-     * A string representation of the severity at the point it was captured. This can be distinct from
-     * [SeverityNumber] - for example, when capturing logs from a 3rd party library with different severity concepts.
-     */
-    public val severityText: String?
-
-    /**
-     * Contains the body of the log message.
-     *
-     * Recommended types are [String] and [io.opentelemetry.kotlin.attributes.AnyValue]. Other
-     * types are converted via toString().
-     */
-    public val body: Any?
-
-    /**
-     * Contains the event name if this is an event, otherwise null
-     */
-    public val eventName: String?
-
-    /**
-     * The span context associated with the log record
-     */
-    public val spanContext: SpanContext
-
-    /**
-     * The resource associated with the log record
-     */
-    public val resource: Resource
-
-    /**
-     * The instrumentation scope information associated with the log record
-     */
-    public val instrumentationScopeInfo: InstrumentationScopeInfo
-
-    /**
-     * The number of attributes that were dropped because the log record's attribute limit was exceeded.
-     */
-    public val droppedAttributesCount: Int
+    public fun toLogRecordData(): LogRecordData
 }

--- a/smoke-test/src/commonTest/kotlin/io/opentelemetry/kotlin/smoketest/FakeOtlpServer.kt
+++ b/smoke-test/src/commonTest/kotlin/io/opentelemetry/kotlin/smoketest/FakeOtlpServer.kt
@@ -5,8 +5,8 @@ import io.ktor.client.engine.mock.respond
 import io.ktor.client.engine.mock.toByteArray
 import io.ktor.http.HttpStatusCode
 import io.ktor.utils.io.ByteReadChannel
-import io.opentelemetry.kotlin.logging.export.toReadableLogRecordList
-import io.opentelemetry.kotlin.logging.model.ReadableLogRecord
+import io.opentelemetry.kotlin.logging.data.LogRecordData
+import io.opentelemetry.kotlin.logging.export.toLogRecordDataList
 import io.opentelemetry.kotlin.tracing.data.SpanData
 import io.opentelemetry.kotlin.tracing.export.toSpanDataList
 import kotlinx.coroutines.delay
@@ -21,7 +21,7 @@ import kotlin.time.TimeSource
 class FakeOtlpServer {
 
     private val spans = mutableListOf<SpanData>()
-    private val logs = mutableListOf<ReadableLogRecord>()
+    private val logs = mutableListOf<LogRecordData>()
     private val timeSource = TimeSource.Monotonic
 
     /**
@@ -33,7 +33,7 @@ class FakeOtlpServer {
 
         when {
             path.contains("/v1/traces") -> spans.addAll(body.toSpanDataList())
-            path.contains("/v1/logs") -> logs.addAll(body.toReadableLogRecordList())
+            path.contains("/v1/logs") -> logs.addAll(body.toLogRecordDataList())
             else -> error("Unsupported path: $path")
         }
 
@@ -90,8 +90,8 @@ class FakeOtlpServer {
      */
     suspend fun awaitLog(
         timeout: Duration = 5.seconds,
-        predicate: (ReadableLogRecord) -> Boolean
-    ): ReadableLogRecord = awaitTelemetry(
+        predicate: (LogRecordData) -> Boolean
+    ): LogRecordData = awaitTelemetry(
         collection = logs,
         timeout = timeout,
         predicate = predicate,
@@ -105,5 +105,5 @@ class FakeOtlpServer {
     /**
      * Returns all collected log records.
      */
-    fun getLogs(): List<ReadableLogRecord> = logs.toList()
+    fun getLogs(): List<LogRecordData> = logs.toList()
 }

--- a/test-fakes/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/FakeLogger.kt
+++ b/test-fakes/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/FakeLogger.kt
@@ -3,14 +3,14 @@ package io.opentelemetry.kotlin.logging
 import io.opentelemetry.kotlin.attributes.AttributesMutator
 import io.opentelemetry.kotlin.attributes.FakeAttributesMutator
 import io.opentelemetry.kotlin.context.Context
-import io.opentelemetry.kotlin.logging.model.FakeReadableLogRecord
+import io.opentelemetry.kotlin.logging.data.FakeLogRecordData
 
 class FakeLogger(
     val name: String,
     var enabledResult: () -> Boolean = { true },
 ) : Logger {
 
-    val logs: MutableList<FakeReadableLogRecord> = mutableListOf()
+    val logs: MutableList<FakeLogRecordData> = mutableListOf()
 
     override fun enabled(
         context: Context?,
@@ -51,7 +51,7 @@ class FakeLogger(
     ) {
         eventName.toString()
         logs.add(
-            FakeReadableLogRecord(
+            FakeLogRecordData(
                 timestamp,
                 observedTimestamp,
                 severityNumber,
@@ -59,7 +59,7 @@ class FakeLogger(
                 body,
                 eventName,
                 attributes?.let { FakeAttributesMutator().apply(it).attributes }
-                    ?: FakeReadableLogRecord().attributes,
+                    ?: FakeLogRecordData().attributes,
             )
         )
     }

--- a/test-fakes/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/data/FakeLogRecordData.kt
+++ b/test-fakes/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/data/FakeLogRecordData.kt
@@ -1,4 +1,4 @@
-package io.opentelemetry.kotlin.logging.model
+package io.opentelemetry.kotlin.logging.data
 
 import io.opentelemetry.kotlin.FakeInstrumentationScopeInfo
 import io.opentelemetry.kotlin.InstrumentationScopeInfo
@@ -6,8 +6,9 @@ import io.opentelemetry.kotlin.logging.SeverityNumber
 import io.opentelemetry.kotlin.resource.FakeResource
 import io.opentelemetry.kotlin.resource.Resource
 import io.opentelemetry.kotlin.tracing.FakeSpanContext
+import io.opentelemetry.kotlin.tracing.SpanContext
 
-class FakeReadableLogRecord(
+class FakeLogRecordData(
     override val timestamp: Long? = 1000,
     override val observedTimestamp: Long? = 2000,
     override val severityNumber: SeverityNumber? = SeverityNumber.WARN,
@@ -15,8 +16,8 @@ class FakeReadableLogRecord(
     override val body: Any? = "Hello, World!",
     override val eventName: String? = null,
     override val attributes: Map<String, Any> = mapOf("key" to "value"),
-    override val spanContext: FakeSpanContext = FakeSpanContext.INVALID,
+    override val spanContext: SpanContext = FakeSpanContext.INVALID,
     override val resource: Resource = FakeResource(),
     override val instrumentationScopeInfo: InstrumentationScopeInfo = FakeInstrumentationScopeInfo(),
     override val droppedAttributesCount: Int = 0
-) : ReadableLogRecord
+) : LogRecordData

--- a/test-fakes/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/FakeLogRecordExporter.kt
+++ b/test-fakes/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/FakeLogRecordExporter.kt
@@ -1,17 +1,17 @@
 package io.opentelemetry.kotlin.logging.export
 
 import io.opentelemetry.kotlin.export.OperationResultCode
-import io.opentelemetry.kotlin.logging.model.ReadableLogRecord
+import io.opentelemetry.kotlin.logging.data.LogRecordData
 
 class FakeLogRecordExporter(
     var flushCode: () -> OperationResultCode = { OperationResultCode.Success },
     var shutdownCode: () -> OperationResultCode = { OperationResultCode.Success },
-    var action: (telemetry: List<ReadableLogRecord>) -> OperationResultCode = { OperationResultCode.Success }
+    var action: (telemetry: List<LogRecordData>) -> OperationResultCode = { OperationResultCode.Success }
 ) : LogRecordExporter {
 
-    val logs: MutableList<ReadableLogRecord> = mutableListOf()
+    val logs: MutableList<LogRecordData> = mutableListOf()
 
-    override suspend fun export(telemetry: List<ReadableLogRecord>): OperationResultCode {
+    override suspend fun export(telemetry: List<LogRecordData>): OperationResultCode {
         logs += telemetry
         return action(telemetry)
     }

--- a/test-fakes/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/model/FakeReadWriteLogRecord.kt
+++ b/test-fakes/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/model/FakeReadWriteLogRecord.kt
@@ -4,6 +4,8 @@ import io.opentelemetry.kotlin.FakeInstrumentationScopeInfo
 import io.opentelemetry.kotlin.InstrumentationScopeInfo
 import io.opentelemetry.kotlin.attributes.AnyValue
 import io.opentelemetry.kotlin.logging.SeverityNumber
+import io.opentelemetry.kotlin.logging.data.FakeLogRecordData
+import io.opentelemetry.kotlin.logging.data.LogRecordData
 import io.opentelemetry.kotlin.resource.FakeResource
 import io.opentelemetry.kotlin.resource.Resource
 import io.opentelemetry.kotlin.tracing.FakeSpanContext
@@ -65,4 +67,18 @@ class FakeReadWriteLogRecord(
 
     override fun setAnyValueAttribute(key: String, value: AnyValue) {
     }
+
+    override fun toLogRecordData(): LogRecordData = FakeLogRecordData(
+        timestamp = timestamp,
+        observedTimestamp = observedTimestamp,
+        severityNumber = severityNumber,
+        severityText = severityText,
+        body = body,
+        eventName = eventName,
+        attributes = attributes,
+        spanContext = spanContext,
+        resource = resource,
+        instrumentationScopeInfo = instrumentationScopeInfo,
+        droppedAttributesCount = droppedAttributesCount
+    )
 }


### PR DESCRIPTION
## Goal

Takes a similar approach to #816 by taking an immutable copy of the `LogRecord` when sending it to an exporter. This releases unused references on the `LogRecordModel`.

Closes #787