### PR TITLE
fix: sanitize nonsensical BatchTelemetryConfig values

### DIFF
--- a/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/export/BatchTelemetryConfig.kt
+++ b/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/export/BatchTelemetryConfig.kt
@@ -20,7 +20,7 @@ internal class BatchTelemetryConfig(
         configParameterName = "maxQueueSize",
         value = maxQueueSize,
         default = BatchTelemetryDefaults.MAX_QUEUE_SIZE,
-    ) { it >= 0 }
+    ) { it > 0 }
 
     /**
      * Delay between scheduled flushes, in milliseconds.
@@ -35,6 +35,7 @@ internal class BatchTelemetryConfig(
 
     /**
      * Timeout for a single export operation, in milliseconds.
+     * Zero means no limit (infinity).
      */
     val exportTimeoutMs: Long = validateOrUseDefault(
         sdkErrorHandler = sdkErrorHandler,
@@ -42,25 +43,30 @@ internal class BatchTelemetryConfig(
         configParameterName = "exportTimeoutMs",
         value = exportTimeoutMs,
         default = BatchTelemetryDefaults.EXPORT_TIMEOUT_MS,
-    ) { it >= 0 }
+    ) { it >= 0 }.let { timeout ->
+        if (timeout == 0L) {
+            Long.MAX_VALUE
+        } else {
+            timeout
+        }
+    }
 
     /**
      * Maximum number of telemetry items to export per batch. Will be capped at maxQueueSize if it exceeds it.
      */
-    val maxExportBatchSize: Int = if (maxExportBatchSize < 0) {
-        validateOrUseDefault(
+    val maxExportBatchSize: Int = run {
+        val positive = validateOrUseDefault(
             sdkErrorHandler = sdkErrorHandler,
             api = API,
             configParameterName = "maxExportBatchSize",
             value = maxExportBatchSize,
             default = BatchTelemetryDefaults.MAX_EXPORT_BATCH_SIZE,
-        ) { it >= 0 }
-    } else {
+        ) { it > 0 }
         validateOrUseDefault(
             sdkErrorHandler = sdkErrorHandler,
             api = API,
             configParameterName = "maxExportBatchSize",
-            value = maxExportBatchSize,
+            value = positive,
             default = this.maxQueueSize,
         ) { it <= this.maxQueueSize }
     }
@@ -74,7 +80,7 @@ internal class BatchTelemetryConfig(
         configParameterName = "forceFlushTimeoutMs",
         value = forceFlushTimeoutMs,
         default = BatchTelemetryDefaults.FORCE_FLUSH_TIMEOUT_MS,
-    ) { it >= 0 }
+    ) { it > 0 }
 
     private companion object {
         const val API = "BatchTelemetryConfig"

--- a/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/export/BatchTelemetryConfigTest.kt
+++ b/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/export/BatchTelemetryConfigTest.kt
@@ -4,6 +4,7 @@ import io.opentelemetry.kotlin.error.FakeSdkErrorHandler
 import io.opentelemetry.kotlin.error.NoopSdkErrorHandler
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 internal class BatchTelemetryConfigTest {
 
@@ -35,5 +36,44 @@ internal class BatchTelemetryConfigTest {
         assertEquals(default.exportTimeoutMs, cfg.exportTimeoutMs)
         assertEquals(default.maxExportBatchSize, cfg.maxExportBatchSize)
         assertEquals(default.forceFlushTimeoutMs, cfg.forceFlushTimeoutMs)
+    }
+
+    @Test
+    fun testZeroQueueBatchAndForceFlushFallBackToDefaults() {
+        val handler = FakeSdkErrorHandler()
+        val cfg = BatchTelemetryConfig(
+            maxQueueSize = 0,
+            maxExportBatchSize = 0,
+            forceFlushTimeoutMs = 0,
+            sdkErrorHandler = handler,
+        )
+        assertEquals(3, handler.apiMisuses.size)
+        assertEquals(BatchTelemetryDefaults.MAX_QUEUE_SIZE, cfg.maxQueueSize)
+        assertEquals(BatchTelemetryDefaults.MAX_EXPORT_BATCH_SIZE, cfg.maxExportBatchSize)
+        assertEquals(BatchTelemetryDefaults.FORCE_FLUSH_TIMEOUT_MS, cfg.forceFlushTimeoutMs)
+    }
+
+    @Test
+    fun testMaxExportBatchSizeCappedToQueueSize() {
+        val handler = FakeSdkErrorHandler()
+        val cfg = BatchTelemetryConfig(
+            maxQueueSize = 10,
+            maxExportBatchSize = 100,
+            sdkErrorHandler = handler,
+        )
+        assertEquals(1, handler.apiMisuses.size)
+        assertEquals(10, cfg.maxExportBatchSize)
+        assertEquals(10, cfg.maxQueueSize)
+    }
+
+    @Test
+    fun testZeroExportTimeoutMeansNoLimit() {
+        val handler = FakeSdkErrorHandler()
+        val cfg = BatchTelemetryConfig(
+            exportTimeoutMs = 0,
+            sdkErrorHandler = handler,
+        )
+        assertTrue(handler.apiMisuses.isEmpty())
+        assertEquals(Long.MAX_VALUE, cfg.exportTimeoutMs)
     }
 }

--- a/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/export/BatchTelemetryProcessorTest.kt
+++ b/exporters-core/src/commonTest/kotlin/io/opentelemetry/kotlin/export/BatchTelemetryProcessorTest.kt
@@ -117,15 +117,6 @@ internal class BatchTelemetryProcessorTest {
     }
 
     @Test
-    fun testZeroQueueSizeDropsAllTelemetry() = runTest {
-        val exports = assertTelemetryBatched(
-            telemetry = listOf(1, 2, 3),
-            maxQueueSize = 0,
-        )
-        assertEquals(emptyList(), exports)
-    }
-
-    @Test
     fun testExportThrowsError() = runTest {
         val exports = assertTelemetryBatched(
             telemetry = listOf(1, 2, 3, 4, 5, 6, 7, 8),


### PR DESCRIPTION
## Goal
Sanitize BatchTelemetryConfig so zero/negative queue and batch sizes (and a zero forceFlush timeout) fall back to defaults, oversized batches cap at the queue, and exportTimeout 0 means no limit.

## Testing
Extended BatchTelemetryConfigTest; removed the zero-queue processor test. Ran :exporters-core:jvmTest for BatchTelemetryConfigTest and BatchTelemetryProcessorTest.

Fixes #877