### PR TITLE
Read config from all sources for log limit

### DIFF
--- a/behavior/src/commonMain/kotlin/io/opentelemetry/kotlin/behavior/Limits.kt
+++ b/behavior/src/commonMain/kotlin/io/opentelemetry/kotlin/behavior/Limits.kt
@@ -1,0 +1,16 @@
+package io.opentelemetry.kotlin.behavior
+
+import io.opentelemetry.kotlin.ExperimentalApi
+
+/**
+ * Returns [value] as a limit, or `null` if it is negative, so an invalid value leaves the limit
+ * unset. Zero is a valid limit.
+ */
+@ExperimentalApi
+fun limitOrUnset(value: Int?): Int? = value?.takeIf { it >= 0 }
+
+/**
+ * Returns [value] as a limit, or `null` if it is negative or too large to represent as an [Int].
+ */
+@ExperimentalApi
+fun limitOrUnset(value: Long?): Int? = value?.takeIf { it >= 0 && it <= Int.MAX_VALUE }?.toInt()

--- a/behavior/src/commonTest/kotlin/io/opentelemetry/kotlin/behavior/LimitsTest.kt
+++ b/behavior/src/commonTest/kotlin/io/opentelemetry/kotlin/behavior/LimitsTest.kt
@@ -1,0 +1,35 @@
+package io.opentelemetry.kotlin.behavior
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+internal class LimitsTest {
+
+    @Test
+    fun keepsNonNegativeValues() {
+        assertEquals(0, limitOrUnset(0))
+        assertEquals(128, limitOrUnset(128))
+        assertEquals(0, limitOrUnset(0L))
+        assertEquals(128, limitOrUnset(128L))
+        assertEquals(Int.MAX_VALUE, limitOrUnset(Int.MAX_VALUE.toLong()))
+    }
+
+    @Test
+    fun leavesNegativeValuesUnset() {
+        assertNull(limitOrUnset(-1))
+        assertNull(limitOrUnset(-1L))
+    }
+
+    @Test
+    fun leavesValuesTooLargeForAnIntUnset() {
+        assertNull(limitOrUnset(Int.MAX_VALUE.toLong() + 1))
+        assertNull(limitOrUnset(Long.MAX_VALUE))
+    }
+
+    @Test
+    fun leavesUnsetValuesUnset() {
+        assertNull(limitOrUnset(null as Int?))
+        assertNull(limitOrUnset(null as Long?))
+    }
+}

--- a/config-dsl/README.md
+++ b/config-dsl/README.md
@@ -3,4 +3,4 @@
 This module contains the implementations of the programmatic configuration DSL, shared by
 `implementation` and `compat`. The DSL interfaces themselves live in `sdk-api`.
 
-This module is currently an empty placeholder for that structure.
+Each implementation maps what the caller configured onto the `behavior` it supplies.

--- a/config-dsl/src/commonMain/kotlin/io/opentelemetry/kotlin/config/dsl/BehaviorSupplier.kt
+++ b/config-dsl/src/commonMain/kotlin/io/opentelemetry/kotlin/config/dsl/BehaviorSupplier.kt
@@ -1,0 +1,16 @@
+package io.opentelemetry.kotlin.config.dsl
+
+import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.behavior.Behavior
+
+/**
+ * A configuration DSL implementation that supplies the [Behavior] it captured.
+ */
+@ExperimentalApi
+fun interface BehaviorSupplier<T : Behavior<T>> {
+
+    /**
+     * Returns the behavior configured via the DSL.
+     */
+    fun toBehavior(): T
+}

--- a/config-dsl/src/commonMain/kotlin/io/opentelemetry/kotlin/config/dsl/LogLimitsConfigDslImpl.kt
+++ b/config-dsl/src/commonMain/kotlin/io/opentelemetry/kotlin/config/dsl/LogLimitsConfigDslImpl.kt
@@ -1,0 +1,21 @@
+package io.opentelemetry.kotlin.config.dsl
+
+import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.behavior.LogLimitsBehavior
+import io.opentelemetry.kotlin.behavior.limitOrUnset
+import io.opentelemetry.kotlin.init.LogLimitsConfigDsl
+
+/**
+ * Captures the log record limits configured programmatically, and maps them onto a behavior.
+ */
+@ExperimentalApi
+class LogLimitsConfigDslImpl : LogLimitsConfigDsl, BehaviorSupplier<LogLimitsBehavior> {
+
+    override var attributeCountLimit: Int? = null
+    override var attributeValueLengthLimit: Int? = null
+
+    override fun toBehavior(): LogLimitsBehavior = LogLimitsBehavior(
+        attributeCountLimit = limitOrUnset(attributeCountLimit),
+        attributeValueLengthLimit = limitOrUnset(attributeValueLengthLimit),
+    )
+}

