### PR TITLE
metrics: add synchronous UpDownCounter API (#382)

### DIFF
--- a/api/api/jvm/api.api
+++ b/api/api/jvm/api.api
@@ -240,13 +240,30 @@ public final class io/opentelemetry/kotlin/logging/SeverityNumber : java/lang/En
 public abstract interface class io/opentelemetry/kotlin/metrics/AsynchronousInstrument : io/opentelemetry/kotlin/metrics/Instrument, java/lang/AutoCloseable {
 }
 
+public abstract interface class io/opentelemetry/kotlin/metrics/DoubleUpDownCounter : io/opentelemetry/kotlin/metrics/SynchronousInstrument {
+	public abstract fun add (D)V
+	public abstract fun add (DLkotlin/jvm/functions/Function1;)V
+}
+
 public abstract interface class io/opentelemetry/kotlin/metrics/Instrument {
 	public abstract fun getDescription ()Ljava/lang/String;
 	public abstract fun getName ()Ljava/lang/String;
 	public abstract fun getUnit ()Ljava/lang/String;
 }
 
+public abstract interface class io/opentelemetry/kotlin/metrics/LongUpDownCounter : io/opentelemetry/kotlin/metrics/SynchronousInstrument {
+	public abstract fun add (J)V
+	public abstract fun add (JLkotlin/jvm/functions/Function1;)V
+}
+
 public abstract interface class io/opentelemetry/kotlin/metrics/Meter {
+	public abstract fun createDoubleUpDownCounter (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lio/opentelemetry/kotlin/metrics/DoubleUpDownCounter;
+	public abstract fun createLongUpDownCounter (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lio/opentelemetry/kotlin/metrics/LongUpDownCounter;
+}
+
+public final class io/opentelemetry/kotlin/metrics/Meter$DefaultImpls {
+	public static synthetic fun createDoubleUpDownCounter$default (Lio/opentelemetry/kotlin/metrics/Meter;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/opentelemetry/kotlin/metrics/DoubleUpDownCounter;
+	public static synthetic fun createLongUpDownCounter$default (Lio/opentelemetry/kotlin/metrics/Meter;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/opentelemetry/kotlin/metrics/LongUpDownCounter;
 }
 
 public abstract interface class io/opentelemetry/kotlin/metrics/MeterProvider {

--- a/api/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/DoubleUpDownCounter.kt
+++ b/api/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/DoubleUpDownCounter.kt
@@ -1,0 +1,36 @@
+package io.opentelemetry.kotlin.metrics
+
+import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.ThreadSafe
+import io.opentelemetry.kotlin.attributes.AttributesMutator
+
+/**
+ * A synchronous [Instrument] which supports increments and decrements.
+ *
+ * If the value is monotonically increasing, use a Counter instead.
+ *
+ * Example uses: the number of active requests, the number of items in a queue.
+ *
+ * https://opentelemetry.io/docs/specs/otel/metrics/api/#updowncounter
+ */
+@ExperimentalApi
+@ThreadSafe
+public interface DoubleUpDownCounter : SynchronousInstrument {
+
+    /**
+     * Increments or decrements this counter by [value].
+     *
+     * [value] may be positive, negative, or zero.
+     */
+    @ThreadSafe
+    public fun add(value: Double)
+
+    /**
+     * Increments or decrements this counter by [value], associating [attributes] with the
+     * measurement.
+     *
+     * [value] may be positive, negative, or zero.
+     */
+    @ThreadSafe
+    public fun add(value: Double, attributes: AttributesMutator.() -> Unit)
+}

--- a/api/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/LongUpDownCounter.kt
+++ b/api/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/LongUpDownCounter.kt
@@ -1,0 +1,36 @@
+package io.opentelemetry.kotlin.metrics
+
+import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.ThreadSafe
+import io.opentelemetry.kotlin.attributes.AttributesMutator
+
+/**
+ * A synchronous [Instrument] which supports increments and decrements.
+ *
+ * If the value is monotonically increasing, use a Counter instead.
+ *
+ * Example uses: the number of active requests, the number of items in a queue.
+ *
+ * https://opentelemetry.io/docs/specs/otel/metrics/api/#updowncounter
+ */
+@ExperimentalApi
+@ThreadSafe
+public interface LongUpDownCounter : SynchronousInstrument {
+
+    /**
+     * Increments or decrements this counter by [value].
+     *
+     * [value] may be positive, negative, or zero.
+     */
+    @ThreadSafe
+    public fun add(value: Long)
+
+    /**
+     * Increments or decrements this counter by [value], associating [attributes] with the
+     * measurement.
+     *
+     * [value] may be positive, negative, or zero.
+     */
+    @ThreadSafe
+    public fun add(value: Long, attributes: AttributesMutator.() -> Unit)
+}

--- a/api/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/Meter.kt
+++ b/api/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/Meter.kt
@@ -6,7 +6,8 @@ import io.opentelemetry.kotlin.ThreadSafe
 /**
  * Provides instruments used to record measurements which are aggregated to metrics.
  *
- * Instruments are obtained through methods provided by this interface.
+ * Instruments are obtained through methods provided by this interface. Implementations of
+ * [Meter] and the instruments it creates must be safe for concurrent use.
  *
  * See the [instrument selection guidelines](https://opentelemetry.io/docs/specs/otel/metrics/supplementary-guidelines/#instrument-selection)
  * for help choosing the right instrument.
@@ -15,4 +16,41 @@ import io.opentelemetry.kotlin.ThreadSafe
  */
 @ExperimentalApi
 @ThreadSafe
-public interface Meter
+public interface Meter {
+
+    /**
+     * Creates a [LongUpDownCounter] for recording signed integer increments and decrements.
+     *
+     * [name] is required and should conform to the
+     * [instrument name syntax](https://opentelemetry.io/docs/specs/otel/metrics/api/#instrument-name-syntax).
+     * [unit] and [description] are optional.
+     *
+     * There is no API for creating an UpDownCounter other than with a [Meter].
+     *
+     * https://opentelemetry.io/docs/specs/otel/metrics/api/#updowncounter-creation
+     */
+    @ThreadSafe
+    public fun createLongUpDownCounter(
+        name: String,
+        unit: String? = null,
+        description: String? = null,
+    ): LongUpDownCounter
+
+    /**
+     * Creates a [DoubleUpDownCounter] for recording signed floating-point increments and decrements.
+     *
+     * [name] is required and should conform to the
+     * [instrument name syntax](https://opentelemetry.io/docs/specs/otel/metrics/api/#instrument-name-syntax).
+     * [unit] and [description] are optional.
+     *
+     * There is no API for creating an UpDownCounter other than with a [Meter].
+     *
+     * https://opentelemetry.io/docs/specs/otel/metrics/api/#updowncounter-creation
+     */
+    @ThreadSafe
+    public fun createDoubleUpDownCounter(
+        name: String,
+        unit: String? = null,
+        description: String? = null,
+    ): DoubleUpDownCounter
+}

--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/metrics/DoubleUpDownCounterAdapter.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/metrics/DoubleUpDownCounterAdapter.kt
@@ -1,0 +1,26 @@
+package io.opentelemetry.kotlin.metrics
+
+import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.aliases.OtelJavaDoubleUpDownCounter
+import io.opentelemetry.kotlin.attributes.AttributesMutator
+import io.opentelemetry.kotlin.attributes.CompatAttributesModel
+
+@ExperimentalApi
+internal class DoubleUpDownCounterAdapter(
+    private val impl: OtelJavaDoubleUpDownCounter,
+    override val name: String,
+    override val unit: String?,
+    override val description: String?,
+) : DoubleUpDownCounter {
+    override fun enabled(): Boolean = impl.isEnabled()
+
+    override fun add(value: Double) {
+        impl.add(value)
+    }
+
+    override fun add(value: Double, attributes: AttributesMutator.() -> Unit) {
+        val container = CompatAttributesModel()
+        attributes(container)
+        impl.add(value, container.otelJavaAttributes())
+    }
+}

--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/metrics/LongUpDownCounterAdapter.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/metrics/LongUpDownCounterAdapter.kt
@@ -1,0 +1,26 @@
+package io.opentelemetry.kotlin.metrics
+
+import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.aliases.OtelJavaLongUpDownCounter
+import io.opentelemetry.kotlin.attributes.AttributesMutator
+import io.opentelemetry.kotlin.attributes.CompatAttributesModel
+
+@ExperimentalApi
+internal class LongUpDownCounterAdapter(
+    private val impl: OtelJavaLongUpDownCounter,
+    override val name: String,
+    override val unit: String?,
+    override val description: String?,
+) : LongUpDownCounter {
+    override fun enabled(): Boolean = impl.isEnabled()
+
+    override fun add(value: Long) {
+        impl.add(value)
+    }
+
+    override fun add(value: Long, attributes: AttributesMutator.() -> Unit) {
+        val container = CompatAttributesModel()
+        attributes(container)
+        impl.add(value, container.otelJavaAttributes())
+    }
+}

--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/metrics/MeterAdapter.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/metrics/MeterAdapter.kt
@@ -5,5 +5,27 @@ import io.opentelemetry.kotlin.aliases.OtelJavaMeter
 
 @ExperimentalApi
 internal class MeterAdapter(
-    @Suppress("UnusedPrivateProperty") private val impl: OtelJavaMeter,
-) : Meter
+    private val impl: OtelJavaMeter,
+) : Meter {
+    override fun createLongUpDownCounter(
+        name: String,
+        unit: String?,
+        description: String?,
+    ): LongUpDownCounter {
+        val builder = impl.upDownCounterBuilder(name)
+        unit?.let(builder::setUnit)
+        description?.let(builder::setDescription)
+        return LongUpDownCounterAdapter(builder.build(), name, unit, description)
+    }
+
+    override fun createDoubleUpDownCounter(
+        name: String,
+        unit: String?,
+        description: String?,
+    ): DoubleUpDownCounter {
+        val builder = impl.upDownCounterBuilder(name).ofDoubles()
+        unit?.let(builder::setUnit)
+        description?.let(builder::setDescription)
+        return DoubleUpDownCounterAdapter(builder.build(), name, unit, description)
+    }
+}

--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/metrics/OtelJavaDoubleUpDownCounterAdapter.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/metrics/OtelJavaDoubleUpDownCounterAdapter.kt
@@ -1,0 +1,29 @@
+package io.opentelemetry.kotlin.metrics
+
+import io.opentelemetry.kotlin.aliases.OtelJavaAttributes
+import io.opentelemetry.kotlin.aliases.OtelJavaContext
+import io.opentelemetry.kotlin.aliases.OtelJavaDoubleUpDownCounter
+import io.opentelemetry.kotlin.attributes.convertToMap
+import io.opentelemetry.kotlin.attributes.setTypedAttributes
+
+internal class OtelJavaDoubleUpDownCounterAdapter(
+    private val impl: DoubleUpDownCounter,
+) : OtelJavaDoubleUpDownCounter {
+    override fun isEnabled(): Boolean = impl.enabled()
+
+    override fun add(value: Double) {
+        impl.add(value)
+    }
+
+    override fun add(value: Double, attributes: OtelJavaAttributes) {
+        if (attributes.isEmpty) {
+            impl.add(value)
+        } else {
+            impl.add(value) { setTypedAttributes(attributes.convertToMap()) }
+        }
+    }
+
+    override fun add(value: Double, attributes: OtelJavaAttributes, context: OtelJavaContext) {
+        add(value, attributes)
+    }
+}

--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/metrics/OtelJavaDoubleUpDownCounterBuilderAdapter.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/metrics/OtelJavaDoubleUpDownCounterBuilderAdapter.kt
@@ -1,0 +1,35 @@
+package io.opentelemetry.kotlin.metrics
+
+import io.opentelemetry.kotlin.aliases.OtelJavaDoubleUpDownCounter
+import io.opentelemetry.kotlin.aliases.OtelJavaDoubleUpDownCounterBuilder
+import io.opentelemetry.kotlin.aliases.OtelJavaMeterProvider
+import io.opentelemetry.kotlin.aliases.OtelJavaObservableDoubleMeasurement
+import io.opentelemetry.kotlin.aliases.OtelJavaObservableDoubleUpDownCounter
+import java.util.function.Consumer
+
+internal class OtelJavaDoubleUpDownCounterBuilderAdapter(
+    private val meter: Meter,
+    private val name: String,
+    private var unit: String? = null,
+    private var description: String? = null,
+) : OtelJavaDoubleUpDownCounterBuilder {
+
+    override fun setDescription(description: String): OtelJavaDoubleUpDownCounterBuilder {
+        this.description = description
+        return this
+    }
+
+    override fun setUnit(unit: String): OtelJavaDoubleUpDownCounterBuilder {
+        this.unit = unit
+        return this
+    }
+
+    override fun build(): OtelJavaDoubleUpDownCounter =
+        OtelJavaDoubleUpDownCounterAdapter(meter.createDoubleUpDownCounter(name, unit, description))
+
+    override fun buildWithCallback(
+        callback: Consumer<OtelJavaObservableDoubleMeasurement>,
+    ): OtelJavaObservableDoubleUpDownCounter =
+        OtelJavaMeterProvider.noop().get("").upDownCounterBuilder(name).ofDoubles()
+            .buildWithCallback(callback)
+}

--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/metrics/OtelJavaLongUpDownCounterAdapter.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/metrics/OtelJavaLongUpDownCounterAdapter.kt
@@ -1,0 +1,29 @@
+package io.opentelemetry.kotlin.metrics
+
+import io.opentelemetry.kotlin.aliases.OtelJavaAttributes
+import io.opentelemetry.kotlin.aliases.OtelJavaContext
+import io.opentelemetry.kotlin.aliases.OtelJavaLongUpDownCounter
+import io.opentelemetry.kotlin.attributes.convertToMap
+import io.opentelemetry.kotlin.attributes.setTypedAttributes
+
+internal class OtelJavaLongUpDownCounterAdapter(
+    private val impl: LongUpDownCounter,
+) : OtelJavaLongUpDownCounter {
+    override fun isEnabled(): Boolean = impl.enabled()
+
+    override fun add(value: Long) {
+        impl.add(value)
+    }
+
+    override fun add(value: Long, attributes: OtelJavaAttributes) {
+        if (attributes.isEmpty) {
+            impl.add(value)
+        } else {
+            impl.add(value) { setTypedAttributes(attributes.convertToMap()) }
+        }
+    }
+
+    override fun add(value: Long, attributes: OtelJavaAttributes, context: OtelJavaContext) {
+        add(value, attributes)
+    }
+}

--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/metrics/OtelJavaLongUpDownCounterBuilderAdapter.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/metrics/OtelJavaLongUpDownCounterBuilderAdapter.kt
@@ -1,0 +1,38 @@
+package io.opentelemetry.kotlin.metrics
+
+import io.opentelemetry.kotlin.aliases.OtelJavaDoubleUpDownCounterBuilder
+import io.opentelemetry.kotlin.aliases.OtelJavaLongUpDownCounter
+import io.opentelemetry.kotlin.aliases.OtelJavaLongUpDownCounterBuilder
+import io.opentelemetry.kotlin.aliases.OtelJavaMeterProvider
+import io.opentelemetry.kotlin.aliases.OtelJavaObservableLongMeasurement
+import io.opentelemetry.kotlin.aliases.OtelJavaObservableLongUpDownCounter
+import java.util.function.Consumer
+
+internal class OtelJavaLongUpDownCounterBuilderAdapter(
+    private val meter: Meter,
+    private val name: String,
+    private var unit: String? = null,
+    private var description: String? = null,
+) : OtelJavaLongUpDownCounterBuilder {
+
+    override fun setDescription(description: String): OtelJavaLongUpDownCounterBuilder {
+        this.description = description
+        return this
+    }
+
+    override fun setUnit(unit: String): OtelJavaLongUpDownCounterBuilder {
+        this.unit = unit
+        return this
+    }
+
+    override fun ofDoubles(): OtelJavaDoubleUpDownCounterBuilder =
+        OtelJavaDoubleUpDownCounterBuilderAdapter(meter, name, unit, description)
+
+    override fun build(): OtelJavaLongUpDownCounter =
+        OtelJavaLongUpDownCounterAdapter(meter.createLongUpDownCounter(name, unit, description))
+
+    override fun buildWithCallback(
+        callback: Consumer<OtelJavaObservableLongMeasurement>,
+    ): OtelJavaObservableLongUpDownCounter =
+        OtelJavaMeterProvider.noop().get("").upDownCounterBuilder(name).buildWithCallback(callback)
+}

--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/metrics/OtelJavaMeterAdapter.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/metrics/OtelJavaMeterAdapter.kt
@@ -1,15 +1,18 @@
 package io.opentelemetry.kotlin.metrics
 
+import io.opentelemetry.kotlin.aliases.OtelJavaLongUpDownCounterBuilder
 import io.opentelemetry.kotlin.aliases.OtelJavaMeter
 import io.opentelemetry.kotlin.aliases.OtelJavaMeterProvider
 
 /**
  * Adapts a Kotlin [Meter] to a Java [OtelJavaMeter].
  *
- * TODO Until instruments are implemented on the Kotlin side, all instrument-builder calls delegate
- *  to Java OTel's no-op meter — i.e., builders, instruments, and observables are valid types
- *  but record nothing.
+ * UpDownCounter builders are wired to the Kotlin API. Other instrument-builder calls still
+ * delegate to Java OTel's no-op meter until those instruments are implemented.
  */
 internal class OtelJavaMeterAdapter(
-    @Suppress("UnusedPrivateProperty") private val impl: Meter,
-) : OtelJavaMeter by OtelJavaMeterProvider.noop().get("")
+    private val impl: Meter,
+) : OtelJavaMeter by OtelJavaMeterProvider.noop().get("") {
+    override fun upDownCounterBuilder(name: String): OtelJavaLongUpDownCounterBuilder =
+        OtelJavaLongUpDownCounterBuilderAdapter(impl, name)
+}

--- a/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/metrics/MeterAdapterUpDownCounterTest.kt
+++ b/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/metrics/MeterAdapterUpDownCounterTest.kt
@@ -1,0 +1,47 @@
+package io.opentelemetry.kotlin.metrics
+
+import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.aliases.OtelJavaSdkMeterProvider
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalApi::class)
+internal class MeterAdapterUpDownCounterTest {
+
+    private val adapter = MeterProviderAdapter(OtelJavaSdkMeterProvider.builder().build())
+        .getMeter("test")
+
+    @Test
+    fun createLongUpDownCounterDelegatesAdd() {
+        val counter = adapter.createLongUpDownCounter(
+            name = "grocery.customers",
+            unit = "{customer}",
+            description = "customers in store",
+        )
+        assertEquals("grocery.customers", counter.name)
+        assertEquals("{customer}", counter.unit)
+        assertEquals("customers in store", counter.description)
+        counter.enabled()
+        counter.add(1)
+        counter.add(-1)
+        counter.add(0)
+        counter.add(2) { setStringAttribute("account.type", "commercial") }
+    }
+
+    @Test
+    fun createDoubleUpDownCounterDelegatesAdd() {
+        val counter = adapter.createDoubleUpDownCounter(
+            name = "queue.depth",
+            unit = "{item}",
+            description = "queue size",
+        )
+        assertEquals("queue.depth", counter.name)
+        assertEquals("{item}", counter.unit)
+        assertEquals("queue size", counter.description)
+        counter.enabled()
+        counter.add(1.0)
+        counter.add(-1.0)
+        counter.add(0.0)
+        counter.add(2.5) { setStringAttribute("account.type", "residential") }
+    }
+}

--- a/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/metrics/OtelJavaMeterBuilderAdapterTest.kt
+++ b/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/metrics/OtelJavaMeterBuilderAdapterTest.kt
@@ -78,7 +78,7 @@ internal class OtelJavaMeterBuilderAdapterTest {
             capturedName = name
             capturedVersion = version
             capturedSchemaUrl = schemaUrl
-            return object : Meter {}
+            return FakeMeter(name)
         }
     }
 }

--- a/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/metrics/OtelJavaUpDownCounterAdapterTest.kt
+++ b/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/metrics/OtelJavaUpDownCounterAdapterTest.kt
@@ -1,0 +1,67 @@
+package io.opentelemetry.kotlin.metrics
+
+import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.aliases.OtelJavaAttributes
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalApi::class)
+internal class OtelJavaUpDownCounterAdapterTest {
+
+    @Test
+    fun upDownCounterBuilderBuildRecordsOnKotlinMeter() {
+        val meter = FakeMeter("test")
+        val javaCounter = OtelJavaMeterAdapter(meter)
+            .upDownCounterBuilder("grocery.customers")
+            .setUnit("{customer}")
+            .setDescription("customers in store")
+            .build()
+
+        assertTrue(javaCounter.isEnabled)
+        javaCounter.add(1)
+        javaCounter.add(-1, OtelJavaAttributes.builder().put("account.type", "commercial").build())
+
+        val fake = meter.longUpDownCounters.single()
+        assertEquals("grocery.customers", fake.name)
+        assertEquals("{customer}", fake.unit)
+        assertEquals("customers in store", fake.description)
+        assertEquals(1L, fake.adds[0].first)
+        assertEquals(-1L, fake.adds[1].first)
+        assertEquals("commercial", fake.adds[1].second["account.type"])
+    }
+
+    @Test
+    fun ofDoublesBuildRecordsOnKotlinMeter() {
+        val meter = FakeMeter("test")
+        OtelJavaMeterAdapter(meter)
+            .upDownCounterBuilder("queue.depth")
+            .ofDoubles()
+            .setUnit("{item}")
+            .build()
+            .add(-2.5)
+
+        val fake = meter.doubleUpDownCounters.single()
+        assertEquals("queue.depth", fake.name)
+        assertEquals("{item}", fake.unit)
+        assertEquals(-2.5, fake.adds.single().first)
+    }
+
+    @Test
+    fun builderSettersReturnThis() {
+        val builder = OtelJavaLongUpDownCounterBuilderAdapter(FakeMeter("test"), "n")
+        assertSame(builder, builder.setUnit("1"))
+        assertSame(builder, builder.setDescription("d"))
+    }
+
+    @Test
+    fun isEnabledDelegates() {
+        val fake = FakeLongUpDownCounter("n")
+        val adapter = OtelJavaLongUpDownCounterAdapter(fake)
+        assertTrue(adapter.isEnabled)
+        fake.enabledResult = { false }
+        assertFalse(adapter.isEnabled)
+    }
+}

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/DoubleUpDownCounterImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/DoubleUpDownCounterImpl.kt
@@ -1,0 +1,13 @@
+package io.opentelemetry.kotlin.metrics
+
+import io.opentelemetry.kotlin.attributes.AttributesMutator
+
+internal class DoubleUpDownCounterImpl(
+    override val name: String,
+    override val unit: String?,
+    override val description: String?,
+) : DoubleUpDownCounter {
+    override fun enabled(): Boolean = true
+    override fun add(value: Double) {}
+    override fun add(value: Double, attributes: AttributesMutator.() -> Unit) {}
+}

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/LongUpDownCounterImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/LongUpDownCounterImpl.kt
@@ -1,0 +1,13 @@
+package io.opentelemetry.kotlin.metrics
+
+import io.opentelemetry.kotlin.attributes.AttributesMutator
+
+internal class LongUpDownCounterImpl(
+    override val name: String,
+    override val unit: String?,
+    override val description: String?,
+) : LongUpDownCounter {
+    override fun enabled(): Boolean = true
+    override fun add(value: Long) {}
+    override fun add(value: Long, attributes: AttributesMutator.() -> Unit) {}
+}

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/MeterImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/MeterImpl.kt
@@ -6,4 +6,16 @@ import io.opentelemetry.kotlin.resource.Resource
 internal class MeterImpl(
     val instrumentationScopeInfo: InstrumentationScopeInfo,
     val resource: Resource,
-) : Meter
+) : Meter {
+    override fun createLongUpDownCounter(
+        name: String,
+        unit: String?,
+        description: String?,
+    ): LongUpDownCounter = LongUpDownCounterImpl(name, unit, description)
+
+    override fun createDoubleUpDownCounter(
+        name: String,
+        unit: String?,
+        description: String?,
+    ): DoubleUpDownCounter = DoubleUpDownCounterImpl(name, unit, description)
+}

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/metrics/FakeUpDownCounterTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/metrics/FakeUpDownCounterTest.kt
@@ -1,0 +1,51 @@
+package io.opentelemetry.kotlin.metrics
+
+import io.opentelemetry.kotlin.ExperimentalApi
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalApi::class)
+internal class FakeUpDownCounterTest {
+
+    @Test
+    fun longAddRecordsValueAndAttributes() {
+        val meter = FakeMeter("test")
+        val counter = meter.createLongUpDownCounter(
+            name = "store.inventory",
+            unit = "{item}",
+            description = "items in stock",
+        ) as FakeLongUpDownCounter
+
+        counter.add(1)
+        counter.add(-1) { setStringAttribute("color", "red") }
+
+        assertEquals("store.inventory", counter.name)
+        assertEquals("{item}", counter.unit)
+        assertEquals("items in stock", counter.description)
+        assertTrue(counter.enabled())
+        assertEquals(listOf(1L to emptyMap(), -1L to mapOf("color" to "red")), counter.adds)
+        assertEquals(1, meter.longUpDownCounters.size)
+    }
+
+    @Test
+    fun doubleAddRecordsValueAndAttributes() {
+        val meter = FakeMeter("test")
+        val counter = meter.createDoubleUpDownCounter("queue.depth") as FakeDoubleUpDownCounter
+
+        counter.add(1.5)
+        counter.add(-0.5) { setStringAttribute("material", "steel") }
+
+        assertEquals(listOf(1.5 to emptyMap(), -0.5 to mapOf("material" to "steel")), counter.adds)
+        assertEquals(1, meter.doubleUpDownCounters.size)
+    }
+
+    @Test
+    fun enabledResultCanChange() {
+        val counter = FakeLongUpDownCounter("n")
+        assertTrue(counter.enabled())
+        counter.enabledResult = { false }
+        assertFalse(counter.enabled())
+    }
+}

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/metrics/UpDownCounterImplTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/metrics/UpDownCounterImplTest.kt
@@ -1,0 +1,79 @@
+package io.opentelemetry.kotlin.metrics
+
+import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.attributes.AttributesModel
+import io.opentelemetry.kotlin.error.NoopSdkErrorHandler
+import io.opentelemetry.kotlin.init.config.MetricsConfig
+import io.opentelemetry.kotlin.resource.ResourceImpl
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalApi::class)
+internal class UpDownCounterImplTest {
+
+    private lateinit var meter: Meter
+
+    @BeforeTest
+    fun setup() {
+        meter = MeterProviderImpl(
+            MetricsConfig(
+                resource = ResourceImpl(AttributesModel(), null),
+                sdkErrorHandler = NoopSdkErrorHandler,
+            )
+        ).getMeter("test")
+    }
+
+    @Test
+    fun createLongUpDownCounterExposesIdentity() {
+        val counter = meter.createLongUpDownCounter(
+            name = "store.inventory",
+            unit = "{item}",
+            description = "items in stock",
+        )
+        assertEquals("store.inventory", counter.name)
+        assertEquals("{item}", counter.unit)
+        assertEquals("items in stock", counter.description)
+        assertTrue(counter.enabled())
+    }
+
+    @Test
+    fun createDoubleUpDownCounterExposesIdentity() {
+        val counter = meter.createDoubleUpDownCounter(
+            name = "queue.depth",
+            unit = "{item}",
+            description = "queue size",
+        )
+        assertEquals("queue.depth", counter.name)
+        assertEquals("{item}", counter.unit)
+        assertEquals("queue size", counter.description)
+        assertTrue(counter.enabled())
+    }
+
+    @Test
+    fun longAddAcceptsPositiveNegativeAndZero() {
+        val counter = meter.createLongUpDownCounter("grocery.customers")
+        counter.add(1)
+        counter.add(-1)
+        counter.add(0)
+        counter.add(2) { setStringAttribute("account.type", "commercial") }
+    }
+
+    @Test
+    fun doubleAddAcceptsPositiveNegativeAndZero() {
+        val counter = meter.createDoubleUpDownCounter("grocery.customers")
+        counter.add(1.5)
+        counter.add(-1.5)
+        counter.add(0.0)
+        counter.add(2.0) { setStringAttribute("account.type", "residential") }
+    }
+
+    @Test
+    fun createUsesNullUnitAndDescriptionByDefault() {
+        val counter = meter.createLongUpDownCounter("grocery.customers")
+        assertEquals("grocery.customers", counter.name)
+        assertEquals(null, counter.unit)
+        assertEquals(null, counter.description)
+    }
+}

