### PR TITLE
Allow shutting down SDK

### DIFF
--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/CompatOpenTelemetryImpl.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/CompatOpenTelemetryImpl.kt
@@ -1,5 +1,10 @@
 package io.opentelemetry.kotlin
 
+import io.opentelemetry.kotlin.error.SdkErrorHandler
+import io.opentelemetry.kotlin.export.CompositeTelemetryCloseable
+import io.opentelemetry.kotlin.export.MutableShutdownState
+import io.opentelemetry.kotlin.export.OperationResultCode
+import io.opentelemetry.kotlin.export.TelemetryCloseable
 import io.opentelemetry.kotlin.factory.BaggageFactory
 import io.opentelemetry.kotlin.factory.ContextFactory
 import io.opentelemetry.kotlin.factory.IdGenerator
@@ -27,4 +32,24 @@ internal class CompatOpenTelemetryImpl(
     override val idGenerator: IdGenerator,
     override val resource: ResourceFactory,
     override val propagator: TextMapPropagator,
-) : OpenTelemetrySdk
+    sdkErrorHandler: SdkErrorHandler,
+) : OpenTelemetrySdk {
+
+    private val shutdownState: MutableShutdownState = MutableShutdownState()
+
+    private val closeable = CompositeTelemetryCloseable(
+        closeables = listOfNotNull(
+            tracerProvider as? TelemetryCloseable,
+            loggerProvider as? TelemetryCloseable,
+            meterProvider as? TelemetryCloseable,
+        ),
+        sdkErrorHandler = sdkErrorHandler,
+    )
+
+    override suspend fun forceFlush(): OperationResultCode = when {
+        shutdownState.isShutdown -> OperationResultCode.Success
+        else -> closeable.forceFlush()
+    }
+
+    override suspend fun shutdown(): OperationResultCode = shutdownState.shutdown { closeable.shutdown() }
+}

--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/OpenTelemetryCompatEntrypoint.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/OpenTelemetryCompatEntrypoint.kt
@@ -48,5 +48,6 @@ public fun createCompatOpenTelemetry(
         idGenerator = resolvedIdGenerator,
         resource = CompatResourceFactory,
         propagator = cfg.propagatorCfg.buildPropagator(),
+        sdkErrorHandler = cfg.sdkErrorHandler,
     )
 }

--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/OtelJavaOpenTelemetryExt.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/OtelJavaOpenTelemetryExt.kt
@@ -1,8 +1,13 @@
 package io.opentelemetry.kotlin
 
 import io.opentelemetry.kotlin.aliases.OtelJavaClock
+import io.opentelemetry.kotlin.aliases.OtelJavaLoggerProvider
+import io.opentelemetry.kotlin.aliases.OtelJavaMeterProvider
 import io.opentelemetry.kotlin.aliases.OtelJavaOpenTelemetry
+import io.opentelemetry.kotlin.aliases.OtelJavaOpenTelemetrySdk
+import io.opentelemetry.kotlin.aliases.OtelJavaTracerProvider
 import io.opentelemetry.kotlin.clock.ClockAdapter
+import io.opentelemetry.kotlin.error.NoopSdkErrorHandler
 import io.opentelemetry.kotlin.factory.CompatBaggageFactory
 import io.opentelemetry.kotlin.factory.CompatContextFactory
 import io.opentelemetry.kotlin.factory.CompatIdGenerator
