### PR TITLE
Fix/711-implementation-propagation

### DIFF
--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/OpenTelemetryImplEntrypoint.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/OpenTelemetryImplEntrypoint.kt
@@ -44,6 +44,7 @@ public fun createOpenTelemetry(
         traceStateFactory = traceState,
         spanContextFactory = spanContext,
         spanFactory = span,
+        sdkErrorHandler = cfg.sdkErrorHandler,
     )
 
     val tracingConfig = cfg.generateTracingConfig()

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/PropagatorConfigImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/PropagatorConfigImpl.kt
@@ -3,6 +3,7 @@ package io.opentelemetry.kotlin.init
 import io.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.kotlin.NoopOpenTelemetry
 import io.opentelemetry.kotlin.context.Context
+import io.opentelemetry.kotlin.error.SdkErrorHandler
 import io.opentelemetry.kotlin.factory.SpanContextFactory
 import io.opentelemetry.kotlin.factory.SpanFactory
 import io.opentelemetry.kotlin.factory.TraceFlagsFactory
@@ -58,15 +59,31 @@ internal class PropagatorConfigImpl : PropagatorConfigDsl {
         traceStateFactory: TraceStateFactory,
         spanContextFactory: SpanContextFactory,
         spanFactory: SpanFactory,
+        sdkErrorHandler: SdkErrorHandler,
     ) {
         w3cTraceContextImpl = W3CTraceContextPropagator(
             traceFlagsFactory = traceFlagsFactory,
             traceStateFactory = traceStateFactory,
             spanContextFactory = spanContextFactory,
             spanFactory = spanFactory,
+            sdkErrorHandler = sdkErrorHandler,
         )
-        b3SingleImpl = B3Propagator(B3Format.SINGLE, traceFlagsFactory, traceStateFactory, spanContextFactory, spanFactory)
-        b3MultiImpl = B3Propagator(B3Format.MULTI, traceFlagsFactory, traceStateFactory, spanContextFactory, spanFactory)
+        b3SingleImpl = B3Propagator(
+            B3Format.SINGLE,
+            traceFlagsFactory,
+            traceStateFactory,
+            spanContextFactory,
+            spanFactory,
+            sdkErrorHandler,
+        )
+        b3MultiImpl = B3Propagator(
+            B3Format.MULTI,
+            traceFlagsFactory,
+            traceStateFactory,
+            spanContextFactory,
+            spanFactory,
+            sdkErrorHandler,
+        )
     }
 
     internal fun buildPropagator(): TextMapPropagator = configured

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/propagation/B3Propagator.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/propagation/B3Propagator.kt
@@ -4,6 +4,9 @@ import io.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.kotlin.context.Context
 import io.opentelemetry.kotlin.context.ContextKey
 import io.opentelemetry.kotlin.context.ContextKeyImpl
+import io.opentelemetry.kotlin.error.SdkError
+import io.opentelemetry.kotlin.error.SdkErrorHandler
+import io.opentelemetry.kotlin.error.SdkErrorSeverity
 import io.opentelemetry.kotlin.factory.SpanContextFactory
 import io.opentelemetry.kotlin.factory.SpanFactory
 import io.opentelemetry.kotlin.factory.TraceFlagsFactory
@@ -11,7 +14,6 @@ import io.opentelemetry.kotlin.factory.TraceStateFactory
 import io.opentelemetry.kotlin.factory.isAllZerosHex
 import io.opentelemetry.kotlin.factory.isValidHex
 import io.opentelemetry.kotlin.init.B3Format
