### PR TITLE
fix: deep-copy events, links, and attributes in toSpanData

### DIFF
--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/SpanDataSnapshot.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/SpanDataSnapshot.kt
@@ -1,6 +1,5 @@
 package io.opentelemetry.kotlin.tracing
 
-import io.opentelemetry.kotlin.tracing.SpanContext
 import io.opentelemetry.kotlin.tracing.data.SpanEventData
 import io.opentelemetry.kotlin.tracing.data.SpanLinkData
 

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/SpanDataSnapshot.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/SpanDataSnapshot.kt
@@ -1,0 +1,44 @@
+package io.opentelemetry.kotlin.tracing
+
+import io.opentelemetry.kotlin.tracing.SpanContext
+import io.opentelemetry.kotlin.tracing.data.SpanEventData
+import io.opentelemetry.kotlin.tracing.data.SpanLinkData
+
+internal fun Map<String, Any>.frozenCopy(): Map<String, Any> {
+    if (isEmpty()) {
+        return emptyMap()
+    }
+    return mapValues { (_, value) -> freezeAttributeValue(value) }
+}
+
+private fun freezeAttributeValue(value: Any): Any = when (value) {
+    is ByteArray -> value.copyOf()
+    is List<*> -> value.toList()
+    else -> value
+}
+
+internal fun SpanEventData.toSnapshot(): SpanEventData = SnapshotSpanEventData(
+    name = name,
+    timestamp = timestamp,
+    attributes = attributes.frozenCopy(),
+    droppedAttributesCount = droppedAttributesCount,
+)
+
+internal fun SpanLinkData.toSnapshot(): SpanLinkData = SnapshotSpanLinkData(
+    spanContext = spanContext,
+    attributes = attributes.frozenCopy(),
+    droppedAttributesCount = droppedAttributesCount,
+)
+
+private class SnapshotSpanEventData(
+    override val name: String,
+    override val timestamp: Long,
+    override val attributes: Map<String, Any>,
+    override val droppedAttributesCount: Int,
+) : SpanEventData
+
+private class SnapshotSpanLinkData(
+    override val spanContext: SpanContext,
+    override val attributes: Map<String, Any>,
+    override val droppedAttributesCount: Int,
+) : SpanLinkData

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/model/SpanModel.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/model/SpanModel.kt
@@ -17,11 +17,11 @@ import io.opentelemetry.kotlin.tracing.SpanDataImpl
 import io.opentelemetry.kotlin.tracing.SpanEventImpl
 import io.opentelemetry.kotlin.tracing.SpanKind
 import io.opentelemetry.kotlin.tracing.StatusData
-import io.opentelemetry.kotlin.tracing.frozenCopy
-import io.opentelemetry.kotlin.tracing.toSnapshot
 import io.opentelemetry.kotlin.tracing.data.SpanEventData
 import io.opentelemetry.kotlin.tracing.data.SpanLinkData
 import io.opentelemetry.kotlin.tracing.export.SpanProcessor
