### PR TITLE
Address IndexOutOfBoundsException in protobuf deserialization

### DIFF
--- a/exporters-protobuf/build.gradle.kts
+++ b/exporters-protobuf/build.gradle.kts
@@ -51,6 +51,7 @@ kotlin {
         val commonMain by getting {
             dependencies {
                 implementation(project(":sdk-api"))
+                implementation(project(":sdk-common"))
                 implementation(project(":api-ext"))
                 implementation(libs.wire.runtime)
             }

--- a/exporters-protobuf/src/commonMain/kotlin/io/opentelemetry/kotlin/export/conversion/CommonProtobufConversion.kt
+++ b/exporters-protobuf/src/commonMain/kotlin/io/opentelemetry/kotlin/export/conversion/CommonProtobufConversion.kt
@@ -2,6 +2,7 @@ package io.opentelemetry.kotlin.export.conversion
 
 import io.opentelemetry.kotlin.InstrumentationScopeInfo
 import io.opentelemetry.kotlin.factory.toHexString
+import io.opentelemetry.kotlin.propagation.W3CTraceStateCodec
 import io.opentelemetry.kotlin.resource.MutableResource
 import io.opentelemetry.kotlin.resource.Resource
 import io.opentelemetry.kotlin.tracing.SpanContext
@@ -33,8 +34,7 @@ internal fun io.opentelemetry.proto.resource.v1.Resource.toResource(): Resource 
 
 internal fun TraceFlags.toFlagsInt(): Int = hex.toInt(16)
 
-internal fun TraceState.toW3CString(): String =
-    asMap().entries.joinToString(",") { "${it.key}=${it.value}" }
+internal fun TraceState.toW3CString(): String = W3CTraceStateCodec.encode(asMap())
 
 private class DeserializedInstrumentationScopeInfo(
     override val name: String,
@@ -68,21 +68,14 @@ internal class DeserializedSpanContext(
     override val spanId: String by lazy { spanIdBytes.toHexString() }
     override val traceFlags: TraceFlags = DeserializedTraceFlags(flags and 0xFF)
     override val isValid: Boolean by lazy { traceId != "0".repeat(32) && spanId != "0".repeat(16) }
-    override val traceState: TraceState = parseTraceState(traceStateString)
+    override val traceState: TraceState by lazy {
+        DeserializedTraceState(W3CTraceStateCodec.decode(traceStateString))
+    }
 }
 
 private class DeserializedTraceFlags(private val value: Int) : TraceFlags {
     override val isSampled: Boolean = (value and 0x01) != 0
     override val isRandom: Boolean = (value and 0x02) != 0
-}
-
-private fun parseTraceState(traceStateString: String): TraceState {
-    if (traceStateString.isEmpty()) return DeserializedTraceState(emptyMap())
-    val map = traceStateString.split(",").associate { entry ->
-        val parts = entry.split("=", limit = 2)
-        parts[0] to parts[1]
-    }
-    return DeserializedTraceState(map)
 }
 
 private class DeserializedTraceState(private val entries: Map<String, String>) : TraceState {

--- a/exporters-protobuf/src/commonTest/kotlin/io/opentelemetry/kotlin/export/conversion/CommonProtobufConversionTest.kt
+++ b/exporters-protobuf/src/commonTest/kotlin/io/opentelemetry/kotlin/export/conversion/CommonProtobufConversionTest.kt
@@ -182,6 +182,36 @@ class CommonProtobufConversionTest {
     }
 
     @Test
+    fun testDeserializedSpanContext_malformedTraceState() {
+        val context = DeserializedSpanContext(
+            traceIdBytes = "12345678901234567890123456789012".hexToByteArray(),
+            spanIdBytes = "1234567890123456".hexToByteArray(),
+            traceStateString = "foo=bar,nokey,baz=qux"
+        )
+        assertEquals(mapOf("foo" to "bar", "baz" to "qux"), context.traceState.asMap())
+    }
+
+    @Test
+    fun testDeserializedSpanContext_traceStateWithTrailingSeparator() {
+        val context = DeserializedSpanContext(
+            traceIdBytes = "12345678901234567890123456789012".hexToByteArray(),
+            spanIdBytes = "1234567890123456".hexToByteArray(),
+            traceStateString = "foo=bar,"
+        )
+        assertEquals(mapOf("foo" to "bar"), context.traceState.asMap())
+    }
+
+    @Test
+    fun testDeserializedSpanContext_traceStateOfOnlySeparators() {
+        val context = DeserializedSpanContext(
+            traceIdBytes = "12345678901234567890123456789012".hexToByteArray(),
+            spanIdBytes = "1234567890123456".hexToByteArray(),
+            traceStateString = ",,,"
+        )
+        assertEquals(0, context.traceState.asMap().size)
+    }
+
+    @Test
     fun testDeserializedTraceFlags_sampled() {
         val context = DeserializedSpanContext(
             traceIdBytes = "12345678901234567890123456789012".hexToByteArray(),

--- a/exporters-protobuf/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/export/SpanDataProtobufConversionTest.kt
+++ b/exporters-protobuf/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/export/SpanDataProtobufConversionTest.kt
@@ -8,7 +8,6 @@ import io.opentelemetry.kotlin.resource.FakeResource
 import io.opentelemetry.kotlin.tracing.FakeSpanContext
 import io.opentelemetry.kotlin.tracing.FakeTraceFlags
 import io.opentelemetry.kotlin.tracing.FakeTraceState
-import io.opentelemetry.kotlin.tracing.SpanContext
 import io.opentelemetry.kotlin.tracing.SpanKind
 import io.opentelemetry.kotlin.tracing.data.FakeSpanEventData
 import io.opentelemetry.kotlin.tracing.data.FakeSpanLinkData
@@ -222,12 +221,9 @@ class SpanDataProtobufConversionTest {
             val proto = linksList[index]
             assertEquals(link.spanContext.traceId, proto.trace_id.toByteArray().toHexString())
             assertEquals(link.spanContext.spanId, proto.span_id.toByteArray().toHexString())
-            assertEquals(expectedTraceState(link.spanContext), proto.trace_state)
+            assertEquals("foo=bar", proto.trace_state)
             assertEquals(expectedFlags, proto.flags)
             assertAttributesMatch(link.attributes, proto.attributes)
         }
     }
-
-    private fun expectedTraceState(spanContext: SpanContext) =
-        spanContext.traceState.asMap().entries.joinToString(",") { "${it.key}=${it.value}" }
 }

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/propagation/TraceStateMarshaller.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/propagation/TraceStateMarshaller.kt
@@ -16,52 +16,18 @@ internal class TraceStateMarshaller(internal val traceState: TraceState) {
         traceState.asMap()
     }
 
-    fun encode(): String = buildString {
-        state.forEach {
-            if (isNotEmpty()) {
-                append(LIST_MEMBER_SEPARATOR)
-            }
-            append(it.key)
-            append(KEY_VALUE_SEPARATOR)
-            append(it.value)
-        }
-    }
+    fun encode(): String = W3CTraceStateCodec.encode(state)
 
     companion object {
-        private const val LIST_MEMBER_SEPARATOR = ','
-        private const val KEY_VALUE_SEPARATOR = '='
-        private const val OWS_SPACE = ' '
-        private const val OWS_HTAB = '\t'
-
         fun decode(header: String, traceStateFactory: TraceStateFactory): TraceStateMarshaller {
             var state = traceStateFactory.default
-            val seen = mutableSetOf<String>()
-            val split = header.split(LIST_MEMBER_SEPARATOR)
-            split.forEach { raw ->
-                val parsed = parseMember(raw, seen) ?: return@forEach
-                val (key, value) = parsed
+            W3CTraceStateCodec.decode(header).forEach { (key, value) ->
                 val next = state.put(key, value)
                 if (next.get(key) == value) {
                     state = next
                 }
             }
             return TraceStateMarshaller(state)
-        }
-
-        private fun parseMember(raw: String, seen: MutableSet<String>): Pair<String, String>? {
-            val member = raw.trim(OWS_SPACE, OWS_HTAB)
-            if (member.isEmpty()) {
-                return null
-            }
-            val eq = member.indexOf(KEY_VALUE_SEPARATOR)
-            if (eq <= 0 || eq == member.length - 1) {
-                return null
-            }
-            val key = member.substring(0, eq)
-            if (!seen.add(key)) {
-                return null
-            }
-            return key to member.substring(eq + 1)
         }
     }
 }

--- a/sdk-common/api/jvm/sdk-common.api
+++ b/sdk-common/api/jvm/sdk-common.api
@@ -62,6 +62,12 @@ public final class io/opentelemetry/kotlin/export/TimeoutOperationKt {
 	public static final fun runWithTimeout (JLkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
+public final class io/opentelemetry/kotlin/propagation/W3CTraceStateCodec {
+	public static final field INSTANCE Lio/opentelemetry/kotlin/propagation/W3CTraceStateCodec;
+	public final fun decode (Ljava/lang/String;)Ljava/util/Map;
+	public final fun encode (Ljava/util/Map;)Ljava/lang/String;
+}
+
 public final class io/opentelemetry/kotlin/resource/ResourceDetectionKt {
 	public static final fun detectResource (Ljava/util/List;Lio/opentelemetry/kotlin/factory/ResourceFactory;Lio/opentelemetry/kotlin/error/SdkErrorHandler;)Lio/opentelemetry/kotlin/resource/Resource;
 }

--- a/sdk-common/src/commonMain/kotlin/io/opentelemetry/kotlin/propagation/W3CTraceStateCodec.kt
+++ b/sdk-common/src/commonMain/kotlin/io/opentelemetry/kotlin/propagation/W3CTraceStateCodec.kt
@@ -1,0 +1,57 @@
+package io.opentelemetry.kotlin.propagation
+
+/**
+ * Codec for the list format used by the W3C `tracestate` header.
+ *
+ * https://www.w3.org/TR/trace-context-2/#tracestate-header
+ *
+ * This handles the structure of the list only: splitting on the list-member separator, trimming
+ * optional whitespace, and locating the key/value separator. Validating the characters of a key or
+ * value, and capping the number of entries, is the responsibility of the `TraceState`
+ * implementation.
+ */
+public object W3CTraceStateCodec {
+
+    private const val LIST_MEMBER_SEPARATOR = ','
+    private const val KEY_VALUE_SEPARATOR = '='
+    private const val OWS_SPACE = ' '
+    private const val OWS_HTAB = '\t'
+
+    /**
+     * Encodes [entries] as a `tracestate` header value, preserving iteration order.
+     */
+    public fun encode(entries: Map<String, String>): String = buildString {
+        entries.forEach {
+            if (isNotEmpty()) {
+                append(LIST_MEMBER_SEPARATOR)
+            }
+            append(it.key)
+            append(KEY_VALUE_SEPARATOR)
+            append(it.value)
+        }
+    }
+
+    /**
+     * Decodes a `tracestate` header value into its entries, preserving the order in which they
+     * appear in [header].
+     *
+     * Malformed list members are skipped rather than failing the whole header, and where a key is
+     * repeated the first occurrence wins. This never throws.
+     */
+    public fun decode(header: String): Map<String, String> {
+        val entries = mutableMapOf<String, String>()
+        header.split(LIST_MEMBER_SEPARATOR).forEach { raw ->
+            val member = raw.trim(OWS_SPACE, OWS_HTAB)
+            val eq = member.indexOf(KEY_VALUE_SEPARATOR)
+            if (eq <= 0 || eq == member.length - 1) {
+                // skip empty/invalid members
+                return@forEach
+            }
+            val key = member.substring(0, eq)
+            if (!entries.containsKey(key)) {
+                entries[key] = member.substring(eq + 1)
+            }
+        }
+        return entries
+    }
+}

--- a/sdk-common/src/commonTest/kotlin/io/opentelemetry/kotlin/propagation/W3CTraceStateCodecTest.kt
+++ b/sdk-common/src/commonTest/kotlin/io/opentelemetry/kotlin/propagation/W3CTraceStateCodecTest.kt
@@ -1,0 +1,118 @@
+package io.opentelemetry.kotlin.propagation
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Asserts the structure of the W3C `tracestate` list format:
+ * https://www.w3.org/TR/trace-context-2/#tracestate-header
+ */
+internal class W3CTraceStateCodecTest {
+
+    @Test
+    fun testEncodeSingleListMember() {
+        assertEquals("foo=bar", W3CTraceStateCodec.encode(mapOf("foo" to "bar")))
+    }
+
+    @Test
+    fun testEncodeJoinsListMembersPreservingOrder() {
+        val entries = linkedMapOf("foo" to "1", "bar" to "2", "baz" to "3")
+        assertEquals("foo=1,bar=2,baz=3", W3CTraceStateCodec.encode(entries))
+    }
+
+    @Test
+    fun testEncodeEmptyEntries() {
+        assertEquals("", W3CTraceStateCodec.encode(emptyMap()))
+    }
+
+    @Test
+    fun testEncodeMultiTenantKey() {
+        val encoded = W3CTraceStateCodec.encode(mapOf("tenant@vendor" to "value"))
+        assertEquals("tenant@vendor=value", encoded)
+    }
+
+    @Test
+    fun testDecodeSingleListMember() {
+        assertEquals(mapOf("foo" to "bar"), W3CTraceStateCodec.decode("foo=bar"))
+    }
+
+    @Test
+    fun testDecodeMultipleListMembersPreservingOrder() {
+        val decoded = W3CTraceStateCodec.decode("foo=1,bar=2,baz=3")
+        assertEquals(listOf("foo", "bar", "baz"), decoded.keys.toList())
+        assertEquals(mapOf("foo" to "1", "bar" to "2", "baz" to "3"), decoded)
+    }
+
+    @Test
+    fun testDecodeMultiTenantKey() {
+        assertEquals(mapOf("tenant@vendor" to "value"), W3CTraceStateCodec.decode("tenant@vendor=value"))
+    }
+
+    @Test
+    fun testDecodeEmptyHeader() {
+        assertEquals(emptyMap(), W3CTraceStateCodec.decode(""))
+    }
+
+    @Test
+    fun testDecodeHeaderOfOnlyCommas() {
+        assertEquals(emptyMap(), W3CTraceStateCodec.decode(","))
+        assertEquals(emptyMap(), W3CTraceStateCodec.decode(",,,"))
+    }
+
+    @Test
+    fun testDecodeHeaderOfOnlyWhitespace() {
+        assertEquals(emptyMap(), W3CTraceStateCodec.decode("   \t  "))
+    }
+
+    @Test
+    fun testDecodeTrimsSurroundingWhitespace() {
+        val decoded = W3CTraceStateCodec.decode(" foo=bar ,\tbaz=qux\t")
+        assertEquals(mapOf("foo" to "bar", "baz" to "qux"), decoded)
+    }
+
+    @Test
+    fun testDecodeSkipsEmptyListMembers() {
+        assertEquals(mapOf("foo" to "bar", "baz" to "qux"), W3CTraceStateCodec.decode("foo=bar,,baz=qux"))
+    }
+
+    @Test
+    fun testDecodeSkipsMemberLackingEqualsSign() {
+        assertEquals(emptyMap(), W3CTraceStateCodec.decode("nokey"))
+        assertEquals(mapOf("foo" to "bar"), W3CTraceStateCodec.decode("foo=bar,nokey"))
+        assertEquals(
+            mapOf("foo" to "bar", "baz" to "qux"),
+            W3CTraceStateCodec.decode("foo=bar,nokey,baz=qux")
+        )
+    }
+
+    @Test
+    fun testDecodeSkipsTrailingListMemberSeparator() {
+        assertEquals(mapOf("a" to "1"), W3CTraceStateCodec.decode("a=1,"))
+    }
+
+    @Test
+    fun testDecodeSkipsMemberWithEmptyKey() {
+        assertEquals(mapOf("foo" to "bar"), W3CTraceStateCodec.decode("=value,foo=bar"))
+    }
+
+    @Test
+    fun testDecodeSkipsMemberWithEmptyValue() {
+        assertEquals(mapOf("bar" to "baz"), W3CTraceStateCodec.decode("foo=,bar=baz"))
+    }
+
+    @Test
+    fun testDecodeSplitsOnTheFirstEqualsSign() {
+        assertEquals(mapOf("k" to "v=w"), W3CTraceStateCodec.decode("k=v=w"))
+    }
+
+    @Test
+    fun testDecodeKeepsFirstOccurrenceOfDuplicateKey() {
+        assertEquals(mapOf("a" to "1"), W3CTraceStateCodec.decode("a=1,a=2"))
+    }
+
+    @Test
+    fun testDecodeThenEncodeRoundTrips() {
+        val header = "foo=1,bar=2,baz=3"
+        assertEquals(header, W3CTraceStateCodec.encode(W3CTraceStateCodec.decode(header)))
+    }
+}


### PR DESCRIPTION
## Goal

Partially addresses #786 by catching an `IndexOutOfBoundsException` if a trace state entry doesn't have an `=` sign. The fix involved consolidation as trace state was handled differently in two different parts of the SDK.
