### PR TITLE
Make log snapshot internally consistent

### DIFF
--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/model/LogRecordModel.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/model/LogRecordModel.kt
@@ -34,6 +34,14 @@ internal class LogRecordModel(
 
     private val lock = ReentrantReadWriteLock()
 
+    private var timestampImpl: Long? = timestamp
+    private var observedTimestampImpl: Long? = observedTimestamp
+    private var severityNumberImpl: SeverityNumber? = severityNumber
+    private var severityTextImpl: String? = severityText
+    private var bodyImpl: Any? = body
+    private var spanContextImpl: SpanContext = spanContext
+    private var eventNameImpl: String? = eventName
+
     /**
      * Runs [action] behind the write lock. Input supplied by the host application must never escape
      * a public API method, so a failure is reported and swallowed.
@@ -46,74 +54,46 @@ internal class LogRecordModel(
         }
     }
 
-    override var timestamp: Long? = timestamp
-        get() = lock.read {
-            field
-        }
-        set(value) {
-            mutate("LogRecord.timestamp failed") {
-                field = value
-            }
+    override var timestamp: Long?
+        get() = lock.read { timestampImpl }
+        set(value) = mutate("LogRecord.timestamp failed") {
+            timestampImpl = value
         }
 
-    override var observedTimestamp: Long? = observedTimestamp
-        get() = lock.read {
-            field
-        }
-        set(value) {
-            mutate("LogRecord.observedTimestamp failed") {
-                field = value
-            }
+    override var observedTimestamp: Long?
+        get() = lock.read { observedTimestampImpl }
+        set(value) = mutate("LogRecord.observedTimestamp failed") {
+            observedTimestampImpl = value
         }
 
-    override var severityNumber: SeverityNumber? = severityNumber
-        get() = lock.read {
-            field
-        }
-        set(value) {
-            mutate("LogRecord.severityNumber failed") {
-                field = value
-            }
+    override var severityNumber: SeverityNumber?
+        get() = lock.read { severityNumberImpl }
+        set(value) = mutate("LogRecord.severityNumber failed") {
+            severityNumberImpl = value
         }
 
-    override var severityText: String? = severityText
-        get() = lock.read {
-            field
-        }
-        set(value) {
-            mutate("LogRecord.severityText failed") {
-                field = value
-            }
+    override var severityText: String?
+        get() = lock.read { severityTextImpl }
+        set(value) = mutate("LogRecord.severityText failed") {
+            severityTextImpl = value
         }
 
-    override var body: Any? = body
-        get() = lock.read {
-            field
-        }
-        set(value) {
-            mutate("LogRecord.body failed") {
-                field = value
-            }
+    override var body: Any?
+        get() = lock.read { bodyImpl }
+        set(value) = mutate("LogRecord.body failed") {
+            bodyImpl = value
         }
 
-    override var spanContext: SpanContext = spanContext
-        get() = lock.read {
-            field
-        }
-        set(value) {
-            mutate("LogRecord.spanContext failed") {
-                field = value
-            }
+    override var spanContext: SpanContext
+        get() = lock.read { spanContextImpl }
+        set(value) = mutate("LogRecord.spanContext failed") {
+            spanContextImpl = value
         }
 
-    override var eventName: String? = eventName
-        get() = lock.read {
-            field
-        }
-        set(value) {
-            mutate("LogRecord.eventName failed") {
-                field = value
-            }
+    override var eventName: String?
+        get() = lock.read { eventNameImpl }
+        set(value) = mutate("LogRecord.eventName failed") {
+            eventNameImpl = value
         }
 
     private val attrs by lazy {
@@ -126,7 +106,7 @@ internal class LogRecordModel(
 
     override val attributes: Map<String, Any>
         get() = lock.read {
-            attrs.attributes.toMap()
+            attrs.attributes
         }
 
     override val droppedAttributesCount: Int
@@ -206,17 +186,23 @@ internal class LogRecordModel(
         }
     }
 
-    override fun toLogRecordData(): LogRecordData = LogRecordDataImpl(
-        timestamp,
-        observedTimestamp,
-        severityNumber,
-        severityText,
-        body,
-        eventName,
-        spanContext,
-        attributes,
-        resource,
-        instrumentationScopeInfo,
-        droppedAttributesCount
-    )
+    /**
+     * Takes the snapshot under a single read lock so that the returned [LogRecordData] is internally
+     * consistent.
+     */
+    override fun toLogRecordData(): LogRecordData = lock.read {
+        LogRecordDataImpl(
+            timestampImpl,
+            observedTimestampImpl,
+            severityNumberImpl,
+            severityTextImpl,
+            bodyImpl,
+            eventNameImpl,
+            spanContextImpl,
+            attrs.attributes,
+            resource,
+            instrumentationScopeInfo,
+            attrs.droppedAttributesCount
+        )
+    }
 }

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/LogRecordSnapshotTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/LogRecordSnapshotTest.kt
@@ -9,6 +9,7 @@ import io.opentelemetry.kotlin.factory.FakeSpanContextFactory
 import io.opentelemetry.kotlin.init.config.LogLimitConfig
 import io.opentelemetry.kotlin.logging.export.FakeLogRecordProcessor
 import io.opentelemetry.kotlin.resource.FakeResource
+import io.opentelemetry.kotlin.tracing.FakeSpanContext
 import io.opentelemetry.kotlin.tracing.fakeLogLimitsConfig
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -96,5 +97,31 @@ internal class LogRecordSnapshotTest {
         val data = processor.logs.single().toLogRecordData()
         assertEquals(2, data.attributes.size)
         assertEquals(1, data.droppedAttributesCount)
+    }
+
+    @Test
+    fun testSnapshotReflectsMutatedFields() {
+        logger.emit("my_log")
+
+        val log = processor.logs.single()
+        val spanContext = FakeSpanContext.VALID
+        log.timestamp = 5L
+        log.observedTimestamp = 6L
+        log.severityNumber = SeverityNumber.ERROR
+        log.severityText = "error"
+        log.body = "changed_body"
+        log.eventName = "changed_event"
+        log.spanContext = spanContext
+        log.setStringAttribute("key", "value")
+
+        val data = log.toLogRecordData()
+        assertEquals(5L, data.timestamp)
+        assertEquals(6L, data.observedTimestamp)
+        assertEquals(SeverityNumber.ERROR, data.severityNumber)
+        assertEquals("error", data.severityText)
+        assertEquals("changed_body", data.body)
+        assertEquals("changed_event", data.eventName)
+        assertEquals(spanContext, data.spanContext)
+        assertEquals(mapOf("key" to "value"), data.attributes)
     }
 }


### PR DESCRIPTION
## Goal

Alters the log snapshotting so that it remains internally consistent similar to `SpanModel`. Closes #858