@@ -37,9 +42,9 @@ public fun OtelJavaOpenTelemetry.toOtelKotlinApi(): OpenTelemetry {
     val span = CompatSpanFactory(spanContext)
     val clock = ClockAdapter(OtelJavaClock.getDefault())
     return CompatOpenTelemetryImpl(
-        tracerProvider = TracerProviderAdapter(tracerProvider, clock, CompatSpanLimitsConfig()),
-        loggerProvider = LoggerProviderAdapter(logsBridge),
-        meterProvider = MeterProviderAdapter(meterProvider),
+        tracerProvider = TracerProviderAdapter(unobfuscatedTracerProvider(), clock, CompatSpanLimitsConfig()),
+        loggerProvider = LoggerProviderAdapter(unobfuscatedLoggerProvider()),
+        meterProvider = MeterProviderAdapter(unobfuscatedMeterProvider()),
         clock = clock,
         spanContext = spanContext,
         traceFlags = traceFlags,
@@ -50,5 +55,26 @@ public fun OtelJavaOpenTelemetry.toOtelKotlinApi(): OpenTelemetry {
         idGenerator = idGenerator,
         resource = CompatResourceFactory,
         propagator = TextMapPropagatorAdapter(propagators.textMapPropagator),
+        sdkErrorHandler = NoopSdkErrorHandler,
     )
+}
+
+/**
+ * [OtelJavaOpenTelemetrySdk] hides its SDK providers behind obfuscated wrappers, which prevents
+ * the adapters from delegating flush/shutdown to them. These functions return the SDK providers
+ * where they are available.
+ */
+private fun OtelJavaOpenTelemetry.unobfuscatedTracerProvider(): OtelJavaTracerProvider = when (this) {
+    is OtelJavaOpenTelemetrySdk -> sdkTracerProvider
+    else -> tracerProvider
+}
+
+private fun OtelJavaOpenTelemetry.unobfuscatedLoggerProvider(): OtelJavaLoggerProvider = when (this) {
+    is OtelJavaOpenTelemetrySdk -> sdkLoggerProvider
+    else -> logsBridge
+}
+
+private fun OtelJavaOpenTelemetry.unobfuscatedMeterProvider(): OtelJavaMeterProvider = when (this) {
+    is OtelJavaOpenTelemetrySdk -> sdkMeterProvider
+    else -> meterProvider
 }

--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/init/CompatOpenTelemetryConfig.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/init/CompatOpenTelemetryConfig.kt
@@ -26,7 +26,7 @@ internal class CompatOpenTelemetryConfig(
 ) : OpenTelemetryConfigDsl {
 
     @Volatile private var configuredErrorHandler: SdkErrorHandler = NoopSdkErrorHandler
-    private val sdkErrorHandler = GuardedSdkErrorHandler { configuredErrorHandler.onError(it) }
+    internal val sdkErrorHandler = GuardedSdkErrorHandler { configuredErrorHandler.onError(it) }
 
     internal val tracerProviderConfig = CompatTracerProviderConfig(clock, sdkErrorHandler)
     internal val loggerProviderConfig = CompatLoggerProviderConfig(clock, sdkErrorHandler)

--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/logging/LoggerProviderAdapter.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/logging/LoggerProviderAdapter.kt
@@ -3,12 +3,18 @@ package io.opentelemetry.kotlin.logging
 import io.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.kotlin.InstrumentationScopeInfo
 import io.opentelemetry.kotlin.aliases.OtelJavaLoggerProvider
+import io.opentelemetry.kotlin.aliases.OtelJavaSdkLoggerProvider
 import io.opentelemetry.kotlin.attributes.AttributesMutator
+import io.opentelemetry.kotlin.awaitOperationResultCode
+import io.opentelemetry.kotlin.export.OperationResultCode
+import io.opentelemetry.kotlin.export.TelemetryCloseable
 import io.opentelemetry.kotlin.scope.scopeCacheKey
 import java.util.concurrent.ConcurrentHashMap
 
 @ExperimentalApi
-internal class LoggerProviderAdapter(private val impl: OtelJavaLoggerProvider) : LoggerProvider {
+internal class LoggerProviderAdapter(
+    private val impl: OtelJavaLoggerProvider,
+) : LoggerProvider, TelemetryCloseable {
 
     private val map = ConcurrentHashMap<InstrumentationScopeInfo, LoggerAdapter>()
 
@@ -29,5 +35,15 @@ internal class LoggerProviderAdapter(private val impl: OtelJavaLoggerProvider) :
             }
             LoggerAdapter(builder.build())
         }
+    }
+
+    override suspend fun forceFlush(): OperationResultCode = when (impl) {
+        is OtelJavaSdkLoggerProvider -> awaitOperationResultCode { impl.forceFlush() }
+        else -> OperationResultCode.Success
+    }
+
+    override suspend fun shutdown(): OperationResultCode = when (impl) {
+        is OtelJavaSdkLoggerProvider -> awaitOperationResultCode { impl.shutdown() }
+        else -> OperationResultCode.Success
     }
 }

