### PR TITLE
fix: map StatusCode to protobuf with when, not ordinal

### DIFF
--- a/exporters-protobuf/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/SpanDataProtobufConversion.kt
+++ b/exporters-protobuf/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/SpanDataProtobufConversion.kt
@@ -10,6 +10,7 @@ import io.opentelemetry.kotlin.resource.Resource
 import io.opentelemetry.kotlin.tracing.data.SpanEventData
 import io.opentelemetry.kotlin.tracing.data.SpanLinkData
 import io.opentelemetry.kotlin.tracing.data.SpanData
+import io.opentelemetry.kotlin.tracing.StatusCode
 import io.opentelemetry.kotlin.tracing.StatusData
 import io.opentelemetry.kotlin.tracing.SpanContext
 import io.opentelemetry.kotlin.tracing.SpanKind
@@ -31,8 +32,7 @@ fun SpanData.toProtobuf() = Span(
     attributes = attributes.createKeyValues(),
     status = Status(
         message = status.description ?: "",
-        code = Status.StatusCode.fromValue(status.statusCode.ordinal)
-            ?: Status.StatusCode.STATUS_CODE_UNSET
+        code = status.statusCode.toProtoStatusCode(),
     ),
     events = events.toSpanEvent(),
     dropped_events_count = droppedEventsCount,
@@ -106,6 +106,12 @@ private fun SpanContext.toSpanFlagsInt(remoteContext: SpanContext): Int {
 private fun Int.isRemoteContext(): Boolean =
     (this and SpanFlags.SPAN_FLAGS_CONTEXT_HAS_IS_REMOTE_MASK.value) != 0 &&
         (this and SpanFlags.SPAN_FLAGS_CONTEXT_IS_REMOTE_MASK.value) != 0
+
+private fun StatusCode.toProtoStatusCode(): Status.StatusCode = when (this) {
+    StatusCode.UNSET -> Status.StatusCode.STATUS_CODE_UNSET
+    StatusCode.OK -> Status.StatusCode.STATUS_CODE_OK
+    StatusCode.ERROR -> Status.StatusCode.STATUS_CODE_ERROR
+}
 
 private fun SpanKind.toProtoSpanKind(): Span.SpanKind = when (this) {
     SpanKind.SERVER -> Span.SpanKind.SPAN_KIND_SERVER

--- a/exporters-protobuf/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/export/SpanDataProtobufConversionTest.kt
+++ b/exporters-protobuf/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/export/SpanDataProtobufConversionTest.kt
@@ -16,6 +16,7 @@ import io.opentelemetry.kotlin.tracing.data.FakeSpanData
 import io.opentelemetry.kotlin.tracing.data.SpanLinkData
 import io.opentelemetry.kotlin.tracing.StatusData
 import io.opentelemetry.proto.trace.v1.Span
+import io.opentelemetry.proto.trace.v1.Status
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -56,7 +57,7 @@ class SpanDataProtobufConversionTest {
         assertEquals(obj.spanContext.spanId, protobuf.span_id.toByteArray().toHexString())
         assertEquals(obj.startTimestamp, protobuf.start_time_unix_nano)
         assertEquals(obj.endTimestamp, protobuf.end_time_unix_nano)
-        assertEquals(obj.status.statusCode.ordinal, protobuf.status?.code?.ordinal)
+        assertEquals(Status.StatusCode.STATUS_CODE_ERROR, protobuf.status?.code)
         assertEquals(obj.status.description, protobuf.status?.message)
         assertAttributesMatch(obj.attributes, protobuf.attributes)
         assertEventsMatch(obj.events, protobuf.events)
@@ -198,6 +199,19 @@ class SpanDataProtobufConversionTest {
         kindMappings.forEach { (spanKind, protoKind) ->
             val protobuf = FakeSpanData(spanKind = spanKind).toProtobuf()
             assertEquals(protoKind, protobuf.kind)
+        }
+    }
+
+    @Test
+    fun testStatusCodeMapping() {
+        val statusMappings = mapOf(
+            StatusData.Unset to Status.StatusCode.STATUS_CODE_UNSET,
+            StatusData.Ok to Status.StatusCode.STATUS_CODE_OK,
+            StatusData.Error("Whoops") to Status.StatusCode.STATUS_CODE_ERROR,
+        )
+        statusMappings.forEach { (status, protoCode) ->
+            val protobuf = FakeSpanData(status = status).toProtobuf()
+            assertEquals(protoCode, protobuf.status?.code)
         }
     }
 


### PR DESCRIPTION
## Goal
Map span StatusCode to protobuf with when instead of enum ordinal so OTLP status does not depend on declaration order.

## Testing
Updated SpanDataProtobufConversionTest to assert proto StatusCode values and cover UNSET/OK/ERROR. Ran :exporters-protobuf:jvmTest for SpanDataProtobufConversionTest.

Fixes #859