### PR TITLE
Implement log limits behavior

### DIFF
--- a/behavior/src/commonMain/kotlin/io/opentelemetry/kotlin/behavior/LogLimitsBehavior.kt
+++ b/behavior/src/commonMain/kotlin/io/opentelemetry/kotlin/behavior/LogLimitsBehavior.kt
@@ -1,0 +1,28 @@
+package io.opentelemetry.kotlin.behavior
+
+import io.opentelemetry.kotlin.ExperimentalApi
+
+/**
+ * Limits on log record data capture.
+ *
+ * https://opentelemetry.io/docs/specs/otel/logs/sdk/#logrecord-limits
+ */
+@ExperimentalApi
+data class LogLimitsBehavior(
+
+    /**
+     * Maximum number of attributes that may be recorded on a log record.
+     */
+    val attributeCountLimit: Int? = null,
+
+    /**
+     * Maximum length of a recorded attribute value.
+     */
+    val attributeValueLengthLimit: Int? = null,
+) : Behavior<LogLimitsBehavior> {
+
+    override fun mergeWith(higher: LogLimitsBehavior): LogLimitsBehavior = copy(
+        attributeCountLimit = higher.attributeCountLimit ?: attributeCountLimit,
+        attributeValueLengthLimit = higher.attributeValueLengthLimit ?: attributeValueLengthLimit,
+    )
+}

--- a/behavior/src/commonMain/kotlin/io/opentelemetry/kotlin/behavior/LoggerProviderBehavior.kt
+++ b/behavior/src/commonMain/kotlin/io/opentelemetry/kotlin/behavior/LoggerProviderBehavior.kt
@@ -1,0 +1,22 @@
+package io.opentelemetry.kotlin.behavior
+
+import io.opentelemetry.kotlin.ExperimentalApi
+
+/**
+ * Behavior of logging.
+ *
+ * https://opentelemetry.io/docs/specs/otel/logs/sdk/#loggerprovider
+ */
+@ExperimentalApi
+data class LoggerProviderBehavior(
+
+    /**
+     * Limits on log record data capture.
+     */
+    val logLimits: LogLimitsBehavior? = null,
+) : Behavior<LoggerProviderBehavior> {
+
+    override fun mergeWith(higher: LoggerProviderBehavior): LoggerProviderBehavior = copy(
+        logLimits = mergeNode(logLimits, higher.logLimits),
+    )
+}

--- a/behavior/src/commonMain/kotlin/io/opentelemetry/kotlin/behavior/OpenTelemetryBehavior.kt
+++ b/behavior/src/commonMain/kotlin/io/opentelemetry/kotlin/behavior/OpenTelemetryBehavior.kt
@@ -10,10 +10,12 @@ import io.opentelemetry.kotlin.ExperimentalApi
 @ExperimentalApi
 data class OpenTelemetryBehavior(
     val tracerProvider: TracerProviderBehavior? = null,
+    val loggerProvider: LoggerProviderBehavior? = null,
 ) : Behavior<OpenTelemetryBehavior> {
 
     override fun mergeWith(higher: OpenTelemetryBehavior): OpenTelemetryBehavior = copy(
         tracerProvider = mergeNode(tracerProvider, higher.tracerProvider),
+        loggerProvider = mergeNode(loggerProvider, higher.loggerProvider),
     )
 }
 

--- a/behavior/src/commonTest/kotlin/io/opentelemetry/kotlin/behavior/BehaviorResolverImplTest.kt
+++ b/behavior/src/commonTest/kotlin/io/opentelemetry/kotlin/behavior/BehaviorResolverImplTest.kt
@@ -14,6 +14,7 @@ internal class BehaviorResolverImplTest {
 
         assertEquals(OpenTelemetryBehavior(), resolved)
         assertNull(resolved.tracerProvider)
+        assertNull(resolved.loggerProvider)
     }
 
     @Test