--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/metrics/MeterProviderAdapter.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/metrics/MeterProviderAdapter.kt
@@ -4,7 +4,11 @@ import io.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.kotlin.InstrumentationScopeInfo
 import io.opentelemetry.kotlin.ThreadSafe
 import io.opentelemetry.kotlin.aliases.OtelJavaMeterProvider
+import io.opentelemetry.kotlin.aliases.OtelJavaSdkMeterProvider
 import io.opentelemetry.kotlin.attributes.AttributesMutator
+import io.opentelemetry.kotlin.awaitOperationResultCode
+import io.opentelemetry.kotlin.export.OperationResultCode
+import io.opentelemetry.kotlin.export.TelemetryCloseable
 import io.opentelemetry.kotlin.scope.scopeCacheKey
 import java.util.concurrent.ConcurrentHashMap
 
@@ -12,7 +16,7 @@ import java.util.concurrent.ConcurrentHashMap
 @ExperimentalApi
 internal class MeterProviderAdapter(
     private val impl: OtelJavaMeterProvider
-) : MeterProvider {
+) : MeterProvider, TelemetryCloseable {
 
     private val map = ConcurrentHashMap<InstrumentationScopeInfo, MeterAdapter>()
 
@@ -28,5 +32,15 @@ internal class MeterProviderAdapter(
             version?.let(builder::setInstrumentationVersion)
             MeterAdapter(builder.build())
         }
+    }
+
+    override suspend fun forceFlush(): OperationResultCode = when (impl) {
+        is OtelJavaSdkMeterProvider -> awaitOperationResultCode { impl.forceFlush() }
+        else -> OperationResultCode.Success
+    }
+
+    override suspend fun shutdown(): OperationResultCode = when (impl) {
+        is OtelJavaSdkMeterProvider -> awaitOperationResultCode { impl.shutdown() }
+        else -> OperationResultCode.Success
     }
 }

--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/tracing/TracerProviderAdapter.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/tracing/TracerProviderAdapter.kt
@@ -3,8 +3,12 @@ package io.opentelemetry.kotlin.tracing
 import io.opentelemetry.kotlin.Clock
 import io.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.kotlin.InstrumentationScopeInfo
+import io.opentelemetry.kotlin.aliases.OtelJavaSdkTracerProvider
 import io.opentelemetry.kotlin.aliases.OtelJavaTracerProvider
 import io.opentelemetry.kotlin.attributes.AttributesMutator
+import io.opentelemetry.kotlin.awaitOperationResultCode
+import io.opentelemetry.kotlin.export.OperationResultCode
+import io.opentelemetry.kotlin.export.TelemetryCloseable
 import io.opentelemetry.kotlin.init.CompatSpanLimitsConfig
 import io.opentelemetry.kotlin.scope.scopeCacheKey
 import java.util.concurrent.ConcurrentHashMap
@@ -14,7 +18,7 @@ internal class TracerProviderAdapter(
     private val tracerProvider: OtelJavaTracerProvider,
     private val clock: Clock,
     private val spanLimitsConfig: CompatSpanLimitsConfig,
-) : TracerProvider {
+) : TracerProvider, TelemetryCloseable {
 
     private val map = ConcurrentHashMap<InstrumentationScopeInfo, TracerAdapter>()
 
@@ -32,5 +36,15 @@ internal class TracerProviderAdapter(
             val tracer = tracerBuilder.build()
             TracerAdapter(tracer, clock, spanLimitsConfig)
         }
+    }
+
+    override suspend fun forceFlush(): OperationResultCode = when (tracerProvider) {
+        is OtelJavaSdkTracerProvider -> awaitOperationResultCode { tracerProvider.forceFlush() }
+        else -> OperationResultCode.Success
+    }
+
+    override suspend fun shutdown(): OperationResultCode = when (tracerProvider) {
+        is OtelJavaSdkTracerProvider -> awaitOperationResultCode { tracerProvider.shutdown() }
+        else -> OperationResultCode.Success
     }
 }

