### PR TITLE
Exclude config-schema module from codecov

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -47,7 +47,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: open-telemetry/opentelemetry-kotlin
           fail_ci_if_error: false
-          files: build/reports/kover/reportRelease.xml
+          files: build/reports/kover/report.xml
 
   # Runs on macOS because the klib fixture consumes the library's iOS klibs, which KGP only
   # publishes from a macOS host. The rest of the suite is host-independent, so it all runs here.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,7 +40,12 @@ kover {
         filters {
             excludes {
                 androidGeneratedClasses()
-                classes("*.BuildConfig", "io.opentelemetry.proto.*")
+                // generated code: protobuf messages and the opentelemetry-configuration schema model
+                classes(
+                    "*.BuildConfig",
+                    "io.opentelemetry.proto.*",
+                    "io.opentelemetry.kotlin.config.schema.model.*",
+                )
             }
         }
     }

--- a/config-schema/build.gradle.kts
+++ b/config-schema/build.gradle.kts
@@ -8,7 +8,6 @@ plugins {
     id("io.opentelemetry.kotlin.build-logic")
     id("signing")
     id("com.vanniktech.maven.publish")
-    id("org.jetbrains.kotlinx.kover")
     alias(libs.plugins.download)
     alias(libs.plugins.kotlin.serialization)
 }


### PR DESCRIPTION
## Goal

Closes #885 by excluding the `config-schema` module from codecov as all the code is generated.