### PR TITLE
fix: do not inherit isRemote on locally created spans

### DIFF
--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/TracerImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/TracerImpl.kt
@@ -88,7 +88,6 @@ internal class TracerImpl(
                     inheritTraceId -> parentSpanContext.traceFlags.isRandom
                     else -> idGenerator.generatesRandomTraceIds
                 }
-                val remoteParent = inheritTraceId && parentSpanContext.isRemote
                 val spanIdBytes = idGenerator.generateSpanIdBytes()
 
                 val collector = SpanCreationCollector(spanLimitConfig)
@@ -109,7 +108,6 @@ internal class TracerImpl(
                     spanIdBytes = spanIdBytes,
                     sampled = sampled,
                     randomTraceId = randomTraceId,
-                    remoteParent = remoteParent,
                     traceState = result.traceState,
                 )
 
@@ -147,7 +145,6 @@ internal class TracerImpl(
         spanIdBytes: ByteArray,
         sampled: Boolean,
         randomTraceId: Boolean,
-        remoteParent: Boolean,
         traceState: TraceState,
     ): SpanContext {
         val validTraceId = traceIdBytes.isValidTraceIdBytes()
@@ -170,7 +167,7 @@ internal class TracerImpl(
                 else -> unsampledFlags
             },
             isValid = validTraceId && validSpanId,
-            isRemote = remoteParent,
+            isRemote = false,
             traceState = traceState,
         )
     }

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/TracerInvalidIdTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/TracerInvalidIdTest.kt
@@ -106,15 +106,17 @@ internal class TracerInvalidIdTest {
     }
 
     @Test
-    fun testChildOfRemoteParentIsRemote() {
+    fun testChildOfRemoteParentIsNotRemote() {
         val idGenerator = IdGeneratorImpl()
-        val span = startChildOf(remoteParent(idGenerator), idGenerator)
-        assertTrue(span.spanContext.isRemote)
+        val parent = remoteParent(idGenerator)
+        val span = startChildOf(parent, idGenerator)
+        assertFalse(span.spanContext.isRemote)
+        assertTrue(span.toReadableSpan().parent.isRemote)
         assertTrue(span.spanContext.isValid)
     }
 
     @Test
-    fun testDescendantOfRemoteParentIsRemote() {
+    fun testDescendantOfRemoteParentIsNotRemote() {
         val idGenerator = IdGeneratorImpl()
         val tracer = buildTracer(idGenerator)
         val spanFactory = SpanFactoryImpl(
@@ -136,7 +138,10 @@ internal class TracerInvalidIdTest {
             parentContext = contextFactory.root().storeSpan(child),
         )
 
-        assertTrue(grandchild.spanContext.isRemote)
+        assertFalse(child.spanContext.isRemote)
+        assertFalse(grandchild.spanContext.isRemote)
+        assertTrue(child.toReadableSpan().parent.isRemote)
+        assertFalse(grandchild.toReadableSpan().parent.isRemote)
     }
 
     @Test


### PR DESCRIPTION
## Goal
Locally created spans were copying isRemote from a remote parent. Extracted parents stay remote; child SpanContexts are always local.

## Testing
Updated TracerInvalidIdTest. Ran implementation JVM tests for TracerInvalidIdTest and BuiltInSamplersTest.

Fixes #879 