--- a/java-typealiases/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/aliases/Aliases.kt
+++ b/java-typealiases/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/aliases/Aliases.kt
@@ -16,11 +16,17 @@ import io.opentelemetry.api.logs.Logger
 import io.opentelemetry.api.logs.LoggerBuilder
 import io.opentelemetry.api.logs.LoggerProvider
 import io.opentelemetry.api.logs.Severity
+import io.opentelemetry.api.metrics.DoubleUpDownCounter
+import io.opentelemetry.api.metrics.DoubleUpDownCounterBuilder
+import io.opentelemetry.api.metrics.LongUpDownCounter
+import io.opentelemetry.api.metrics.LongUpDownCounterBuilder
 import io.opentelemetry.api.metrics.Meter
 import io.opentelemetry.api.metrics.MeterBuilder
 import io.opentelemetry.api.metrics.MeterProvider
 import io.opentelemetry.api.metrics.ObservableDoubleMeasurement
+import io.opentelemetry.api.metrics.ObservableDoubleUpDownCounter
 import io.opentelemetry.api.metrics.ObservableLongMeasurement
+import io.opentelemetry.api.metrics.ObservableLongUpDownCounter
 import io.opentelemetry.api.metrics.ObservableMeasurement
 import io.opentelemetry.api.trace.Span
 import io.opentelemetry.api.trace.SpanBuilder
