### PR TITLE
fix: copy list and AnyValue attribute inputs on write

### DIFF
--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/attributes/AttributesModel.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/attributes/AttributesModel.kt
@@ -40,7 +40,7 @@ internal class AttributesModel(
         value: List<Boolean>
     ) {
         ifPreconditionsOk(key) {
-            attrs[key] = value
+            attrs[key] = value.toList()
         }
     }
 
@@ -62,7 +62,7 @@ internal class AttributesModel(
         value: List<Long>
     ) {
         ifPreconditionsOk(key) {
-            attrs[key] = value
+            attrs[key] = value.toList()
         }
     }
 
@@ -71,7 +71,7 @@ internal class AttributesModel(
         value: List<Double>
     ) {
         ifPreconditionsOk(key) {
-            attrs[key] = value
+            attrs[key] = value.toList()
         }
     }
 
@@ -83,7 +83,7 @@ internal class AttributesModel(
 
     override fun setAnyValueAttribute(key: String, value: AnyValue) {
         ifPreconditionsOk(key) {
-            attrs[key] = truncateAnyValue(value)
+            attrs[key] = copyAnyValue(truncateAnyValue(value))
         }
     }
 
@@ -159,6 +159,17 @@ internal class AttributesModel(
                 value
             }
         }
+    }
+
+    private fun copyAnyValue(value: AnyValue): AnyValue = when (value) {
+        is AnyValue.BytesValue -> AnyValue.BytesValue(value.value.copyOf())
+        is AnyValue.ListValue -> AnyValue.ListValue(value.values.map(::copyAnyValue))
+        is AnyValue.MapValue -> AnyValue.MapValue(value.values.mapValues { (_, nested) -> copyAnyValue(nested) })
+        AnyValue.NullValue,
+        is AnyValue.StringValue,
+        is AnyValue.BoolValue,
+        is AnyValue.LongValue,
+        is AnyValue.DoubleValue -> value
     }
 
     private var droppedAttributesCountImpl = 0

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/attributes/AttributesMutatorImplTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/attributes/AttributesMutatorImplTest.kt
@@ -288,6 +288,51 @@ internal class AttributesMutatorImplTest {
         assertNotEquals(a, b)
     }
 
+    @Test
+    fun testBooleanLongDoubleListsAreCopied() {
+        val bools = mutableListOf(true)
+        val longs = mutableListOf(1L)
+        val doubles = mutableListOf(1.0)
+        val attrs = AttributesModel(attributeLimit).apply {
+            setBooleanListAttribute("bools", bools)
+            setLongListAttribute("longs", longs)
+            setDoubleListAttribute("doubles", doubles)
+        }.attributes
+        bools.add(false)
+        longs.add(2L)
+        doubles.add(2.0)
+        assertEquals(listOf(true), attrs["bools"])
+        assertEquals(listOf(1L), attrs["longs"])
+        assertEquals(listOf(1.0), attrs["doubles"])
+    }
+
+    @Test
+    fun testAnyValueListAndBytesAreCopied() {
+        val items = mutableListOf<AnyValue>(AnyValue.StringValue("a"))
+        val bytes = byteArrayOf(1, 2)
+        val nestedItems = mutableListOf<AnyValue>(AnyValue.LongValue(1L))
+        val nested = mutableMapOf<String, AnyValue>("list" to AnyValue.ListValue(nestedItems))
+        val attrs = AttributesModel(attributeLimit).apply {
+            setAnyValueAttribute("list", AnyValue.ListValue(items))
+            setAnyValueAttribute("bytes", AnyValue.BytesValue(bytes))
+            setAnyValueAttribute("map", AnyValue.MapValue(nested))
+        }.attributes
+        items.add(AnyValue.StringValue("b"))
+        bytes[0] = 9
+        nestedItems.add(AnyValue.LongValue(2L))
+        nested["extra"] = AnyValue.StringValue("x")
+
+        val storedList = (attrs["list"] as AnyValue.ListValue).values
+        assertEquals(listOf(AnyValue.StringValue("a")), storedList)
+        assertTrue((attrs["bytes"] as AnyValue.BytesValue).value.contentEquals(byteArrayOf(1, 2)))
+        val storedMap = attrs["map"] as AnyValue.MapValue
+        assertEquals(
+            listOf(AnyValue.LongValue(1L)),
+            (storedMap.values["list"] as AnyValue.ListValue).values,
+        )
+        assertEquals(null, storedMap.values["extra"])
+    }
+
     private fun AttributesMutator.addTestAttributes(keyToken: String = "") {
         setStringAttribute("string$keyToken", "value")
         setDoubleAttribute("double$keyToken", 3.14)


### PR DESCRIPTION
## Goal
Copy boolean/long/double lists and AnyValue payloads in AttributesModel so callers cannot mutate stored attributes after set.

## Testing
Added AttributesMutatorImplTest cases that mutate inputs after set. Ran :implementation:jvmTest for AttributesMutatorImplTest.

Fixes #862