### PR TITLE
Alter NoopSpanContext to use correct length IDs

### DIFF
--- a/noop/src/commonMain/kotlin/io/opentelemetry/kotlin/factory/NoopIdGenerator.kt
+++ b/noop/src/commonMain/kotlin/io/opentelemetry/kotlin/factory/NoopIdGenerator.kt
@@ -1,9 +1,8 @@
 package io.opentelemetry.kotlin.factory
 
 internal object NoopIdGenerator : IdGenerator {
-    private val empty = ByteArray(0)
-    override fun generateSpanIdBytes(): ByteArray = empty
-    override fun generateTraceIdBytes(): ByteArray = empty
-    override val invalidTraceId: ByteArray = empty
-    override val invalidSpanId: ByteArray = empty
+    override val invalidTraceId: ByteArray = ByteArray(16)
+    override val invalidSpanId: ByteArray = ByteArray(8)
+    override fun generateSpanIdBytes(): ByteArray = invalidSpanId
+    override fun generateTraceIdBytes(): ByteArray = invalidTraceId
 }

--- a/noop/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/NoopSpanContext.kt
+++ b/noop/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/NoopSpanContext.kt
@@ -1,14 +1,14 @@
 package io.opentelemetry.kotlin.tracing
 
 import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.factory.toHexString
 
 @ExperimentalApi
 internal object NoopSpanContext : SpanContext {
-    override val traceId: String = ""
-    override val spanId: String = ""
-    private val empty = ByteArray(0)
-    override val traceIdBytes: ByteArray = empty
-    override val spanIdBytes: ByteArray = empty
+    override val traceIdBytes: ByteArray = ByteArray(16)
+    override val spanIdBytes: ByteArray = ByteArray(8)
+    override val traceId: String = traceIdBytes.toHexString()
+    override val spanId: String = spanIdBytes.toHexString()
     override val traceFlags: TraceFlags = NoopTraceFlags
     override val isValid: Boolean = false
     override val isRemote: Boolean = false

--- a/noop/src/commonTest/kotlin/io/opentelemetry/kotlin/NoopTests.kt
+++ b/noop/src/commonTest/kotlin/io/opentelemetry/kotlin/NoopTests.kt
@@ -46,8 +46,8 @@ internal class NoopTests {
 
         // Test span context default values
         val context = span.spanContext
-        assertEquals("", context.traceId)
-        assertEquals("", context.spanId)
+        assertEquals("0".repeat(32), context.traceId)
+        assertEquals("0".repeat(16), context.spanId)
         assertFalse(context.isValid)
         assertFalse(context.isRemote)
 
@@ -163,6 +163,8 @@ internal class NoopTests {
         val invalid = otel.spanContext.invalid
         assertTrue(invalid is NoopSpanContext)
         assertFalse(invalid.isValid)
+        assertEquals(16, invalid.traceIdBytes.size)
+        assertEquals(8, invalid.spanIdBytes.size)
 
         val other = otel.spanContext.create(
             otel.idGenerator.generateTraceIdBytes(),


### PR DESCRIPTION
## Goal

`NoopSpanContext` currently uses empty trace/span IDs (`""` / `ByteArray(0)`). The spec requires invalid IDs to be all-zero values of fixed length (16-byte trace ID, 8-byte span ID). This updates the noop context and id generator to match that, so consumers always see correctly sized IDs.

Fixes #856.

## Testing

Updated noop unit tests for hex and byte lengths. Verified with `:noop:jvmTest`, `:noop:jsTest`, and Detekt.