### PR TITLE
fix: do not throw on out-of-range OtelTraceState threshold

### DIFF
--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/sampling/OtelTraceState.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/sampling/OtelTraceState.kt
@@ -12,7 +12,9 @@ internal class OtelTraceState private constructor(
         get() = pairs[THRESHOLD_KEY]?.threshold()
 
     fun setThreshold(threshold: Long) {
-        require(threshold in 0x0..0xffffffffffffff)
+        if (threshold !in 0x0..0xffffffffffffff) {
+            return
+        }
         pairs[THRESHOLD_KEY] = if (threshold == 0L) {
             "0"
         } else {

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/sampling/OtelTraceStateTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/sampling/OtelTraceStateTest.kt
@@ -2,7 +2,6 @@ package io.opentelemetry.kotlin.tracing.sampling
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
@@ -71,19 +70,26 @@ internal class OtelTraceStateTest {
     }
 
     @Test
-    fun rejectsNegativeThreshold() {
+    fun ignoresNegativeThreshold() {
         val ot = OtelTraceState.parse("")
-        assertFailsWith(IllegalArgumentException::class) {
-            ot.setThreshold(-1L)
-        }
+        ot.setThreshold(-1L)
+        assertTrue(ot.encode().isEmpty())
     }
 
     @Test
-    fun rejectsThresholdExceeding14HexDigits() {
+    fun ignoresThresholdExceeding14HexDigits() {
         val ot = OtelTraceState.parse("")
-        assertFailsWith(IllegalArgumentException::class) {
-            ot.setThreshold(0xffffffffffffff + 1)
-        }
+        ot.setThreshold(0xffffffffffffff + 1)
+        assertTrue(ot.encode().isEmpty())
+    }
+
+    @Test
+    fun keepsExistingThresholdWhenOutOfRange() {
+        val ot = OtelTraceState.parse("th:123")
+        ot.setThreshold(-1L)
+        assertEquals(0x12300000000000, ot.th)
+        ot.setThreshold(0xffffffffffffff + 1)
+        assertEquals(0x12300000000000, ot.th)
     }
 
     @Test


### PR DESCRIPTION
## Goal
Stop OtelTraceState.setThreshold from throwing on an out-of-range threshold. Skip the write instead.

## Testing
Updated OtelTraceStateTest for negative and >14-hex-digit values. Ran :implementation:jvmTest for OtelTraceStateTest.

Fixes #876