@@ -134,6 +140,12 @@ typealias OtelJavaScopeConfigurator<T> = ScopeConfigurator<T>
 typealias OtelJavaMeterProvider = MeterProvider
 typealias OtelJavaMeterBuilder = MeterBuilder
 typealias OtelJavaMeter = Meter
+typealias OtelJavaLongUpDownCounter = LongUpDownCounter
+typealias OtelJavaDoubleUpDownCounter = DoubleUpDownCounter
+typealias OtelJavaLongUpDownCounterBuilder = LongUpDownCounterBuilder
+typealias OtelJavaDoubleUpDownCounterBuilder = DoubleUpDownCounterBuilder
+typealias OtelJavaObservableLongUpDownCounter = ObservableLongUpDownCounter
+typealias OtelJavaObservableDoubleUpDownCounter = ObservableDoubleUpDownCounter
 typealias OtelJavaObservableMeasurement = ObservableMeasurement
 typealias OtelJavaObservableLongMeasurement = ObservableLongMeasurement
 typealias OtelJavaObservableDoubleMeasurement = ObservableDoubleMeasurement

--- a/noop/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/NoopDoubleUpDownCounter.kt
+++ b/noop/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/NoopDoubleUpDownCounter.kt
@@ -1,0 +1,18 @@
+package io.opentelemetry.kotlin.metrics
+
+import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.attributes.AttributesMutator
+
+/**
+ * No-op implementation of [DoubleUpDownCounter].
+ */
+@ExperimentalApi
+internal class NoopDoubleUpDownCounter(
+    override val name: String,
+    override val unit: String?,
+    override val description: String?,
+) : DoubleUpDownCounter {
+    override fun enabled(): Boolean = false
+    override fun add(value: Double) {}
+    override fun add(value: Double, attributes: AttributesMutator.() -> Unit) {}
+}

