### PR TITLE
Remove context key API extension

### DIFF
--- a/api-ext/api/jvm/api-ext.api
+++ b/api-ext/api/jvm/api-ext.api
@@ -10,7 +10,6 @@ public final class io/opentelemetry/kotlin/attributes/AttributesMutatorExtKt {
 
 public final class io/opentelemetry/kotlin/context/ContextFactoryApiExtKt {
 	public static final fun asImplicitContext (Lio/opentelemetry/kotlin/context/Context;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
-	public static final fun with (Lio/opentelemetry/kotlin/factory/ContextFactory;Lio/opentelemetry/kotlin/context/Context;Ljava/util/Map;)Lio/opentelemetry/kotlin/context/Context;
 }
 
 public final class io/opentelemetry/kotlin/tracing/SpanExtKt {

--- a/api-ext/src/commonMain/kotlin/io/opentelemetry/kotlin/context/ContextFactoryApiExt.kt
+++ b/api-ext/src/commonMain/kotlin/io/opentelemetry/kotlin/context/ContextFactoryApiExt.kt
@@ -2,21 +2,6 @@ package io.opentelemetry.kotlin.context
 
 import io.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.kotlin.ThreadSafe
-import io.opentelemetry.kotlin.factory.ContextFactory
-
-/**
- * This function returns a new immutable [io.opentelemetry.kotlin.context.Context] that contains the key-value pairs
- * in the supplied map.
- */
-@ThreadSafe
-@ExperimentalApi
-public fun ContextFactory.with(context: Context, values: Map<String, Any>): Context {
-    var ctx = context
-    values.forEach { (key, value) ->
-        ctx = ctx.set(createKey(key), value)
-    }
-    return ctx
-}
 
 /**
  * Sets this context as the implicit context for the duration of [block], automatically

--- a/api-ext/src/commonTest/kotlin/io/opentelemetry/kotlin/context/ContextExtTest.kt
+++ b/api-ext/src/commonTest/kotlin/io/opentelemetry/kotlin/context/ContextExtTest.kt
@@ -1,40 +1,11 @@
 package io.opentelemetry.kotlin.context
 
-import io.opentelemetry.kotlin.factory.FakeContextFactory
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
 internal class ContextExtTest {
-
-    private val factory = FakeContextFactory()
-
-    @Test
-    fun testContext() {
-        val root = FakeContext()
-        val attrs = mapOf(
-            "a" to true,
-            "b" to 1,
-        )
-        val firstCtx = factory.with(root, attrs) as FakeContext
-        assertEquals(attrs, firstCtx.findAttrs())
-
-        val extra = mapOf(
-            "a" to "test",
-            "c" to "test",
-        )
-        val secondCtx = factory.with(firstCtx, extra) as FakeContext
-        val expected = mapOf(
-            "a" to "test",
-            "b" to 1,
-            "c" to "test",
-        )
-        assertEquals(expected, secondCtx.findAttrs())
-
-        val thirdCtx = factory.with(secondCtx, emptyMap()) as FakeContext
-        assertEquals(expected, thirdCtx.findAttrs())
-    }
 
     @Test
     fun testAsImplicitContext() {
@@ -78,6 +49,4 @@ internal class ContextExtTest {
         assertTrue(attached)
         assertTrue(detached)
     }
-
-    private fun FakeContext.findAttrs(): Map<String, Any?> = attrs.mapKeys { it.key.toString() }
 }

--- a/api/README.md
+++ b/api/README.md
@@ -52,8 +52,8 @@ essentially it composes of these parts:
 3. When a context object no longer needs to be the implicit context, there needs to be a way to
    reset the implicit context to its previous state. A `Scope` object is a token that achieves this
    goal by calling `detach()`
-4. A means of determining what the implicit context is at any one time. `implicitContext()` solves
-   this.
+4. A means of determining what the implicit context is at any one time. `ContextFactory.implicit()`
+   solves this.
 5. The library users calls `attach()` for contexts at appropriate units of execution in their
    application (e.g. spanning a function, or a particular workflow). Nested calls are allowed
 
@@ -61,20 +61,24 @@ essentially it composes of these parts:
 
 A code sample makes this easier to understand:
 
-```
+```kotlin
+// Declare keys once and share the instance with whatever needs to read the value back.
+// A key with a matching name is a different key - see the ContextKey docs.
+private val USER_ID: ContextKey<String> = api.context.createKey("user.id")
+
 internal fun exampleUsage(api: OpenTelemetry) {
     // 1. obtain the current context. Defaults to root() if no implicit context is available.
-    val ctx = api.contextFactory.implicitContext()
+    val ctx = api.context.implicit()
 
     // 2. create a new context but don't set it as the implicit context.
-    val newContext = ctx.with(mapOf("key" to "value"))
+    val newContext = ctx.set(USER_ID, "abc123")
 
     // 3. set the new context as the implicit context.
     val scope = newContext.attach()
 
-    // 4. perform tracing/logging here. tracers/loggers should call implicitContext()
+    // 4. perform tracing/logging here. tracers/loggers should call implicit()
     // internally so the appropriate context is set automatically.
-    api.getTracer("tracer").startSpan("my_span")
+    api.tracerProvider.getTracer("tracer").startSpan("my_span")
 
     // 5. unset the new context as the implicit context and restore the previous context.
     scope.detach()

--- a/api/src/commonMain/kotlin/io/opentelemetry/kotlin/context/ContextKey.kt
+++ b/api/src/commonMain/kotlin/io/opentelemetry/kotlin/context/ContextKey.kt
@@ -5,6 +5,13 @@ import io.opentelemetry.kotlin.ThreadSafe
 
 /**
  * A key that identifies a value in a [Context].
+ *
+ * Keys are compared by reference, so
+ * [io.opentelemetry.kotlin.factory.ContextFactory.createKey] returns a distinct key on every call
+ * even when given the same name. The name is used for debugging only and does not identify the
+ * value.
+ *
+ * In practice, this means you MUST retain the [ContextKey] instance and use it as a shared constant.
  */
 @ExperimentalApi
 @ThreadSafe

--- a/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/factory/ContextFactoryImplTest.kt
+++ b/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/factory/ContextFactoryImplTest.kt
@@ -5,6 +5,8 @@ import io.opentelemetry.kotlin.assertions.assertSpanContextsMatch
 import io.opentelemetry.kotlin.context.toOtelJavaContext
 import io.opentelemetry.kotlin.createCompatOpenTelemetry
 import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
 import kotlin.test.assertSame
 
 internal class ContextFactoryImplTest {
@@ -23,6 +25,16 @@ internal class ContextFactoryImplTest {
         val ctx = contextFactory.root().storeSpan(span)
         val retrievedSpan = ctx.extractSpan()
         assertSpanContextsMatch(span.spanContext, retrievedSpan.spanContext)
+    }
+
+    @Test
+    fun `test same named keys are not interchangeable`() {
+        val key = contextFactory.createKey<String>("my_key")
+        val sameName = contextFactory.createKey<String>("my_key")
+        val ctx = contextFactory.root().set(key, "my_value")
+
+        assertEquals("my_value", ctx.get(key))
+        assertNull(ctx.get(sameName))
     }
 
     @Test

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/context/ContextImplTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/context/ContextImplTest.kt
@@ -35,6 +35,16 @@ internal class ContextImplTest {
     }
 
     @Test
+    fun testContextSameNamedKeysAreNotInterchangeable() {
+        val key = factory.createKey<String>("my_key")
+        val sameName = factory.createKey<String>("my_key")
+        val ctx = factory.root().set(key, "my_value")
+
+        assertEquals("my_value", ctx.get(key))
+        assertNull(ctx.get(sameName))
+    }
+
+    @Test
     fun testContextGetAbsentValue() {
         val ctx = factory.root()
         val key = factory.createKey<String>("my_key")

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/context/ImplicitContextTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/context/ImplicitContextTest.kt
@@ -32,7 +32,7 @@ internal class ImplicitContextTest {
 
     @Test
     fun testDupeAttach() {
-        val newCtx = factory.with(factory.root(), mapOf("key" to "value"))
+        val newCtx = newContext()
         newCtx.attach()
         assertSame(newCtx, factory.implicit())
 
@@ -47,7 +47,7 @@ internal class ImplicitContextTest {
     fun testDupeDetach() {
         assertSame(factory.root(), factory.implicit())
 
-        val newCtx = factory.with(factory.root(), mapOf("key" to "value"))
+        val newCtx = newContext()
         val scope = newCtx.attach()
         assertSame(newCtx, factory.implicit())
 
@@ -60,14 +60,14 @@ internal class ImplicitContextTest {
 
     @Test
     fun testDetachReturnsTrueOnSuccess() {
-        val newCtx = factory.with(factory.root(), mapOf("key" to "value"))
+        val newCtx = newContext()
         val scope = newCtx.attach()
         assertTrue(scope.detach())
     }
 
     @Test
     fun testDetachReturnsFalseWhenAlreadyDetached() {
-        val newCtx = factory.with(factory.root(), mapOf("key" to "value"))
+        val newCtx = newContext()
         val scope = newCtx.attach()
         assertTrue(scope.detach())
         assertFalse(scope.detach())
@@ -75,9 +75,9 @@ internal class ImplicitContextTest {
 
     @Test
     fun testDetachReturnsFalseWhenOutOfOrder() {
-        val ctx1 = factory.with(factory.root(), mapOf("key" to "value"))
+        val ctx1 = newContext()
         val scope1 = ctx1.attach()
-        val ctx2 = factory.with(factory.root(), mapOf("another" to "value"))
+        val ctx2 = newContext()
         val scope2 = ctx2.attach()
 
         // scope1 is out of order — ctx2 is current
@@ -94,12 +94,12 @@ internal class ImplicitContextTest {
         assertSame(root, factory.implicit())
 
         // set first scope
-        val ctx1 = factory.with(root, mapOf("key" to "value"))
+        val ctx1 = newContext()
         val scope1 = ctx1.attach()
         assertSame(ctx1, factory.implicit())
 
         // set second scope
-        val ctx2 = factory.with(root, mapOf("another" to "value"))
+        val ctx2 = newContext()
         val scope2 = ctx2.attach()
         assertSame(ctx2, factory.implicit())
 
@@ -115,4 +115,7 @@ internal class ImplicitContextTest {
         scope1.detach()
         assertSame(root, factory.implicit())
     }
+
+    private fun newContext(): Context =
+        factory.root().set(factory.createKey<String>("key"), "value")
 }


### PR DESCRIPTION
## Goal

Closes #799 by removing a function in the api-ext module. This sets value on the `Context` but because `ContextKey` is never returned, it's impossible to ever read them back, making them useless.

I've therefore removed them from the API and updated the docs to state what the preferred approach is (inline with the OTel spec)