@@ -103,6 +104,21 @@ internal class BehaviorResolverImplTest {
         assertEquals(0, limits?.linkCountLimit)
     }
 
+    @Test
+    fun dslOverridesEnvarsForLogLimits() {
+        val resolved = resolver.resolve(
+            envars = configWithLogLimits(
+                LogLimitsBehavior(attributeCountLimit = 5, attributeValueLengthLimit = 6),
+            ),
+            declarativeFile = null,
+            dsl = configWithLogLimits(LogLimitsBehavior(attributeCountLimit = 50)),
+        )
+
+        val limits = resolved.loggerProvider?.logLimits
+        assertEquals(50, limits?.attributeCountLimit)
+        assertEquals(6, limits?.attributeValueLengthLimit)
+    }
+
     private fun resolveSpanLimits(
         envars: OpenTelemetryBehavior? = null,
         declarativeFile: OpenTelemetryBehavior? = null,
@@ -111,4 +127,7 @@ internal class BehaviorResolverImplTest {
 
     private fun configWithSpanLimits(spanLimits: SpanLimitsBehavior) =
         OpenTelemetryBehavior(tracerProvider = TracerProviderBehavior(spanLimits = spanLimits))
+
+    private fun configWithLogLimits(logLimits: LogLimitsBehavior) =
+        OpenTelemetryBehavior(loggerProvider = LoggerProviderBehavior(logLimits = logLimits))
 }

--- a/behavior/src/commonTest/kotlin/io/opentelemetry/kotlin/behavior/LogLimitsBehaviorTest.kt
+++ b/behavior/src/commonTest/kotlin/io/opentelemetry/kotlin/behavior/LogLimitsBehaviorTest.kt
@@ -1,0 +1,33 @@
+package io.opentelemetry.kotlin.behavior
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+internal class LogLimitsBehaviorTest {
+
+    @Test
+    fun everyFieldStartsUnset() {
+        val behavior = LogLimitsBehavior()
+
+        assertNull(behavior.attributeCountLimit)
+        assertNull(behavior.attributeValueLengthLimit)
+    }
+
+    @Test
+    fun higherLayerWinsAndLowerFillsTheGaps() {
+        val merged = LogLimitsBehavior(attributeCountLimit = 1, attributeValueLengthLimit = 2)
+            .mergeWith(LogLimitsBehavior(attributeValueLengthLimit = 99))
+
+        assertEquals(1, merged.attributeCountLimit)
+        assertEquals(99, merged.attributeValueLengthLimit)
+    }
+
+    @Test
+    fun treatsZeroAsAConfiguredValue() {
+        val merged = LogLimitsBehavior(attributeCountLimit = 128)
+            .mergeWith(LogLimitsBehavior(attributeCountLimit = 0))
+
+        assertEquals(0, merged.attributeCountLimit)
+    }
+}

--- a/behavior/src/commonTest/kotlin/io/opentelemetry/kotlin/behavior/LoggerProviderBehaviorTest.kt
+++ b/behavior/src/commonTest/kotlin/io/opentelemetry/kotlin/behavior/LoggerProviderBehaviorTest.kt
@@ -1,0 +1,25 @@
+package io.opentelemetry.kotlin.behavior
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+internal class LoggerProviderBehaviorTest {
+
+    @Test
+    fun logLimitsStartUnset() {
+        assertNull(LoggerProviderBehavior().logLimits)
+    }
+
+    @Test
+    fun mergesLogLimitsWhenBothLayersSuppliedThem() {
+        val merged = LoggerProviderBehavior(
+            logLimits = LogLimitsBehavior(attributeCountLimit = 1, attributeValueLengthLimit = 3),
+        ).mergeWith(
+            LoggerProviderBehavior(logLimits = LogLimitsBehavior(attributeValueLengthLimit = 99)),
+        )
+
+        assertEquals(1, merged.logLimits?.attributeCountLimit)
+        assertEquals(99, merged.logLimits?.attributeValueLengthLimit)
+    }
+}

--- a/behavior/src/commonTest/kotlin/io/opentelemetry/kotlin/behavior/OpenTelemetryBehaviorTest.kt
+++ b/behavior/src/commonTest/kotlin/io/opentelemetry/kotlin/behavior/OpenTelemetryBehaviorTest.kt
@@ -8,7 +8,10 @@ internal class OpenTelemetryBehaviorTest {
 
     @Test
     fun everyFieldStartsUnset() {
-        assertNull(OpenTelemetryBehavior().tracerProvider)
+        val behavior = OpenTelemetryBehavior()
+
+        assertNull(behavior.tracerProvider)
+        assertNull(behavior.loggerProvider)
     }
 
     @Test
@@ -51,6 +54,21 @@ internal class OpenTelemetryBehaviorTest {
 
         assertEquals(1, merged.tracerProvider?.spanLimits?.attributeCountLimit)
         assertEquals(99, merged.tracerProvider?.spanLimits?.eventCountLimit)
+    }
+
+    @Test
+    fun mergesTracingAndLoggingBranchesIndependently() {
+        val tracing = OpenTelemetryBehavior(
+            tracerProvider = TracerProviderBehavior(spanLimits = SpanLimitsBehavior(linkCountLimit = 3)),
+        )
+        val logging = OpenTelemetryBehavior(
+            loggerProvider = LoggerProviderBehavior(logLimits = LogLimitsBehavior(attributeCountLimit = 7)),
+        )
+
+        val merged = tracing.mergeWith(logging)
+
+        assertEquals(3, merged.tracerProvider?.spanLimits?.linkCountLimit)
+        assertEquals(7, merged.loggerProvider?.logLimits?.attributeCountLimit)
     }
 
     @Test

--- a/config-yaml/src/commonTest/kotlin/io/opentelemetry/kotlin/config/yaml/OpenTelemetryConfigurationParserTest.kt
+++ b/config-yaml/src/commonTest/kotlin/io/opentelemetry/kotlin/config/yaml/OpenTelemetryConfigurationParserTest.kt
@@ -2,6 +2,8 @@ package io.opentelemetry.kotlin.config.yaml
 
 import io.opentelemetry.kotlin.config.schema.model.AttributeNameValue
 import io.opentelemetry.kotlin.config.schema.model.AttributeType
+import io.opentelemetry.kotlin.config.schema.model.LogRecordLimits
+import io.opentelemetry.kotlin.config.schema.model.LoggerProvider
 import io.opentelemetry.kotlin.config.schema.model.OpenTelemetryConfiguration
 import io.opentelemetry.kotlin.config.schema.model.Resource
 import io.opentelemetry.kotlin.config.schema.model.SeverityNumber
@@ -17,6 +19,7 @@ import okio.fakefilesystem.FakeFileSystem
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
 
 @OptIn(ExperimentalSerializationApi::class)
 internal class OpenTelemetryConfigurationParserTest {
@@ -40,6 +43,13 @@ internal class OpenTelemetryConfigurationParserTest {
                 schemaUrl = "https://opentelemetry.io/schemas/1.37.0",
                 attributesList = "service.namespace=demo,service.version=1.0.0",
             ),
+            loggerProvider = LoggerProvider(
+                processors = emptyList(),
+                limits = LogRecordLimits(
+                    attributeValueLengthLimit = 256,
+                    attributeCountLimit = 64,
+                ),
+            ),
             tracerProvider = TracerProvider(
                 processors = emptyList(),
                 limits = SpanLimits(attributeCountLimit = 128, eventCountLimit = 64),
@@ -59,6 +69,27 @@ internal class OpenTelemetryConfigurationParserTest {
             OpenTelemetryConfiguration(fileFormat = "1.0"),
             parser.parse(fileSystem, path),
         )
+    }
+
+    @Test
+    fun loggerProviderLimitsMayBeOmitted() {
+        val yaml = "$MINIMAL_DOCUMENT\nlogger_provider:\n  processors: []"
+
+        val config = parser.parse(yaml)
+
+        assertEquals(LoggerProvider(processors = emptyList()), config.loggerProvider)
+        assertNull(config.loggerProvider?.limits)
+    }
+
+    @Test
+    fun logRecordLimitFieldsMayBeOmitted() {
+        val yaml = "$MINIMAL_DOCUMENT\nlogger_provider:\n  processors: []\n  limits: {}"
+
+        val limits = parser.parse(yaml).loggerProvider?.limits
+
+        assertEquals(LogRecordLimits(), limits)
+        assertNull(limits?.attributeCountLimit)
+        assertNull(limits?.attributeValueLengthLimit)
     }
 
     @Test

--- a/config-yaml/src/commonTest/resources/minimal_config.yaml
+++ b/config-yaml/src/commonTest/resources/minimal_config.yaml
@@ -8,6 +8,11 @@ resource:
     - name: service.name
       value: unknown_service
       type: string
+logger_provider:
+  processors: []
+  limits:
+    attribute_count_limit: 64
+    attribute_value_length_limit: 256
 tracer_provider:
   processors: []
   limits:

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/config/envar/logging/LogLimitEnvVarConfigProcessorImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/config/envar/logging/LogLimitEnvVarConfigProcessorImpl.kt
@@ -11,7 +11,7 @@ import io.opentelemetry.kotlin.init.config.LogLimitConfig
 internal class LogLimitEnvVarConfigProcessorImpl(
     override val envVars: List<EnvVarName>
 ) : LogLimitEnvVarConfigProcessor() {
-    override fun parse(rawValue: String?): Int? = rawValue?.toInt()
+    override fun parse(rawValue: String?): Int? = rawValue?.toIntOrNull()?.takeIf { it >= 0 }
 
     override fun process(
         entries: Map<EnvVarName, EnvironmentVariable<Int>>,

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/config/envar/logging/LogLimitEnvVarConfigProcessorImplTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/config/envar/logging/LogLimitEnvVarConfigProcessorImplTest.kt
@@ -93,11 +93,44 @@ internal class LogLimitEnvVarConfigProcessorImplTest {
         assertEquals(128, config.attributeCountLimit)
     }
 
+    @Test
+    fun `should preserve defaults for invalid environment variables`() {
+        val processor = LogLimitEnvVarConfigProcessorImpl(
+            envVars = EnvVarConstants.LogLimits.envVars
+        )
+        val clock = FakeClock()
+        val otelConfig = OpenTelemetryConfigImpl(clock)
+        otelConfig.loggerProvider {
+            export { FakeLogRecordProcessor() }
+        }
+        val defaultValue = otelConfig.generateLoggingConfig().logLimits
+
+        INVALID_VALUES.forEach { rawValue ->
+            val config = processor.configure(defaultValue = defaultValue) { rawValue }
+
+            assertEquals(
+                Int.MAX_VALUE,
+                config.attributeValueLengthLimit,
+                "<$rawValue> should not override the default",
+            )
+            assertEquals(
+                128,
+                config.attributeCountLimit,
+                "<$rawValue> should not override the default",
+            )
+        }
+    }
+
     private fun getFakeEnvVarValue(envVar: String): String {
         return when (envVar) {
             "OTEL_LOGRECORD_ATTRIBUTE_COUNT_LIMIT" -> "1"
             "OTEL_LOGRECORD_ATTRIBUTE_VALUE_LENGTH_LIMIT" -> "2"
             else -> "-1"
         }
+    }
+
+    private companion object {
+        /** Non-numeric, empty, negative, and greater than [Int.MAX_VALUE]. */
+        val INVALID_VALUES = listOf("invalid", "", "-1", "2147483648")
     }
 }


### PR DESCRIPTION
## Goal

Implements a behavior class for log limits. This is not currently hooked up to the SDK but will be used to drive its behavior with resolved config.
