### PR TITLE
fix: Default AttributesModel to mutableMapOf

### DIFF
--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/attributes/AttributesModel.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/attributes/AttributesModel.kt
@@ -1,13 +1,9 @@
 package io.opentelemetry.kotlin.attributes
 
-import io.opentelemetry.kotlin.ThreadSafe
-import io.opentelemetry.kotlin.threadSafeMap
-
-@ThreadSafe
 internal class AttributesModel(
     private val attributeLimit: Int = DEFAULT_ATTRIBUTE_LIMIT,
     private val attributeValueLengthLimit: Int = DEFAULT_ATTRIBUTE_VALUE_LENGTH_LIMIT,
-    private val attrs: MutableMap<String, Any> = threadSafeMap()
+    private val attrs: MutableMap<String, Any> = mutableMapOf()
 ) : AttributesMutator, AttributeContainer {
 
     /**


### PR DESCRIPTION
## Goal

Close https://github.com/open-telemetry/opentelemetry-kotlin/issues/810.

`AttributesModel` should not default to the platform-specific `threadSafeMap()`. Most instances are short-lived or are protected by their owning model, so the default backing map can be a plain `mutableMapOf()` without implying that `AttributesModel` itself is thread-safe.

This removes the `@ThreadSafe` marker from the internal implementation and leaves synchronization decisions to the owner/call site. Attribute behavior is otherwise unchanged: validation, overwrite behavior, truncation, limits, and dropped-attribute counting still use the same `AttributesModel` logic.

## Testing

- Not run yet