--- a/config-dsl/src/commonMain/kotlin/io/opentelemetry/kotlin/config/dsl/Placeholder.kt
+++ b/config-dsl/src/commonMain/kotlin/io/opentelemetry/kotlin/config/dsl/Placeholder.kt
@@ -1,2 +1,0 @@
-// This file exists to give a target something to compile against - delete it once the module is non-empty.
-package io.opentelemetry.kotlin.config.dsl

--- a/config-dsl/src/commonTest/kotlin/io/opentelemetry/kotlin/config/dsl/LogLimitsConfigDslImplTest.kt
+++ b/config-dsl/src/commonTest/kotlin/io/opentelemetry/kotlin/config/dsl/LogLimitsConfigDslImplTest.kt
@@ -1,0 +1,43 @@
+package io.opentelemetry.kotlin.config.dsl
+
+import io.opentelemetry.kotlin.behavior.LogLimitsBehavior
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+internal class LogLimitsConfigDslImplTest {
+
+    @Test
+    fun everyLimitStartsUnset() {
+        assertEquals(LogLimitsBehavior(), LogLimitsConfigDslImpl().toBehavior())
+    }
+
+    @Test
+    fun mapsEveryConfiguredLimit() {
+        val dsl = LogLimitsConfigDslImpl().apply {
+            attributeCountLimit = 64
+            attributeValueLengthLimit = 256
+        }
+
+        assertEquals(
+            LogLimitsBehavior(attributeCountLimit = 64, attributeValueLengthLimit = 256),
+            dsl.toBehavior(),
+        )
+    }
+
+    @Test
+    fun preservesALimitOfZero() {
+        val dsl = LogLimitsConfigDslImpl().apply { attributeCountLimit = 0 }
+
+        assertEquals(0, dsl.toBehavior().attributeCountLimit)
+    }
+
+    @Test
+    fun leavesNegativeLimitsUnset() {
+        val dsl = LogLimitsConfigDslImpl().apply {
+            attributeCountLimit = -1
+            attributeValueLengthLimit = -1
+        }
+
+        assertEquals(LogLimitsBehavior(), dsl.toBehavior())
+    }
+}

--- a/config-envar/README.md
+++ b/config-envar/README.md
@@ -1,5 +1,6 @@
 # config-envar
 
-This module contains the machinery for configuring the SDK from environment variables.
+This module contains the machinery for configuring the SDK from environment variables, mapping the
+variables that are set onto the `behavior` they supply.
 
 https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/

