### PR TITLE
Improve batch processor

### DIFF
--- a/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/export/BatchTelemetryProcessor.kt
+++ b/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/export/BatchTelemetryProcessor.kt
@@ -21,7 +21,7 @@ internal class BatchTelemetryProcessor<T>(
     private val scope =
         CoroutineScope(SupervisorJob() + dispatcher + telemetryExceptionHandler("Batch processor"))
     private val mutex = Mutex()
-    private val queue = mutableListOf<T>()
+    private val queue = ArrayDeque<T>()
 
     init {
         scope.launch {
@@ -34,7 +34,7 @@ internal class BatchTelemetryProcessor<T>(
 
     fun processTelemetry(telemetry: T) {
         shutdownState.execute {
-            if (queue.size <= config.maxQueueSize) {
+            if (queue.size < config.maxQueueSize) {
                 queue.add(telemetry)
             }
         }
@@ -57,21 +57,22 @@ internal class BatchTelemetryProcessor<T>(
         }
 
     private suspend fun flushInternal() {
-        while (queue.isNotEmpty()) {
-            val batch = mutableListOf<T>()
-            mutex.withLock {
+        while (true) {
+            val batch = mutex.withLock {
                 val size = minOf(queue.size, config.maxExportBatchSize)
-                repeat(size) { batch += queue.removeAt(0) }
+                List(size) { queue.removeFirst() }
             }
 
-            if (batch.isNotEmpty()) {
-                try {
-                    withTimeout(config.exportTimeoutMs) {
-                        exportAction(batch)
-                    }
-                } catch (ignored: Throwable) {
-                    // drop, continue as normal.
+            if (batch.isEmpty()) {
+                return
+            }
+
+            try {
+                withTimeout(config.exportTimeoutMs) {
+                    exportAction(batch)
                 }
+            } catch (ignored: Throwable) {
+                // drop, continue as normal.
             }
         }
     }

--- a/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/export/BatchTelemetryProcessorTest.kt
+++ b/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/export/BatchTelemetryProcessorTest.kt
@@ -11,7 +11,6 @@ import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertTrue
 
 @OptIn(ExperimentalApi::class, ExperimentalCoroutinesApi::class)
 internal class BatchTelemetryProcessorTest {
@@ -111,12 +110,19 @@ internal class BatchTelemetryProcessorTest {
 
     @Test
     fun testQueueSaturation() = runTest {
-        val sendAttempts = 1000
         val exports = assertTelemetryBatched(
-            telemetry = (0..sendAttempts).toList()
+            telemetry = (0..1000).toList()
         )
-        val sent = exports.flatten()
-        assertTrue(sent.size < sendAttempts)
+        assertEquals((0..19).toList(), exports.flatten())
+    }
+
+    @Test
+    fun testZeroQueueSizeDropsAllTelemetry() = runTest {
+        val exports = assertTelemetryBatched(
+            telemetry = listOf(1, 2, 3),
+            maxQueueSize = 0,
+        )
+        assertEquals(emptyList(), exports)
     }
 
     @Test
@@ -153,13 +159,14 @@ internal class BatchTelemetryProcessorTest {
         telemetry: List<T>,
         batchSize: Int = 3,
         exportTimeoutMs: Long = 1000,
+        maxQueueSize: Int = 20,
         exportAction: suspend (telemetry: List<T>) -> Unit = {},
     ): List<List<T>> {
         val exports = mutableListOf<List<T>>()
         val dispatcher = StandardTestDispatcher(testScheduler)
         val processor = BatchTelemetryProcessor(
             config = BatchTelemetryConfig(
-                maxQueueSize = 20,
+                maxQueueSize = maxQueueSize,
                 maxExportBatchSize = batchSize,
                 scheduleDelayMs = 1,
                 exportTimeoutMs = exportTimeoutMs,


### PR DESCRIPTION
## Goal

Uses `ArrayDeque` instead of `List` in batch processor to reduce the number of element moves, and fixes an off-by-one error. Partially addresses #809.
