### PR TITLE
Fix/711-exporters

### DIFF
--- a/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/export/BatchTelemetryConfig.kt
+++ b/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/export/BatchTelemetryConfig.kt
@@ -9,7 +9,7 @@ internal class BatchTelemetryConfig(
     exportTimeoutMs: Long = BatchTelemetryDefaults.EXPORT_TIMEOUT_MS,
     maxExportBatchSize: Int = BatchTelemetryDefaults.MAX_EXPORT_BATCH_SIZE,
     forceFlushTimeoutMs: Long = BatchTelemetryDefaults.FORCE_FLUSH_TIMEOUT_MS,
-    sdkErrorHandler: SdkErrorHandler,
+    val sdkErrorHandler: SdkErrorHandler,
 ) {
     /**
      * Maximum number of telemetry items the queue can hold before items are dropped.

--- a/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/export/BatchTelemetryProcessor.kt
+++ b/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/export/BatchTelemetryProcessor.kt
@@ -19,7 +19,9 @@ internal class BatchTelemetryProcessor<T>(
 
     private val shutdownState: MutableShutdownState = MutableShutdownState()
     private val scope =
-        CoroutineScope(SupervisorJob() + dispatcher + telemetryExceptionHandler("Batch processor"))
+        CoroutineScope(
+            SupervisorJob() + dispatcher + telemetryExceptionHandler("Batch processor", config.sdkErrorHandler)
+        )
     private val mutex = Mutex()
     private val queue = ArrayDeque<T>()
 

--- a/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/CoreLogRecordExporterApi.kt
+++ b/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/CoreLogRecordExporterApi.kt
@@ -2,10 +2,11 @@
 package io.opentelemetry.kotlin.logging.export
 
 import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.error.SdkError
+import io.opentelemetry.kotlin.error.SdkErrorSeverity
 import io.opentelemetry.kotlin.export.BatchTelemetryDefaults
 import io.opentelemetry.kotlin.export.telemetryExceptionHandler
 import io.opentelemetry.kotlin.init.LogExportConfigDsl
-import io.opentelemetry.kotlin.platformLog
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -17,7 +18,13 @@ import kotlinx.coroutines.SupervisorJob
 @ExperimentalApi
 public fun LogExportConfigDsl.compositeLogRecordProcessor(vararg processors: LogRecordProcessor): LogRecordProcessor {
     if (processors.isEmpty()) {
-        platformLog("At least one processor must be provided")
+        sdkErrorHandler.onError(
+            SdkError.ApiMisuse(
+                api = "LogExportConfigDsl.compositeLogRecordProcessor",
+                message = "At least one processor must be provided",
+                severity = SdkErrorSeverity.WARNING,
+            )
+        )
         return NoopLogRecordProcessor
     }
     return CompositeLogRecordProcessor(processors.toList(), sdkErrorHandler)
@@ -30,7 +37,7 @@ public fun LogExportConfigDsl.compositeLogRecordProcessor(vararg processors: Log
 public fun LogExportConfigDsl.simpleLogRecordProcessor(exporter: LogRecordExporter): LogRecordProcessor {
     val dispatcher: CoroutineDispatcher = Dispatchers.Default
     val scope = CoroutineScope(
-        SupervisorJob() + dispatcher + telemetryExceptionHandler("Simple log record processor")
+        SupervisorJob() + dispatcher + telemetryExceptionHandler("Simple log record processor", sdkErrorHandler)
     )
     return SimpleLogRecordProcessor(exporter, scope)
 }
@@ -41,7 +48,13 @@ public fun LogExportConfigDsl.simpleLogRecordProcessor(exporter: LogRecordExport
 @ExperimentalApi
 public fun LogExportConfigDsl.compositeLogRecordExporter(vararg exporters: LogRecordExporter): LogRecordExporter {
     if (exporters.isEmpty()) {
-        platformLog("At least one exporter must be provided")
+        sdkErrorHandler.onError(
+            SdkError.ApiMisuse(
+                api = "LogExportConfigDsl.compositeLogRecordExporter",
+                message = "At least one exporter must be provided",
+                severity = SdkErrorSeverity.WARNING,
+            )
+        )
         return NoopLogRecordExporter
     }
     return CompositeLogRecordExporter(exporters.toList(), sdkErrorHandler)

--- a/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/CoreSpanExporterApi.kt
+++ b/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/CoreSpanExporterApi.kt
@@ -1,10 +1,11 @@
 package io.opentelemetry.kotlin.tracing.export
 
 import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.error.SdkError
+import io.opentelemetry.kotlin.error.SdkErrorSeverity
 import io.opentelemetry.kotlin.export.BatchTelemetryDefaults
 import io.opentelemetry.kotlin.export.telemetryExceptionHandler
 import io.opentelemetry.kotlin.init.TraceExportConfigDsl
-import io.opentelemetry.kotlin.platformLog
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -16,7 +17,13 @@ import kotlinx.coroutines.SupervisorJob
 @ExperimentalApi
 public fun TraceExportConfigDsl.compositeSpanProcessor(vararg processors: SpanProcessor): SpanProcessor {
     if (processors.isEmpty()) {
-        platformLog("At least one processor must be provided")
+        sdkErrorHandler.onError(
+            SdkError.ApiMisuse(
+                api = "TraceExportConfigDsl.compositeSpanProcessor",
+                message = "At least one processor must be provided",
+                severity = SdkErrorSeverity.WARNING,
+            )
+        )
         return NoopSpanProcessor
     }
     return CompositeSpanProcessor(processors.toList(), sdkErrorHandler)
@@ -29,7 +36,7 @@ public fun TraceExportConfigDsl.compositeSpanProcessor(vararg processors: SpanPr
 public fun TraceExportConfigDsl.simpleSpanProcessor(exporter: SpanExporter): SpanProcessor {
     val dispatcher: CoroutineDispatcher = Dispatchers.Default
     val scope = CoroutineScope(
-        SupervisorJob() + dispatcher + telemetryExceptionHandler("Simple span processor")
+        SupervisorJob() + dispatcher + telemetryExceptionHandler("Simple span processor", sdkErrorHandler)
     )
     return SimpleSpanProcessor(exporter, scope)
 }
@@ -40,7 +47,13 @@ public fun TraceExportConfigDsl.simpleSpanProcessor(exporter: SpanExporter): Spa
 @ExperimentalApi
 public fun TraceExportConfigDsl.compositeSpanExporter(vararg exporters: SpanExporter): SpanExporter {
     if (exporters.isEmpty()) {
-        platformLog("At least one exporter must be provided")
+        sdkErrorHandler.onError(
+            SdkError.ApiMisuse(
+                api = "TraceExportConfigDsl.compositeSpanExporter",
+                message = "At least one exporter must be provided",
+                severity = SdkErrorSeverity.WARNING,
+            )
+        )
         return NoopSpanExporter
     }
     return CompositeSpanExporter(exporters.toList(), sdkErrorHandler)

--- a/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/export/CoreLogRecordExporterApiTest.kt
+++ b/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/export/CoreLogRecordExporterApiTest.kt
@@ -2,6 +2,7 @@ package io.opentelemetry.kotlin.logging.export
 
 import io.opentelemetry.kotlin.FakeInstrumentationScopeInfo
 import io.opentelemetry.kotlin.context.FakeContext
+import io.opentelemetry.kotlin.error.FakeSdkErrorHandler
 import io.opentelemetry.kotlin.export.FakeLogExportConfig
 import io.opentelemetry.kotlin.export.OperationResultCode
 import io.opentelemetry.kotlin.logging.model.FakeReadWriteLogRecord
@@ -38,5 +39,29 @@ internal class CoreLogRecordExporterApiTest {
             assertEquals(OperationResultCode.Success, shutdown())
         }
         assertSame(NoopLogRecordExporter, emptyExporter)
+    }
+
+    @Test
+    fun compositeLogRecordProcessorEmptyReportsApiMisuse() {
+        val handler = FakeSdkErrorHandler()
+        val config = FakeLogExportConfig(sdkErrorHandler = handler)
+        config.compositeLogRecordProcessor()
+        assertEquals(1, handler.apiMisuses.size)
+        assertEquals(
+            "LogExportConfigDsl.compositeLogRecordProcessor",
+            handler.apiMisuses.single().api,
+        )
+    }
+
+    @Test
+    fun compositeLogRecordExporterEmptyReportsApiMisuse() {
+        val handler = FakeSdkErrorHandler()
+        val config = FakeLogExportConfig(sdkErrorHandler = handler)
+        config.compositeLogRecordExporter()
+        assertEquals(1, handler.apiMisuses.size)
+        assertEquals(
+            "LogExportConfigDsl.compositeLogRecordExporter",
+            handler.apiMisuses.single().api,
+        )
     }
 }

--- a/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/export/CoreSpanExporterApiTest.kt
+++ b/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/export/CoreSpanExporterApiTest.kt
@@ -1,6 +1,7 @@
 package io.opentelemetry.kotlin.tracing.export
 
 import io.opentelemetry.kotlin.context.FakeContext
+import io.opentelemetry.kotlin.error.FakeSdkErrorHandler
 import io.opentelemetry.kotlin.export.FakeTraceExportConfig
 import io.opentelemetry.kotlin.export.OperationResultCode
 import io.opentelemetry.kotlin.tracing.FakeReadWriteSpan
@@ -36,5 +37,29 @@ internal class CoreSpanExporterApiTest {
             assertEquals(OperationResultCode.Success, shutdown())
         }
         assertSame(NoopSpanExporter, emptyExporter)
+    }
+
+    @Test
+    fun compositeSpanProcessorEmptyReportsApiMisuse() {
+        val handler = FakeSdkErrorHandler()
+        val config = FakeTraceExportConfig(sdkErrorHandler = handler)
+        config.compositeSpanProcessor()
+        assertEquals(1, handler.apiMisuses.size)
+        assertEquals(
+            "TraceExportConfigDsl.compositeSpanProcessor",
+            handler.apiMisuses.single().api,
+        )
+    }
+
+    @Test
+    fun compositeSpanExporterEmptyReportsApiMisuse() {
+        val handler = FakeSdkErrorHandler()
+        val config = FakeTraceExportConfig(sdkErrorHandler = handler)
+        config.compositeSpanExporter()
+        assertEquals(1, handler.apiMisuses.size)
+        assertEquals(
+            "TraceExportConfigDsl.compositeSpanExporter",
+            handler.apiMisuses.single().api,
+        )
     }
 }

--- a/exporters-otlp/src/commonMain/kotlin/io/opentelemetry/kotlin/export/OtlpClient.kt
+++ b/exporters-otlp/src/commonMain/kotlin/io/opentelemetry/kotlin/export/OtlpClient.kt
@@ -11,6 +11,9 @@ import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
 import io.ktor.http.contentType
 import io.ktor.utils.io.readRemaining
+import io.opentelemetry.kotlin.error.SdkError
+import io.opentelemetry.kotlin.error.SdkErrorHandler
+import io.opentelemetry.kotlin.error.SdkErrorSeverity
 import io.opentelemetry.kotlin.export.OtlpClient.Companion.MAX_ERROR_BODY_BYTES
 import io.opentelemetry.kotlin.export.OtlpResponse.ClientError
 import io.opentelemetry.kotlin.export.OtlpResponse.PartialSuccess
@@ -21,7 +24,6 @@ import io.opentelemetry.kotlin.export.OtlpResponse.Unknown
 import io.opentelemetry.kotlin.logging.data.LogRecordData
 import io.opentelemetry.kotlin.logging.export.deserializeLogRecordPartialSuccess
 import io.opentelemetry.kotlin.logging.export.toProtobufByteArray
-import io.opentelemetry.kotlin.platformLog
 import io.opentelemetry.kotlin.tracing.data.SpanData
 import io.opentelemetry.kotlin.tracing.export.deserializeTraceRecordPartialSuccess
 import io.opentelemetry.kotlin.tracing.export.toProtobufByteArray
@@ -30,7 +32,8 @@ import kotlin.coroutines.cancellation.CancellationException
 
 internal class OtlpClient(
     private val baseUrl: String,
-    private val httpClient: HttpClient = defaultHttpClient
+    private val httpClient: HttpClient = defaultHttpClient,
+    private val sdkErrorHandler: SdkErrorHandler,
 ) {
 
     private val contentType = ContentType.parse("application/x-protobuf")
@@ -81,7 +84,13 @@ internal class OtlpClient(
         } catch (e: CancellationException) {
             throw e
         } catch (e: Throwable) {
-            platformLog("OTLP export failed: ${e.message}")
+            sdkErrorHandler.onError(
+                SdkError.UserCodeError(
+                    e,
+                    "OTLP export failed",
+                    SdkErrorSeverity.WARNING,
+                )
+            )
             Unknown
         }
     }

--- a/exporters-otlp/src/commonMain/kotlin/io/opentelemetry/kotlin/export/TelemetryExporter.kt
+++ b/exporters-otlp/src/commonMain/kotlin/io/opentelemetry/kotlin/export/TelemetryExporter.kt
@@ -1,5 +1,6 @@
 package io.opentelemetry.kotlin.export
 
+import io.opentelemetry.kotlin.error.SdkErrorHandler
 import io.opentelemetry.kotlin.export.OperationResultCode.Success
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -16,6 +17,7 @@ internal class TelemetryExporter<T>(
     private val initialDelayMs: Long,
     private val maxAttemptIntervalMs: Long,
     private val maxAttempts: Int,
+    private val sdkErrorHandler: SdkErrorHandler,
     coroutineContext: CoroutineContext = Dispatchers.Default,
     private val random: Random = Random.Default,
     private val exportAction: suspend (telemetry: List<T>) -> OtlpResponse,
@@ -23,7 +25,7 @@ internal class TelemetryExporter<T>(
 
     private val shutdownState: MutableShutdownState = MutableShutdownState()
     private val scope: CoroutineScope =
-        CoroutineScope(SupervisorJob() + coroutineContext + telemetryExceptionHandler("OTLP exporter"))
+        CoroutineScope(SupervisorJob() + coroutineContext + telemetryExceptionHandler("OTLP exporter", sdkErrorHandler))
 
     /**
      * Exports telemetry via coroutines and uses exponential backoff when a failure

--- a/exporters-otlp/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/OtlpHttpLogRecordExporter.kt
+++ b/exporters-otlp/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/OtlpHttpLogRecordExporter.kt
@@ -1,5 +1,6 @@
 package io.opentelemetry.kotlin.logging.export
 
+import io.opentelemetry.kotlin.error.SdkErrorHandler
 import io.opentelemetry.kotlin.export.OperationResultCode
 import io.opentelemetry.kotlin.export.OtlpClient
 import io.opentelemetry.kotlin.export.TelemetryExporter
@@ -10,9 +11,15 @@ internal class OtlpHttpLogRecordExporter(
     initialDelayMs: Long,
     maxAttemptIntervalMs: Long,
     maxAttempts: Int,
+    sdkErrorHandler: SdkErrorHandler,
 ) : LogRecordExporter {
 
-    private val exporter = TelemetryExporter(initialDelayMs, maxAttemptIntervalMs, maxAttempts) {
+    private val exporter = TelemetryExporter(
+        initialDelayMs,
+        maxAttemptIntervalMs,
+        maxAttempts,
+        sdkErrorHandler,
+    ) {
         otlpClient.exportLogs(it)
     }
 

--- a/exporters-otlp/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/OtlpLogRecordExporterApi.kt
+++ b/exporters-otlp/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/OtlpLogRecordExporterApi.kt
@@ -23,10 +23,11 @@ public fun LogExportConfigDsl.otlpHttpLogRecordExporter(
     timeoutMs: Long = EXPORT_REQUEST_TIMEOUT_MS,
 ): LogRecordExporter =
     OtlpHttpLogRecordExporter(
-        OtlpClient(baseUrl, createDefaultHttpClient(requestTimeoutMs = timeoutMs, engine = httpClientEngine)),
+        OtlpClient(baseUrl, createDefaultHttpClient(requestTimeoutMs = timeoutMs, engine = httpClientEngine), sdkErrorHandler),
         EXPORT_INITIAL_DELAY_MS,
         EXPORT_MAX_ATTEMPT_INTERVAL_MS,
-        EXPORT_MAX_ATTEMPTS
+        EXPORT_MAX_ATTEMPTS,
+        sdkErrorHandler,
     )
 
 /**
@@ -45,8 +46,9 @@ public fun LogExportConfigDsl.otlpHttpLogRecordExporter(
     httpClient: HttpClient,
 ): LogRecordExporter =
     OtlpHttpLogRecordExporter(
-        OtlpClient(baseUrl, httpClient),
+        OtlpClient(baseUrl, httpClient, sdkErrorHandler),
         EXPORT_INITIAL_DELAY_MS,
         EXPORT_MAX_ATTEMPT_INTERVAL_MS,
-        EXPORT_MAX_ATTEMPTS
+        EXPORT_MAX_ATTEMPTS,
+        sdkErrorHandler,
     )

--- a/exporters-otlp/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/OtlpHttpSpanExporter.kt
+++ b/exporters-otlp/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/OtlpHttpSpanExporter.kt
@@ -1,5 +1,6 @@
 package io.opentelemetry.kotlin.tracing.export
 
+import io.opentelemetry.kotlin.error.SdkErrorHandler
 import io.opentelemetry.kotlin.export.OperationResultCode
 import io.opentelemetry.kotlin.export.OtlpClient
 import io.opentelemetry.kotlin.export.TelemetryExporter
@@ -10,9 +11,15 @@ internal class OtlpHttpSpanExporter(
     initialDelayMs: Long,
     maxAttemptIntervalMs: Long,
     maxAttempts: Int,
+    sdkErrorHandler: SdkErrorHandler,
 ) : SpanExporter {
 
-    private val exporter = TelemetryExporter(initialDelayMs, maxAttemptIntervalMs, maxAttempts) {
+    private val exporter = TelemetryExporter(
+        initialDelayMs,
+        maxAttemptIntervalMs,
+        maxAttempts,
+        sdkErrorHandler,
+    ) {
         otlpClient.exportTraces(it)
     }
 

--- a/exporters-otlp/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/OtlpSpanExporterApi.kt
+++ b/exporters-otlp/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/OtlpSpanExporterApi.kt
@@ -21,10 +21,11 @@ public fun TraceExportConfigDsl.otlpHttpSpanExporter(
     httpClientEngine: HttpClientEngine = createHttpEngine(),
     timeoutMs: Long = EXPORT_REQUEST_TIMEOUT_MS,
 ): SpanExporter = OtlpHttpSpanExporter(
-    OtlpClient(baseUrl, createDefaultHttpClient(requestTimeoutMs = timeoutMs, engine = httpClientEngine)),
+    OtlpClient(baseUrl, createDefaultHttpClient(requestTimeoutMs = timeoutMs, engine = httpClientEngine), sdkErrorHandler),
     EXPORT_INITIAL_DELAY_MS,
     EXPORT_MAX_ATTEMPT_INTERVAL_MS,
-    EXPORT_MAX_ATTEMPTS
+    EXPORT_MAX_ATTEMPTS,
+    sdkErrorHandler,
 )
 
 /**
@@ -42,8 +43,9 @@ public fun TraceExportConfigDsl.otlpHttpSpanExporter(
     baseUrl: String,
     httpClient: HttpClient,
 ): SpanExporter = OtlpHttpSpanExporter(
-    OtlpClient(baseUrl, httpClient),
+    OtlpClient(baseUrl, httpClient, sdkErrorHandler),
     EXPORT_INITIAL_DELAY_MS,
     EXPORT_MAX_ATTEMPT_INTERVAL_MS,
-    EXPORT_MAX_ATTEMPTS
+    EXPORT_MAX_ATTEMPTS,
+    sdkErrorHandler,
 )

--- a/exporters-otlp/src/commonTest/kotlin/io/opentelemetry/kotlin/export/OtlpClientTest.kt
+++ b/exporters-otlp/src/commonTest/kotlin/io/opentelemetry/kotlin/export/OtlpClientTest.kt
@@ -11,6 +11,8 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.http.headersOf
 import io.ktor.util.toMap
 import io.ktor.utils.io.ByteReadChannel
+import io.opentelemetry.kotlin.error.FakeSdkErrorHandler
+import io.opentelemetry.kotlin.error.NoopSdkErrorHandler
 import io.opentelemetry.kotlin.logging.data.FakeLogRecordData
 import io.opentelemetry.kotlin.logging.data.LogRecordData
 import io.opentelemetry.kotlin.logging.export.toProtobufByteArray
@@ -42,6 +44,7 @@ internal class OtlpClientTest {
     private val expectedUserAgent = "OTel-OTLP-Exporter-Kotlin/${BuildKonfig.VERSION}"
 
     private lateinit var client: OtlpClient
+    private var errorHandler: FakeSdkErrorHandler = FakeSdkErrorHandler()
     private lateinit var server: MockEngine
     private lateinit var mockResponseStatus: HttpStatusCode
     private var mockResponseHeaders: Headers = Headers.Empty
@@ -51,6 +54,7 @@ internal class OtlpClientTest {
 
     @BeforeTest
     fun setUp() {
+        errorHandler = FakeSdkErrorHandler()
         server = MockEngine {
             if (serverThrows) {
                 error("network unreachable")
@@ -65,7 +69,7 @@ internal class OtlpClientTest {
             )
         }
         val httpClient = createDefaultHttpClient(INFINITE_TIMEOUT_MS, server)
-        client = OtlpClient(baseUrl, httpClient = httpClient)
+        client = OtlpClient(baseUrl, httpClient = httpClient, sdkErrorHandler = errorHandler)
     }
 
     @Test
@@ -173,6 +177,8 @@ internal class OtlpClientTest {
         serverThrows = true
         val response = client.exportLogs(logRecords)
         assertIs<OtlpResponse.Unknown>(response)
+        assertEquals(1, errorHandler.userCodeErrors.size)
+        assertEquals("OTLP export failed", errorHandler.userCodeErrors.single().message)
     }
 
     @Test
@@ -180,6 +186,8 @@ internal class OtlpClientTest {
         serverThrows = true
         val response = client.exportTraces(spans)
         assertIs<OtlpResponse.Unknown>(response)
+        assertEquals(1, errorHandler.userCodeErrors.size)
+        assertEquals("OTLP export failed", errorHandler.userCodeErrors.single().message)
     }
 
     @Test
@@ -385,6 +393,6 @@ internal class OtlpClientTest {
 
     private fun useRequestTimeout() {
         val httpClient = createDefaultHttpClient(requestTimeoutMs, server)
-        client = OtlpClient(baseUrl, httpClient = httpClient)
+        client = OtlpClient(baseUrl, httpClient = httpClient, sdkErrorHandler = NoopSdkErrorHandler)
     }
 }

--- a/exporters-otlp/src/commonTest/kotlin/io/opentelemetry/kotlin/export/TelemetryExporterTest.kt
+++ b/exporters-otlp/src/commonTest/kotlin/io/opentelemetry/kotlin/export/TelemetryExporterTest.kt
@@ -1,6 +1,7 @@
 package io.opentelemetry.kotlin.export
 
 import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.error.NoopSdkErrorHandler
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -22,7 +23,8 @@ internal class TelemetryExporterTest {
             initialDelayMs = 100,
             maxAttemptIntervalMs = 1000,
             maxAttempts = 3,
-            exportAction = { OtlpResponse.Success }
+            sdkErrorHandler = NoopSdkErrorHandler,
+            exportAction = { OtlpResponse.Success },
         )
     }
 
@@ -56,6 +58,7 @@ internal class TelemetryExporterTest {
             initialDelayMs = 100,
             maxAttemptIntervalMs = 1000,
             maxAttempts = 3,
+            sdkErrorHandler = NoopSdkErrorHandler,
             coroutineContext = StandardTestDispatcher(testScheduler),
         ) {
             attempts++
@@ -73,6 +76,7 @@ internal class TelemetryExporterTest {
             initialDelayMs = 100,
             maxAttemptIntervalMs = 1000,
             maxAttempts = 3,
+            sdkErrorHandler = NoopSdkErrorHandler,
             coroutineContext = StandardTestDispatcher(testScheduler),
         ) {
             attempts++
@@ -93,6 +97,7 @@ internal class TelemetryExporterTest {
             initialDelayMs = initialDelayMs,
             maxAttemptIntervalMs = maxIntervalMs,
             maxAttempts = maxAttempts,
+            sdkErrorHandler = NoopSdkErrorHandler,
             coroutineContext = StandardTestDispatcher(testScheduler),
             random = Random(0),
         ) {
@@ -126,6 +131,7 @@ internal class TelemetryExporterTest {
             maxAttempts = 3,
             coroutineContext = StandardTestDispatcher(testScheduler),
             random = Random(0),
+            sdkErrorHandler = NoopSdkErrorHandler,
         ) {
             timestamps += testScheduler.currentTime
             if (attempts++ == 0) {
@@ -146,7 +152,8 @@ internal class TelemetryExporterTest {
             initialDelayMs = 1,
             maxAttemptIntervalMs = 1,
             maxAttempts = 1,
-            exportAction = { error("network unreachable") }
+            sdkErrorHandler = NoopSdkErrorHandler,
+            exportAction = { error("network unreachable") },
         )
         // The failure occurs on a background coroutine whose scope has a CoroutineExceptionHandler,
         // so it must not propagate to the caller nor crash the process.

--- a/exporters-otlp/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/export/OtlpHttpLogRecordExporterTest.kt
+++ b/exporters-otlp/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/export/OtlpHttpLogRecordExporterTest.kt
@@ -49,12 +49,13 @@ internal class OtlpHttpLogRecordExporterTest {
             )
         }
         val httpClient = createDefaultHttpClient(engine = server)
-        client = OtlpClient(baseUrl, httpClient = httpClient)
+        client = OtlpClient(baseUrl, httpClient = httpClient, sdkErrorHandler = NoopSdkErrorHandler)
         exporter = OtlpHttpLogRecordExporter(
             client,
             initialDelayMs = 3,
             maxAttemptIntervalMs = 5,
-            maxAttempts = 3
+            maxAttempts = 3,
+            sdkErrorHandler = NoopSdkErrorHandler,
         )
     }
 

--- a/exporters-otlp/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/export/OtlpHttpSpanExporterTest.kt
+++ b/exporters-otlp/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/export/OtlpHttpSpanExporterTest.kt
@@ -49,12 +49,13 @@ internal class OtlpHttpSpanExporterTest {
             )
         }
         val httpClient = createDefaultHttpClient(engine = server)
-        client = OtlpClient(baseUrl, httpClient = httpClient)
+        client = OtlpClient(baseUrl, httpClient = httpClient, sdkErrorHandler = NoopSdkErrorHandler)
         exporter = OtlpHttpSpanExporter(
             client,
             initialDelayMs = 3,
             maxAttemptIntervalMs = 5,
-            maxAttempts = 3
+            maxAttempts = 3,
+            sdkErrorHandler = NoopSdkErrorHandler,
         )
     }
 

--- a/exporters-persistence/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/PersistingLogRecordProcessor.kt
+++ b/exporters-persistence/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/PersistingLogRecordProcessor.kt
@@ -84,7 +84,7 @@ internal class PersistingLogRecordProcessor(
 
     private val flushMutex = Mutex()
     private val flushScope = CoroutineScope(
-        SupervisorJob() + dispatcher + telemetryExceptionHandler("Persisting log record processor")
+        SupervisorJob() + dispatcher + telemetryExceptionHandler("Persisting log record processor", sdkErrorHandler)
     )
 
     init {

--- a/exporters-persistence/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/PersistingSpanProcessor.kt
+++ b/exporters-persistence/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/PersistingSpanProcessor.kt
@@ -83,7 +83,7 @@ internal class PersistingSpanProcessor(
 
     private val flushMutex = Mutex()
     private val flushScope = CoroutineScope(
-        SupervisorJob() + dispatcher + telemetryExceptionHandler("Persisting span processor")
+        SupervisorJob() + dispatcher + telemetryExceptionHandler("Persisting span processor", sdkErrorHandler)
     )
 
     init {

--- a/sdk-common/api/jvm/sdk-common.api
+++ b/sdk-common/api/jvm/sdk-common.api
@@ -61,7 +61,7 @@ public abstract class io/opentelemetry/kotlin/export/ShutdownState {
 }
 
 public final class io/opentelemetry/kotlin/export/TelemetryExceptionHandlerKt {
-	public static final fun telemetryExceptionHandler (Ljava/lang/String;)Lkotlinx/coroutines/CoroutineExceptionHandler;
+	public static final fun telemetryExceptionHandler (Ljava/lang/String;Lio/opentelemetry/kotlin/error/SdkErrorHandler;)Lkotlinx/coroutines/CoroutineExceptionHandler;
 }
 
 public final class io/opentelemetry/kotlin/export/TimeoutOperationKt {

--- a/sdk-common/src/commonMain/kotlin/io/opentelemetry/kotlin/export/TelemetryExceptionHandler.kt
+++ b/sdk-common/src/commonMain/kotlin/io/opentelemetry/kotlin/export/TelemetryExceptionHandler.kt
@@ -1,6 +1,8 @@
 package io.opentelemetry.kotlin.export
 
-import io.opentelemetry.kotlin.platformLog
+import io.opentelemetry.kotlin.error.SdkError
+import io.opentelemetry.kotlin.error.SdkErrorHandler
+import io.opentelemetry.kotlin.error.SdkErrorSeverity
 import kotlinx.coroutines.CoroutineExceptionHandler
 
 /**
@@ -14,7 +16,13 @@ import kotlinx.coroutines.CoroutineExceptionHandler
  * [kotlinx.coroutines.CancellationException] is never routed here by the framework, so normal
  * cancellation (e.g. on shutdown) is unaffected.
  */
-public fun telemetryExceptionHandler(context: String): CoroutineExceptionHandler =
+public fun telemetryExceptionHandler(context: String, sdkErrorHandler: SdkErrorHandler): CoroutineExceptionHandler =
     CoroutineExceptionHandler { _, throwable ->
-        platformLog("$context coroutine failed: ${throwable.message}")
+        sdkErrorHandler.onError(
+            SdkError.UserCodeError(
+                cause = throwable,
+                message = "$context coroutine failed",
+                severity = SdkErrorSeverity.WARNING,
+            )
+        )
     }

--- a/sdk-common/src/commonTest/kotlin/io/opentelemetry/kotlin/export/TelemetryExceptionHandlerTest.kt
+++ b/sdk-common/src/commonTest/kotlin/io/opentelemetry/kotlin/export/TelemetryExceptionHandlerTest.kt
@@ -1,0 +1,27 @@
+package io.opentelemetry.kotlin.export
+
+import io.opentelemetry.kotlin.error.FakeSdkErrorHandler
+import io.opentelemetry.kotlin.error.SdkErrorSeverity
+import kotlin.coroutines.EmptyCoroutineContext
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+internal class TelemetryExceptionHandlerTest {
+
+    @Test
+    fun testCoroutineFailureReportsUserCodeError() {
+        val handler = FakeSdkErrorHandler()
+        val cause = IllegalStateException("boom")
+
+        telemetryExceptionHandler("Test context", handler)
+            .handleException(EmptyCoroutineContext, cause)
+
+        assertEquals(1, handler.userCodeErrors.size)
+        val error = handler.userCodeErrors.single()
+        assertEquals("Test context coroutine failed", error.message)
+        assertEquals(SdkErrorSeverity.WARNING, error.severity)
+        assertIs<IllegalStateException>(error.cause)
+        assertEquals("boom", error.cause.message)
+    }
+}


### PR DESCRIPTION
Part 2 of #711 - migrates exporter error reporting from platformLog() to sdkErrorHandler.onError(...).

# Summary
Routes exporter failures through the configurable SdkErrorHandler from #710 instead of platformLog().

Depends on #839 (PR1, telemetryExceptionHandler API change).

# Scope
exporters-core - batch processor wiring, core exporter API misuse (CoreSpanExporterApi, CoreLogRecordExporterApi)
exporters-otlp - OTLP HTTP export failures, exporter API wiring
exporters-persistence - persisting processor failure paths
Failures are reported as UserCodeError with WARNING severity.

Stdout*Exporter and PlatformLogger are intentionally unchanged.

# Testing
Updated/added tests in exporters-core and exporters-otlp
Targeted: :exporters-core:jvmTest, :exporters-otlp:jvmTest