--- a/config-envar/build.gradle.kts
+++ b/config-envar/build.gradle.kts
@@ -12,6 +12,7 @@ kotlin {
         val commonMain by getting {
             dependencies {
                 api(project(":api"))
+                api(project(":behavior"))
             }
         }
         val commonTest by getting {

--- a/config-envar/src/commonMain/kotlin/io/opentelemetry/kotlin/config/envar/EnvVarReader.kt
+++ b/config-envar/src/commonMain/kotlin/io/opentelemetry/kotlin/config/envar/EnvVarReader.kt
@@ -1,0 +1,26 @@
+package io.opentelemetry.kotlin.config.envar
+
+import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.config.envar.model.EnvVarName
+
+/**
+ * Reads environment variables, turning each raw value into the type the configuration expects.
+ *
+ * A variable that is unset, or that holds a value which cannot be read as the requested type, is
+ * reported as `null`, meaning the environment configured nothing for it. [getEnvVar] is supplied by
+ * the platform, so it is treated as hostile: a failure to read a variable is reported the same way.
+ */
+@ExperimentalApi
+class EnvVarReader(private val getEnvVar: (String) -> String?) {
+
+    /**
+     * Returns the value of [name] as an [Int], or `null` if it is unset or is not an [Int].
+     */
+    fun readInt(name: EnvVarName): Int? = read(name)?.toIntOrNull()
+
+    private fun read(name: EnvVarName): String? = try {
+        getEnvVar(name.value)
+    } catch (_: Throwable) {
+        null
+    }
+}

--- a/config-envar/src/commonMain/kotlin/io/opentelemetry/kotlin/config/envar/logging/LogLimitsEnvVars.kt
+++ b/config-envar/src/commonMain/kotlin/io/opentelemetry/kotlin/config/envar/logging/LogLimitsEnvVars.kt
@@ -1,0 +1,28 @@
+package io.opentelemetry.kotlin.config.envar.logging
+
+import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.behavior.LogLimitsBehavior
+import io.opentelemetry.kotlin.behavior.limitOrUnset
+import io.opentelemetry.kotlin.config.envar.EnvVarReader
+import io.opentelemetry.kotlin.config.envar.model.EnvVarName.Companion.envVarName
+
+/**
+ * Maps the log record limit environment variables onto the behavior they supply. A variable that is
+ * unset, or that holds a value the spec disallows, leaves its limit unset.
+ *
+ * https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#attribute-limits
+ */
+@ExperimentalApi
+class LogLimitsEnvVars(private val reader: EnvVarReader) {
+
+    fun toBehavior(): LogLimitsBehavior = LogLimitsBehavior(
+        attributeCountLimit = limitOrUnset(reader.readInt(ATTRIBUTE_COUNT_LIMIT)),
+        attributeValueLengthLimit = limitOrUnset(reader.readInt(ATTRIBUTE_VALUE_LENGTH_LIMIT)),
+    )
+
+    private companion object {
+        val ATTRIBUTE_COUNT_LIMIT = envVarName("OTEL_LOGRECORD_ATTRIBUTE_COUNT_LIMIT")
+        val ATTRIBUTE_VALUE_LENGTH_LIMIT =
+            envVarName("OTEL_LOGRECORD_ATTRIBUTE_VALUE_LENGTH_LIMIT")
+    }
+}

--- a/config-envar/src/commonTest/kotlin/io/opentelemetry/kotlin/config/envar/EnvVarReaderTest.kt
+++ b/config-envar/src/commonTest/kotlin/io/opentelemetry/kotlin/config/envar/EnvVarReaderTest.kt
@@ -1,0 +1,50 @@
+package io.opentelemetry.kotlin.config.envar
+
+import io.opentelemetry.kotlin.config.envar.model.EnvVarName.Companion.envVarName
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+internal class EnvVarReaderTest {
+
+    private val name = envVarName("OTEL_LOGRECORD_ATTRIBUTE_COUNT_LIMIT")
+
+    @Test
+    fun `should read an int`() {
+        assertEquals(64, EnvVarReader { "64" }.readInt(name))
+        assertEquals(0, EnvVarReader { "0" }.readInt(name))
+        assertEquals(-1, EnvVarReader { "-1" }.readInt(name))
+    }
+
+    @Test
+    fun `should look up the name it was asked for`() {
+        var requested: String? = null
+
+        EnvVarReader {
+            requested = it
+            null
+        }.readInt(name)
+
+        assertEquals(name.value, requested)
+    }
+
+    @Test
+    fun `should treat an unset env var as unset`() {
+        assertNull(EnvVarReader { null }.readInt(name))
+    }
+
+    @Test
+    fun `should treat a value that is not an int as unset`() {
+        listOf("invalid", "", " ", "64.0", "2147483648").forEach { rawValue ->
+            assertNull(EnvVarReader { rawValue }.readInt(name), "<$rawValue> should not be read")
+        }
+    }
+
+    /**
+     * The platform supplies the lookup, so a failure to read must not escape into the host app.
+     */
+    @Test
+    fun `should treat a failed read as unset`() {
+        assertNull(EnvVarReader { error("cannot read env vars here") }.readInt(name))
+    }
+}

--- a/config-envar/src/commonTest/kotlin/io/opentelemetry/kotlin/config/envar/logging/LogLimitsEnvVarsTest.kt
+++ b/config-envar/src/commonTest/kotlin/io/opentelemetry/kotlin/config/envar/logging/LogLimitsEnvVarsTest.kt
@@ -1,0 +1,55 @@
+package io.opentelemetry.kotlin.config.envar.logging
+
+import io.opentelemetry.kotlin.behavior.LogLimitsBehavior
+import io.opentelemetry.kotlin.config.envar.EnvVarReader
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+internal class LogLimitsEnvVarsTest {
+
+    @Test
+    fun `should read every limit`() {
+        val env = mapOf(
+            "OTEL_LOGRECORD_ATTRIBUTE_COUNT_LIMIT" to "64",
+            "OTEL_LOGRECORD_ATTRIBUTE_VALUE_LENGTH_LIMIT" to "256",
+        )
+        val behavior = toBehavior(env::get)
+        assertEquals(
+            LogLimitsBehavior(attributeCountLimit = 64, attributeValueLengthLimit = 256),
+            behavior,
+        )
+    }
+
+    @Test
+    fun `should leave unset env vars unset`() {
+        assertEquals(LogLimitsBehavior(), toBehavior { null })
+    }
+
+    @Test
+    fun `should preserve a limit of zero`() {
+        val behavior = toBehavior { "0" }
+        assertEquals(
+            LogLimitsBehavior(attributeCountLimit = 0, attributeValueLengthLimit = 0),
+            behavior,
+        )
+    }
+
+    @Test
+    fun `should leave invalid env vars unset`() {
+        INVALID_VALUES.forEach { rawValue ->
+            val behavior = toBehavior { rawValue }
+            assertEquals(
+                LogLimitsBehavior(),
+                behavior,
+                "<$rawValue> should not configure a limit",
+            )
+        }
+    }
+
+    private fun toBehavior(getEnvVar: (String) -> String?) =
+        LogLimitsEnvVars(EnvVarReader(getEnvVar)).toBehavior()
+
+    private companion object {
+        val INVALID_VALUES = listOf("invalid", "", "-1", "2147483648")
+    }
+}

--- a/config-yaml/README.md
+++ b/config-yaml/README.md
@@ -1,6 +1,7 @@
 # config-yaml
 
-This module parses declarative configuration YAML into the `config-schema` types.
+This module parses declarative configuration YAML into the `config-schema` types, then maps those
+onto a `behavior`.
 
 Locating and reading the file is not implemented yet.
 

--- a/config-yaml/build.gradle.kts
+++ b/config-yaml/build.gradle.kts
@@ -12,6 +12,7 @@ kotlin {
         val commonMain by getting {
             dependencies {
                 implementation(project(":sdk-api"))
+                api(project(":behavior"))
                 api(project(":config-schema"))
                 implementation(libs.yamlkt)
                 implementation(libs.okio)

--- a/config-yaml/src/commonMain/kotlin/io/opentelemetry/kotlin/config/yaml/LogRecordLimitsMapper.kt
+++ b/config-yaml/src/commonMain/kotlin/io/opentelemetry/kotlin/config/yaml/LogRecordLimitsMapper.kt
@@ -1,0 +1,16 @@
+package io.opentelemetry.kotlin.config.yaml
+
+import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.behavior.LogLimitsBehavior
+import io.opentelemetry.kotlin.behavior.limitOrUnset
+import io.opentelemetry.kotlin.config.schema.model.LogRecordLimits
+
+/**
+ * Maps the `logger_provider.limits` section of a declarative config file onto the behavior it
+ * supplies. Anything the file omits, or sets to a value the spec disallows, is left unset.
+ */
+@ExperimentalApi
+fun LogRecordLimits.toBehavior(): LogLimitsBehavior = LogLimitsBehavior(
+    attributeCountLimit = limitOrUnset(attributeCountLimit),
+    attributeValueLengthLimit = limitOrUnset(attributeValueLengthLimit),
+)

--- a/config-yaml/src/commonTest/kotlin/io/opentelemetry/kotlin/config/yaml/LogRecordLimitsMapperTest.kt
+++ b/config-yaml/src/commonTest/kotlin/io/opentelemetry/kotlin/config/yaml/LogRecordLimitsMapperTest.kt
@@ -1,0 +1,42 @@
+package io.opentelemetry.kotlin.config.yaml
+
+import io.opentelemetry.kotlin.behavior.LogLimitsBehavior
+import io.opentelemetry.kotlin.config.schema.model.LogRecordLimits
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+internal class LogRecordLimitsMapperTest {
+
+    @Test
+    fun mapsEveryLimit() {
+        val limits = LogRecordLimits(attributeCountLimit = 64, attributeValueLengthLimit = 256)
+        assertEquals(
+            LogLimitsBehavior(attributeCountLimit = 64, attributeValueLengthLimit = 256),
+            limits.toBehavior(),
+        )
+    }
+
+    @Test
+    fun leavesOmittedLimitsUnset() {
+        assertEquals(LogLimitsBehavior(), LogRecordLimits().toBehavior())
+    }
+
+    @Test
+    fun preservesALimitOfZero() {
+        val behavior = LogRecordLimits(attributeCountLimit = 0).toBehavior()
+        assertEquals(0, behavior.attributeCountLimit)
+    }
+
+    @Test
+    fun leavesLimitsTheSpecDisallowsUnset() {
+        val invalid = listOf(-1L, Int.MAX_VALUE.toLong() + 1, Long.MAX_VALUE)
+
+        invalid.forEach { value ->
+            val behavior = LogRecordLimits(
+                attributeCountLimit = value,
+                attributeValueLengthLimit = value,
+            ).toBehavior()
+            assertEquals(LogLimitsBehavior(), behavior, "<$value> should not configure a limit")
+        }
+    }
+}


### PR DESCRIPTION
## Goal

Reads config from all sources (DSL, envars, yaml) for log limits. This is not hooked up to control the SDK yet, but now provides a good model of how config is intended to work. The envars/yaml are read and converted to `LogLimitsBehavior`, as is the DSL.

`LogLimitsBehavior` is then resolved according to its precedence rules and can be used to control the behavior of either implementations of the SDK.

## Testing

Added unit tests.