--- a/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/CompatOpenTelemetrySdkCloseableTest.kt
+++ b/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/CompatOpenTelemetrySdkCloseableTest.kt
@@ -1,0 +1,101 @@
+package io.opentelemetry.kotlin
+
+import io.opentelemetry.kotlin.aliases.OtelJavaOpenTelemetry
+import io.opentelemetry.kotlin.aliases.OtelJavaOpenTelemetrySdk
+import io.opentelemetry.kotlin.aliases.OtelJavaSdkLoggerProvider
+import io.opentelemetry.kotlin.aliases.OtelJavaSdkTracerProvider
+import io.opentelemetry.kotlin.export.OperationResultCode.Success
+import io.opentelemetry.kotlin.fakes.otel.java.FakeOtelJavaLogRecordExporter
+import io.opentelemetry.kotlin.fakes.otel.java.FakeOtelJavaSpanExporter
+import io.opentelemetry.sdk.logs.export.BatchLogRecordProcessor
+import io.opentelemetry.sdk.trace.export.BatchSpanProcessor
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Verifies that flush/shutdown on an [OpenTelemetrySdk] created by the compat module is delegated
+ * to the opentelemetry-java providers it wraps.
+ */
+@OptIn(ExperimentalApi::class)
+internal class CompatOpenTelemetrySdkCloseableTest {
+
+    private val spanExporter = FakeOtelJavaSpanExporter()
+    private val logExporter = FakeOtelJavaLogRecordExporter()
+
+    private fun createSdk(): OpenTelemetrySdk {
+        val otelJavaSdk = OtelJavaOpenTelemetrySdk.builder()
+            .setTracerProvider(
+                OtelJavaSdkTracerProvider.builder()
+                    .addSpanProcessor(BatchSpanProcessor.builder(spanExporter).build())
+                    .build()
+            )
+            .setLoggerProvider(
+                OtelJavaSdkLoggerProvider.builder()
+                    .addLogRecordProcessor(BatchLogRecordProcessor.builder(logExporter).build())
+                    .build()
+            )
+            .build()
+        return otelJavaSdk.toOtelKotlinApi() as OpenTelemetrySdk
+    }
+
+    @Test
+    fun `force flush exports buffered telemetry`() = runBlocking {
+        val sdk = createSdk()
+        sdk.tracerProvider.getTracer("test").startSpan("span").end()
+        sdk.loggerProvider.getLogger("test").emit(body = "log")
+
+        assertEquals(Success, sdk.forceFlush())
+        assertEquals(1, spanExporter.exports.size)
+        assertEquals(1, logExporter.exports.size)
+    }
+
+    @Test
+    fun `shutdown shuts down the wrapped providers`() = runBlocking {
+        val sdk = createSdk()
+        sdk.tracerProvider.getTracer("test").startSpan("span").end()
+        sdk.loggerProvider.getLogger("test").emit(body = "log")
+
+        assertEquals(Success, sdk.shutdown())
+        assertEquals(1, spanExporter.shutdownCount)
+        assertEquals(1, logExporter.shutdownCount)
+        assertEquals(1, spanExporter.exports.size)
+        assertEquals(1, logExporter.exports.size)
+
+        // nothing is exported after shutdown
+        sdk.tracerProvider.getTracer("test").startSpan("after").end()
+        sdk.loggerProvider.getLogger("test").emit(body = "after")
+        assertEquals(Success, sdk.forceFlush())
+        assertEquals(1, spanExporter.exports.size)
+        assertEquals(1, logExporter.exports.size)
+    }
+
+    @Test
+    fun `shutdown is idempotent`() = runBlocking {
+        val sdk = createSdk()
+        assertEquals(Success, sdk.shutdown())
+        assertEquals(Success, sdk.shutdown())
+        assertEquals(1, spanExporter.shutdownCount)
+        assertEquals(1, logExporter.shutdownCount)
+    }
+
+    @Test
+    fun `flush and shutdown succeed when the wrapped providers are not sdk instances`() = runBlocking {
+        val sdk = OtelJavaOpenTelemetry.noop().toOtelKotlinApi() as OpenTelemetrySdk
+        assertEquals(Success, sdk.forceFlush())
+        assertEquals(Success, sdk.shutdown())
+    }
+
+    @Test
+    fun `shutdown of a dsl configured sdk stops spans being recorded`() = runBlocking {
+        val sdk = createCompatOpenTelemetry() as OpenTelemetrySdk
+        val tracer = sdk.tracerProvider.getTracer("test")
+        assertTrue(tracer.startSpan("before").isRecording())
+        assertEquals(Success, sdk.forceFlush())
+        assertEquals(Success, sdk.shutdown())
+        assertEquals(Success, sdk.shutdown())
+        assertFalse(tracer.startSpan("after").isRecording())
+    }
+}

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/OpenTelemetryImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/OpenTelemetryImpl.kt
@@ -34,7 +34,7 @@ internal class OpenTelemetryImpl(
     override val resource: ResourceFactory,
     override val propagator: TextMapPropagator,
     private val timeoutMs: Long = 3000,
-) : OpenTelemetrySdk, TelemetryCloseable {
+) : OpenTelemetrySdk {
 
     private val shutdownState: MutableShutdownState = MutableShutdownState()
 

--- a/noop/build.gradle.kts
+++ b/noop/build.gradle.kts
@@ -14,5 +14,10 @@ kotlin {
                 api(project(":sdk-api"))
             }
         }
