### PR TITLE
Harden SpanModel and LogRecordModel

### DIFF
--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/LoggerImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/LoggerImpl.kt
@@ -110,6 +110,7 @@ internal class LoggerImpl(
                     spanContext = spanContext,
                     logLimitConfig = logLimitConfig,
                     eventName = eventName,
+                    sdkErrorHandler = sdkErrorHandler,
                 )
                 if (exception != null) {
                     log.setExceptionAttributes(exception)

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/model/LogRecordModel.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/model/LogRecordModel.kt
@@ -4,6 +4,8 @@ import io.opentelemetry.kotlin.InstrumentationScopeInfo
 import io.opentelemetry.kotlin.ReentrantReadWriteLock
 import io.opentelemetry.kotlin.attributes.AnyValue
 import io.opentelemetry.kotlin.attributes.AttributesModel
+import io.opentelemetry.kotlin.error.SdkErrorHandler
+import io.opentelemetry.kotlin.error.guard
 import io.opentelemetry.kotlin.init.config.LogLimitConfig
 import io.opentelemetry.kotlin.logging.LogRecordDataImpl
 import io.opentelemetry.kotlin.logging.SeverityNumber
@@ -27,16 +29,29 @@ internal class LogRecordModel(
     severityNumber: SeverityNumber?,
     spanContext: SpanContext,
     logLimitConfig: LogLimitConfig,
+    private val sdkErrorHandler: SdkErrorHandler,
 ) : ReadWriteLogRecord {
 
     private val lock = ReentrantReadWriteLock()
+
+    /**
+     * Runs [action] behind the write lock. Input supplied by the host application must never escape
+     * a public API method, so a failure is reported and swallowed.
+     */
+    private inline fun mutate(details: String, action: () -> Unit) {
+        sdkErrorHandler.guard(details) {
+            lock.write {
+                action()
+            }
+        }
+    }
 
     override var timestamp: Long? = timestamp
         get() = lock.read {
             field
         }
         set(value) {
-            lock.write {
+            mutate("LogRecord.timestamp failed") {
                 field = value
             }
         }
@@ -46,7 +61,7 @@ internal class LogRecordModel(
             field
         }
         set(value) {
-            lock.write {
+            mutate("LogRecord.observedTimestamp failed") {
                 field = value
             }
         }
@@ -56,7 +71,7 @@ internal class LogRecordModel(
             field
         }
         set(value) {
-            lock.write {
+            mutate("LogRecord.severityNumber failed") {
                 field = value
             }
         }
@@ -66,7 +81,7 @@ internal class LogRecordModel(
             field
         }
         set(value) {
-            lock.write {
+            mutate("LogRecord.severityText failed") {
                 field = value
             }
         }
@@ -76,7 +91,7 @@ internal class LogRecordModel(
             field
         }
         set(value) {
-            lock.write {
+            mutate("LogRecord.body failed") {
                 field = value
             }
         }
@@ -86,7 +101,7 @@ internal class LogRecordModel(
             field
         }
         set(value) {
-            lock.write {
+            mutate("LogRecord.spanContext failed") {
                 field = value
             }
         }
@@ -96,7 +111,7 @@ internal class LogRecordModel(
             field
         }
         set(value) {
-            lock.write {
+            mutate("LogRecord.eventName failed") {
                 field = value
             }
         }
@@ -120,25 +135,25 @@ internal class LogRecordModel(
         }
 
     override fun setBooleanAttribute(key: String, value: Boolean) {
-        lock.write {
+        mutate("LogRecord.setBooleanAttribute failed") {
             attrs.setBooleanAttribute(key, value)
         }
     }
 
     override fun setStringAttribute(key: String, value: String) {
-        lock.write {
+        mutate("LogRecord.setStringAttribute failed") {
             attrs.setStringAttribute(key, value)
         }
     }
 
     override fun setLongAttribute(key: String, value: Long) {
-        lock.write {
+        mutate("LogRecord.setLongAttribute failed") {
             attrs.setLongAttribute(key, value)
         }
     }
 
     override fun setDoubleAttribute(key: String, value: Double) {
-        lock.write {
+        mutate("LogRecord.setDoubleAttribute failed") {
             attrs.setDoubleAttribute(key, value)
         }
     }
@@ -147,7 +162,7 @@ internal class LogRecordModel(
         key: String,
         value: List<Boolean>
     ) {
-        lock.write {
+        mutate("LogRecord.setBooleanListAttribute failed") {
             attrs.setBooleanListAttribute(key, value)
         }
     }
@@ -156,7 +171,7 @@ internal class LogRecordModel(
         key: String,
         value: List<String>
     ) {
-        lock.write {
+        mutate("LogRecord.setStringListAttribute failed") {
             attrs.setStringListAttribute(key, value)
         }
     }
@@ -165,7 +180,7 @@ internal class LogRecordModel(
         key: String,
         value: List<Long>
     ) {
-        lock.write {
+        mutate("LogRecord.setLongListAttribute failed") {
             attrs.setLongListAttribute(key, value)
         }
     }
@@ -174,19 +189,19 @@ internal class LogRecordModel(
         key: String,
         value: List<Double>
     ) {
-        lock.write {
+        mutate("LogRecord.setDoubleListAttribute failed") {
             attrs.setDoubleListAttribute(key, value)
         }
     }
 
     override fun setByteArrayAttribute(key: String, value: ByteArray) {
-        lock.write {
+        mutate("LogRecord.setByteArrayAttribute failed") {
             attrs.setByteArrayAttribute(key, value)
         }
     }
 
     override fun setAnyValueAttribute(key: String, value: AnyValue) {
-        lock.write {
+        mutate("LogRecord.setAnyValueAttribute failed") {
             attrs.setAnyValueAttribute(key, value)
         }
     }

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/model/SpanModel.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/model/SpanModel.kt
@@ -8,6 +8,7 @@ import io.opentelemetry.kotlin.attributes.AttributesModel
 import io.opentelemetry.kotlin.attributes.AttributesMutator
 import io.opentelemetry.kotlin.error.SdkErrorHandler
 import io.opentelemetry.kotlin.error.guard
+import io.opentelemetry.kotlin.error.guardOrDefault
 import io.opentelemetry.kotlin.init.config.SpanLimitConfig
 import io.opentelemetry.kotlin.resource.Resource
 import io.opentelemetry.kotlin.tracing.SpanContext
@@ -64,30 +65,46 @@ internal class SpanModel(
 
     override var spanContext: SpanContext
         get() = lock.read { spanContextImpl }
-        set(value) = lock.write {
-            if (isRecordingInternal()) {
-                spanContextImpl = value
-            }
+        set(value) = mutate("Span.spanContext failed") {
+            spanContextImpl = value
         }
 
-    override fun setName(name: String) {
-        lock.write {
-            if (isRecordingInternal()) {
-                nameImpl = name
+    /**
+     * Runs [action] behind the write lock if the span is still recording. Input supplied by the
+     * host application must never escape a public API method, so a failure is reported and
+     * swallowed.
+     */
+    private inline fun mutate(details: String, action: () -> Unit) {
+        sdkErrorHandler.guard(details) {
+            lock.write {
+                if (isRecordingInternal()) {
+                    action()
+                }
             }
         }
     }
 
+    override fun setName(name: String) {
+        mutate("Span.setName failed") {
+            nameImpl = name
+        }
+    }
+
     override fun setStatus(status: StatusData) {
-        lock.write {
-            if (isRecordingInternal() && statusImpl !is StatusData.Ok) {
+        mutate("Span.setStatus failed") {
+            if (statusImpl !is StatusData.Ok) {
                 statusImpl = status
             }
         }
     }
 
     override fun end() {
-        endInternal(clock.now())
+        // a broken clock must not stop the span ending, so fall back to a zero timestamp
+        endInternal(
+            sdkErrorHandler.guardOrDefault(0L, "Clock.now failed during Span.end") {
+                clock.now()
+            }
+        )
     }
 
     override fun end(timestamp: Long) {
@@ -96,25 +113,30 @@ internal class SpanModel(
 
     @Suppress("NOTHING_TO_INLINE")
     private inline fun endInternal(timestamp: Long) {
-        lock.write {
-            if (state == State.STARTED) {
-                state = State.ENDING
-                endTimestampImpl = timestamp
-                sdkErrorHandler.guard {
-                    processor?.onEnding(ReadWriteSpanImpl(this))
-                }
-                state = State.ENDED
-                sdkErrorHandler.guard {
-                    // take a snapshot so that processors retain plain data rather than this
-                    // model, releasing its properties once the span
-                    // has ended. Only built if a processor needs it.
-                    processor?.takeIf(SpanProcessor::isEndRequired)?.onEnd(toSpanData())
+        sdkErrorHandler.guard("Span.end failed") {
+            lock.write {
+                if (state == State.STARTED) {
+                    state = State.ENDING
+                    endTimestampImpl = timestamp
+                    sdkErrorHandler.guard {
+                        processor?.onEnding(ReadWriteSpanImpl(this))
+                    }
+                    state = State.ENDED
+                    sdkErrorHandler.guard {
+                        // take a snapshot so that processors retain plain data rather than this
+                        // model, releasing its properties once the span
+                        // has ended. Only built if a processor needs it.
+                        processor?.takeIf(SpanProcessor::isEndRequired)?.onEnd(toSpanData())
+                    }
                 }
             }
         }
     }
 
-    override fun isRecording(): Boolean = lock.read { isRecordingInternal() }
+    override fun isRecording(): Boolean =
+        sdkErrorHandler.guardOrDefault(false, "Span.isRecording failed") {
+            lock.read { isRecordingInternal() }
+        }
 
     /**
      * Reads [state] without acquiring [lock]. Callers must already hold [lock].
@@ -153,14 +175,12 @@ internal class SpanModel(
         spanContext: SpanContext,
         attributes: (AttributesMutator.() -> Unit)?
     ) {
-        lock.write {
-            if (isRecordingInternal()) {
-                if (linksList.size < spanLimitConfig.linkCountLimit) {
-                    val link = buildSpanLink(spanContext, attributes, spanLimitConfig)
-                    linksList.add(link)
-                } else {
-                    droppedLinksCountImpl++
-                }
+        mutate("Span.addLink failed") {
+            if (linksList.size < spanLimitConfig.linkCountLimit) {
+                val link = buildSpanLink(spanContext, attributes, spanLimitConfig)
+                linksList.add(link)
+            } else {
+                droppedLinksCountImpl++
             }
         }
     }
@@ -170,21 +190,19 @@ internal class SpanModel(
         timestamp: Long?,
         attributes: (AttributesMutator.() -> Unit)?
     ) {
-        lock.write {
-            if (isRecordingInternal()) {
-                if (eventsList.size < spanLimitConfig.eventCountLimit) {
-                    val container = AttributesModel(
-                        attributeLimit = spanLimitConfig.attributeCountPerEventLimit,
-                        attributeValueLengthLimit = spanLimitConfig.attributeValueLengthLimit
-                    )
-                    if (attributes != null) {
-                        attributes(container)
-                    }
-                    val event = SpanEventImpl(name, timestamp ?: clock.now(), container)
-                    eventsList.add(event)
-                } else {
-                    droppedEventsCountImpl++
+        mutate("Span.addEvent failed") {
+            if (eventsList.size < spanLimitConfig.eventCountLimit) {
+                val container = AttributesModel(
+                    attributeLimit = spanLimitConfig.attributeCountPerEventLimit,
+                    attributeValueLengthLimit = spanLimitConfig.attributeValueLengthLimit
+                )
+                if (attributes != null) {
+                    attributes(container)
                 }
+                val event = SpanEventImpl(name, timestamp ?: clock.now(), container)
+                eventsList.add(event)
+            } else {
+                droppedEventsCountImpl++
             }
         }
     }
@@ -241,34 +259,26 @@ internal class SpanModel(
         }
 
     override fun setBooleanAttribute(key: String, value: Boolean) {
-        lock.write {
-            if (isRecordingInternal()) {
-                attrs.setBooleanAttribute(key, value)
-            }
+        mutate("Span.setBooleanAttribute failed") {
+            attrs.setBooleanAttribute(key, value)
         }
     }
 
     override fun setStringAttribute(key: String, value: String) {
-        lock.write {
-            if (isRecordingInternal()) {
-                attrs.setStringAttribute(key, value)
-            }
+        mutate("Span.setStringAttribute failed") {
+            attrs.setStringAttribute(key, value)
         }
     }
 
     override fun setLongAttribute(key: String, value: Long) {
-        lock.write {
-            if (isRecordingInternal()) {
-                attrs.setLongAttribute(key, value)
-            }
+        mutate("Span.setLongAttribute failed") {
+            attrs.setLongAttribute(key, value)
         }
     }
 
     override fun setDoubleAttribute(key: String, value: Double) {
-        lock.write {
-            if (isRecordingInternal()) {
-                attrs.setDoubleAttribute(key, value)
-            }
+        mutate("Span.setDoubleAttribute failed") {
+            attrs.setDoubleAttribute(key, value)
         }
     }
 
@@ -276,10 +286,8 @@ internal class SpanModel(
         key: String,
         value: List<Boolean>
     ) {
-        lock.write {
-            if (isRecordingInternal()) {
-                attrs.setBooleanListAttribute(key, value)
-            }
+        mutate("Span.setBooleanListAttribute failed") {
+            attrs.setBooleanListAttribute(key, value)
         }
     }
 
@@ -287,10 +295,8 @@ internal class SpanModel(
         key: String,
         value: List<String>
     ) {
-        lock.write {
-            if (isRecordingInternal()) {
-                attrs.setStringListAttribute(key, value)
-            }
+        mutate("Span.setStringListAttribute failed") {
+            attrs.setStringListAttribute(key, value)
         }
     }
 
@@ -298,10 +304,8 @@ internal class SpanModel(
         key: String,
         value: List<Long>
     ) {
-        lock.write {
-            if (isRecordingInternal()) {
-                attrs.setLongListAttribute(key, value)
-            }
+        mutate("Span.setLongListAttribute failed") {
+            attrs.setLongListAttribute(key, value)
         }
     }
 
@@ -309,26 +313,20 @@ internal class SpanModel(
         key: String,
         value: List<Double>
     ) {
-        lock.write {
-            if (isRecordingInternal()) {
-                attrs.setDoubleListAttribute(key, value)
-            }
+        mutate("Span.setDoubleListAttribute failed") {
+            attrs.setDoubleListAttribute(key, value)
         }
     }
 
     override fun setByteArrayAttribute(key: String, value: ByteArray) {
-        lock.write {
-            if (isRecordingInternal()) {
-                attrs.setByteArrayAttribute(key, value)
-            }
+        mutate("Span.setByteArrayAttribute failed") {
+            attrs.setByteArrayAttribute(key, value)
         }
     }
 
     override fun setAnyValueAttribute(key: String, value: AnyValue) {
-        lock.write {
-            if (isRecordingInternal()) {
-                attrs.setAnyValueAttribute(key, value)
-            }
+        mutate("Span.setAnyValueAttribute failed") {
+            attrs.setAnyValueAttribute(key, value)
         }
     }
 }

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/LogRecordMutatorErrorHandlingTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/LogRecordMutatorErrorHandlingTest.kt
@@ -1,0 +1,98 @@
+package io.opentelemetry.kotlin.logging
+
+import io.opentelemetry.kotlin.FakeInstrumentationScopeInfo
+import io.opentelemetry.kotlin.attributes.AnyValue
+import io.opentelemetry.kotlin.error.FakeSdkErrorHandler
+import io.opentelemetry.kotlin.error.SdkError
+import io.opentelemetry.kotlin.error.SdkErrorHandler
+import io.opentelemetry.kotlin.error.SdkErrorSeverity
+import io.opentelemetry.kotlin.logging.model.LogRecordModel
+import io.opentelemetry.kotlin.logging.model.ReadWriteLogRecord
+import io.opentelemetry.kotlin.resource.FakeResource
+import io.opentelemetry.kotlin.tracing.FakeSpanContext
+import io.opentelemetry.kotlin.tracing.fakeLogLimitsConfig
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+
+internal class LogRecordMutatorErrorHandlingTest {
+
+    private val hostileCases = listOf(
+        Case("string list attribute") { setStringListAttribute("key", HostileList()) },
+        Case("any value attribute") {
+            setAnyValueAttribute("key", AnyValue.ListValue(HostileList()))
+        },
+    )
+
+    @Test
+    fun testHostileInputDoesNotEscapeMutator() {
+        hostileCases.forEach { case ->
+            val errorHandler = FakeSdkErrorHandler()
+            val log = createLogRecord(errorHandler)
+            case.mutate(log)
+
+            val error = errorHandler.userCodeErrors.single()
+            assertEquals(SdkErrorSeverity.WARNING, error.severity, case.name)
+            assertEquals("boom", error.cause.message, case.name)
+            assertFalse(log.attributes.containsKey("key"), case.name)
+        }
+    }
+
+    @Test
+    fun testLogRecordRemainsUsableAfterHostileInput() {
+        val errorHandler = FakeSdkErrorHandler()
+        val log = createLogRecord(errorHandler)
+
+        log.setStringListAttribute("hostile", HostileList())
+        log.setStringAttribute("key", "value")
+        log.body = "body"
+
+        assertEquals(1, errorHandler.userCodeErrors.size)
+        val data = log.toLogRecordData()
+        assertEquals("value", data.attributes["key"])
+        assertFalse(data.attributes.containsKey("hostile"))
+        assertEquals("body", data.body)
+    }
+
+    @Test
+    fun testThrowingErrorHandlerDoesNotEscapeMutator() {
+        val log = createLogRecord(ThrowingSdkErrorHandler())
+        log.setStringListAttribute("key", HostileList())
+        assertNull(log.attributes["key"])
+    }
+
+    private fun createLogRecord(errorHandler: SdkErrorHandler) = LogRecordModel(
+        resource = FakeResource(),
+        instrumentationScopeInfo = FakeInstrumentationScopeInfo(),
+        timestamp = 0L,
+        observedTimestamp = 0L,
+        body = null,
+        eventName = null,
+        severityText = null,
+        severityNumber = SeverityNumber.INFO,
+        spanContext = FakeSpanContext.VALID,
+        logLimitConfig = fakeLogLimitsConfig,
+        sdkErrorHandler = errorHandler,
+    )
+
+    private class Case(
+        val name: String,
+        val mutate: ReadWriteLogRecord.() -> Unit,
+    )
+
+    private class HostileList<T>(
+        private val delegate: List<T> = emptyList(),
+    ) : List<T> by delegate {
+        override val size: Int
+            get() = boom()
+
+        override fun iterator(): Iterator<T> = boom()
+    }
+
+    private class ThrowingSdkErrorHandler : SdkErrorHandler {
+        override fun onError(error: SdkError): Unit = boom()
+    }
+}
+
+private fun boom(): Nothing = error("boom")

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/SpanMutatorErrorHandlingTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/SpanMutatorErrorHandlingTest.kt
@@ -1,0 +1,139 @@
+package io.opentelemetry.kotlin.tracing
+
+import io.opentelemetry.kotlin.Clock
+import io.opentelemetry.kotlin.FakeInstrumentationScopeInfo
+import io.opentelemetry.kotlin.attributes.AnyValue
+import io.opentelemetry.kotlin.clock.FakeClock
+import io.opentelemetry.kotlin.error.FakeSdkErrorHandler
+import io.opentelemetry.kotlin.error.SdkError
+import io.opentelemetry.kotlin.error.SdkErrorHandler
+import io.opentelemetry.kotlin.error.SdkErrorSeverity
+import io.opentelemetry.kotlin.init.config.SpanLimitConfig
+import io.opentelemetry.kotlin.resource.FakeResource
+import io.opentelemetry.kotlin.tracing.export.FakeSpanProcessor
+import io.opentelemetry.kotlin.tracing.model.ReadWriteSpan
+import io.opentelemetry.kotlin.tracing.model.SpanModel
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+internal class SpanMutatorErrorHandlingTest {
+
+    private val truncatingLimits = SpanLimitConfig(
+        attributeCountLimit = 100,
+        attributeValueLengthLimit = 100,
+        linkCountLimit = 100,
+        eventCountLimit = 100,
+        attributeCountPerEventLimit = 100,
+        attributeCountPerLinkLimit = 100,
+    )
+
+    private val hostileCases = listOf(
+        Case("string list attribute") { setStringListAttribute("key", HostileList()) },
+        Case("any value attribute") {
+            setAnyValueAttribute("key", AnyValue.ListValue(HostileList()))
+        },
+        Case("event attributes") { addEvent("event") { boom() } },
+        Case("link attributes") { addLink(FakeSpanContext.VALID) { boom() } },
+    )
+
+    @Test
+    fun testHostileInputDoesNotEscapeMutator() {
+        hostileCases.forEach { case ->
+            val errorHandler = FakeSdkErrorHandler()
+            val span = createSpan(errorHandler = errorHandler)
+            case.mutate(span)
+
+            val error = errorHandler.userCodeErrors.single()
+            assertEquals(SdkErrorSeverity.WARNING, error.severity, case.name)
+            assertEquals("boom", error.cause.message, case.name)
+            assertTrue(span.isRecording(), case.name)
+        }
+    }
+
+    @Test
+    fun testSpanRemainsUsableAfterHostileInput() {
+        val errorHandler = FakeSdkErrorHandler()
+        val processor = FakeSpanProcessor()
+        val span = createSpan(processor = processor, errorHandler = errorHandler)
+
+        span.setStringListAttribute("hostile", HostileList())
+        span.setStringAttribute("key", "value")
+        span.end()
+
+        assertEquals(1, errorHandler.userCodeErrors.size)
+        assertEquals("value", span.attributes["key"])
+        assertFalse(span.attributes.containsKey("hostile"))
+        assertTrue(span.hasEnded)
+        assertEquals(1, processor.endCalls.size)
+    }
+
+    @Test
+    fun testHostileClockStillEndsSpan() {
+        val errorHandler = FakeSdkErrorHandler()
+        val processor = FakeSpanProcessor()
+        val span = createSpan(
+            clock = { boom() },
+            processor = processor,
+            errorHandler = errorHandler,
+        )
+        span.end()
+
+        assertTrue(span.hasEnded)
+        assertFalse(span.isRecording())
+        assertEquals(0L, span.endTimestamp)
+        assertEquals(1, processor.endCalls.size)
+        assertEquals("boom", errorHandler.userCodeErrors.single().cause.message)
+    }
+
+    @Test
+    fun testThrowingErrorHandlerDoesNotEscapeMutator() {
+        val span = createSpan(errorHandler = ThrowingSdkErrorHandler())
+        span.setStringListAttribute("key", HostileList())
+        assertTrue(span.isRecording())
+    }
+
+    private fun createSpan(
+        clock: Clock = FakeClock(),
+        processor: FakeSpanProcessor? = null,
+        errorHandler: SdkErrorHandler,
+    ) = SpanModel(
+        clock = clock,
+        processor = processor,
+        name = "span",
+        spanKind = SpanKind.INTERNAL,
+        startTimestamp = 0L,
+        instrumentationScopeInfo = FakeInstrumentationScopeInfo(),
+        resource = FakeResource(),
+        parent = FakeSpanContext.INVALID,
+        spanContext = FakeSpanContext.VALID,
+        spanLimitConfig = truncatingLimits,
+        initialLinks = emptyList(),
+        sdkErrorHandler = errorHandler,
+    )
+
+    private class Case(
+        val name: String,
+        val mutate: ReadWriteSpan.() -> Unit,
+    )
+
+    /**
+     * A list that throws when read. Both [size] and [iterator] are hostile so that every path
+     * through the attribute code hits the failure.
+     */
+    private class HostileList<T>(
+        private val delegate: List<T> = emptyList(),
+    ) : List<T> by delegate {
+        override val size: Int
+            get() = boom()
+
+        override fun iterator(): Iterator<T> = boom()
+    }
+
+    private class ThrowingSdkErrorHandler : SdkErrorHandler {
+        override fun onError(error: SdkError): Unit = boom()
+    }
+}
+
+private fun boom(): Nothing = error("boom")


### PR DESCRIPTION
## Goal

Hardens the `SpanModel` and `LogRecordModel` classes by using `SdkErrorHandler` to guard potentially risky inputs.

## Testing

Added unit tests.
