### PR TITLE
Fix/711-implementation-providers

### DIFF
--- a/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/export/BatchTelemetryConfig.kt
+++ b/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/export/BatchTelemetryConfig.kt
@@ -9,7 +9,7 @@ internal class BatchTelemetryConfig(
     exportTimeoutMs: Long = BatchTelemetryDefaults.EXPORT_TIMEOUT_MS,
     maxExportBatchSize: Int = BatchTelemetryDefaults.MAX_EXPORT_BATCH_SIZE,
     forceFlushTimeoutMs: Long = BatchTelemetryDefaults.FORCE_FLUSH_TIMEOUT_MS,
-    sdkErrorHandler: SdkErrorHandler,
+    val sdkErrorHandler: SdkErrorHandler,
 ) {
     /**
      * Maximum number of telemetry items the queue can hold before items are dropped.

--- a/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/export/BatchTelemetryProcessor.kt
+++ b/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/export/BatchTelemetryProcessor.kt
@@ -19,7 +19,9 @@ internal class BatchTelemetryProcessor<T>(
 
     private val shutdownState: MutableShutdownState = MutableShutdownState()
     private val scope =
-        CoroutineScope(SupervisorJob() + dispatcher + telemetryExceptionHandler("Batch processor"))
+        CoroutineScope(
+            SupervisorJob() + dispatcher + telemetryExceptionHandler("Batch processor", config.sdkErrorHandler)
+        )
     private val mutex = Mutex()
     private val queue = ArrayDeque<T>()
 

--- a/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/CoreLogRecordExporterApi.kt
+++ b/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/CoreLogRecordExporterApi.kt
@@ -2,10 +2,11 @@
 package io.opentelemetry.kotlin.logging.export
 
 import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.error.SdkError
+import io.opentelemetry.kotlin.error.SdkErrorSeverity
 import io.opentelemetry.kotlin.export.BatchTelemetryDefaults
 import io.opentelemetry.kotlin.export.telemetryExceptionHandler
 import io.opentelemetry.kotlin.init.LogExportConfigDsl
-import io.opentelemetry.kotlin.platformLog
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -17,7 +18,13 @@ import kotlinx.coroutines.SupervisorJob
 @ExperimentalApi
 public fun LogExportConfigDsl.compositeLogRecordProcessor(vararg processors: LogRecordProcessor): LogRecordProcessor {
     if (processors.isEmpty()) {
-        platformLog("At least one processor must be provided")
+        sdkErrorHandler.onError(
+            SdkError.ApiMisuse(
+                api = "LogExportConfigDsl.compositeLogRecordProcessor",
+                message = "At least one processor must be provided",
+                severity = SdkErrorSeverity.WARNING,
+            )
+        )
         return NoopLogRecordProcessor
     }
     return CompositeLogRecordProcessor(processors.toList(), sdkErrorHandler)
@@ -30,7 +37,7 @@ public fun LogExportConfigDsl.compositeLogRecordProcessor(vararg processors: Log
 public fun LogExportConfigDsl.simpleLogRecordProcessor(exporter: LogRecordExporter): LogRecordProcessor {
     val dispatcher: CoroutineDispatcher = Dispatchers.Default
     val scope = CoroutineScope(
-        SupervisorJob() + dispatcher + telemetryExceptionHandler("Simple log record processor")
+        SupervisorJob() + dispatcher + telemetryExceptionHandler("Simple log record processor", sdkErrorHandler)
     )
     return SimpleLogRecordProcessor(exporter, scope)
 }
@@ -41,7 +48,13 @@ public fun LogExportConfigDsl.simpleLogRecordProcessor(exporter: LogRecordExport
 @ExperimentalApi
 public fun LogExportConfigDsl.compositeLogRecordExporter(vararg exporters: LogRecordExporter): LogRecordExporter {
     if (exporters.isEmpty()) {
-        platformLog("At least one exporter must be provided")
+        sdkErrorHandler.onError(
+            SdkError.ApiMisuse(
+                api = "LogExportConfigDsl.compositeLogRecordExporter",
+                message = "At least one exporter must be provided",
+                severity = SdkErrorSeverity.WARNING,
+            )
+        )
         return NoopLogRecordExporter
     }
     return CompositeLogRecordExporter(exporters.toList(), sdkErrorHandler)

--- a/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/CoreSpanExporterApi.kt
+++ b/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/CoreSpanExporterApi.kt
@@ -1,10 +1,11 @@
 package io.opentelemetry.kotlin.tracing.export
 
 import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.error.SdkError
+import io.opentelemetry.kotlin.error.SdkErrorSeverity
 import io.opentelemetry.kotlin.export.BatchTelemetryDefaults
 import io.opentelemetry.kotlin.export.telemetryExceptionHandler
 import io.opentelemetry.kotlin.init.TraceExportConfigDsl
-import io.opentelemetry.kotlin.platformLog
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -16,7 +17,13 @@ import kotlinx.coroutines.SupervisorJob
 @ExperimentalApi
 public fun TraceExportConfigDsl.compositeSpanProcessor(vararg processors: SpanProcessor): SpanProcessor {
     if (processors.isEmpty()) {
-        platformLog("At least one processor must be provided")
+        sdkErrorHandler.onError(
+            SdkError.ApiMisuse(
+                api = "TraceExportConfigDsl.compositeSpanProcessor",
+                message = "At least one processor must be provided",
+                severity = SdkErrorSeverity.WARNING,
+            )
+        )
         return NoopSpanProcessor
     }
     return CompositeSpanProcessor(processors.toList(), sdkErrorHandler)
@@ -29,7 +36,7 @@ public fun TraceExportConfigDsl.compositeSpanProcessor(vararg processors: SpanPr
 public fun TraceExportConfigDsl.simpleSpanProcessor(exporter: SpanExporter): SpanProcessor {
     val dispatcher: CoroutineDispatcher = Dispatchers.Default
     val scope = CoroutineScope(
-        SupervisorJob() + dispatcher + telemetryExceptionHandler("Simple span processor")
+        SupervisorJob() + dispatcher + telemetryExceptionHandler("Simple span processor", sdkErrorHandler)
     )
     return SimpleSpanProcessor(exporter, scope)
 }
@@ -40,7 +47,13 @@ public fun TraceExportConfigDsl.simpleSpanProcessor(exporter: SpanExporter): Spa
 @ExperimentalApi
 public fun TraceExportConfigDsl.compositeSpanExporter(vararg exporters: SpanExporter): SpanExporter {
     if (exporters.isEmpty()) {
-        platformLog("At least one exporter must be provided")
+        sdkErrorHandler.onError(
+            SdkError.ApiMisuse(
+                api = "TraceExportConfigDsl.compositeSpanExporter",
+                message = "At least one exporter must be provided",
+                severity = SdkErrorSeverity.WARNING,
+            )
+        )
         return NoopSpanExporter
     }
     return CompositeSpanExporter(exporters.toList(), sdkErrorHandler)

--- a/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/export/CoreLogRecordExporterApiTest.kt
+++ b/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/export/CoreLogRecordExporterApiTest.kt
@@ -2,6 +2,7 @@ package io.opentelemetry.kotlin.logging.export
 
 import io.opentelemetry.kotlin.FakeInstrumentationScopeInfo
 import io.opentelemetry.kotlin.context.FakeContext
+import io.opentelemetry.kotlin.error.FakeSdkErrorHandler
 import io.opentelemetry.kotlin.export.FakeLogExportConfig
 import io.opentelemetry.kotlin.export.OperationResultCode
 import io.opentelemetry.kotlin.logging.model.FakeReadWriteLogRecord
@@ -38,5 +39,29 @@ internal class CoreLogRecordExporterApiTest {
             assertEquals(OperationResultCode.Success, shutdown())
         }
         assertSame(NoopLogRecordExporter, emptyExporter)
+    }
+
+    @Test
+    fun compositeLogRecordProcessorEmptyReportsApiMisuse() {
+        val handler = FakeSdkErrorHandler()
+        val config = FakeLogExportConfig(sdkErrorHandler = handler)
+        config.compositeLogRecordProcessor()
+        assertEquals(1, handler.apiMisuses.size)
+        assertEquals(
+            "LogExportConfigDsl.compositeLogRecordProcessor",
+            handler.apiMisuses.single().api,
+        )
+    }
+
+    @Test
+    fun compositeLogRecordExporterEmptyReportsApiMisuse() {
+        val handler = FakeSdkErrorHandler()
+        val config = FakeLogExportConfig(sdkErrorHandler = handler)
+        config.compositeLogRecordExporter()
+        assertEquals(1, handler.apiMisuses.size)
+        assertEquals(
+            "LogExportConfigDsl.compositeLogRecordExporter",
+            handler.apiMisuses.single().api,
+        )
     }
 }

--- a/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/export/CoreSpanExporterApiTest.kt
+++ b/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/export/CoreSpanExporterApiTest.kt
@@ -1,6 +1,7 @@
 package io.opentelemetry.kotlin.tracing.export
 
 import io.opentelemetry.kotlin.context.FakeContext
+import io.opentelemetry.kotlin.error.FakeSdkErrorHandler
 import io.opentelemetry.kotlin.export.FakeTraceExportConfig
 import io.opentelemetry.kotlin.export.OperationResultCode
 import io.opentelemetry.kotlin.tracing.FakeReadWriteSpan
@@ -36,5 +37,29 @@ internal class CoreSpanExporterApiTest {
             assertEquals(OperationResultCode.Success, shutdown())
         }
         assertSame(NoopSpanExporter, emptyExporter)
+    }
+
+    @Test
+    fun compositeSpanProcessorEmptyReportsApiMisuse() {
+        val handler = FakeSdkErrorHandler()
+        val config = FakeTraceExportConfig(sdkErrorHandler = handler)
+        config.compositeSpanProcessor()
+        assertEquals(1, handler.apiMisuses.size)
+        assertEquals(
+            "TraceExportConfigDsl.compositeSpanProcessor",
+            handler.apiMisuses.single().api,
+        )
+    }
+
+    @Test
+    fun compositeSpanExporterEmptyReportsApiMisuse() {
+        val handler = FakeSdkErrorHandler()
+        val config = FakeTraceExportConfig(sdkErrorHandler = handler)
+        config.compositeSpanExporter()
+        assertEquals(1, handler.apiMisuses.size)
+        assertEquals(
+            "TraceExportConfigDsl.compositeSpanExporter",
+            handler.apiMisuses.single().api,
+        )
     }
 }

--- a/exporters-otlp/src/commonMain/kotlin/io/opentelemetry/kotlin/export/OtlpClient.kt
+++ b/exporters-otlp/src/commonMain/kotlin/io/opentelemetry/kotlin/export/OtlpClient.kt
@@ -11,6 +11,9 @@ import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
 import io.ktor.http.contentType
 import io.ktor.utils.io.readRemaining
+import io.opentelemetry.kotlin.error.SdkError
+import io.opentelemetry.kotlin.error.SdkErrorHandler
+import io.opentelemetry.kotlin.error.SdkErrorSeverity
 import io.opentelemetry.kotlin.export.OtlpClient.Companion.MAX_ERROR_BODY_BYTES
 import io.opentelemetry.kotlin.export.OtlpResponse.ClientError
 import io.opentelemetry.kotlin.export.OtlpResponse.PartialSuccess
@@ -21,7 +24,6 @@ import io.opentelemetry.kotlin.export.OtlpResponse.Unknown
 import io.opentelemetry.kotlin.logging.data.LogRecordData
 import io.opentelemetry.kotlin.logging.export.deserializeLogRecordPartialSuccess
 import io.opentelemetry.kotlin.logging.export.toProtobufByteArray
-import io.opentelemetry.kotlin.platformLog
 import io.opentelemetry.kotlin.tracing.data.SpanData
 import io.opentelemetry.kotlin.tracing.export.deserializeTraceRecordPartialSuccess
 import io.opentelemetry.kotlin.tracing.export.toProtobufByteArray
@@ -30,7 +32,8 @@ import kotlin.coroutines.cancellation.CancellationException
 
 internal class OtlpClient(
     private val baseUrl: String,
-    private val httpClient: HttpClient = defaultHttpClient
+    private val httpClient: HttpClient = defaultHttpClient,
+    private val sdkErrorHandler: SdkErrorHandler,
 ) {
 
     private val contentType = ContentType.parse("application/x-protobuf")
@@ -81,7 +84,13 @@ internal class OtlpClient(
         } catch (e: CancellationException) {
             throw e
         } catch (e: Throwable) {
-            platformLog("OTLP export failed: ${e.message}")
+            sdkErrorHandler.onError(
+                SdkError.UserCodeError(
+                    e,
+                    "OTLP export failed",
+                    SdkErrorSeverity.WARNING,
+                )
+            )
             Unknown
         }
     }

--- a/exporters-otlp/src/commonMain/kotlin/io/opentelemetry/kotlin/export/TelemetryExporter.kt
+++ b/exporters-otlp/src/commonMain/kotlin/io/opentelemetry/kotlin/export/TelemetryExporter.kt
@@ -1,5 +1,6 @@
 package io.opentelemetry.kotlin.export
 
+import io.opentelemetry.kotlin.error.SdkErrorHandler
 import io.opentelemetry.kotlin.export.OperationResultCode.Success
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -16,6 +17,7 @@ internal class TelemetryExporter<T>(
     private val initialDelayMs: Long,
     private val maxAttemptIntervalMs: Long,
     private val maxAttempts: Int,
+    private val sdkErrorHandler: SdkErrorHandler,
     coroutineContext: CoroutineContext = Dispatchers.Default,
     private val random: Random = Random.Default,
     private val exportAction: suspend (telemetry: List<T>) -> OtlpResponse,
@@ -23,7 +25,7 @@ internal class TelemetryExporter<T>(
 
     private val shutdownState: MutableShutdownState = MutableShutdownState()
     private val scope: CoroutineScope =
-        CoroutineScope(SupervisorJob() + coroutineContext + telemetryExceptionHandler("OTLP exporter"))
+        CoroutineScope(SupervisorJob() + coroutineContext + telemetryExceptionHandler("OTLP exporter", sdkErrorHandler))
 
     /**
      * Exports telemetry via coroutines and uses exponential backoff when a failure

--- a/exporters-otlp/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/OtlpHttpLogRecordExporter.kt
+++ b/exporters-otlp/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/OtlpHttpLogRecordExporter.kt
@@ -1,5 +1,6 @@
 package io.opentelemetry.kotlin.logging.export
 
+import io.opentelemetry.kotlin.error.SdkErrorHandler
 import io.opentelemetry.kotlin.export.OperationResultCode
 import io.opentelemetry.kotlin.export.OtlpClient
 import io.opentelemetry.kotlin.export.TelemetryExporter
@@ -10,9 +11,15 @@ internal class OtlpHttpLogRecordExporter(
     initialDelayMs: Long,
     maxAttemptIntervalMs: Long,
     maxAttempts: Int,
+    sdkErrorHandler: SdkErrorHandler,
 ) : LogRecordExporter {
 
-    private val exporter = TelemetryExporter(initialDelayMs, maxAttemptIntervalMs, maxAttempts) {
+    private val exporter = TelemetryExporter(
+        initialDelayMs,
+        maxAttemptIntervalMs,
+        maxAttempts,
+        sdkErrorHandler,
+    ) {
         otlpClient.exportLogs(it)
     }
 

--- a/exporters-otlp/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/OtlpLogRecordExporterApi.kt
+++ b/exporters-otlp/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/OtlpLogRecordExporterApi.kt
@@ -23,10 +23,11 @@ public fun LogExportConfigDsl.otlpHttpLogRecordExporter(
     timeoutMs: Long = EXPORT_REQUEST_TIMEOUT_MS,
 ): LogRecordExporter =
     OtlpHttpLogRecordExporter(
-        OtlpClient(baseUrl, createDefaultHttpClient(requestTimeoutMs = timeoutMs, engine = httpClientEngine)),
+        OtlpClient(baseUrl, createDefaultHttpClient(requestTimeoutMs = timeoutMs, engine = httpClientEngine), sdkErrorHandler),
         EXPORT_INITIAL_DELAY_MS,
         EXPORT_MAX_ATTEMPT_INTERVAL_MS,
-        EXPORT_MAX_ATTEMPTS
+        EXPORT_MAX_ATTEMPTS,
+        sdkErrorHandler,
     )
 
 /**
@@ -45,8 +46,9 @@ public fun LogExportConfigDsl.otlpHttpLogRecordExporter(
     httpClient: HttpClient,
 ): LogRecordExporter =
     OtlpHttpLogRecordExporter(
-        OtlpClient(baseUrl, httpClient),
+        OtlpClient(baseUrl, httpClient, sdkErrorHandler),
         EXPORT_INITIAL_DELAY_MS,
         EXPORT_MAX_ATTEMPT_INTERVAL_MS,
-        EXPORT_MAX_ATTEMPTS
+        EXPORT_MAX_ATTEMPTS,
+        sdkErrorHandler,
     )

--- a/exporters-otlp/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/OtlpHttpSpanExporter.kt
+++ b/exporters-otlp/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/OtlpHttpSpanExporter.kt
@@ -1,5 +1,6 @@
 package io.opentelemetry.kotlin.tracing.export
 
+import io.opentelemetry.kotlin.error.SdkErrorHandler
 import io.opentelemetry.kotlin.export.OperationResultCode
 import io.opentelemetry.kotlin.export.OtlpClient
 import io.opentelemetry.kotlin.export.TelemetryExporter
@@ -10,9 +11,15 @@ internal class OtlpHttpSpanExporter(
     initialDelayMs: Long,
     maxAttemptIntervalMs: Long,
     maxAttempts: Int,
+    sdkErrorHandler: SdkErrorHandler,
 ) : SpanExporter {
 
-    private val exporter = TelemetryExporter(initialDelayMs, maxAttemptIntervalMs, maxAttempts) {
+    private val exporter = TelemetryExporter(
+        initialDelayMs,
+        maxAttemptIntervalMs,
+        maxAttempts,
+        sdkErrorHandler,
+    ) {
         otlpClient.exportTraces(it)
     }
 

--- a/exporters-otlp/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/OtlpSpanExporterApi.kt
+++ b/exporters-otlp/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/OtlpSpanExporterApi.kt
@@ -21,10 +21,11 @@ public fun TraceExportConfigDsl.otlpHttpSpanExporter(
     httpClientEngine: HttpClientEngine = createHttpEngine(),
     timeoutMs: Long = EXPORT_REQUEST_TIMEOUT_MS,
 ): SpanExporter = OtlpHttpSpanExporter(
-    OtlpClient(baseUrl, createDefaultHttpClient(requestTimeoutMs = timeoutMs, engine = httpClientEngine)),
+    OtlpClient(baseUrl, createDefaultHttpClient(requestTimeoutMs = timeoutMs, engine = httpClientEngine), sdkErrorHandler),
     EXPORT_INITIAL_DELAY_MS,
     EXPORT_MAX_ATTEMPT_INTERVAL_MS,
-    EXPORT_MAX_ATTEMPTS
+    EXPORT_MAX_ATTEMPTS,
+    sdkErrorHandler,
 )
 
 /**
@@ -42,8 +43,9 @@ public fun TraceExportConfigDsl.otlpHttpSpanExporter(
     baseUrl: String,
     httpClient: HttpClient,
 ): SpanExporter = OtlpHttpSpanExporter(
-    OtlpClient(baseUrl, httpClient),
+    OtlpClient(baseUrl, httpClient, sdkErrorHandler),
     EXPORT_INITIAL_DELAY_MS,
     EXPORT_MAX_ATTEMPT_INTERVAL_MS,
-    EXPORT_MAX_ATTEMPTS
+    EXPORT_MAX_ATTEMPTS,
+    sdkErrorHandler,
 )

--- a/exporters-otlp/src/commonTest/kotlin/io/opentelemetry/kotlin/export/OtlpClientTest.kt
+++ b/exporters-otlp/src/commonTest/kotlin/io/opentelemetry/kotlin/export/OtlpClientTest.kt
@@ -11,6 +11,8 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.http.headersOf
 import io.ktor.util.toMap
 import io.ktor.utils.io.ByteReadChannel
+import io.opentelemetry.kotlin.error.FakeSdkErrorHandler
+import io.opentelemetry.kotlin.error.NoopSdkErrorHandler
 import io.opentelemetry.kotlin.logging.data.FakeLogRecordData
 import io.opentelemetry.kotlin.logging.data.LogRecordData
 import io.opentelemetry.kotlin.logging.export.toProtobufByteArray
@@ -42,6 +44,7 @@ internal class OtlpClientTest {
     private val expectedUserAgent = "OTel-OTLP-Exporter-Kotlin/${BuildKonfig.VERSION}"
 
     private lateinit var client: OtlpClient
+    private var errorHandler: FakeSdkErrorHandler = FakeSdkErrorHandler()
     private lateinit var server: MockEngine
     private lateinit var mockResponseStatus: HttpStatusCode
     private var mockResponseHeaders: Headers = Headers.Empty
@@ -51,6 +54,7 @@ internal class OtlpClientTest {
 
     @BeforeTest
     fun setUp() {
+        errorHandler = FakeSdkErrorHandler()
         server = MockEngine {
             if (serverThrows) {
                 error("network unreachable")
@@ -65,7 +69,7 @@ internal class OtlpClientTest {
             )
         }
         val httpClient = createDefaultHttpClient(INFINITE_TIMEOUT_MS, server)
-        client = OtlpClient(baseUrl, httpClient = httpClient)
+        client = OtlpClient(baseUrl, httpClient = httpClient, sdkErrorHandler = errorHandler)
     }
 
     @Test
@@ -173,6 +177,8 @@ internal class OtlpClientTest {
         serverThrows = true
         val response = client.exportLogs(logRecords)
         assertIs<OtlpResponse.Unknown>(response)
+        assertEquals(1, errorHandler.userCodeErrors.size)
+        assertEquals("OTLP export failed", errorHandler.userCodeErrors.single().message)
     }
 
     @Test
@@ -180,6 +186,8 @@ internal class OtlpClientTest {
         serverThrows = true
         val response = client.exportTraces(spans)
         assertIs<OtlpResponse.Unknown>(response)
+        assertEquals(1, errorHandler.userCodeErrors.size)
+        assertEquals("OTLP export failed", errorHandler.userCodeErrors.single().message)
     }
 
     @Test
@@ -385,6 +393,6 @@ internal class OtlpClientTest {
 
     private fun useRequestTimeout() {
         val httpClient = createDefaultHttpClient(requestTimeoutMs, server)
-        client = OtlpClient(baseUrl, httpClient = httpClient)
+        client = OtlpClient(baseUrl, httpClient = httpClient, sdkErrorHandler = NoopSdkErrorHandler)
     }
 }

--- a/exporters-otlp/src/commonTest/kotlin/io/opentelemetry/kotlin/export/TelemetryExporterTest.kt
+++ b/exporters-otlp/src/commonTest/kotlin/io/opentelemetry/kotlin/export/TelemetryExporterTest.kt
@@ -1,6 +1,7 @@
 package io.opentelemetry.kotlin.export
 
 import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.error.NoopSdkErrorHandler
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -22,7 +23,8 @@ internal class TelemetryExporterTest {
             initialDelayMs = 100,
             maxAttemptIntervalMs = 1000,
             maxAttempts = 3,
-            exportAction = { OtlpResponse.Success }
+            sdkErrorHandler = NoopSdkErrorHandler,
+            exportAction = { OtlpResponse.Success },
         )
     }
 
@@ -56,6 +58,7 @@ internal class TelemetryExporterTest {
             initialDelayMs = 100,
             maxAttemptIntervalMs = 1000,
             maxAttempts = 3,
+            sdkErrorHandler = NoopSdkErrorHandler,
             coroutineContext = StandardTestDispatcher(testScheduler),
         ) {
             attempts++
@@ -73,6 +76,7 @@ internal class TelemetryExporterTest {
             initialDelayMs = 100,
             maxAttemptIntervalMs = 1000,
             maxAttempts = 3,
+            sdkErrorHandler = NoopSdkErrorHandler,
             coroutineContext = StandardTestDispatcher(testScheduler),
         ) {
             attempts++
@@ -93,6 +97,7 @@ internal class TelemetryExporterTest {
             initialDelayMs = initialDelayMs,
             maxAttemptIntervalMs = maxIntervalMs,
             maxAttempts = maxAttempts,
+            sdkErrorHandler = NoopSdkErrorHandler,
             coroutineContext = StandardTestDispatcher(testScheduler),
             random = Random(0),
         ) {
@@ -126,6 +131,7 @@ internal class TelemetryExporterTest {
             maxAttempts = 3,
             coroutineContext = StandardTestDispatcher(testScheduler),
             random = Random(0),
+            sdkErrorHandler = NoopSdkErrorHandler,
         ) {
             timestamps += testScheduler.currentTime
             if (attempts++ == 0) {
@@ -146,7 +152,8 @@ internal class TelemetryExporterTest {
             initialDelayMs = 1,
             maxAttemptIntervalMs = 1,
             maxAttempts = 1,
-            exportAction = { error("network unreachable") }
+            sdkErrorHandler = NoopSdkErrorHandler,
+            exportAction = { error("network unreachable") },
         )
         // The failure occurs on a background coroutine whose scope has a CoroutineExceptionHandler,
         // so it must not propagate to the caller nor crash the process.

--- a/exporters-otlp/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/export/OtlpHttpLogRecordExporterTest.kt
+++ b/exporters-otlp/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/export/OtlpHttpLogRecordExporterTest.kt
@@ -49,12 +49,13 @@ internal class OtlpHttpLogRecordExporterTest {
             )
         }
         val httpClient = createDefaultHttpClient(engine = server)
-        client = OtlpClient(baseUrl, httpClient = httpClient)
+        client = OtlpClient(baseUrl, httpClient = httpClient, sdkErrorHandler = NoopSdkErrorHandler)
         exporter = OtlpHttpLogRecordExporter(
             client,
             initialDelayMs = 3,
             maxAttemptIntervalMs = 5,
-            maxAttempts = 3
+            maxAttempts = 3,
+            sdkErrorHandler = NoopSdkErrorHandler,
         )
     }
 

--- a/exporters-otlp/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/export/OtlpHttpSpanExporterTest.kt
+++ b/exporters-otlp/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/export/OtlpHttpSpanExporterTest.kt
@@ -49,12 +49,13 @@ internal class OtlpHttpSpanExporterTest {
             )
         }
         val httpClient = createDefaultHttpClient(engine = server)
-        client = OtlpClient(baseUrl, httpClient = httpClient)
+        client = OtlpClient(baseUrl, httpClient = httpClient, sdkErrorHandler = NoopSdkErrorHandler)
         exporter = OtlpHttpSpanExporter(
             client,
             initialDelayMs = 3,
             maxAttemptIntervalMs = 5,
-            maxAttempts = 3
+            maxAttempts = 3,
+            sdkErrorHandler = NoopSdkErrorHandler,
         )
     }
 

--- a/exporters-persistence/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/PersistingLogRecordProcessor.kt
+++ b/exporters-persistence/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/PersistingLogRecordProcessor.kt
@@ -84,7 +84,7 @@ internal class PersistingLogRecordProcessor(
 
     private val flushMutex = Mutex()
     private val flushScope = CoroutineScope(
-        SupervisorJob() + dispatcher + telemetryExceptionHandler("Persisting log record processor")
+        SupervisorJob() + dispatcher + telemetryExceptionHandler("Persisting log record processor", sdkErrorHandler)
     )
 
     init {

--- a/exporters-persistence/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/PersistingSpanProcessor.kt
+++ b/exporters-persistence/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/PersistingSpanProcessor.kt
@@ -83,7 +83,7 @@ internal class PersistingSpanProcessor(
 
     private val flushMutex = Mutex()
     private val flushScope = CoroutineScope(
-        SupervisorJob() + dispatcher + telemetryExceptionHandler("Persisting span processor")
+        SupervisorJob() + dispatcher + telemetryExceptionHandler("Persisting span processor", sdkErrorHandler)
     )
 
     init {

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/OpenTelemetryImplEntrypoint.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/OpenTelemetryImplEntrypoint.kt
@@ -38,7 +38,7 @@ public fun createOpenTelemetry(
     val spanContext = SpanContextFactoryImpl(idGenerator, traceFlags, traceState)
 
     val span = SpanFactoryImpl(spanContext)
-    val contextFactory = ContextFactoryImpl(span, cfg.contextConfig::generateStorage)
+    val contextFactory = ContextFactoryImpl(span, cfg.sdkErrorHandler, cfg.contextConfig::generateStorage)
     cfg.propagatorCfg.installFactories(
         traceFlagsFactory = traceFlags,
         traceStateFactory = traceState,

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/context/ContextImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/context/ContextImpl.kt
@@ -2,6 +2,7 @@ package io.opentelemetry.kotlin.context
 
 import io.opentelemetry.kotlin.baggage.Baggage
 import io.opentelemetry.kotlin.baggage.BaggageImpl
+import io.opentelemetry.kotlin.error.SdkErrorHandler
 import io.opentelemetry.kotlin.factory.SpanFactory
 import io.opentelemetry.kotlin.tracing.Span
 
@@ -11,6 +12,7 @@ private val SPAN_KEY: ContextKey<Span> = ContextKeyImpl("otel-kotlin-span")
 internal class ContextImpl(
     private val storage: ImplicitContextStorage,
     private val spanFactory: SpanFactory,
+    private val sdkErrorHandler: SdkErrorHandler,
     private val impl: Map<ContextKey<*>, Any?> = emptyMap()
 ) : Context {
 
@@ -19,7 +21,7 @@ internal class ContextImpl(
         value: T?
     ): Context {
         val newValues = impl.plus(Pair(key, value))
-        return ContextImpl(storage, spanFactory, newValues)
+        return ContextImpl(storage, spanFactory, sdkErrorHandler, newValues)
     }
 
     @Suppress("UNCHECKED_CAST")
@@ -33,7 +35,7 @@ internal class ContextImpl(
         }
         val current = storage.implicitContext()
         storage.setImplicitContext(this)
-        return ScopeImpl.create(current, this, storage)
+        return ScopeImpl.create(current, this, storage, sdkErrorHandler)
     }
 
     override fun storeSpan(span: Span): Context = set(SPAN_KEY, span)

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/context/ScopeImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/context/ScopeImpl.kt
@@ -1,12 +1,15 @@
 package io.opentelemetry.kotlin.context
 
-import io.opentelemetry.kotlin.platformLog
+import io.opentelemetry.kotlin.error.SdkError
+import io.opentelemetry.kotlin.error.SdkErrorHandler
+import io.opentelemetry.kotlin.error.SdkErrorSeverity
 import kotlin.concurrent.Volatile
 
 internal class ScopeImpl private constructor(
     private val previousContext: Context,
     private val currentContext: Context,
     private val storage: ImplicitContextStorage,
+    private val sdkErrorHandler: SdkErrorHandler,
 ) : Scope {
 
     @Volatile
@@ -14,10 +17,22 @@ internal class ScopeImpl private constructor(
 
     override fun detach(): Boolean {
         return if (detached) {
-            platformLog("Scope.detach() called on an already-detached scope")
+            sdkErrorHandler.onError(
+                SdkError.ApiMisuse(
+                    api = "Scope.detach",
+                    message = "Scope.detach() called on an already-detached scope",
+                    severity = SdkErrorSeverity.WARNING,
+                )
+            )
             false
         } else if (storage.implicitContext() != currentContext) {
-            platformLog("Scope.detach() called out of order — context has already changed")
+            sdkErrorHandler.onError(
+                SdkError.ApiMisuse(
+                    api = "Scope.detach",
+                    message = "Scope.detach() called out of order — context has already changed",
+                    severity = SdkErrorSeverity.WARNING,
+                )
+            )
             false
         } else {
             detached = true
@@ -31,15 +46,23 @@ internal class ScopeImpl private constructor(
             previousContext: Context,
             currentContext: Context,
             storage: ImplicitContextStorage,
+            sdkErrorHandler: SdkErrorHandler,
         ): Scope =
             if (previousContext == currentContext) {
-                platformLog("Cannot create scope with two matching contexts")
+                sdkErrorHandler.onError(
+                    SdkError.ApiMisuse(
+                        api = "Context.attach",
+                        message = "Cannot create scope with two matching contexts",
+                        severity = SdkErrorSeverity.WARNING,
+                    )
+                )
                 DetachedScope
             } else {
                 ScopeImpl(
                     previousContext = previousContext,
                     currentContext = currentContext,
-                    storage = storage
+                    storage = storage,
+                    sdkErrorHandler = sdkErrorHandler,
                 )
             }
     }

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/factory/ContextFactoryImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/factory/ContextFactoryImpl.kt
@@ -6,14 +6,17 @@ import io.opentelemetry.kotlin.context.ContextKey
 import io.opentelemetry.kotlin.context.ContextKeyImpl
 import io.opentelemetry.kotlin.context.DefaultImplicitContextStorage
 import io.opentelemetry.kotlin.context.ImplicitContextStorage
+import io.opentelemetry.kotlin.error.NoopSdkErrorHandler
+import io.opentelemetry.kotlin.error.SdkErrorHandler
 
 internal class ContextFactoryImpl(
     private val spanFactory: SpanFactory,
+    private val sdkErrorHandler: SdkErrorHandler = NoopSdkErrorHandler,
     storageFactory: (supplier: () -> Context) -> ImplicitContextStorage = ::DefaultImplicitContextStorage,
 ) : ContextFactory {
 
     private val storage: ImplicitContextStorage = storageFactory { root }
-    private val root by lazy { ContextImpl(storage, spanFactory) }
+    private val root by lazy { ContextImpl(storage, spanFactory, sdkErrorHandler) }
 
     override fun root(): Context = root
 

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/LoggerProviderConfigImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/LoggerProviderConfigImpl.kt
@@ -3,13 +3,14 @@ package io.opentelemetry.kotlin.init
 import io.opentelemetry.kotlin.Clock
 import io.opentelemetry.kotlin.attributes.DEFAULT_ATTRIBUTE_LIMIT
 import io.opentelemetry.kotlin.attributes.DEFAULT_ATTRIBUTE_VALUE_LENGTH_LIMIT
+import io.opentelemetry.kotlin.error.SdkError
 import io.opentelemetry.kotlin.error.SdkErrorHandler
+import io.opentelemetry.kotlin.error.SdkErrorSeverity
 import io.opentelemetry.kotlin.init.config.LogLimitConfig
 import io.opentelemetry.kotlin.init.config.LoggingConfig
 import io.opentelemetry.kotlin.logging.LoggerConfigImpl
 import io.opentelemetry.kotlin.logging.LoggerConfigurator
 import io.opentelemetry.kotlin.logging.export.LogRecordProcessor
-import io.opentelemetry.kotlin.platformLog
 import io.opentelemetry.kotlin.resource.Resource
 
 internal class LoggerProviderConfigImpl(
@@ -27,7 +28,13 @@ internal class LoggerProviderConfigImpl(
 
     override fun export(action: LogExportConfigDsl.() -> LogRecordProcessor) {
         if (processor != null) {
-            platformLog("export() should only be called once.")
+            sdkErrorHandler.onError(
+                SdkError.ApiMisuse(
+                    api = "LoggerProviderConfigDsl.export",
+                    message = "export() should only be called once.",
+                    severity = SdkErrorSeverity.WARNING,
+                )
+            )
             return
         }
         processor = LogExportConfigImpl(clock, sdkErrorHandler).action()

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/OpenTelemetryConfigImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/OpenTelemetryConfigImpl.kt
@@ -24,7 +24,7 @@ internal class OpenTelemetryConfigImpl(
      * The handler is configured after the sub-configs below have been created, so they receive a
      * forwarder that resolves the configured handler on each report instead.
      */
-    private val sdkErrorHandler = GuardedSdkErrorHandler { configuredErrorHandler.onError(it) }
+    internal val sdkErrorHandler = GuardedSdkErrorHandler { configuredErrorHandler.onError(it) }
 
     internal val tracingConfig: TracerProviderConfigImpl = TracerProviderConfigImpl(clock, sdkErrorHandler)
     internal val loggingConfig: LoggerProviderConfigImpl = LoggerProviderConfigImpl(clock, sdkErrorHandler)

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/TracerProviderConfigImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/TracerProviderConfigImpl.kt
@@ -3,13 +3,14 @@ package io.opentelemetry.kotlin.init
 import io.opentelemetry.kotlin.Clock
 import io.opentelemetry.kotlin.attributes.DEFAULT_ATTRIBUTE_LIMIT
 import io.opentelemetry.kotlin.attributes.DEFAULT_ATTRIBUTE_VALUE_LENGTH_LIMIT
+import io.opentelemetry.kotlin.error.SdkError
 import io.opentelemetry.kotlin.error.SdkErrorHandler
+import io.opentelemetry.kotlin.error.SdkErrorSeverity
 import io.opentelemetry.kotlin.factory.SpanFactory
 import io.opentelemetry.kotlin.init.config.DEFAULT_EVENT_LIMIT
 import io.opentelemetry.kotlin.init.config.DEFAULT_LINK_LIMIT
 import io.opentelemetry.kotlin.init.config.SpanLimitConfig
 import io.opentelemetry.kotlin.init.config.TracingConfig
-import io.opentelemetry.kotlin.platformLog
 import io.opentelemetry.kotlin.resource.Resource
 import io.opentelemetry.kotlin.tracing.TracerConfigImpl
 import io.opentelemetry.kotlin.tracing.TracerConfigurator
@@ -38,7 +39,13 @@ internal class TracerProviderConfigImpl(
 
     override fun export(action: TraceExportConfigDsl.() -> SpanProcessor) {
         if (processor != null) {
-            platformLog("export() should only be called once.")
+            sdkErrorHandler.onError(
+                SdkError.ApiMisuse(
+                    api = "TracerProviderConfigDsl.export",
+                    message = "export() should only be called once.",
+                    severity = SdkErrorSeverity.WARNING,
+                )
+            )
             return
         }
         processor = TraceExportConfigImpl(clock, sdkErrorHandler).action()

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/LoggerProviderImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/LoggerProviderImpl.kt
@@ -3,6 +3,8 @@ package io.opentelemetry.kotlin.logging
 import io.opentelemetry.kotlin.Clock
 import io.opentelemetry.kotlin.NoopOpenTelemetry
 import io.opentelemetry.kotlin.attributes.AttributesMutator
+import io.opentelemetry.kotlin.error.SdkError
+import io.opentelemetry.kotlin.error.SdkErrorSeverity
 import io.opentelemetry.kotlin.error.guardOrDefault
 import io.opentelemetry.kotlin.error.guardOrDefaultSuspend
 import io.opentelemetry.kotlin.export.BatchTelemetryDefaults
@@ -14,7 +16,6 @@ import io.opentelemetry.kotlin.export.runWithTimeout
 import io.opentelemetry.kotlin.factory.ContextFactory
 import io.opentelemetry.kotlin.factory.SpanContextFactory
 import io.opentelemetry.kotlin.init.config.LoggingConfig
-import io.opentelemetry.kotlin.platformLog
 import io.opentelemetry.kotlin.provider.ApiProviderImpl
 
 internal class LoggerProviderImpl(
@@ -63,7 +64,13 @@ internal class LoggerProviderImpl(
         sdkErrorHandler.guardOrDefault(noopLogger, "LoggerProvider.getLogger failed") {
             shutdownState.ifActiveOrElse(noopLogger) {
                 if (name.isEmpty()) {
-                    platformLog("Logger requested without instrumentation scope name")
+                    sdkErrorHandler.onError(
+                        SdkError.ApiMisuse(
+                            api = "LoggerProvider.getLogger",
+                            message = "Logger requested without instrumentation scope name",
+                            severity = SdkErrorSeverity.WARNING,
+                        )
+                    )
                 }
                 val key = apiProvider.createInstrumentationScopeInfo(name, version, schemaUrl, attributes)
                 apiProvider.getOrCreate(key)

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/MeterProviderImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/MeterProviderImpl.kt
@@ -2,6 +2,8 @@ package io.opentelemetry.kotlin.metrics
 
 import io.opentelemetry.kotlin.NoopOpenTelemetry
 import io.opentelemetry.kotlin.attributes.AttributesMutator
+import io.opentelemetry.kotlin.error.SdkError
+import io.opentelemetry.kotlin.error.SdkErrorSeverity
 import io.opentelemetry.kotlin.error.guardOrDefault
 import io.opentelemetry.kotlin.error.guardOrDefaultSuspend
 import io.opentelemetry.kotlin.export.BatchTelemetryDefaults
@@ -11,7 +13,6 @@ import io.opentelemetry.kotlin.export.OperationResultCode
 import io.opentelemetry.kotlin.export.TelemetryCloseable
 import io.opentelemetry.kotlin.export.runWithTimeout
 import io.opentelemetry.kotlin.init.config.MetricsConfig
-import io.opentelemetry.kotlin.platformLog
 import io.opentelemetry.kotlin.provider.ApiProviderImpl
 
 internal class MeterProviderImpl(
@@ -41,7 +42,13 @@ internal class MeterProviderImpl(
         sdkErrorHandler.guardOrDefault(noopMeter, "MeterProvider.getMeter failed") {
             shutdownState.ifActiveOrElse(noopMeter) {
                 if (name.isEmpty()) {
-                    platformLog("Meter requested without instrumentation scope name")
+                    sdkErrorHandler.onError(
+                        SdkError.ApiMisuse(
+                            api = "MeterProvider.getMeter",
+                            message = "Meter requested without instrumentation scope name",
+                            severity = SdkErrorSeverity.WARNING,
+                        )
+                    )
                 }
                 val key = apiProvider.createInstrumentationScopeInfo(name, version, schemaUrl, attributes)
                 apiProvider.getOrCreate(key)

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/TracerProviderImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/TracerProviderImpl.kt
@@ -3,6 +3,8 @@ package io.opentelemetry.kotlin.tracing
 import io.opentelemetry.kotlin.Clock
 import io.opentelemetry.kotlin.NoopOpenTelemetry
 import io.opentelemetry.kotlin.attributes.AttributesMutator
+import io.opentelemetry.kotlin.error.SdkError
+import io.opentelemetry.kotlin.error.SdkErrorSeverity
 import io.opentelemetry.kotlin.error.guardOrDefault
 import io.opentelemetry.kotlin.error.guardOrDefaultSuspend
 import io.opentelemetry.kotlin.export.BatchTelemetryDefaults
@@ -17,7 +19,6 @@ import io.opentelemetry.kotlin.factory.SpanContextFactory
 import io.opentelemetry.kotlin.factory.SpanFactory
 import io.opentelemetry.kotlin.factory.TraceFlagsFactory
 import io.opentelemetry.kotlin.init.config.TracingConfig
-import io.opentelemetry.kotlin.platformLog
 import io.opentelemetry.kotlin.provider.ApiProviderImpl
 
 internal class TracerProviderImpl(
@@ -71,7 +72,13 @@ internal class TracerProviderImpl(
         sdkErrorHandler.guardOrDefault(noopTracer, "TracerProvider.getTracer failed") {
             shutdownState.ifActiveOrElse(noopTracer) {
                 if (name.isEmpty()) {
-                    platformLog("Tracer requested without instrumentation scope name")
+                    sdkErrorHandler.onError(
+                        SdkError.ApiMisuse(
+                            api = "TracerProvider.getTracer",
+                            message = "Tracer requested without instrumentation scope name",
+                            severity = SdkErrorSeverity.WARNING,
+                        )
+                    )
                 }
                 val key = apiProvider.createInstrumentationScopeInfo(
                     name = name,

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/context/ImplicitContextTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/context/ImplicitContextTest.kt
@@ -1,5 +1,6 @@
 package io.opentelemetry.kotlin.context
 
+import io.opentelemetry.kotlin.error.NoopSdkErrorHandler
 import io.opentelemetry.kotlin.factory.ContextFactory
 import io.opentelemetry.kotlin.factory.ContextFactoryImpl
 import io.opentelemetry.kotlin.factory.IdGeneratorImpl
@@ -26,6 +27,7 @@ internal class ImplicitContextTest {
             factory.root(),
             factory.root(),
             DefaultImplicitContextStorage(factory::root),
+            NoopSdkErrorHandler,
         )
         assertTrue(scope.detach())
     }

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/context/ScopeImplTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/context/ScopeImplTest.kt
@@ -1,0 +1,75 @@
+package io.opentelemetry.kotlin.context
+
+import io.opentelemetry.kotlin.error.FakeSdkErrorHandler
+import io.opentelemetry.kotlin.error.SdkErrorSeverity
+import io.opentelemetry.kotlin.factory.ContextFactoryImpl
+import io.opentelemetry.kotlin.factory.IdGeneratorImpl
+import io.opentelemetry.kotlin.factory.SpanContextFactoryImpl
+import io.opentelemetry.kotlin.factory.SpanFactoryImpl
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+internal class ScopeImplTest {
+
+    private lateinit var handler: FakeSdkErrorHandler
+    private lateinit var factory: ContextFactoryImpl
+    private lateinit var storage: DefaultImplicitContextStorage
+
+    @BeforeTest
+    fun setUp() {
+        handler = FakeSdkErrorHandler()
+        factory = ContextFactoryImpl(
+            SpanFactoryImpl(SpanContextFactoryImpl(IdGeneratorImpl())),
+            sdkErrorHandler = handler,
+        )
+        storage = DefaultImplicitContextStorage(factory::root)
+    }
+
+    @Test
+    fun testCreateWithMatchingContextsReportsApiMisuse() {
+        val root = factory.root()
+        val scope = ScopeImpl.create(root, root, storage, handler)
+
+        assertTrue(scope.detach())
+        assertEquals(1, handler.apiMisuses.size)
+        val error = handler.apiMisuses.single()
+        assertEquals("Context.attach", error.api)
+        assertEquals("Cannot create scope with two matching contexts", error.message)
+        assertEquals(SdkErrorSeverity.WARNING, error.severity)
+    }
+
+    @Test
+    fun testDoubleDetachReportsApiMisuse() {
+        val newCtx = factory.with(factory.root(), mapOf("key" to "value"))
+        val scope = newCtx.attach()
+
+        assertTrue(scope.detach())
+        assertFalse(scope.detach())
+
+        assertEquals(1, handler.apiMisuses.size)
+        val error = handler.apiMisuses.single()
+        assertEquals("Scope.detach", error.api)
+        assertEquals("Scope.detach() called on an already-detached scope", error.message)
+        assertEquals(SdkErrorSeverity.WARNING, error.severity)
+    }
+
+    @Test
+    fun testOutOfOrderDetachReportsApiMisuse() {
+        val ctx1 = factory.with(factory.root(), mapOf("key" to "value"))
+        val scope1 = ctx1.attach()
+        val ctx2 = factory.with(factory.root(), mapOf("another" to "value"))
+        val scope2 = ctx2.attach()
+
+        assertFalse(scope1.detach())
+        assertTrue(scope2.detach())
+
+        assertEquals(1, handler.apiMisuses.size)
+        val error = handler.apiMisuses.single()
+        assertEquals("Scope.detach", error.api)
+        assertEquals("Scope.detach() called out of order — context has already changed", error.message)
+        assertEquals(SdkErrorSeverity.WARNING, error.severity)
+    }
+}

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/init/LoggerProviderConfigImplTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/init/LoggerProviderConfigImplTest.kt
@@ -2,6 +2,7 @@ package io.opentelemetry.kotlin.init
 
 import io.opentelemetry.kotlin.attributes.DEFAULT_ATTRIBUTE_LIMIT
 import io.opentelemetry.kotlin.clock.FakeClock
+import io.opentelemetry.kotlin.error.FakeSdkErrorHandler
 import io.opentelemetry.kotlin.error.NoopSdkErrorHandler
 import io.opentelemetry.kotlin.logging.export.FakeLogRecordProcessor
 import io.opentelemetry.kotlin.logging.export.LogRecordProcessor
@@ -86,6 +87,18 @@ internal class LoggerProviderConfigImplTest {
         }.generateLoggingConfig(base)
         assertSame(first, cfg.processor)
         assertNotSame(second, cfg.processor)
+    }
+
+    @Test
+    fun testDoubleExportReportsApiMisuse() {
+        val handler = FakeSdkErrorHandler()
+        LoggerProviderConfigImpl(clock, handler).apply {
+            export { simpleLogRecordProcessor(stdoutLogRecordExporter()) }
+            export { simpleLogRecordProcessor(stdoutLogRecordExporter()) }
+        }.generateLoggingConfig(base)
+        assertEquals(1, handler.apiMisuses.size)
+        assertEquals("LoggerProviderConfigDsl.export", handler.apiMisuses.single().api)
+        assertEquals("export() should only be called once.", handler.apiMisuses.single().message)
     }
 
     @Test

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/init/TracerProviderConfigImplTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/init/TracerProviderConfigImplTest.kt
@@ -5,6 +5,7 @@ import io.opentelemetry.kotlin.attributes.AttributesModel
 import io.opentelemetry.kotlin.attributes.DEFAULT_ATTRIBUTE_LIMIT
 import io.opentelemetry.kotlin.clock.FakeClock
 import io.opentelemetry.kotlin.context.Context
+import io.opentelemetry.kotlin.error.FakeSdkErrorHandler
 import io.opentelemetry.kotlin.error.NoopSdkErrorHandler
 import io.opentelemetry.kotlin.factory.ContextFactoryImpl
 import io.opentelemetry.kotlin.factory.FakeSpanFactory
@@ -188,6 +189,18 @@ internal class TracerProviderConfigImplTest {
         }.generateTracingConfig(base)
         assertSame(first, cfg.processor)
         assertNotSame(second, cfg.processor)
+    }
+
+    @Test
+    fun testDoubleExportReportsApiMisuse() {
+        val handler = FakeSdkErrorHandler()
+        TracerProviderConfigImpl(clock, handler).apply {
+            export { compositeSpanProcessor(FakeSpanProcessor()) }
+            export { compositeSpanProcessor(FakeSpanProcessor()) }
+        }.generateTracingConfig(base)
+        assertEquals(1, handler.apiMisuses.size)
+        assertEquals("TracerProviderConfigDsl.export", handler.apiMisuses.single().api)
+        assertEquals("export() should only be called once.", handler.apiMisuses.single().message)
     }
 
     @Test

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/LoggerProviderImplTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/LoggerProviderImplTest.kt
@@ -50,6 +50,22 @@ internal class LoggerProviderImplTest {
     }
 
     @Test
+    fun testEmptyLoggerNameReportsApiMisuse() {
+        val handler = FakeSdkErrorHandler()
+        val config = LoggingConfig(
+            null,
+            LogLimitConfig(100, 100),
+            ResourceImpl(AttributesModel(), null),
+            handler,
+            loggerConfigurator,
+        )
+        val provider = LoggerProviderImpl(clock, config, contextFactory, spanContextFactory)
+        provider.getLogger(name = "")
+        assertEquals(1, handler.apiMisuses.size)
+        assertEquals("LoggerProvider.getLogger", handler.apiMisuses.single().api)
+    }
+
+    @Test
     fun testFullLoggerProvider() {
         val first = impl.getLogger(
             name = "name",

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/metrics/MeterProviderImplTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/metrics/MeterProviderImplTest.kt
@@ -34,6 +34,19 @@ internal class MeterProviderImplTest {
     }
 
     @Test
+    fun testEmptyMeterNameReportsApiMisuse() {
+        val handler = FakeSdkErrorHandler()
+        val config = MetricsConfig(
+            resource = ResourceImpl(AttributesModel(), null),
+            sdkErrorHandler = handler,
+        )
+        val provider = MeterProviderImpl(config)
+        provider.getMeter(name = "")
+        assertEquals(1, handler.apiMisuses.size)
+        assertEquals("MeterProvider.getMeter", handler.apiMisuses.single().api)
+    }
+
+    @Test
     fun testDupeMeterProviderName() {
         val first = impl.getMeter(name = "name")
         val second = impl.getMeter(name = "name")

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/TracerProviderImplTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/TracerProviderImplTest.kt
@@ -56,6 +56,29 @@ internal class TracerProviderImplTest {
     }
 
     @Test
+    fun testEmptyTracerNameReportsApiMisuse() {
+        val handler = FakeSdkErrorHandler()
+        val config = TracingConfig(
+            null,
+            fakeSpanLimitsConfig,
+            ResourceImpl(AttributesModel(), null),
+            handler,
+        )
+        val provider = TracerProviderImpl(
+            clock = FakeClock(),
+            tracingConfig = config,
+            contextFactory = FakeContextFactory(),
+            spanContextFactory = FakeSpanContextFactory(),
+            traceFlagsFactory = FakeTraceFlagsFactory(),
+            spanFactory = FakeSpanFactory(),
+            idGenerator = FakeIdGenerator(),
+        )
+        provider.getTracer(name = "")
+        assertEquals(1, handler.apiMisuses.size)
+        assertEquals("TracerProvider.getTracer", handler.apiMisuses.single().api)
+    }
+
+    @Test
     fun testFullTracerProvider() {
         val first = impl.getTracer(
             name = "name",

--- a/sdk-common/api/jvm/sdk-common.api
+++ b/sdk-common/api/jvm/sdk-common.api
@@ -61,7 +61,7 @@ public abstract class io/opentelemetry/kotlin/export/ShutdownState {
 }
 
 public final class io/opentelemetry/kotlin/export/TelemetryExceptionHandlerKt {
-	public static final fun telemetryExceptionHandler (Ljava/lang/String;)Lkotlinx/coroutines/CoroutineExceptionHandler;
+	public static final fun telemetryExceptionHandler (Ljava/lang/String;Lio/opentelemetry/kotlin/error/SdkErrorHandler;)Lkotlinx/coroutines/CoroutineExceptionHandler;
 }
 
 public final class io/opentelemetry/kotlin/export/TimeoutOperationKt {

--- a/sdk-common/src/commonMain/kotlin/io/opentelemetry/kotlin/export/TelemetryExceptionHandler.kt
+++ b/sdk-common/src/commonMain/kotlin/io/opentelemetry/kotlin/export/TelemetryExceptionHandler.kt
@@ -1,6 +1,8 @@
 package io.opentelemetry.kotlin.export
 
-import io.opentelemetry.kotlin.platformLog
+import io.opentelemetry.kotlin.error.SdkError
+import io.opentelemetry.kotlin.error.SdkErrorHandler
+import io.opentelemetry.kotlin.error.SdkErrorSeverity
 import kotlinx.coroutines.CoroutineExceptionHandler
 
 /**
@@ -14,7 +16,13 @@ import kotlinx.coroutines.CoroutineExceptionHandler
  * [kotlinx.coroutines.CancellationException] is never routed here by the framework, so normal
  * cancellation (e.g. on shutdown) is unaffected.
  */
-public fun telemetryExceptionHandler(context: String): CoroutineExceptionHandler =
+public fun telemetryExceptionHandler(context: String, sdkErrorHandler: SdkErrorHandler): CoroutineExceptionHandler =
     CoroutineExceptionHandler { _, throwable ->
-        platformLog("$context coroutine failed: ${throwable.message}")
+        sdkErrorHandler.onError(
+            SdkError.UserCodeError(
+                cause = throwable,
+                message = "$context coroutine failed",
+                severity = SdkErrorSeverity.WARNING,
+            )
+        )
     }

--- a/sdk-common/src/commonTest/kotlin/io/opentelemetry/kotlin/export/TelemetryExceptionHandlerTest.kt
+++ b/sdk-common/src/commonTest/kotlin/io/opentelemetry/kotlin/export/TelemetryExceptionHandlerTest.kt
@@ -1,0 +1,27 @@
+package io.opentelemetry.kotlin.export
+
+import io.opentelemetry.kotlin.error.FakeSdkErrorHandler
+import io.opentelemetry.kotlin.error.SdkErrorSeverity
+import kotlin.coroutines.EmptyCoroutineContext
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+internal class TelemetryExceptionHandlerTest {
+
+    @Test
+    fun testCoroutineFailureReportsUserCodeError() {
+        val handler = FakeSdkErrorHandler()
+        val cause = IllegalStateException("boom")
+
+        telemetryExceptionHandler("Test context", handler)
+            .handleException(EmptyCoroutineContext, cause)
+
+        assertEquals(1, handler.userCodeErrors.size)
+        val error = handler.userCodeErrors.single()
+        assertEquals("Test context coroutine failed", error.message)
+        assertEquals(SdkErrorSeverity.WARNING, error.severity)
+        assertIs<IllegalStateException>(error.cause)
+        assertEquals("boom", error.cause.message)
+    }
+}


### PR DESCRIPTION
Part 3 of #711 - routes provider and scope API misuse through sdkErrorHandler instead of platformLog().

# Summary
Reports SDK API misuse via sdkErrorHandler.onError(...) with ApiMisuse and WARNING severity.

Depends on #840  (PR2, fix/711-exporters).

# Scope
Providers - empty instrumentation scope names (TracerProvider, LoggerProvider, MeterProvider)
Config - duplicate export() calls (TracerProviderConfig, LoggerProviderConfig)
Context / scope - invalid scope detachment and matching-context scope creation (ScopeImpl, ContextFactoryImpl)
OpenTelemetryConfigImpl - exposes sdkErrorHandler to the entrypoint for context wiring
Propagation (B3, TraceParent, ProbabilitySampler) is in PR4.

# Testing
Added ScopeImplTest
Updated provider/config tests in implementation
Targeted: :implementation:jvmTest (provider, scope, config tests)