+        val commonTest by getting {
+            dependencies {
+                implementation(libs.kotlinx.coroutines.test)
+            }
+        }
     }
 }

--- a/noop/src/commonMain/kotlin/io/opentelemetry/kotlin/NoopOpenTelemetryImpl.kt
+++ b/noop/src/commonMain/kotlin/io/opentelemetry/kotlin/NoopOpenTelemetryImpl.kt
@@ -1,5 +1,6 @@
 package io.opentelemetry.kotlin
 
+import io.opentelemetry.kotlin.export.OperationResultCode
 import io.opentelemetry.kotlin.factory.BaggageFactory
 import io.opentelemetry.kotlin.factory.ContextFactory
 import io.opentelemetry.kotlin.factory.IdGenerator
@@ -40,4 +41,7 @@ internal object NoopOpenTelemetryImpl : OpenTelemetrySdk {
     override val idGenerator: IdGenerator = NoopIdGenerator
     override val resource: ResourceFactory = NoopResourceFactory
     override val propagator: TextMapPropagator = NoopTextMapPropagator
+
+    override suspend fun forceFlush(): OperationResultCode = OperationResultCode.Success
+    override suspend fun shutdown(): OperationResultCode = OperationResultCode.Success
 }

--- a/noop/src/commonTest/kotlin/io/opentelemetry/kotlin/NoopTests.kt
+++ b/noop/src/commonTest/kotlin/io/opentelemetry/kotlin/NoopTests.kt
@@ -5,6 +5,7 @@ import io.opentelemetry.kotlin.config.NoopConfigProperties
 import io.opentelemetry.kotlin.config.NoopConfigProvider
 import io.opentelemetry.kotlin.context.NoopContext
 import io.opentelemetry.kotlin.context.NoopContextKey
+import io.opentelemetry.kotlin.export.OperationResultCode
 import io.opentelemetry.kotlin.factory.NoopBaggageFactory
 import io.opentelemetry.kotlin.logging.SeverityNumber
 import io.opentelemetry.kotlin.propagation.NoopTextMapPropagator
@@ -14,6 +15,7 @@ import io.opentelemetry.kotlin.tracing.NoopSpan
 import io.opentelemetry.kotlin.tracing.NoopSpanContext
 import io.opentelemetry.kotlin.tracing.NoopTraceFlags
 import io.opentelemetry.kotlin.tracing.SpanKind
+import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -310,5 +312,12 @@ internal class NoopTests {
 
         // Verify no data is recorded
         assertFalse(span.isRecording())
+    }
+
+    @Test
+    fun testNoopFlushAndShutdown() = runTest {
+        val otel = NoopOpenTelemetry as OpenTelemetrySdk
+        assertEquals(OperationResultCode.Success, otel.forceFlush())
+        assertEquals(OperationResultCode.Success, otel.shutdown())
     }
 }