--- a/noop/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/NoopLongUpDownCounter.kt
+++ b/noop/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/NoopLongUpDownCounter.kt
@@ -1,0 +1,18 @@
+package io.opentelemetry.kotlin.metrics
+
+import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.attributes.AttributesMutator
+
+/**
+ * No-op implementation of [LongUpDownCounter].
+ */
+@ExperimentalApi
+internal class NoopLongUpDownCounter(
+    override val name: String,
+    override val unit: String?,
+    override val description: String?,
+) : LongUpDownCounter {
+    override fun enabled(): Boolean = false
+    override fun add(value: Long) {}
+    override fun add(value: Long, attributes: AttributesMutator.() -> Unit) {}
+}

--- a/noop/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/NoopMeter.kt
+++ b/noop/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/NoopMeter.kt
@@ -8,4 +8,16 @@ import io.opentelemetry.kotlin.ExperimentalApi
  * This implementation should induce as close to zero overhead as possible.
  */
 @ExperimentalApi
-internal object NoopMeter : Meter
+internal object NoopMeter : Meter {
+    override fun createLongUpDownCounter(
+        name: String,
+        unit: String?,
+        description: String?,
+    ): LongUpDownCounter = NoopLongUpDownCounter(name, unit, description)
+
+    override fun createDoubleUpDownCounter(
+        name: String,
+        unit: String?,
+        description: String?,
+    ): DoubleUpDownCounter = NoopDoubleUpDownCounter(name, unit, description)
+}

