### PR TITLE
fix: accept only ASCII digits in hex validators

### DIFF
--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/factory/CompatTraceFlagsFactory.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/factory/CompatTraceFlagsFactory.kt
@@ -22,7 +22,7 @@ internal class CompatTraceFlagsFactory : TraceFlagsFactory {
      * Returns true if the character is a valid hexadecimal digit (0-9, a-f, A-F).
      */
     private fun Char.isHexDigit(): Boolean {
-        return this.isDigit() || this in 'a'..'f' || this in 'A'..'F'
+        return this in '0'..'9' || this in 'a'..'f' || this in 'A'..'F'
     }
 
     /**

--- a/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/factory/TraceFlagsFactoryTest.kt
+++ b/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/factory/TraceFlagsFactoryTest.kt
@@ -95,4 +95,22 @@ internal class TraceFlagsFactoryTest {
         assertFalse(invalidHex.isSampled)
         assertFalse(invalidHex.isRandom)
     }
+
+    @Test
+    fun `fromHex with lowercase hex letters`() {
+        val flags = factory.fromHex("0a")
+        assertFalse(flags.isSampled)
+        assertTrue(flags.isRandom)
+    }
+
+    @Test
+    fun `fromHex with non-ascii digits is invalid`() {
+        val mixed = factory.fromHex("0٠")
+        assertFalse(mixed.isSampled)
+        assertFalse(mixed.isRandom)
+
+        val space = factory.fromHex("0 ")
+        assertFalse(space.isSampled)
+        assertFalse(space.isRandom)
+    }
 }

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/factory/HexUtils.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/factory/HexUtils.kt
@@ -4,14 +4,14 @@ package io.opentelemetry.kotlin.factory
  * Returns true if the character is a valid hexadecimal digit (0-9, a-f, A-F).
  */
 internal fun Char.isHexDigit(): Boolean {
-    return this.isDigit() || this in 'a'..'f' || this in 'A'..'F'
+    return this in '0'..'9' || this in 'a'..'f' || this in 'A'..'F'
 }
 
 /**
  * Returns true if the character is a valid lowercase hexadecimal digit (0-9, a-f).
  */
 internal fun Char.isLowercaseHexDigit(): Boolean {
-    return this.isDigit() || this in 'a'..'f'
+    return this in '0'..'9' || this in 'a'..'f'
 }
 
 /**

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/factory/HexConversionsTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/factory/HexConversionsTest.kt
@@ -50,6 +50,7 @@ internal class HexConversionsTest {
     fun hexToByteArrayNonAsciiCharacterReturnsEmptyByteArray() {
         assertContentEquals(ByteArray(0), "0é".hexToByteArray())
         assertContentEquals(ByteArray(0), "😀".hexToByteArray())
+        assertContentEquals(ByteArray(0), "0٠".hexToByteArray())
     }
 
     @Test

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/factory/HexTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/factory/HexTest.kt
@@ -41,6 +41,12 @@ internal class HexTest {
     }
 
     @Test
+    fun testNonAsciiDigitIsNotHexDigit() {
+        assertFalse('٠'.isHexDigit())
+        assertFalse("٠١٢".isValidHex())
+    }
+
+    @Test
     fun testEmptyStringIsValidHex() {
         assertTrue("".isValidHex())
     }
@@ -122,6 +128,12 @@ internal class HexTest {
     @Test
     fun testHyphenIsNotLowercaseHexDigit() {
         assertFalse('-'.isLowercaseHexDigit())
+    }
+
+    @Test
+    fun testNonAsciiDigitIsNotLowercaseHexDigit() {
+        assertFalse('٠'.isLowercaseHexDigit())
+        assertFalse("٠١٢".isValidLowercaseHex())
     }
 
     @Test


### PR DESCRIPTION
## Goal

Hex validators used `Char.isDigit()`, which accepts non-ASCII digits. That can make `isValidLowercaseHex()` succeed and later `toLong(16)` / `fromHex` throw. Check digits with `c in '0'..'9'` instead.

## Testing

Added HexTest cases for Arabic-Indic digits. Verified with `:implementation:jvmTest` (Hex*) and `:compat:jvmTest`.

Fixes #868