--- a/sdk-api/api/jvm/sdk-api.api
+++ b/sdk-api/api/jvm/sdk-api.api
@@ -9,7 +9,7 @@ public abstract interface class io/opentelemetry/kotlin/InstrumentationScopeInfo
 	public abstract fun getVersion ()Ljava/lang/String;
 }
 
-public abstract interface class io/opentelemetry/kotlin/OpenTelemetrySdk : io/opentelemetry/kotlin/OpenTelemetry {
+public abstract interface class io/opentelemetry/kotlin/OpenTelemetrySdk : io/opentelemetry/kotlin/OpenTelemetry, io/opentelemetry/kotlin/export/TelemetryCloseable {
 	public abstract fun getClock ()Lio/opentelemetry/kotlin/Clock;
 	public abstract fun getIdGenerator ()Lio/opentelemetry/kotlin/factory/IdGenerator;
 	public abstract fun getResource ()Lio/opentelemetry/kotlin/factory/ResourceFactory;

--- a/sdk-api/src/commonMain/kotlin/io/opentelemetry/kotlin/OpenTelemetrySdk.kt
+++ b/sdk-api/src/commonMain/kotlin/io/opentelemetry/kotlin/OpenTelemetrySdk.kt
@@ -1,5 +1,6 @@
 package io.opentelemetry.kotlin
 
+import io.opentelemetry.kotlin.export.TelemetryCloseable
 import io.opentelemetry.kotlin.factory.IdGenerator
 import io.opentelemetry.kotlin.factory.ResourceFactory
 
@@ -8,9 +9,12 @@ import io.opentelemetry.kotlin.factory.ResourceFactory
  *
  * This contains interfaces in the SDK package and is not intended for use by instrumentation
  * authors: https://opentelemetry.io/docs/specs/otel/overview/#sdk
+ *
+ * This interface extends [TelemetryCloseable] which allows the owner of the SDK instance
+ * to flush and shutdown the SDK.
  */
 @ExperimentalApi
-public interface OpenTelemetrySdk : OpenTelemetry {
+public interface OpenTelemetrySdk : OpenTelemetry, TelemetryCloseable {
 
     /**
      * The [Clock] that will be used for obtaining timestamps by this instance.

--- a/test-fakes/src/commonMain/kotlin/io/opentelemetry/kotlin/FakeOpenTelemetry.kt
+++ b/test-fakes/src/commonMain/kotlin/io/opentelemetry/kotlin/FakeOpenTelemetry.kt
@@ -1,6 +1,7 @@
 package io.opentelemetry.kotlin
 
 import io.opentelemetry.kotlin.clock.FakeClock
+import io.opentelemetry.kotlin.export.OperationResultCode
 import io.opentelemetry.kotlin.factory.BaggageFactory
 import io.opentelemetry.kotlin.factory.ContextFactory
 import io.opentelemetry.kotlin.factory.FakeBaggageFactory
@@ -40,4 +41,20 @@ class FakeOpenTelemetry : OpenTelemetrySdk {
     override val idGenerator: IdGenerator = FakeIdGenerator()
     override val resource: ResourceFactory = FakeResourceFactory()
     override val propagator: TextMapPropagator = FakeTextMapPropagator()
+
+    var forceFlushCount: Int = 0
+        private set
+
+    var shutdownCount: Int = 0
+        private set
+
+    override suspend fun forceFlush(): OperationResultCode {
+        forceFlushCount++
+        return OperationResultCode.Success
+    }
+
+    override suspend fun shutdown(): OperationResultCode {
+        shutdownCount++
+        return OperationResultCode.Success
+    }
 }


### PR DESCRIPTION
## Goal

Closes #854 by allowing the SDK to shutdown, by making `OpenTelemetrySdk` implement `TelemetryCloseable`. This makes it much more practical for a library user to call `forceFlush` and `shutdown` in one place if they wish to stop the SDK.

I've avoided making this an explicit public API for now - folks still need to cast as this is technically an implementation detail according to the spec. We could revisit making this a public API in future.

## Testing

Added unit tests.