--- a/test-fakes/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/FakeDoubleUpDownCounter.kt
+++ b/test-fakes/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/FakeDoubleUpDownCounter.kt
@@ -1,0 +1,24 @@
+package io.opentelemetry.kotlin.metrics
+
+import io.opentelemetry.kotlin.attributes.AttributesMutator
+import io.opentelemetry.kotlin.attributes.FakeAttributesMutator
+
+class FakeDoubleUpDownCounter(
+    override val name: String,
+    override val unit: String? = null,
+    override val description: String? = null,
+    var enabledResult: () -> Boolean = { true },
+) : DoubleUpDownCounter {
+
+    val adds: MutableList<Pair<Double, Map<String, Any>>> = mutableListOf()
+
+    override fun enabled(): Boolean = enabledResult()
+
+    override fun add(value: Double) {
+        adds.add(value to emptyMap())
+    }
+
+    override fun add(value: Double, attributes: AttributesMutator.() -> Unit) {
+        adds.add(value to FakeAttributesMutator().apply(attributes).attributes)
+    }
+}

--- a/test-fakes/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/FakeLongUpDownCounter.kt
+++ b/test-fakes/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/FakeLongUpDownCounter.kt
@@ -1,0 +1,24 @@
+package io.opentelemetry.kotlin.metrics
+
+import io.opentelemetry.kotlin.attributes.AttributesMutator
+import io.opentelemetry.kotlin.attributes.FakeAttributesMutator
+
+class FakeLongUpDownCounter(
+    override val name: String,
+    override val unit: String? = null,
+    override val description: String? = null,
+    var enabledResult: () -> Boolean = { true },
+) : LongUpDownCounter {
+
+    val adds: MutableList<Pair<Long, Map<String, Any>>> = mutableListOf()
+
+    override fun enabled(): Boolean = enabledResult()
+
+    override fun add(value: Long) {
+        adds.add(value to emptyMap())
+    }
+
+    override fun add(value: Long, attributes: AttributesMutator.() -> Unit) {
+        adds.add(value to FakeAttributesMutator().apply(attributes).attributes)
+    }
+}