+import io.opentelemetry.kotlin.tracing.frozenCopy
+import io.opentelemetry.kotlin.tracing.toSnapshot
 
 /**
  * The single source of truth for span state. This is not exposed to consumers of the API - they

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/model/SpanModel.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/model/SpanModel.kt
@@ -17,6 +17,8 @@ import io.opentelemetry.kotlin.tracing.SpanDataImpl
 import io.opentelemetry.kotlin.tracing.SpanEventImpl
 import io.opentelemetry.kotlin.tracing.SpanKind
 import io.opentelemetry.kotlin.tracing.StatusData
+import io.opentelemetry.kotlin.tracing.frozenCopy
+import io.opentelemetry.kotlin.tracing.toSnapshot
 import io.opentelemetry.kotlin.tracing.data.SpanEventData
 import io.opentelemetry.kotlin.tracing.data.SpanLinkData
 import io.opentelemetry.kotlin.tracing.export.SpanProcessor
@@ -220,10 +222,10 @@ internal class SpanModel(
             spanKind,
             startTimestamp,
             endTimestampImpl,
-            attrs.attributes,
-            eventsList.toList(),
+            attrs.attributes.frozenCopy(),
+            eventsList.map { it.toSnapshot() },
             droppedEventsCountImpl,
-            linksList.toList(),
+            linksList.map { it.toSnapshot() },
             droppedLinksCountImpl,
             resource,
             instrumentationScopeInfo,

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/SpanDataTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/SpanDataTest.kt
@@ -9,6 +9,7 @@ import io.opentelemetry.kotlin.factory.FakeIdGenerator
 import io.opentelemetry.kotlin.factory.FakeSpanContextFactory
 import io.opentelemetry.kotlin.factory.FakeTraceFlagsFactory
 import io.opentelemetry.kotlin.resource.FakeResource
+import io.opentelemetry.kotlin.attributes.AttributesMutator
 import io.opentelemetry.kotlin.tracing.data.SpanData
 import io.opentelemetry.kotlin.tracing.export.FakeSpanProcessor
 import io.opentelemetry.kotlin.tracing.model.ReadableSpan
@@ -80,6 +81,56 @@ internal class SpanDataTest {
         assertFalse(tracer.startSpan("test").isRecording())
     }
 
+    @Test
+    fun testToSpanDataCopiesByteArrayAttributes() {
+        val bytes = byteArrayOf(1, 2, 3)
+        val span = tracer.startSpan("test")
+        span.setByteArrayAttribute("bytes", bytes)
+        val data = span.toReadableSpan().toSpanData()
+        bytes[0] = 9
+        assertEquals(1.toByte(), (data.attributes["bytes"] as ByteArray)[0])
+    }
+
+    @Test
+    fun testToSpanDataCopiesListAttributes() {
+        val flags = mutableListOf(true)
+        val span = tracer.startSpan("test")
+        span.setBooleanListAttribute("flags", flags)
+        val data = span.toReadableSpan().toSpanData()
+        flags.add(false)
+        assertEquals(listOf(true), data.attributes["flags"])
+    }
+
+    @Test
+    fun testToSpanDataCopiesEventAndLinkAttributeValues() {
+        val eventList = mutableListOf(true)
+        val linkBytes = byteArrayOf(1)
+        val span = tracer.startSpan("test")
+        span.addEvent("event") {
+            setBooleanListAttribute("flags", eventList)
+        }
+        span.addLink(fakeSpanContext) {
+            setByteArrayAttribute("bytes", linkBytes)
+        }
+        val data = span.toReadableSpan().toSpanData()
+        eventList.add(false)
+        linkBytes[0] = 9
+        assertEquals(listOf(true), data.events.single().attributes["flags"])
+        assertEquals(1.toByte(), (data.links.single().attributes["bytes"] as ByteArray)[0])
+    }
+
+    @Test
+    fun testToSpanDataEventsAndLinksAreNotMutators() {
+        val span = tracer.startSpan("test").apply {
+            addEvent("event") { setStringAttribute("k", "v") }
+            addLink(fakeSpanContext) { setStringAttribute("k", "v") }
+            end()
+        }
+        val data = processor.endCalls.single()
+        assertFalse(data.events.single() is AttributesMutator)
+        assertFalse(data.links.single() is AttributesMutator)
+    }
+
     private fun simulateSpan(): ReadableSpan {
         return tracer.startSpan(
             name = "test",
@@ -107,9 +158,18 @@ internal class SpanDataTest {
         assertEquals(span.startTimestamp, data.startTimestamp)
         assertEquals(span.status, data.status)
         assertEquals(span.attributes, data.attributes)
-        assertEquals(span.events, data.events)
+        assertEquals(span.events.size, data.events.size)
+        span.events.zip(data.events).forEach { (expected, actual) ->
+            assertEquals(expected.name, actual.name)
+            assertEquals(expected.timestamp, actual.timestamp)
+            assertEquals(expected.attributes, actual.attributes)
+        }
         assertEquals(span.droppedEventsCount, data.droppedEventsCount)
-        assertEquals(span.links, data.links)
+        assertEquals(span.links.size, data.links.size)
+        span.links.zip(data.links).forEach { (expected, actual) ->
+            assertEquals(expected.spanContext, actual.spanContext)
+            assertEquals(expected.attributes, actual.attributes)
+        }
         assertEquals(span.droppedLinksCount, data.droppedLinksCount)
         assertSame(fakeResource, data.resource)
         assertSame(key, data.instrumentationScopeInfo)

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/SpanDataTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/SpanDataTest.kt
@@ -1,6 +1,7 @@
 package io.opentelemetry.kotlin.tracing
 
 import io.opentelemetry.kotlin.InstrumentationScopeInfoImpl
+import io.opentelemetry.kotlin.attributes.AttributesMutator
 import io.opentelemetry.kotlin.clock.FakeClock
 import io.opentelemetry.kotlin.error.NoopSdkErrorHandler
 import io.opentelemetry.kotlin.export.MutableShutdownState
@@ -9,7 +10,6 @@ import io.opentelemetry.kotlin.factory.FakeIdGenerator
 import io.opentelemetry.kotlin.factory.FakeSpanContextFactory
 import io.opentelemetry.kotlin.factory.FakeTraceFlagsFactory
 import io.opentelemetry.kotlin.resource.FakeResource
-import io.opentelemetry.kotlin.attributes.AttributesMutator
 import io.opentelemetry.kotlin.tracing.data.SpanData
 import io.opentelemetry.kotlin.tracing.export.FakeSpanProcessor
 import io.opentelemetry.kotlin.tracing.model.ReadableSpan


### PR DESCRIPTION
## Goal
Make SpanModel.toSpanData() deep-copy attributes/events/links so the snapshot cannot be mutated after a span ends.

## Testing
Added tests that mutate caller lists/byte arrays and assert the snapshot is unchanged. Ran :implementation:jvmTest for SpanData tests.

Fixes #869