### PR TITLE
Replace getOrPut with alternative

### DIFF
--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/context/ContextKeyRepository.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/context/ContextKeyRepository.kt
@@ -15,12 +15,14 @@ internal class ContextKeyRepository {
 
     @Suppress("UNCHECKED_CAST")
     fun <T> get(key: ContextKey<T>): OtelJavaContextKey<T> {
-        return impl.getOrPut(key) {
-            if (key is ContextKeyAdapter) {
-                key.impl
-            } else {
-                OtelJavaContextKey.named(key.toString())
-            }
+        impl[key]?.let { return it as OtelJavaContextKey<T> }
+        val candidate = if (key is ContextKeyAdapter) {
+            key.impl
+        } else {
+            OtelJavaContextKey.named(key.toString())
+        }
+        return synchronized(impl) {
+            impl[key] ?: candidate.also { impl[key] = it }
         } as OtelJavaContextKey<T>
     }
 }

--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/context/OtelJavaContextKeyRepository.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/context/OtelJavaContextKeyRepository.kt
@@ -14,8 +14,10 @@ internal class OtelJavaContextKeyRepository {
     private val impl = Collections.synchronizedMap(WeakHashMap<OtelJavaContextKey<*>, ContextKey<*>>())
 
     fun <T> get(key: OtelJavaContextKey<T>): ContextKey<T> {
-        return impl.getOrPut(key) {
-            ContextKeyAdapter(key)
+        impl[key]?.let { return it as ContextKey<T> }
+        val candidate = ContextKeyAdapter(key)
+        return synchronized(impl) {
+            impl[key] ?: candidate.also { impl[key] = it }
         } as ContextKey<T>
     }
 }

--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/logging/LoggerProviderAdapter.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/logging/LoggerProviderAdapter.kt
@@ -6,11 +6,14 @@ import io.opentelemetry.kotlin.aliases.OtelJavaLoggerProvider
 import io.opentelemetry.kotlin.attributes.AttributesMutator
 import io.opentelemetry.kotlin.scope.scopeCacheKey
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.locks.ReentrantReadWriteLock
+import kotlin.concurrent.write
 
 @ExperimentalApi
 internal class LoggerProviderAdapter(private val impl: OtelJavaLoggerProvider) : LoggerProvider {
 
     private val map = ConcurrentHashMap<InstrumentationScopeInfo, LoggerAdapter>()
+    private val lock = ReentrantReadWriteLock()
 
     override fun getLogger(
         name: String,
@@ -18,16 +21,16 @@ internal class LoggerProviderAdapter(private val impl: OtelJavaLoggerProvider) :
         schemaUrl: String?,
         attributes: (AttributesMutator.() -> Unit)?
     ): Logger {
-        return map.getOrPut(scopeCacheKey(name, version, schemaUrl)) {
-            val builder = impl.loggerBuilder(name)
-
-            if (schemaUrl != null) {
-                builder.setSchemaUrl(schemaUrl)
-            }
-            if (version != null) {
-                builder.setInstrumentationVersion(version)
-            }
-            LoggerAdapter(builder.build())
+        val key = scopeCacheKey(name, version, schemaUrl)
+        map[key]?.let { return it }
+        val builder = impl.loggerBuilder(name)
+        if (schemaUrl != null) {
+            builder.setSchemaUrl(schemaUrl)
         }
+        if (version != null) {
+            builder.setInstrumentationVersion(version)
+        }
+        val candidate = LoggerAdapter(builder.build())
+        return lock.write { map[key] ?: candidate.also { map[key] = it } }
     }
 }

--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/metrics/MeterProviderAdapter.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/metrics/MeterProviderAdapter.kt
@@ -7,6 +7,8 @@ import io.opentelemetry.kotlin.aliases.OtelJavaMeterProvider
 import io.opentelemetry.kotlin.attributes.AttributesMutator
 import io.opentelemetry.kotlin.scope.scopeCacheKey
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.locks.ReentrantReadWriteLock
+import kotlin.concurrent.write
 
 @ThreadSafe
 @ExperimentalApi
@@ -15,6 +17,7 @@ internal class MeterProviderAdapter(
 ) : MeterProvider {
 
     private val map = ConcurrentHashMap<InstrumentationScopeInfo, MeterAdapter>()
+    private val lock = ReentrantReadWriteLock()
 
     override fun getMeter(
         name: String,
@@ -22,11 +25,12 @@ internal class MeterProviderAdapter(
         schemaUrl: String?,
         attributes: (AttributesMutator.() -> Unit)?,
     ): Meter {
-        return map.getOrPut(scopeCacheKey(name, version, schemaUrl)) {
-            val builder = impl.meterBuilder(name)
-            schemaUrl?.let(builder::setSchemaUrl)
-            version?.let(builder::setInstrumentationVersion)
-            MeterAdapter(builder.build())
-        }
+        val key = scopeCacheKey(name, version, schemaUrl)
+        map[key]?.let { return it }
+        val builder = impl.meterBuilder(name)
+        schemaUrl?.let(builder::setSchemaUrl)
+        version?.let(builder::setInstrumentationVersion)
+        val candidate = MeterAdapter(builder.build())
+        return lock.write { map[key] ?: candidate.also { map[key] = it } }
     }
 }

--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/tracing/TracerProviderAdapter.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/tracing/TracerProviderAdapter.kt
@@ -8,6 +8,8 @@ import io.opentelemetry.kotlin.attributes.AttributesMutator
 import io.opentelemetry.kotlin.init.CompatSpanLimitsConfig
 import io.opentelemetry.kotlin.scope.scopeCacheKey
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.locks.ReentrantReadWriteLock
+import kotlin.concurrent.write
 
 @ExperimentalApi
 internal class TracerProviderAdapter(
@@ -17,6 +19,7 @@ internal class TracerProviderAdapter(
 ) : TracerProvider {
 
     private val map = ConcurrentHashMap<InstrumentationScopeInfo, TracerAdapter>()
+    private val lock = ReentrantReadWriteLock()
 
     override fun getTracer(
         name: String,
@@ -24,13 +27,12 @@ internal class TracerProviderAdapter(
         schemaUrl: String?,
         attributes: (AttributesMutator.() -> Unit)?
     ): Tracer {
-        return map.getOrPut(scopeCacheKey(name, version, schemaUrl)) {
-            val tracerBuilder = tracerProvider.tracerBuilder(name)
-
-            schemaUrl?.let(tracerBuilder::setSchemaUrl)
-            version?.let(tracerBuilder::setInstrumentationVersion)
-            val tracer = tracerBuilder.build()
-            TracerAdapter(tracer, clock, spanLimitsConfig)
-        }
+        val key = scopeCacheKey(name, version, schemaUrl)
+        map[key]?.let { return it }
+        val tracerBuilder = tracerProvider.tracerBuilder(name)
+        schemaUrl?.let(tracerBuilder::setSchemaUrl)
+        version?.let(tracerBuilder::setInstrumentationVersion)
+        val candidate = TracerAdapter(tracerBuilder.build(), clock, spanLimitsConfig)
+        return lock.write { map[key] ?: candidate.also { map[key] = it } }
     }
 }

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/provider/ApiProviderImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/provider/ApiProviderImpl.kt
@@ -2,6 +2,7 @@ package io.opentelemetry.kotlin.provider
 
 import io.opentelemetry.kotlin.InstrumentationScopeInfo
 import io.opentelemetry.kotlin.InstrumentationScopeInfoImpl
+import io.opentelemetry.kotlin.ReentrantReadWriteLock
 import io.opentelemetry.kotlin.ThreadSafe
 import io.opentelemetry.kotlin.attributes.AttributesModel
 import io.opentelemetry.kotlin.attributes.AttributesMutator
@@ -24,9 +25,12 @@ internal class ApiProviderImpl<T>(
 ) {
 
     private val map = threadSafeMap<InstrumentationScopeInfo, T>()
+    private val lock = ReentrantReadWriteLock()
 
-    fun getOrCreate(key: InstrumentationScopeInfo): T = map.getOrPut(key) {
-        supplier(key)
+    fun getOrCreate(key: InstrumentationScopeInfo): T {
+        map[key]?.let { return it }
+        val candidate = supplier(key)
+        return lock.write { map[key] ?: candidate.also { map[key] = it } }
     }
 
     fun createInstrumentationScopeInfo(

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/provider/ApiProviderImplTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/provider/ApiProviderImplTest.kt
@@ -1,0 +1,17 @@
+package io.opentelemetry.kotlin.provider
+
+import io.opentelemetry.kotlin.InstrumentationScopeInfoImpl
+import kotlin.test.Test
+import kotlin.test.assertSame
+
+internal class ApiProviderImplTest {
+
+    @Test
+    fun getOrCreateReturnsSameInstanceForSameKey() {
+        val provider = ApiProviderImpl { Any() }
+        val key = InstrumentationScopeInfoImpl("name", null, null, emptyMap())
+        val first = provider.getOrCreate(key)
+        val second = provider.getOrCreate(key)
+        assertSame(first, second)
+    }
+}


### PR DESCRIPTION
## Goal

`getOrPut` is not atomic when the backing map is concurrent, so two callers can observe different cached Tracer/Meter/Logger (or context-key) instances. Replace those sites with a double-check and a write lock so the map winner is always returned, matching the pattern in #873 (`ApiProviderImpl` and the other production caches).

Fixes #873.

## Testing

Existing provider identity tests still assert the same instance is reused. Added a focused `ApiProviderImpl` unit test. Verified with `:implementation:jvmTest` and `:compat:jvmTest`.