--- a/test-fakes/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/FakeMeter.kt
+++ b/test-fakes/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/FakeMeter.kt
@@ -2,4 +2,24 @@ package io.opentelemetry.kotlin.metrics
 
 class FakeMeter(
     val name: String
-) : Meter
+) : Meter {
+
+    val longUpDownCounters: MutableList<FakeLongUpDownCounter> = mutableListOf()
+    val doubleUpDownCounters: MutableList<FakeDoubleUpDownCounter> = mutableListOf()
+
+    override fun createLongUpDownCounter(
+        name: String,
+        unit: String?,
+        description: String?,
+    ): LongUpDownCounter = FakeLongUpDownCounter(name, unit, description).also {
+        longUpDownCounters.add(it)
+    }
+
+    override fun createDoubleUpDownCounter(
+        name: String,
+        unit: String?,
+        description: String?,
+    ): DoubleUpDownCounter = FakeDoubleUpDownCounter(name, unit, description).also {
+        doubleUpDownCounters.add(it)
+    }
+}


### PR DESCRIPTION
Expose Long/Double UpDownCounter on Meter with noop, fakes, a dummy impl, and Java compat adapters. Aggregation and metric readers are deferred until the Metrics SDK exists.

## Goal

Add the synchronous UpDownCounter API from the spec for #382.

## Testing

- New unit tests
- Compat tests to cover Kotlin/Java and Java/Kotlin wiring for interop
