### PR TITLE
Route export coroutine failures through sdkErrorHandler (#711)

### DIFF
--- a/sdk-common/api/jvm/sdk-common.api
+++ b/sdk-common/api/jvm/sdk-common.api
@@ -61,7 +61,7 @@ public abstract class io/opentelemetry/kotlin/export/ShutdownState {
 }
 
 public final class io/opentelemetry/kotlin/export/TelemetryExceptionHandlerKt {
-	public static final fun telemetryExceptionHandler (Ljava/lang/String;)Lkotlinx/coroutines/CoroutineExceptionHandler;
+	public static final fun telemetryExceptionHandler (Ljava/lang/String;Lio/opentelemetry/kotlin/error/SdkErrorHandler;)Lkotlinx/coroutines/CoroutineExceptionHandler;
 }
 
 public final class io/opentelemetry/kotlin/export/TimeoutOperationKt {

--- a/sdk-common/src/commonMain/kotlin/io/opentelemetry/kotlin/export/TelemetryExceptionHandler.kt
+++ b/sdk-common/src/commonMain/kotlin/io/opentelemetry/kotlin/export/TelemetryExceptionHandler.kt
@@ -1,6 +1,8 @@
 package io.opentelemetry.kotlin.export
 
-import io.opentelemetry.kotlin.platformLog
+import io.opentelemetry.kotlin.error.SdkError
+import io.opentelemetry.kotlin.error.SdkErrorHandler
+import io.opentelemetry.kotlin.error.SdkErrorSeverity
 import kotlinx.coroutines.CoroutineExceptionHandler
 
 /**
@@ -14,7 +16,13 @@ import kotlinx.coroutines.CoroutineExceptionHandler
  * [kotlinx.coroutines.CancellationException] is never routed here by the framework, so normal
  * cancellation (e.g. on shutdown) is unaffected.
  */
-public fun telemetryExceptionHandler(context: String): CoroutineExceptionHandler =
+public fun telemetryExceptionHandler(context: String, sdkErrorHandler: SdkErrorHandler): CoroutineExceptionHandler =
     CoroutineExceptionHandler { _, throwable ->
-        platformLog("$context coroutine failed: ${throwable.message}")
+        sdkErrorHandler.onError(
+            SdkError.UserCodeError(
+                cause = throwable,
+                message = "$context coroutine failed",
+                severity = SdkErrorSeverity.WARNING,
+            )
+        )
     }

--- a/sdk-common/src/commonTest/kotlin/io/opentelemetry/kotlin/export/TelemetryExceptionHandlerTest.kt
+++ b/sdk-common/src/commonTest/kotlin/io/opentelemetry/kotlin/export/TelemetryExceptionHandlerTest.kt
@@ -1,0 +1,27 @@
+package io.opentelemetry.kotlin.export
+
+import io.opentelemetry.kotlin.error.FakeSdkErrorHandler
+import io.opentelemetry.kotlin.error.SdkErrorSeverity
+import kotlin.coroutines.EmptyCoroutineContext
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+internal class TelemetryExceptionHandlerTest {
+
+    @Test
+    fun testCoroutineFailureReportsUserCodeError() {
+        val handler = FakeSdkErrorHandler()
+        val cause = IllegalStateException("boom")
+
+        telemetryExceptionHandler("Test context", handler)
+            .handleException(EmptyCoroutineContext, cause)
+
+        assertEquals(1, handler.userCodeErrors.size)
+        val error = handler.userCodeErrors.single()
+        assertEquals("Test context coroutine failed", error.message)
+        assertEquals(SdkErrorSeverity.WARNING, error.severity)
+        assertIs<IllegalStateException>(error.cause)
+        assertEquals("boom", error.cause.message)
+    }
+}


### PR DESCRIPTION
Part 1 of #711 - routes export coroutine failures through sdkErrorHandler instead of platformLog().

## Summary
Updates telemetryExceptionHandler in sdk-common to report uncaught export coroutine failures via the configurable SdkErrorHandler from #710, rather than platformLog().

Export runs on fire-and-forget coroutines; without a handler, failures can reach the platform default handler and crash the app. Failures are now reported as UserCodeError with WARNING severity and swallowed, preserving existing behavior.

## API change
telemetryExceptionHandler now requires an SdkErrorHandler:

```
// Before
telemetryExceptionHandler(context: String)
// After
telemetryExceptionHandler(context: String, sdkErrorHandler: SdkErrorHandler)
The sdk-common.api dump has been updated.
```

## Scope
This PR only covers sdk-common. Follow-up PRs will migrate exporters and implementation (#711).

## Testing
Added TelemetryExceptionHandlerTest
Follow-up PRs will wire call sites to pass sdkErrorHandler