### PR TITLE
fix: derive SpanContextImpl.isValid from ID bytes

### DIFF
--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/factory/CompatSpanContextFactory.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/factory/CompatSpanContextFactory.kt
@@ -20,7 +20,6 @@ internal class CompatSpanContextFactory : SpanContextFactory {
             traceIdBytes = impl.traceId.hexToByteArray(),
             spanIdBytes = impl.spanId.hexToByteArray(),
             traceFlags = TraceFlagsAdapter(impl.traceFlags),
-            isValid = impl.isValid,
             isRemote = impl.isRemote,
             traceState = TraceStateAdapter(impl.traceState)
         )

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/factory/SpanContextFactoryImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/factory/SpanContextFactoryImpl.kt
@@ -16,7 +16,6 @@ internal class SpanContextFactoryImpl(
             traceIdBytes = idGenerator.invalidTraceId,
             spanIdBytes = idGenerator.invalidSpanId,
             traceFlags = traceFlagsFactory.default,
-            isValid = false,
             isRemote = false,
             traceState = traceStateFactory.default
         )
@@ -42,7 +41,6 @@ internal class SpanContextFactoryImpl(
                 else -> idGenerator.invalidSpanId
             },
             traceFlags = traceFlags,
-            isValid = isValidTraceId && isValidSpanId,
             isRemote = isRemote,
             traceState = traceState
         )

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/TracerImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/TracerImpl.kt
@@ -166,7 +166,6 @@ internal class TracerImpl(
                 randomTraceId -> unsampledRandomFlags
                 else -> unsampledFlags
             },
-            isValid = validTraceId && validSpanId,
             isRemote = false,
             traceState = traceState,
         )

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/factory/SpanContextFactoryImplTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/factory/SpanContextFactoryImplTest.kt
@@ -198,4 +198,18 @@ internal class SpanContextFactoryImplTest {
         assertFalse(spanContext.isValid)
         assertFalse(spanContext.isRemote)
     }
+
+    @Test
+    internal fun testZeroIdsAreInvalidEvenWhenSampled() {
+        val spanContext = factory.create(
+            "00000000000000000000000000000000",
+            "0000000000000000",
+            traceFlagsFactory.fromHex("01"),
+            traceStateFactory.default,
+            false,
+        )
+
+        assertTrue(spanContext.traceFlags.isSampled)
+        assertFalse(spanContext.isValid)
+    }
 }

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/SpanContextImplTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/SpanContextImplTest.kt
@@ -1,0 +1,49 @@
+package io.opentelemetry.kotlin.tracing
+
+import io.opentelemetry.kotlin.factory.TraceFlagsFactoryImpl
+import io.opentelemetry.kotlin.factory.TraceStateFactoryImpl
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+internal class SpanContextImplTest {
+
+    private val traceFlags = TraceFlagsFactoryImpl().default
+    private val traceState = TraceStateFactoryImpl().default
+
+    @Test
+    fun testValidIds() {
+        val spanContext = SpanContextImpl(
+            traceIdBytes = ByteArray(16) { 1 },
+            spanIdBytes = ByteArray(8) { 1 },
+            traceFlags = traceFlags,
+            isRemote = false,
+            traceState = traceState,
+        )
+        assertTrue(spanContext.isValid)
+    }
+
+    @Test
+    fun testWrongLengthTraceIdIsInvalid() {
+        val spanContext = SpanContextImpl(
+            traceIdBytes = ByteArray(4) { 1 },
+            spanIdBytes = ByteArray(8) { 1 },
+            traceFlags = traceFlags,
+            isRemote = false,
+            traceState = traceState,
+        )
+        assertFalse(spanContext.isValid)
+    }
+
+    @Test
+    fun testWrongLengthSpanIdIsInvalid() {
+        val spanContext = SpanContextImpl(
+            traceIdBytes = ByteArray(16) { 1 },
+            spanIdBytes = ByteArray(3) { 1 },
+            traceFlags = traceFlags,
+            isRemote = false,
+            traceState = traceState,
+        )
+        assertFalse(spanContext.isValid)
+    }
+}

--- a/model/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/SpanContextImpl.kt
+++ b/model/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/SpanContextImpl.kt
@@ -2,14 +2,19 @@ package io.opentelemetry.kotlin.tracing
 
 import io.opentelemetry.kotlin.factory.toHexString
 
+private const val TRACE_ID_BYTES = 16
+private const val SPAN_ID_BYTES = 8
+
 class SpanContextImpl(
     override val traceIdBytes: ByteArray,
     override val spanIdBytes: ByteArray,
     override val traceFlags: TraceFlags,
-    override val isValid: Boolean,
     override val isRemote: Boolean,
     override val traceState: TraceState,
 ) : SpanContext {
+
+    override val isValid: Boolean =
+        isValidId(traceIdBytes, TRACE_ID_BYTES) && isValidId(spanIdBytes, SPAN_ID_BYTES)
 
     override val traceId: String by lazy {
         traceIdBytes.toHexString()
@@ -18,3 +23,6 @@ class SpanContextImpl(
         spanIdBytes.toHexString()
     }
 }
+
+private fun isValidId(id: ByteArray, expectedSize: Int): Boolean =
+    id.size == expectedSize && id.any { it != 0.toByte() }


### PR DESCRIPTION
## Goal
Derive SpanContextImpl.isValid from the trace/span ID bytes instead of a constructor flag. isRemote is unchanged.

## Testing
Added a SpanContextFactoryImplTest case for sampled flags with zero IDs. Ran implementation and compat JVM tests for SpanContext factories/tracer context.

Fixes #878