-import io.opentelemetry.kotlin.platformLog
 import io.opentelemetry.kotlin.tracing.SpanContext
 
 /**
@@ -29,6 +31,7 @@ internal class B3Propagator(
     private val traceStateFactory: TraceStateFactory,
     private val spanContextFactory: SpanContextFactory,
     private val spanFactory: SpanFactory,
+    private val sdkErrorHandler: SdkErrorHandler,
 ) : TextMapPropagator {
 
     override fun fields(): Collection<String> = when (format) {
@@ -93,11 +96,23 @@ internal class B3Propagator(
         val header = getter.get(carrier, COMBINED_HEADER) ?: return null
         val parts = header.split(DELIMITER)
         if (parts.size !in 2..4) {
-            platformLog("B3 single header has wrong number of parts: $header")
+            sdkErrorHandler.onError(
+                SdkError.ApiMisuse(
+                    api = "B3Propagator.extractSingle",
+                    message = "B3 single header has wrong number of parts: $header",
+                    severity = SdkErrorSeverity.WARNING,
+                )
+            )
             return null
         }
         val traceId = normalizeTraceId(parts[0]) ?: run {
-            platformLog("B3 invalid traceId in single header: ${parts[0]}")
+            sdkErrorHandler.onError(
+                SdkError.ApiMisuse(
+                    api = "B3Propagator.extractSingle",
+                    message = "B3 invalid traceId in single header: ${parts[0]}",
+                    severity = SdkErrorSeverity.WARNING,
+                )
+            )
             return null
         }
         val rawSpanId = parts[1]
@@ -105,7 +120,13 @@ internal class B3Propagator(
         val debug = sampled == "d"
         val spanContext = buildContext(debug, sampled, traceId, rawSpanId)
         if (!spanContext.isValid) {
-            platformLog("B3 invalid spanId in single header: $rawSpanId")
+            sdkErrorHandler.onError(
+                SdkError.ApiMisuse(
+                    api = "B3Propagator.extractSingle",
+                    message = "B3 invalid spanId in single header: $rawSpanId",
+                    severity = SdkErrorSeverity.WARNING,
+                )
+            )
             return null
         }
         return context.storeSpan(spanFactory.fromSpanContext(spanContext)).let {
@@ -117,14 +138,28 @@ internal class B3Propagator(
         val rawTraceId = getter.get(carrier, TRACE_ID_HEADER)
         val rawSpanId = getter.get(carrier, SPAN_ID_HEADER) ?: return null
         val traceId = normalizeTraceId(rawTraceId) ?: run {
-            if (rawTraceId != null) { platformLog("B3 invalid traceId in multi header: $rawTraceId") }
+            if (rawTraceId != null) {
+                sdkErrorHandler.onError(
+                    SdkError.ApiMisuse(
+                        api = "B3Propagator.extractMulti",
+                        message = "B3 invalid traceId in multi header: $rawTraceId",
+                        severity = SdkErrorSeverity.WARNING,
+                    )
+                )
+            }
             return null
         }
         val debug = getter.get(carrier, DEBUG_HEADER) == "1"
         val sampled = getter.get(carrier, SAMPLED_HEADER)
         val spanContext = buildContext(debug, sampled, traceId, rawSpanId)
         if (!spanContext.isValid) {
-            platformLog("B3 invalid spanId in multi header: $rawSpanId")
+            sdkErrorHandler.onError(
+                SdkError.ApiMisuse(
+                    api = "B3Propagator.extractMulti",
+                    message = "B3 invalid spanId in multi header: $rawSpanId",
+                    severity = SdkErrorSeverity.WARNING,
+                )
+            )
             return null
         }
         return context.storeSpan(spanFactory.fromSpanContext(spanContext)).let {

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/propagation/TraceParent.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/propagation/TraceParent.kt
@@ -1,8 +1,10 @@
 package io.opentelemetry.kotlin.propagation
 
 import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.error.SdkError
+import io.opentelemetry.kotlin.error.SdkErrorHandler
+import io.opentelemetry.kotlin.error.SdkErrorSeverity
 import io.opentelemetry.kotlin.factory.TraceFlagsFactory
-import io.opentelemetry.kotlin.platformLog
 import io.opentelemetry.kotlin.tracing.TraceFlags
 
 /**
@@ -52,6 +54,7 @@ internal class TraceParent private constructor(
             traceId: String,
             spanId: String,
             traceFlags: TraceFlags,
+            sdkErrorHandler: SdkErrorHandler,
         ): TraceParent? {
             val errorMessage =
                 if (version.length != VERSION_LEN || !version.isLowerHex() || version == FORBIDDEN_VERSION) {
@@ -67,12 +70,22 @@ internal class TraceParent private constructor(
             return if (errorMessage == null) {
                 TraceParent(version, traceId, spanId, traceFlags)
             } else {
-                platformLog(errorMessage)
+                sdkErrorHandler.onError(
+                    SdkError.ApiMisuse(
+                        api = "TraceParent.create",
+                        message = errorMessage,
+                        severity = SdkErrorSeverity.WARNING,
+                    )
+                )
                 null
             }
         }
 
-        fun decode(header: String, traceFlagsFactory: TraceFlagsFactory): TraceParent? {
+        fun decode(
+            header: String,
+            traceFlagsFactory: TraceFlagsFactory,
+            sdkErrorHandler: SdkErrorHandler,
+        ): TraceParent? {
             if (header.length < LEN_V00) {
                 return null
             }
@@ -101,6 +114,7 @@ internal class TraceParent private constructor(
                 traceId = parts[1],
                 spanId = parts[2],
                 traceFlags = traceFlagsFactory.fromHex(flagsStr),
+                sdkErrorHandler = sdkErrorHandler,
             )
         }
 

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/propagation/W3CTraceContextPropagator.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/propagation/W3CTraceContextPropagator.kt
@@ -2,6 +2,7 @@ package io.opentelemetry.kotlin.propagation
 
 import io.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.kotlin.context.Context
+import io.opentelemetry.kotlin.error.SdkErrorHandler
 import io.opentelemetry.kotlin.factory.SpanContextFactory
 import io.opentelemetry.kotlin.factory.SpanFactory
 import io.opentelemetry.kotlin.factory.TraceFlagsFactory
@@ -18,6 +19,7 @@ internal class W3CTraceContextPropagator(
     private val traceStateFactory: TraceStateFactory,
     private val spanContextFactory: SpanContextFactory,
     private val spanFactory: SpanFactory,
+    private val sdkErrorHandler: SdkErrorHandler,
 ) : TextMapPropagator {
 
     override fun fields(): Collection<String> = FIELDS
@@ -33,6 +35,7 @@ internal class W3CTraceContextPropagator(
             traceId = spanContext.traceId,
             spanId = spanContext.spanId,
             traceFlags = spanContext.traceFlags,
+            sdkErrorHandler = sdkErrorHandler,
         )?.let {
             setter.set(carrier, TRACEPARENT, it.encode())
         }
@@ -45,7 +48,7 @@ internal class W3CTraceContextPropagator(
 
     override fun <T> extract(context: Context, carrier: T?, getter: TextMapGetter<T>): Context {
         val rawTraceparent = getter.get(carrier, TRACEPARENT) ?: return context
-        val parsed = TraceParent.decode(rawTraceparent, traceFlagsFactory) ?: return context
+        val parsed = TraceParent.decode(rawTraceparent, traceFlagsFactory, sdkErrorHandler) ?: return context
 
         val rawTracestate = getter.get(carrier, TRACESTATE)
         val traceState = when (rawTracestate) {

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/sampling/ProbabilitySampler.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/sampling/ProbabilitySampler.kt
@@ -3,14 +3,19 @@ package io.opentelemetry.kotlin.tracing.sampling
 import io.opentelemetry.kotlin.attributes.AttributeContainer
 import io.opentelemetry.kotlin.attributes.EmptyAttributeContainer
 import io.opentelemetry.kotlin.context.Context
-import io.opentelemetry.kotlin.platformLog
+import io.opentelemetry.kotlin.error.SdkError
+import io.opentelemetry.kotlin.error.SdkErrorHandler
+import io.opentelemetry.kotlin.error.SdkErrorSeverity
 import io.opentelemetry.kotlin.tracing.SpanKind
 import io.opentelemetry.kotlin.tracing.model.SpanLink
 import io.opentelemetry.kotlin.tracing.sampling.SamplingResult.Decision
 import kotlin.concurrent.Volatile
 import kotlin.math.max
 
-internal class ProbabilitySampler(ratio: Double) : Sampler {
+internal class ProbabilitySampler(
+    ratio: Double,
+    private val sdkErrorHandler: SdkErrorHandler,
+) : Sampler {
 
     private companion object {
         @Volatile
@@ -46,7 +51,13 @@ internal class ProbabilitySampler(ratio: Double) : Sampler {
         } else {
             if (parentSpanContext.isValid && !parentSpanContext.traceFlags.isRandom && !compatibilityWarningLogged) {
                 compatibilityWarningLogged = true
-                platformLog(COMPATIBILITY_WARNING)
+                sdkErrorHandler.onError(
+                    SdkError.ApiMisuse(
+                        api = "ProbabilitySampler.shouldSample",
+                        message = COMPATIBILITY_WARNING,
+                        severity = SdkErrorSeverity.WARNING,
+                    )
+                )
             }
             randomnessFromTraceIdBytes(traceIdBytes)
         }

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/init/PropagatorConfigImplTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/init/PropagatorConfigImplTest.kt
@@ -1,6 +1,7 @@
 package io.opentelemetry.kotlin.init
 
 import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.error.NoopSdkErrorHandler
 import io.opentelemetry.kotlin.factory.ContextFactoryImpl
 import io.opentelemetry.kotlin.factory.IdGeneratorImpl
 import io.opentelemetry.kotlin.factory.SpanContextFactoryImpl
@@ -47,7 +48,7 @@ internal class PropagatorConfigImplTest {
     @Test
     fun `w3cTraceContext routes through delegate once factories are installed`() {
         val config = PropagatorConfigImpl().apply { w3cTraceContext() }
-        config.installFactories(traceFlagsFactory, traceStateFactory, spanContextFactory, spanFactory)
+        config.installFactories(traceFlagsFactory, traceStateFactory, spanContextFactory, spanFactory, NoopSdkErrorHandler)
         val propagator = config.buildPropagator()
         assertEquals(listOf("traceparent", "tracestate"), propagator.fields().toList())
 

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/propagation/B3PropagatorErrorReportingTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/propagation/B3PropagatorErrorReportingTest.kt
@@ -1,0 +1,130 @@
+package io.opentelemetry.kotlin.propagation
+
+import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.error.FakeSdkErrorHandler
+import io.opentelemetry.kotlin.error.SdkErrorSeverity
+import io.opentelemetry.kotlin.factory.ContextFactoryImpl
+import io.opentelemetry.kotlin.factory.IdGeneratorImpl
+import io.opentelemetry.kotlin.factory.SpanContextFactoryImpl
+import io.opentelemetry.kotlin.factory.SpanFactoryImpl
+import io.opentelemetry.kotlin.factory.TraceFlagsFactoryImpl
+import io.opentelemetry.kotlin.factory.TraceStateFactoryImpl
+import io.opentelemetry.kotlin.init.B3Format
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertSame
+
+@OptIn(ExperimentalApi::class)
+internal class B3PropagatorErrorReportingTest {
+
+    private val traceFlagsFactory = TraceFlagsFactoryImpl()
+    private val traceStateFactory = TraceStateFactoryImpl()
+    private val spanContextFactory = SpanContextFactoryImpl(IdGeneratorImpl(), traceFlagsFactory, traceStateFactory)
+    private val spanFactory = SpanFactoryImpl(spanContextFactory)
+    private val contextFactory = ContextFactoryImpl(spanFactory)
+
+    private lateinit var handler: FakeSdkErrorHandler
+    private lateinit var singlePropagator: B3Propagator
+    private lateinit var multiPropagator: B3Propagator
+
+    private val traceId = "0af7651916cd43dd8448eb211c80319c"
+    private val spanId = "b7ad6b7169203331"
+
+    @BeforeTest
+    fun setUp() {
+        handler = FakeSdkErrorHandler()
+        singlePropagator = B3Propagator(
+            B3Format.SINGLE,
+            traceFlagsFactory,
+            traceStateFactory,
+            spanContextFactory,
+            spanFactory,
+            handler,
+        )
+        multiPropagator = B3Propagator(
+            B3Format.MULTI,
+            traceFlagsFactory,
+            traceStateFactory,
+            spanContextFactory,
+            spanFactory,
+            handler,
+        )
+    }
+
+    @Test
+    fun `extract single reports ApiMisuse for wrong number of parts`() {
+        val ctx = contextFactory.root()
+        assertSame(ctx, singlePropagator.extract(ctx, mapOf("b3" to traceId), MapTextMapGetter))
+
+        assertEquals(1, handler.apiMisuses.size)
+        val error = handler.apiMisuses.single()
+        assertEquals("B3Propagator.extractSingle", error.api)
+        assertEquals("B3 single header has wrong number of parts: $traceId", error.message)
+        assertEquals(SdkErrorSeverity.WARNING, error.severity)
+    }
+
+    @Test
+    fun `extract single reports ApiMisuse for invalid traceId`() {
+        val ctx = contextFactory.root()
+        assertSame(
+            ctx,
+            singlePropagator.extract(ctx, mapOf("b3" to "${"0".repeat(32)}-$spanId-1"), MapTextMapGetter),
+        )
+
+        assertEquals(1, handler.apiMisuses.size)
+        val error = handler.apiMisuses.single()
+        assertEquals("B3Propagator.extractSingle", error.api)
+        assertEquals("B3 invalid traceId in single header: ${"0".repeat(32)}", error.message)
+    }
+
+    @Test
+    fun `extract single reports ApiMisuse for invalid spanId`() {
+        val ctx = contextFactory.root()
+        assertSame(
+            ctx,
+            singlePropagator.extract(ctx, mapOf("b3" to "$traceId-${"0".repeat(16)}-1"), MapTextMapGetter),
+        )
+
+        assertEquals(1, handler.apiMisuses.size)
+        val error = handler.apiMisuses.single()
+        assertEquals("B3Propagator.extractSingle", error.api)
+        assertEquals("B3 invalid spanId in single header: ${"0".repeat(16)}", error.message)
+    }
+
+    @Test
+    fun `extract multi reports ApiMisuse for invalid traceId`() {
+        val ctx = contextFactory.root()
+        assertSame(
+            ctx,
+            multiPropagator.extract(
+                ctx,
+                mapOf("X-B3-TraceId" to "not-a-valid-trace-id", "X-B3-SpanId" to spanId),
+                MapTextMapGetter,
+            ),
+        )
+
+        assertEquals(1, handler.apiMisuses.size)
+        val error = handler.apiMisuses.single()
+        assertEquals("B3Propagator.extractMulti", error.api)
+        assertEquals("B3 invalid traceId in multi header: not-a-valid-trace-id", error.message)
+    }
+
+    @Test
+    fun `extract multi reports ApiMisuse for invalid spanId`() {
+        val ctx = contextFactory.root()
+        assertSame(
+            ctx,
+            multiPropagator.extract(
+                ctx,
+                mapOf("X-B3-TraceId" to traceId, "X-B3-SpanId" to "short"),
+                MapTextMapGetter,
+            ),
+        )
+
+        assertEquals(1, handler.apiMisuses.size)
+        val error = handler.apiMisuses.single()
+        assertEquals("B3Propagator.extractMulti", error.api)
+        assertEquals("B3 invalid spanId in multi header: short", error.message)
+    }
+}

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/propagation/B3PropagatorTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/propagation/B3PropagatorTest.kt
@@ -1,6 +1,7 @@
 package io.opentelemetry.kotlin.propagation
 
 import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.error.NoopSdkErrorHandler
 import io.opentelemetry.kotlin.factory.ContextFactoryImpl
 import io.opentelemetry.kotlin.factory.IdGeneratorImpl
 import io.opentelemetry.kotlin.factory.SpanContextFactoryImpl
@@ -25,9 +26,9 @@ internal class B3PropagatorTest {
     private val contextFactory = ContextFactoryImpl(spanFactory)
 
     private val singlePropagator =
-        B3Propagator(B3Format.SINGLE, traceFlagsFactory, traceStateFactory, spanContextFactory, spanFactory)
+        B3Propagator(B3Format.SINGLE, traceFlagsFactory, traceStateFactory, spanContextFactory, spanFactory, NoopSdkErrorHandler)
     private val multiPropagator =
-        B3Propagator(B3Format.MULTI, traceFlagsFactory, traceStateFactory, spanContextFactory, spanFactory)
+        B3Propagator(B3Format.MULTI, traceFlagsFactory, traceStateFactory, spanContextFactory, spanFactory, NoopSdkErrorHandler)
 
     private val traceId = "0af7651916cd43dd8448eb211c80319c"
     private val spanId = "b7ad6b7169203331"

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/propagation/CorePropagatorApiTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/propagation/CorePropagatorApiTest.kt
@@ -3,6 +3,7 @@ package io.opentelemetry.kotlin.propagation
 import io.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.kotlin.context.Context
 import io.opentelemetry.kotlin.context.ContextKey
+import io.opentelemetry.kotlin.error.NoopSdkErrorHandler
 import io.opentelemetry.kotlin.factory.ContextFactoryImpl
 import io.opentelemetry.kotlin.factory.IdGeneratorImpl
 import io.opentelemetry.kotlin.factory.SpanContextFactoryImpl
@@ -131,6 +132,7 @@ internal class CorePropagatorApiTest {
             traceStateFactory = traceStateFactory,
             spanContextFactory = spanContextFactory,
             spanFactory = spanFactory,
+            sdkErrorHandler = NoopSdkErrorHandler,
         )
     }
 }

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/propagation/TraceParentErrorReportingTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/propagation/TraceParentErrorReportingTest.kt
@@ -1,0 +1,85 @@
+package io.opentelemetry.kotlin.propagation
+
+import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.error.FakeSdkErrorHandler
+import io.opentelemetry.kotlin.error.SdkErrorSeverity
+import io.opentelemetry.kotlin.factory.TraceFlagsFactoryImpl
+import io.opentelemetry.kotlin.tracing.TraceFlagsImpl
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+@OptIn(ExperimentalApi::class)
+internal class TraceParentErrorReportingTest {
+
+    private val flagsFactory = TraceFlagsFactoryImpl()
+    private val traceId = "0af7651916cd43dd8448eb211c80319c"
+    private val spanId = "b7ad6b7169203331"
+    private val traceFlags = TraceFlagsImpl(isSampled = true, isRandom = false)
+
+    private lateinit var handler: FakeSdkErrorHandler
+
+    @BeforeTest
+    fun setUp() {
+        handler = FakeSdkErrorHandler()
+    }
+
+    @Test
+    fun `create reports ApiMisuse for forbidden version`() {
+        assertNull(TraceParent.create("ff", traceId, spanId, traceFlags, handler))
+
+        assertEquals(1, handler.apiMisuses.size)
+        val error = handler.apiMisuses.single()
+        assertEquals("TraceParent.create", error.api)
+        assertEquals(
+            "version must be 2 lowercase hex characters and not ff",
+            error.message,
+        )
+        assertEquals(SdkErrorSeverity.WARNING, error.severity)
+    }
+
+    @Test
+    fun `create reports ApiMisuse for invalid traceId`() {
+        assertNull(
+            TraceParent.create(
+                "00",
+                traceId.replaceFirst('a', 'g'),
+                spanId,
+                traceFlags,
+                handler,
+            )
+        )
+
+        assertEquals(1, handler.apiMisuses.size)
+        assertEquals("traceId must be 32 lowercase hex characters", handler.apiMisuses.single().message)
+    }
+
+    @Test
+    fun `create reports ApiMisuse for invalid spanId`() {
+        assertNull(
+            TraceParent.create(
+                "00",
+                traceId,
+                spanId.replaceFirst('b', 'g'),
+                traceFlags,
+                handler,
+            )
+        )
+
+        assertEquals(1, handler.apiMisuses.size)
+        assertEquals("spanId must be 16 lowercase hex characters", handler.apiMisuses.single().message)
+    }
+
+    @Test
+    fun `decode reports ApiMisuse when parsed fields fail create validation`() {
+        val invalidTraceId = traceId.replaceFirst('a', 'g')
+        assertNull(
+            TraceParent.decode("00-$invalidTraceId-$spanId-01", flagsFactory, handler),
+        )
+
+        assertEquals(1, handler.apiMisuses.size)
+        assertEquals("TraceParent.create", handler.apiMisuses.single().api)
+        assertEquals("traceId must be 32 lowercase hex characters", handler.apiMisuses.single().message)
+    }
+}

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/propagation/TraceParentTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/propagation/TraceParentTest.kt
@@ -1,6 +1,7 @@
 package io.opentelemetry.kotlin.propagation
 
 import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.error.NoopSdkErrorHandler
 import io.opentelemetry.kotlin.factory.TraceFlagsFactoryImpl
 import io.opentelemetry.kotlin.tracing.TraceFlagsImpl
 import kotlin.test.Test
@@ -18,6 +19,7 @@ import kotlin.test.assertTrue
 internal class TraceParentTest {
 
     private val flagsFactory = TraceFlagsFactoryImpl()
+    private val sdkErrorHandler = NoopSdkErrorHandler
     private val traceId = "0af7651916cd43dd8448eb211c80319c"
     private val spanId = "b7ad6b7169203331"
     private val canonicalHeader = "00-$traceId-$spanId-01"
@@ -30,6 +32,7 @@ internal class TraceParentTest {
             traceId = traceId,
             spanId = spanId,
             traceFlags = traceFlags,
+            sdkErrorHandler = sdkErrorHandler,
         )
         assertNotNull(tp)
         assertEquals(canonicalHeader, tp.encode())
@@ -42,6 +45,7 @@ internal class TraceParentTest {
             traceId = traceId,
             spanId = spanId,
             traceFlags = traceFlags,
+            sdkErrorHandler = sdkErrorHandler,
         )
         assertNotNull(tp)
         assertEquals(55, tp.encode().length)
@@ -54,6 +58,7 @@ internal class TraceParentTest {
             traceId = traceId,
             spanId = spanId,
             traceFlags = TraceFlagsImpl(isSampled = false, isRandom = false),
+            sdkErrorHandler = sdkErrorHandler,
         )
         assertNotNull(tp)
         assertEquals("00-$traceId-$spanId-00", tp.encode())
@@ -66,6 +71,7 @@ internal class TraceParentTest {
             traceId = traceId,
             spanId = spanId,
             traceFlags = TraceFlagsImpl(isSampled = false, isRandom = true),
+            sdkErrorHandler = sdkErrorHandler,
         )
         assertNotNull(tp)
         assertEquals("00-$traceId-$spanId-02", tp.encode())
@@ -78,6 +84,7 @@ internal class TraceParentTest {
             traceId = traceId,
             spanId = spanId,
             traceFlags = TraceFlagsImpl(isSampled = true, isRandom = true),
+            sdkErrorHandler = sdkErrorHandler,
         )
         assertNotNull(tp)
         assertEquals("00-$traceId-$spanId-03", tp.encode())
@@ -90,6 +97,7 @@ internal class TraceParentTest {
             traceId = traceId,
             spanId = spanId,
             traceFlags = TraceFlagsImpl(isSampled = false, isRandom = false),
+            sdkErrorHandler = sdkErrorHandler,
         )
         assertNotNull(tp)
         val flags = tp.encode().substringAfterLast('-')
@@ -99,7 +107,7 @@ internal class TraceParentTest {
 
     @Test
     fun `decode parses the canonical version 00 traceparent header`() {
-        val tp = TraceParent.decode(canonicalHeader, flagsFactory)
+        val tp = TraceParent.decode(canonicalHeader, flagsFactory, sdkErrorHandler)
         assertNotNull(tp)
         assertEquals("00", tp.version)
         assertEquals(traceId, tp.traceId)
@@ -110,7 +118,7 @@ internal class TraceParentTest {
 
     @Test
     fun `decode populates flags via the supplied factory`() {
-        val tp = TraceParent.decode("00-$traceId-$spanId-03", flagsFactory)
+        val tp = TraceParent.decode("00-$traceId-$spanId-03", flagsFactory, sdkErrorHandler)
         assertNotNull(tp)
         assertTrue(tp.traceFlags.isSampled)
         assertTrue(tp.traceFlags.isRandom)
@@ -118,7 +126,7 @@ internal class TraceParentTest {
 
     @Test
     fun `decode handles flags 00 by reporting both flags off`() {
-        val tp = TraceParent.decode("00-$traceId-$spanId-00", flagsFactory)
+        val tp = TraceParent.decode("00-$traceId-$spanId-00", flagsFactory, sdkErrorHandler)
         assertNotNull(tp)
         assertFalse(tp.traceFlags.isSampled)
         assertFalse(tp.traceFlags.isRandom)
@@ -126,7 +134,7 @@ internal class TraceParentTest {
 
     @Test
     fun `decode round-trips into encode without loss`() {
-        val tp = TraceParent.decode(canonicalHeader, flagsFactory)
+        val tp = TraceParent.decode(canonicalHeader, flagsFactory, sdkErrorHandler)
         assertNotNull(tp)
         assertEquals(canonicalHeader, tp.encode())
     }
@@ -137,7 +145,7 @@ internal class TraceParentTest {
         // these headers may carry additional `-`-separated fields after flags,
         // so length and field count constraints from version 00 do not apply.
         val header = "01-$traceId-$spanId-01-extra"
-        val tp = TraceParent.decode(header, flagsFactory)
+        val tp = TraceParent.decode(header, flagsFactory, sdkErrorHandler)
         assertNotNull(tp)
         assertEquals("01", tp.version)
         assertEquals(traceId, tp.traceId)
@@ -147,94 +155,94 @@ internal class TraceParentTest {
 
     @Test
     fun `decode rejects an empty header`() {
-        assertNull(TraceParent.decode("", flagsFactory))
+        assertNull(TraceParent.decode("", flagsFactory, sdkErrorHandler))
     }
 
     @Test
     fun `decode rejects a header shorter than 55 chars`() {
         val header = "00-$traceId-${spanId.dropLast(1)}-01"
         assertTrue(header.length < 55)
-        assertNull(TraceParent.decode(header, flagsFactory))
+        assertNull(TraceParent.decode(header, flagsFactory, sdkErrorHandler))
     }
 
     @Test
     fun `decode rejects any uppercase character per spec`() {
         val uppercaseTraceId = traceId.replaceFirst('a', 'A')
-        assertNull(TraceParent.decode("00-$uppercaseTraceId-$spanId-01", flagsFactory))
+        assertNull(TraceParent.decode("00-$uppercaseTraceId-$spanId-01", flagsFactory, sdkErrorHandler))
     }
 
     @Test
     fun `decode rejects header with fewer than four fields`() {
         val header = "0".repeat(55)
-        assertNull(TraceParent.decode(header, flagsFactory))
+        assertNull(TraceParent.decode(header, flagsFactory, sdkErrorHandler))
     }
 
     @Test
     fun `decode rejects forbidden ff version per spec`() {
-        assertNull(TraceParent.decode("ff-$traceId-$spanId-01", flagsFactory))
+        assertNull(TraceParent.decode("ff-$traceId-$spanId-01", flagsFactory, sdkErrorHandler))
     }
 
     @Test
     fun `decode rejects non-hex version`() {
-        assertNull(TraceParent.decode("0g-$traceId-$spanId-01", flagsFactory))
+        assertNull(TraceParent.decode("0g-$traceId-$spanId-01", flagsFactory, sdkErrorHandler))
     }
 
     @Test
     fun `decode rejects version of wrong length`() {
         val header = "001-$traceId-$spanId-01"
-        assertNull(TraceParent.decode(header, flagsFactory))
+        assertNull(TraceParent.decode(header, flagsFactory, sdkErrorHandler))
     }
 
     @Test
     fun `decode rejects version 00 with an additional field`() {
         val header = "00-$traceId-$spanId-01-extra"
-        assertNull(TraceParent.decode(header, flagsFactory))
+        assertNull(TraceParent.decode(header, flagsFactory, sdkErrorHandler))
     }
 
     @Test
     fun `decode rejects trace id of wrong length`() {
         val longTrace = "0".repeat(33)
-        assertNull(TraceParent.decode("01-$longTrace-$spanId-01", flagsFactory))
+        assertNull(TraceParent.decode("01-$longTrace-$spanId-01", flagsFactory, sdkErrorHandler))
     }
 
     @Test
     fun `decode rejects non-hex trace id`() {
         val invalidTraceId = traceId.replaceFirst('a', 'g')
-        assertNull(TraceParent.decode("00-$invalidTraceId-$spanId-01", flagsFactory))
+        assertNull(TraceParent.decode("00-$invalidTraceId-$spanId-01", flagsFactory, sdkErrorHandler))
     }
 
     @Test
     fun `decode rejects span id of wrong length`() {
         val longSpan = "0".repeat(17)
-        assertNull(TraceParent.decode("01-$traceId-$longSpan-01", flagsFactory))
+        assertNull(TraceParent.decode("01-$traceId-$longSpan-01", flagsFactory, sdkErrorHandler))
     }
 
     @Test
     fun `decode rejects non-hex span id`() {
         val invalidSpanId = spanId.replaceFirst('b', 'g')
-        assertNull(TraceParent.decode("00-$traceId-$invalidSpanId-01", flagsFactory))
+        assertNull(TraceParent.decode("00-$traceId-$invalidSpanId-01", flagsFactory, sdkErrorHandler))
     }
 
     @Test
     fun `decode rejects flags of wrong length`() {
-        assertNull(TraceParent.decode("01-$traceId-$spanId-001", flagsFactory))
+        assertNull(TraceParent.decode("01-$traceId-$spanId-001", flagsFactory, sdkErrorHandler))
     }
 
     @Test
     fun `decode rejects non-hex flags`() {
-        assertNull(TraceParent.decode("00-$traceId-$spanId-zz", flagsFactory))
+        assertNull(TraceParent.decode("00-$traceId-$spanId-zz", flagsFactory, sdkErrorHandler))
     }
 
     @Test
     fun `decode rejects header with uppercase version`() {
         val header = "0A-$traceId-$spanId-01"
-        assertNull(TraceParent.decode(header, flagsFactory))
+        assertNull(TraceParent.decode(header, flagsFactory, sdkErrorHandler))
     }
 
     @Test
     fun `decode rejects header with uppercase flags`() {
         val header = "00-$traceId-$spanId-0A"
-        assertNull(TraceParent.decode(header, flagsFactory))
+        assertNull(TraceParent.decode(header, flagsFactory, sdkErrorHandler))
     }
 
     @Test
@@ -244,6 +252,7 @@ internal class TraceParentTest {
             traceId = traceId,
             spanId = spanId,
             traceFlags = traceFlags,
+            sdkErrorHandler = sdkErrorHandler,
         )
         assertNotNull(tp)
         assertEquals(canonicalHeader, tp.encode())
@@ -251,36 +260,36 @@ internal class TraceParentTest {
 
     @Test
     fun `create returns null for version of wrong length`() {
-        assertNull(TraceParent.create("0", traceId, spanId, traceFlags))
+        assertNull(TraceParent.create("0", traceId, spanId, traceFlags, sdkErrorHandler))
     }
 
     @Test
     fun `create returns null for non-hex version`() {
-        assertNull(TraceParent.create("pp", traceId, spanId, traceFlags))
+        assertNull(TraceParent.create("pp", traceId, spanId, traceFlags, sdkErrorHandler))
     }
 
     @Test
     fun `create returns null for forbidden version`() {
-        assertNull(TraceParent.create("ff", traceId, spanId, traceFlags))
+        assertNull(TraceParent.create("ff", traceId, spanId, traceFlags, sdkErrorHandler))
     }
 
     @Test
     fun `create returns null for trace id of wrong length`() {
-        assertNull(TraceParent.create("00", "1234", spanId, traceFlags))
+        assertNull(TraceParent.create("00", "1234", spanId, traceFlags, sdkErrorHandler))
     }
 
     @Test
     fun `create returns null for non-hex trace id`() {
-        assertNull(TraceParent.create("00", traceId.replaceFirst('a', 'g'), spanId, traceFlags))
+        assertNull(TraceParent.create("00", traceId.replaceFirst('a', 'g'), spanId, traceFlags, sdkErrorHandler))
     }
 
     @Test
     fun `create returns null for span id of wrong length`() {
-        assertNull(TraceParent.create("00", traceId, "1234", traceFlags))
+        assertNull(TraceParent.create("00", traceId, "1234", traceFlags, sdkErrorHandler))
     }
 
     @Test
     fun `create returns null for non-hex span id`() {
-        assertNull(TraceParent.create("00", traceId, spanId.replaceFirst('b', 'g'), traceFlags))
+        assertNull(TraceParent.create("00", traceId, spanId.replaceFirst('b', 'g'), traceFlags, sdkErrorHandler))
     }
 }

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/propagation/W3CTraceContextPropagatorFuzzTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/propagation/W3CTraceContextPropagatorFuzzTest.kt
@@ -6,6 +6,7 @@ import io.kotest.property.arbitrary.boolean
 import io.kotest.property.arbitrary.filter
 import io.kotest.property.checkAll
 import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.error.NoopSdkErrorHandler
 import io.opentelemetry.kotlin.factory.ContextFactoryImpl
 import io.opentelemetry.kotlin.factory.IdGeneratorImpl
 import io.opentelemetry.kotlin.factory.SpanContextFactoryImpl
@@ -40,6 +41,7 @@ internal class W3CTraceContextPropagatorFuzzTest {
         traceStateFactory = traceStateFactory,
         spanContextFactory = spanContextFactory,
         spanFactory = spanFactory,
+        sdkErrorHandler = NoopSdkErrorHandler,
     )
 
     private val headerArb = arbitrary { rs ->

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/propagation/W3CTraceContextPropagatorTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/propagation/W3CTraceContextPropagatorTest.kt
@@ -2,6 +2,7 @@ package io.opentelemetry.kotlin.propagation
 
 import io.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.kotlin.context.Context
+import io.opentelemetry.kotlin.error.NoopSdkErrorHandler
 import io.opentelemetry.kotlin.factory.ContextFactoryImpl
 import io.opentelemetry.kotlin.factory.IdGeneratorImpl
 import io.opentelemetry.kotlin.factory.SpanContextFactoryImpl
@@ -37,6 +38,7 @@ internal class W3CTraceContextPropagatorTest {
         traceStateFactory = traceStateFactory,
         spanContextFactory = spanContextFactory,
         spanFactory = spanFactory,
+        sdkErrorHandler = NoopSdkErrorHandler,
     )
 
     private val traceId = "0af7651916cd43dd8448eb211c80319c"

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/TracerRandomTraceIdFlagTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/TracerRandomTraceIdFlagTest.kt
@@ -72,6 +72,7 @@ internal class TracerRandomTraceIdFlagTest {
             traceStateFactory = traceStateFactory,
             spanContextFactory = spanContextFactory,
             spanFactory = spanFactory,
+            sdkErrorHandler = NoopSdkErrorHandler,
         )
         val span = buildTracer(idGenerator).startSpan("test")
         val carrier = mutableMapOf<String, String>()

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/sampling/ProbabilitySamplerTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/sampling/ProbabilitySamplerTest.kt
@@ -3,6 +3,7 @@ package io.opentelemetry.kotlin.tracing.sampling
 import io.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.kotlin.attributes.AttributesModel
 import io.opentelemetry.kotlin.context.Context
+import io.opentelemetry.kotlin.error.NoopSdkErrorHandler
 import io.opentelemetry.kotlin.factory.ContextFactoryImpl
 import io.opentelemetry.kotlin.factory.IdGeneratorImpl
 import io.opentelemetry.kotlin.factory.SpanContextFactoryImpl
@@ -26,6 +27,7 @@ internal class ProbabilitySamplerTest {
     private val spanContextFactory = SpanContextFactoryImpl(idGenerator, traceFlagsFactory, traceStateFactory)
     private val spanFactory = SpanFactoryImpl(spanContextFactory)
     private val contextFactory = ContextFactoryImpl(spanFactory)
+    private val sdkErrorHandler = NoopSdkErrorHandler
 
     private fun createParentContext(traceId: String, otTraceStateValue: String, flags: TraceFlags): Context {
         val traceState = traceStateFactory.default.put("ot", otTraceStateValue)
@@ -41,7 +43,7 @@ internal class ProbabilitySamplerTest {
 
     @Test
     fun testRecordsAndSamplesSpan() {
-        val result = ProbabilitySampler(0.5).shouldSample(
+        val result = ProbabilitySampler(0.5, sdkErrorHandler).shouldSample(
             context = contextFactory.root(),
             traceIdBytes = "000000000000000000ffffffffffffff".hexToByteArray(),
             name = "span",
@@ -54,7 +56,7 @@ internal class ProbabilitySamplerTest {
 
     @Test
     fun testDropsSpan() {
-        val result = ProbabilitySampler(0.5).shouldSample(
+        val result = ProbabilitySampler(0.5, sdkErrorHandler).shouldSample(
             context = contextFactory.root(),
             traceIdBytes = "ffffffffffffffffff00000000000000".hexToByteArray(),
             name = "span",
@@ -68,7 +70,7 @@ internal class ProbabilitySamplerTest {
     @Test
     fun testRecordsAndSamplesSpanAtMinimumRatio() {
         val ratio = 1.0 / (1L shl 56).toDouble()
-        val result = ProbabilitySampler(ratio).shouldSample(
+        val result = ProbabilitySampler(ratio, sdkErrorHandler).shouldSample(
             context = contextFactory.root(),
             traceIdBytes = "000000000000000000ffffffffffffff".hexToByteArray(),
             name = "span",
@@ -82,7 +84,7 @@ internal class ProbabilitySamplerTest {
     @Test
     fun testDropsSpanAtMinimumRatio() {
         val ratio = 1.0 / (1L shl 56).toDouble()
-        val result = ProbabilitySampler(ratio).shouldSample(
+        val result = ProbabilitySampler(ratio, sdkErrorHandler).shouldSample(
             context = contextFactory.root(),
             traceIdBytes = "000000000000000000fffffffffffffe".hexToByteArray(),
             name = "span",
@@ -96,10 +98,10 @@ internal class ProbabilitySamplerTest {
     @Test
     fun testThrowsOnInvalidRatio() {
         assertFailsWith(IllegalArgumentException::class) {
-            ProbabilitySampler(0.0)
+            ProbabilitySampler(0.0, sdkErrorHandler)
         }
         assertFailsWith(IllegalArgumentException::class) {
-            ProbabilitySampler(2.0)
+            ProbabilitySampler(2.0, sdkErrorHandler)
         }
     }
 
@@ -114,7 +116,7 @@ internal class ProbabilitySamplerTest {
             otTraceStateValue = "rv:$aboveThreshold",
             flags = traceFlagsFactory.default
         )
-        val result = ProbabilitySampler(ratio).shouldSample(
+        val result = ProbabilitySampler(ratio, sdkErrorHandler).shouldSample(
             context = context,
             traceIdBytes = traceId.hexToByteArray(),
             name = "span",
@@ -133,7 +135,7 @@ internal class ProbabilitySamplerTest {
             otTraceStateValue = "rv:garbage",
             flags = traceFlagsFactory.default
         )
-        val result = ProbabilitySampler(0.5).shouldSample(
+        val result = ProbabilitySampler(0.5, sdkErrorHandler).shouldSample(
             context = context,
             traceIdBytes = traceId.hexToByteArray(),
             name = "span",
@@ -152,7 +154,7 @@ internal class ProbabilitySamplerTest {
             otTraceStateValue = "th:123",
             flags = traceFlagsFactory.default
         )
-        val result = ProbabilitySampler(0.5).shouldSample(
+        val result = ProbabilitySampler(0.5, sdkErrorHandler).shouldSample(
             context = context,
             traceIdBytes = traceId.hexToByteArray(),
             name = "span",
@@ -171,7 +173,7 @@ internal class ProbabilitySamplerTest {
             otTraceStateValue = "rv:a0000000000000;th:c", // rv < th
             flags = TraceFlagsImpl(isSampled = true, traceFlagsFactory.default.isRandom),
         )
-        val result = ProbabilitySampler(0.5).shouldSample(
+        val result = ProbabilitySampler(0.5, sdkErrorHandler).shouldSample(
             context = context,
             traceIdBytes = traceId.hexToByteArray(),
             name = "span",


### PR DESCRIPTION
Part 4 of #711 (final) - routes propagation and sampler warnings through sdkErrorHandler instead of platformLog().

# Summary
Reports malformed propagation input and sampler compatibility warnings via sdkErrorHandler.onError(...) with ApiMisuse and WARNING severity.

Depends on #841 (PR3, fix/711-implementation-providers).

Closes #711.

# Scope
- B3Propagator - invalid B3 header values
- TraceParent - malformed W3C traceparent input
- W3CTraceContextPropagator - wiring sdkErrorHandler into propagation
- ProbabilitySampler - compatibility warning
- PropagatorConfigImpl / OpenTelemetryImplEntrypoint - pass sdkErrorHandler to propagators

# Testing
- Added B3PropagatorErrorReportingTest and TraceParentErrorReportingTest
- Updated propagation and ProbabilitySampler tests
- Targeted: :implementation:jvmTest (propagation, sampler tests)