### PR TITLE
fix: report SDK errors through Guard.kt

### DIFF
--- a/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/CoreLogRecordExporterApi.kt
+++ b/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/CoreLogRecordExporterApi.kt
@@ -4,6 +4,7 @@ package io.opentelemetry.kotlin.logging.export
 import io.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.kotlin.error.SdkError
 import io.opentelemetry.kotlin.error.SdkErrorSeverity
+import io.opentelemetry.kotlin.error.reportError
 import io.opentelemetry.kotlin.export.BatchTelemetryDefaults
 import io.opentelemetry.kotlin.export.telemetryExceptionHandler
 import io.opentelemetry.kotlin.init.LogExportConfigDsl
@@ -18,7 +19,7 @@ import kotlinx.coroutines.SupervisorJob
 @ExperimentalApi
 public fun LogExportConfigDsl.compositeLogRecordProcessor(vararg processors: LogRecordProcessor): LogRecordProcessor {
     if (processors.isEmpty()) {
-        sdkErrorHandler.onError(
+        sdkErrorHandler.reportError(
             SdkError.ApiMisuse(
                 api = "LogExportConfigDsl.compositeLogRecordProcessor",
                 message = "At least one processor must be provided",
@@ -48,7 +49,7 @@ public fun LogExportConfigDsl.simpleLogRecordProcessor(exporter: LogRecordExport
 @ExperimentalApi
 public fun LogExportConfigDsl.compositeLogRecordExporter(vararg exporters: LogRecordExporter): LogRecordExporter {
     if (exporters.isEmpty()) {
-        sdkErrorHandler.onError(
+        sdkErrorHandler.reportError(
             SdkError.ApiMisuse(
                 api = "LogExportConfigDsl.compositeLogRecordExporter",
                 message = "At least one exporter must be provided",

--- a/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/CoreSpanExporterApi.kt
+++ b/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/CoreSpanExporterApi.kt
@@ -3,6 +3,7 @@ package io.opentelemetry.kotlin.tracing.export
 import io.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.kotlin.error.SdkError
 import io.opentelemetry.kotlin.error.SdkErrorSeverity
+import io.opentelemetry.kotlin.error.reportError
 import io.opentelemetry.kotlin.export.BatchTelemetryDefaults
 import io.opentelemetry.kotlin.export.telemetryExceptionHandler
 import io.opentelemetry.kotlin.init.TraceExportConfigDsl
@@ -17,7 +18,7 @@ import kotlinx.coroutines.SupervisorJob
 @ExperimentalApi
 public fun TraceExportConfigDsl.compositeSpanProcessor(vararg processors: SpanProcessor): SpanProcessor {
     if (processors.isEmpty()) {
-        sdkErrorHandler.onError(
+        sdkErrorHandler.reportError(
             SdkError.ApiMisuse(
                 api = "TraceExportConfigDsl.compositeSpanProcessor",
                 message = "At least one processor must be provided",
@@ -47,7 +48,7 @@ public fun TraceExportConfigDsl.simpleSpanProcessor(exporter: SpanExporter): Spa
 @ExperimentalApi
 public fun TraceExportConfigDsl.compositeSpanExporter(vararg exporters: SpanExporter): SpanExporter {
     if (exporters.isEmpty()) {
-        sdkErrorHandler.onError(
+        sdkErrorHandler.reportError(
             SdkError.ApiMisuse(
                 api = "TraceExportConfigDsl.compositeSpanExporter",
                 message = "At least one exporter must be provided",

--- a/exporters-otlp/src/commonMain/kotlin/io/opentelemetry/kotlin/export/OtlpClient.kt
+++ b/exporters-otlp/src/commonMain/kotlin/io/opentelemetry/kotlin/export/OtlpClient.kt
@@ -11,9 +11,8 @@ import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
 import io.ktor.http.contentType
 import io.ktor.utils.io.readRemaining
-import io.opentelemetry.kotlin.error.SdkError
 import io.opentelemetry.kotlin.error.SdkErrorHandler
-import io.opentelemetry.kotlin.error.SdkErrorSeverity
+import io.opentelemetry.kotlin.error.guardOrDefaultSuspend
 import io.opentelemetry.kotlin.export.OtlpClient.Companion.MAX_ERROR_BODY_BYTES
 import io.opentelemetry.kotlin.export.OtlpResponse.ClientError
 import io.opentelemetry.kotlin.export.OtlpResponse.PartialSuccess
@@ -28,7 +27,6 @@ import io.opentelemetry.kotlin.tracing.data.SpanData
 import io.opentelemetry.kotlin.tracing.export.deserializeTraceRecordPartialSuccess
 import io.opentelemetry.kotlin.tracing.export.toProtobufByteArray
 import kotlinx.io.readByteArray
-import kotlin.coroutines.cancellation.CancellationException
 
 internal class OtlpClient(
     private val baseUrl: String,
@@ -55,45 +53,32 @@ internal class OtlpClient(
         endpoint: OtlpEndpoint,
         requestSerializer: () -> ByteArray,
         parsePartialSuccess: (body: ByteArray) -> OtlpPartialSuccess?,
-    ): OtlpResponse {
-        return try {
-            val url = "$baseUrl/${endpoint.path}"
-            val response = httpClient.post(url) {
-                compress("gzip")
-                contentType(contentType)
-                header(HttpHeaders.UserAgent, userAgent)
-                setBody(requestSerializer())
+    ): OtlpResponse = sdkErrorHandler.guardOrDefaultSuspend(Unknown, "OTLP export failed") {
+        val url = "$baseUrl/${endpoint.path}"
+        val response = httpClient.post(url) {
+            compress("gzip")
+            contentType(contentType)
+            header(HttpHeaders.UserAgent, userAgent)
+            setBody(requestSerializer())
+        }
+        // A 200 can still be a partial success and error responses can carry an error message,
+        // so the body is always parsed rather than relying on the status code alone (see #558).
+        val body = parsePartialSuccess(response.boundedBodyBytes())
+        when (val code = response.status.value) {
+            200 -> when (body) {
+                null -> Success
+                else -> PartialSuccess(body.rejectedCount, body.errorMessage)
             }
-            // A 200 can still be a partial success and error responses can carry an error message,
-            // so the body is always parsed rather than relying on the status code alone (see #558).
-            val body = parsePartialSuccess(response.boundedBodyBytes())
-            when (val code = response.status.value) {
-                200 -> when (body) {
-                    null -> Success
-                    else -> PartialSuccess(body.rejectedCount, body.errorMessage)
-                }
 
-                429, 502, 503, 504 -> RetryableError(
-                    code,
-                    response.parseRetryAfterMs(),
-                    body?.errorMessage,
-                )
-
-                in 400..499 -> ClientError(code, body?.errorMessage)
-                in 500..599 -> ServerError(code, body?.errorMessage)
-                else -> Unknown
-            }
-        } catch (e: CancellationException) {
-            throw e
-        } catch (e: Throwable) {
-            sdkErrorHandler.onError(
-                SdkError.UserCodeError(
-                    e,
-                    "OTLP export failed",
-                    SdkErrorSeverity.WARNING,
-                )
+            429, 502, 503, 504 -> RetryableError(
+                code,
+                response.parseRetryAfterMs(),
+                body?.errorMessage,
             )
-            Unknown
+
+            in 400..499 -> ClientError(code, body?.errorMessage)
+            in 500..599 -> ServerError(code, body?.errorMessage)
+            else -> Unknown
         }
     }
 

--- a/exporters-otlp/src/commonTest/kotlin/io/opentelemetry/kotlin/export/OtlpClientTest.kt
+++ b/exporters-otlp/src/commonTest/kotlin/io/opentelemetry/kotlin/export/OtlpClientTest.kt
@@ -30,7 +30,6 @@ import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
-import kotlin.test.assertFalse
 import kotlin.test.assertIs
 import kotlin.test.assertNull
 import kotlin.time.Duration.Companion.milliseconds
@@ -289,7 +288,9 @@ internal class OtlpClientTest {
         mockResponseStatus = HttpStatusCode.OK
         mockResponseBody = logResponseBody(rejected = 2L, msg = "2 log records rejected")
         val response = client.exportLogs(logRecords)
-        assertFalse(response is OtlpResponse.Success)
+        assertIs<OtlpResponse.PartialSuccess>(response)
+        assertEquals(2L, response.rejectedCount)
+        assertEquals("2 log records rejected", response.errorMessage)
     }
 
     @Test
@@ -297,7 +298,39 @@ internal class OtlpClientTest {
         mockResponseStatus = HttpStatusCode.OK
         mockResponseBody = traceResponseBody(rejected = 3L, msg = "3 spans rejected")
         val response = client.exportTraces(spans)
-        assertFalse(response is OtlpResponse.Success)
+        assertIs<OtlpResponse.PartialSuccess>(response)
+        assertEquals(3L, response.rejectedCount)
+        assertEquals("3 spans rejected", response.errorMessage)
+    }
+
+    @Test
+    fun testExportLogUnknownHttpStatus() = runTest {
+        mockResponseStatus = HttpStatusCode.MovedPermanently
+        val response = client.exportLogs(logRecords)
+        assertIs<OtlpResponse.Unknown>(response)
+    }
+
+    @Test
+    fun testExportTraceUnknownHttpStatus() = runTest {
+        mockResponseStatus = HttpStatusCode.MovedPermanently
+        val response = client.exportTraces(spans)
+        assertIs<OtlpResponse.Unknown>(response)
+    }
+
+    @Test
+    fun testExportLogBadGatewayIsRetryable() = runTest {
+        mockResponseStatus = HttpStatusCode.BadGateway
+        val response = client.exportLogs(logRecords)
+        assertIs<OtlpResponse.RetryableError>(response)
+        assertEquals(502, response.statusCode)
+    }
+
+    @Test
+    fun testExportTraceBadGatewayIsRetryable() = runTest {
+        mockResponseStatus = HttpStatusCode.BadGateway
+        val response = client.exportTraces(spans)
+        assertIs<OtlpResponse.RetryableError>(response)
+        assertEquals(502, response.statusCode)
     }
 
     @Test

--- a/exporters-persistence/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/PersistingLogRecordProcessor.kt
+++ b/exporters-persistence/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/PersistingLogRecordProcessor.kt
@@ -2,9 +2,8 @@ package io.opentelemetry.kotlin.logging.export
 
 import io.opentelemetry.kotlin.InstrumentationScopeInfo
 import io.opentelemetry.kotlin.context.Context
-import io.opentelemetry.kotlin.error.SdkError
 import io.opentelemetry.kotlin.error.SdkErrorHandler
-import io.opentelemetry.kotlin.error.SdkErrorSeverity
+import io.opentelemetry.kotlin.error.guard
 import io.opentelemetry.kotlin.export.MutableShutdownState
 import io.opentelemetry.kotlin.export.OperationResultCode
 import io.opentelemetry.kotlin.export.OperationResultCode.Failure
@@ -98,16 +97,8 @@ internal class PersistingLogRecordProcessor(
 
     override fun onEmit(log: ReadWriteLogRecord, context: Context) {
         shutdownState.execute {
-            try {
+            sdkErrorHandler.guard("LogRecordProcessor.onEmit failed") {
                 composite.onEmit(log, context)
-            } catch (e: Throwable) {
-                sdkErrorHandler.onError(
-                    SdkError.UserCodeError(
-                        e,
-                        "LogRecordProcessor.onEmit failed",
-                        SdkErrorSeverity.WARNING
-                    )
-                )
             }
         }
     }

--- a/exporters-persistence/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/PersistingSpanProcessor.kt
+++ b/exporters-persistence/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/PersistingSpanProcessor.kt
@@ -1,9 +1,8 @@
 package io.opentelemetry.kotlin.tracing.export
 
 import io.opentelemetry.kotlin.context.Context
-import io.opentelemetry.kotlin.error.SdkError
 import io.opentelemetry.kotlin.error.SdkErrorHandler
-import io.opentelemetry.kotlin.error.SdkErrorSeverity
+import io.opentelemetry.kotlin.error.guard
 import io.opentelemetry.kotlin.export.MutableShutdownState
 import io.opentelemetry.kotlin.export.OperationResultCode
 import io.opentelemetry.kotlin.export.OperationResultCode.Failure
@@ -96,44 +95,20 @@ internal class PersistingSpanProcessor(
     }
 
     override fun onStart(span: ReadWriteSpan, parentContext: Context) = shutdownState.execute {
-        try {
+        sdkErrorHandler.guard("SpanProcessor.onStart failed") {
             composite.onStart(span, parentContext)
-        } catch (e: Throwable) {
-            sdkErrorHandler.onError(
-                SdkError.UserCodeError(
-                    e,
-                    "SpanProcessor.onStart failed",
-                    SdkErrorSeverity.WARNING
-                )
-            )
         }
     }
 
     override fun onEnding(span: ReadWriteSpan) = shutdownState.execute {
-        try {
+        sdkErrorHandler.guard("SpanProcessor.onEnding failed") {
             composite.onEnding(span)
-        } catch (e: Throwable) {
-            sdkErrorHandler.onError(
-                SdkError.UserCodeError(
-                    e,
-                    "SpanProcessor.onEnding failed",
-                    SdkErrorSeverity.WARNING
-                )
-            )
         }
     }
 
     override fun onEnd(span: ReadableSpan) = shutdownState.execute {
-        try {
+        sdkErrorHandler.guard("SpanProcessor.onEnd failed") {
             composite.onEnd(span)
-        } catch (e: Throwable) {
-            sdkErrorHandler.onError(
-                SdkError.UserCodeError(
-                    e,
-                    "SpanProcessor.onEnd failed",
-                    SdkErrorSeverity.WARNING
-                )
-            )
         }
     }
 

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/context/ScopeImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/context/ScopeImpl.kt
@@ -3,6 +3,7 @@ package io.opentelemetry.kotlin.context
 import io.opentelemetry.kotlin.error.SdkError
 import io.opentelemetry.kotlin.error.SdkErrorHandler
 import io.opentelemetry.kotlin.error.SdkErrorSeverity
+import io.opentelemetry.kotlin.error.reportError
 import kotlin.concurrent.Volatile
 
 internal class ScopeImpl private constructor(
@@ -17,7 +18,7 @@ internal class ScopeImpl private constructor(
 
     override fun detach(): Boolean {
         return if (detached) {
-            sdkErrorHandler.onError(
+            sdkErrorHandler.reportError(
                 SdkError.ApiMisuse(
                     api = "Scope.detach",
                     message = "Scope.detach() called on an already-detached scope",
@@ -26,7 +27,7 @@ internal class ScopeImpl private constructor(
             )
             false
         } else if (storage.implicitContext() != currentContext) {
-            sdkErrorHandler.onError(
+            sdkErrorHandler.reportError(
                 SdkError.ApiMisuse(
                     api = "Scope.detach",
                     message = "Scope.detach() called out of order — context has already changed",
@@ -49,7 +50,7 @@ internal class ScopeImpl private constructor(
             sdkErrorHandler: SdkErrorHandler,
         ): Scope =
             if (previousContext == currentContext) {
-                sdkErrorHandler.onError(
+                sdkErrorHandler.reportError(
                     SdkError.ApiMisuse(
                         api = "Context.attach",
                         message = "Cannot create scope with two matching contexts",

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/LoggerProviderConfigImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/LoggerProviderConfigImpl.kt
@@ -6,6 +6,7 @@ import io.opentelemetry.kotlin.attributes.DEFAULT_ATTRIBUTE_VALUE_LENGTH_LIMIT
 import io.opentelemetry.kotlin.error.SdkError
 import io.opentelemetry.kotlin.error.SdkErrorHandler
 import io.opentelemetry.kotlin.error.SdkErrorSeverity
+import io.opentelemetry.kotlin.error.reportError
 import io.opentelemetry.kotlin.init.config.LogLimitConfig
 import io.opentelemetry.kotlin.init.config.LoggingConfig
 import io.opentelemetry.kotlin.logging.LoggerConfigImpl
@@ -28,7 +29,7 @@ internal class LoggerProviderConfigImpl(
 
     override fun export(action: LogExportConfigDsl.() -> LogRecordProcessor) {
         if (processor != null) {
-            sdkErrorHandler.onError(
+            sdkErrorHandler.reportError(
                 SdkError.ApiMisuse(
                     api = "LoggerProviderConfigDsl.export",
                     message = "export() should only be called once.",

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/TracerProviderConfigImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/TracerProviderConfigImpl.kt
@@ -6,6 +6,7 @@ import io.opentelemetry.kotlin.attributes.DEFAULT_ATTRIBUTE_VALUE_LENGTH_LIMIT
 import io.opentelemetry.kotlin.error.SdkError
 import io.opentelemetry.kotlin.error.SdkErrorHandler
 import io.opentelemetry.kotlin.error.SdkErrorSeverity
+import io.opentelemetry.kotlin.error.reportError
 import io.opentelemetry.kotlin.factory.SpanFactory
 import io.opentelemetry.kotlin.init.config.DEFAULT_EVENT_LIMIT
 import io.opentelemetry.kotlin.init.config.DEFAULT_LINK_LIMIT
@@ -39,7 +40,7 @@ internal class TracerProviderConfigImpl(
 
     override fun export(action: TraceExportConfigDsl.() -> SpanProcessor) {
         if (processor != null) {
-            sdkErrorHandler.onError(
+            sdkErrorHandler.reportError(
                 SdkError.ApiMisuse(
                     api = "TracerProviderConfigDsl.export",
                     message = "export() should only be called once.",

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/LoggerProviderImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/LoggerProviderImpl.kt
@@ -7,6 +7,7 @@ import io.opentelemetry.kotlin.error.SdkError
 import io.opentelemetry.kotlin.error.SdkErrorSeverity
 import io.opentelemetry.kotlin.error.guardOrDefault
 import io.opentelemetry.kotlin.error.guardOrDefaultSuspend
+import io.opentelemetry.kotlin.error.reportError
 import io.opentelemetry.kotlin.export.BatchTelemetryDefaults
 import io.opentelemetry.kotlin.export.CompositeTelemetryCloseable
 import io.opentelemetry.kotlin.export.MutableShutdownState
@@ -64,7 +65,7 @@ internal class LoggerProviderImpl(
         sdkErrorHandler.guardOrDefault(noopLogger, "LoggerProvider.getLogger failed") {
             shutdownState.ifActiveOrElse(noopLogger) {
                 if (name.isEmpty()) {
-                    sdkErrorHandler.onError(
+                    sdkErrorHandler.reportError(
                         SdkError.ApiMisuse(
                             api = "LoggerProvider.getLogger",
                             message = "Logger requested without instrumentation scope name",

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/MeterProviderImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/MeterProviderImpl.kt
@@ -6,6 +6,7 @@ import io.opentelemetry.kotlin.error.SdkError
 import io.opentelemetry.kotlin.error.SdkErrorSeverity
 import io.opentelemetry.kotlin.error.guardOrDefault
 import io.opentelemetry.kotlin.error.guardOrDefaultSuspend
+import io.opentelemetry.kotlin.error.reportError
 import io.opentelemetry.kotlin.export.BatchTelemetryDefaults
 import io.opentelemetry.kotlin.export.CompositeTelemetryCloseable
 import io.opentelemetry.kotlin.export.MutableShutdownState
@@ -42,7 +43,7 @@ internal class MeterProviderImpl(
         sdkErrorHandler.guardOrDefault(noopMeter, "MeterProvider.getMeter failed") {
             shutdownState.ifActiveOrElse(noopMeter) {
                 if (name.isEmpty()) {
-                    sdkErrorHandler.onError(
+                    sdkErrorHandler.reportError(
                         SdkError.ApiMisuse(
                             api = "MeterProvider.getMeter",
                             message = "Meter requested without instrumentation scope name",

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/propagation/B3Propagator.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/propagation/B3Propagator.kt
@@ -7,6 +7,7 @@ import io.opentelemetry.kotlin.context.ContextKeyImpl
 import io.opentelemetry.kotlin.error.SdkError
 import io.opentelemetry.kotlin.error.SdkErrorHandler
 import io.opentelemetry.kotlin.error.SdkErrorSeverity
+import io.opentelemetry.kotlin.error.reportError
 import io.opentelemetry.kotlin.factory.SpanContextFactory
 import io.opentelemetry.kotlin.factory.SpanFactory
 import io.opentelemetry.kotlin.factory.TraceFlagsFactory
@@ -96,7 +97,7 @@ internal class B3Propagator(
         val header = getter.get(carrier, COMBINED_HEADER) ?: return null
         val parts = header.split(DELIMITER)
         if (parts.size !in 2..4) {
-            sdkErrorHandler.onError(
+            sdkErrorHandler.reportError(
                 SdkError.ApiMisuse(
                     api = "B3Propagator.extractSingle",
                     message = "B3 single header has wrong number of parts: $header",
@@ -106,7 +107,7 @@ internal class B3Propagator(
             return null
         }
         val traceId = normalizeTraceId(parts[0]) ?: run {
-            sdkErrorHandler.onError(
+            sdkErrorHandler.reportError(
                 SdkError.ApiMisuse(
                     api = "B3Propagator.extractSingle",
                     message = "B3 invalid traceId in single header: ${parts[0]}",
@@ -120,7 +121,7 @@ internal class B3Propagator(
         val debug = sampled == "d"
         val spanContext = buildContext(debug, sampled, traceId, rawSpanId)
         if (!spanContext.isValid) {
-            sdkErrorHandler.onError(
+            sdkErrorHandler.reportError(
                 SdkError.ApiMisuse(
                     api = "B3Propagator.extractSingle",
                     message = "B3 invalid spanId in single header: $rawSpanId",
@@ -139,7 +140,7 @@ internal class B3Propagator(
         val rawSpanId = getter.get(carrier, SPAN_ID_HEADER) ?: return null
         val traceId = normalizeTraceId(rawTraceId) ?: run {
             if (rawTraceId != null) {
-                sdkErrorHandler.onError(
+                sdkErrorHandler.reportError(
                     SdkError.ApiMisuse(
                         api = "B3Propagator.extractMulti",
                         message = "B3 invalid traceId in multi header: $rawTraceId",
@@ -153,7 +154,7 @@ internal class B3Propagator(
         val sampled = getter.get(carrier, SAMPLED_HEADER)
         val spanContext = buildContext(debug, sampled, traceId, rawSpanId)
         if (!spanContext.isValid) {
-            sdkErrorHandler.onError(
+            sdkErrorHandler.reportError(
                 SdkError.ApiMisuse(
                     api = "B3Propagator.extractMulti",
                     message = "B3 invalid spanId in multi header: $rawSpanId",

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/propagation/TraceParent.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/propagation/TraceParent.kt
@@ -4,6 +4,7 @@ import io.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.kotlin.error.SdkError
 import io.opentelemetry.kotlin.error.SdkErrorHandler
 import io.opentelemetry.kotlin.error.SdkErrorSeverity
+import io.opentelemetry.kotlin.error.reportError
 import io.opentelemetry.kotlin.factory.TraceFlagsFactory
 import io.opentelemetry.kotlin.tracing.TraceFlags
 
@@ -70,7 +71,7 @@ internal class TraceParent private constructor(
             return if (errorMessage == null) {
                 TraceParent(version, traceId, spanId, traceFlags)
             } else {
-                sdkErrorHandler.onError(
+                sdkErrorHandler.reportError(
                     SdkError.ApiMisuse(
                         api = "TraceParent.create",
                         message = errorMessage,

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/TracerProviderImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/TracerProviderImpl.kt
@@ -7,6 +7,7 @@ import io.opentelemetry.kotlin.error.SdkError
 import io.opentelemetry.kotlin.error.SdkErrorSeverity
 import io.opentelemetry.kotlin.error.guardOrDefault
 import io.opentelemetry.kotlin.error.guardOrDefaultSuspend
+import io.opentelemetry.kotlin.error.reportError
 import io.opentelemetry.kotlin.export.BatchTelemetryDefaults
 import io.opentelemetry.kotlin.export.CompositeTelemetryCloseable
 import io.opentelemetry.kotlin.export.MutableShutdownState
@@ -72,7 +73,7 @@ internal class TracerProviderImpl(
         sdkErrorHandler.guardOrDefault(noopTracer, "TracerProvider.getTracer failed") {
             shutdownState.ifActiveOrElse(noopTracer) {
                 if (name.isEmpty()) {
-                    sdkErrorHandler.onError(
+                    sdkErrorHandler.reportError(
                         SdkError.ApiMisuse(
                             api = "TracerProvider.getTracer",
                             message = "Tracer requested without instrumentation scope name",

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/sampling/ProbabilitySampler.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/sampling/ProbabilitySampler.kt
@@ -6,6 +6,7 @@ import io.opentelemetry.kotlin.context.Context
 import io.opentelemetry.kotlin.error.SdkError
 import io.opentelemetry.kotlin.error.SdkErrorHandler
 import io.opentelemetry.kotlin.error.SdkErrorSeverity
+import io.opentelemetry.kotlin.error.reportError
 import io.opentelemetry.kotlin.tracing.SpanKind
 import io.opentelemetry.kotlin.tracing.model.SpanLink
 import io.opentelemetry.kotlin.tracing.sampling.SamplingResult.Decision
@@ -51,7 +52,7 @@ internal class ProbabilitySampler(
         } else {
             if (parentSpanContext.isValid && !parentSpanContext.traceFlags.isRandom && !compatibilityWarningLogged) {
                 compatibilityWarningLogged = true
-                sdkErrorHandler.onError(
+                sdkErrorHandler.reportError(
                     SdkError.ApiMisuse(
                         api = "ProbabilitySampler.shouldSample",
                         message = COMPATIBILITY_WARNING,

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/error/GuardTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/error/GuardTest.kt
@@ -29,4 +29,22 @@ internal class GuardTest {
         assertEquals("SpanProcessor.onStart failed", error.message)
         assertEquals(SdkErrorSeverity.WARNING, error.severity)
     }
+
+    @Test
+    fun testReportErrorForwardsApiMisuse() {
+        val error = SdkError.ApiMisuse("TestApi", "boom", SdkErrorSeverity.WARNING)
+
+        handler.reportError(error)
+
+        assertSame(error, handler.apiMisuses.single())
+    }
+
+    @Test
+    fun testReportErrorSwallowsThrowingHandler() {
+        val throwingHandler = SdkErrorHandler { throw IllegalStateException("boom") }
+
+        throwingHandler.reportError(
+            SdkError.ApiMisuse("TestApi", "boom", SdkErrorSeverity.WARNING)
+        )
+    }
 }

--- a/sdk-common/api/jvm/sdk-common.api
+++ b/sdk-common/api/jvm/sdk-common.api
@@ -18,6 +18,7 @@ public final class io/opentelemetry/kotlin/error/GuardKt {
 	public static synthetic fun guardOrDefault$default (Lio/opentelemetry/kotlin/error/SdkErrorHandler;Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)Ljava/lang/Object;
 	public static final fun guardOrDefaultSuspend (Lio/opentelemetry/kotlin/error/SdkErrorHandler;Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun guardOrDefaultSuspend$default (Lio/opentelemetry/kotlin/error/SdkErrorHandler;Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static final fun reportError (Lio/opentelemetry/kotlin/error/SdkErrorHandler;Lio/opentelemetry/kotlin/error/SdkError;)V
 	public static final fun reportUserCodeError (Lio/opentelemetry/kotlin/error/SdkErrorHandler;Ljava/lang/Throwable;Ljava/lang/String;)V
 }
 

--- a/sdk-common/src/commonMain/kotlin/io/opentelemetry/kotlin/config/Validation.kt
+++ b/sdk-common/src/commonMain/kotlin/io/opentelemetry/kotlin/config/Validation.kt
@@ -3,6 +3,7 @@ package io.opentelemetry.kotlin.config
 import io.opentelemetry.kotlin.error.SdkError
 import io.opentelemetry.kotlin.error.SdkErrorHandler
 import io.opentelemetry.kotlin.error.SdkErrorSeverity
+import io.opentelemetry.kotlin.error.reportError
 
 /**
  * Validate the given value against a validating function, and return that value if it's valid. Otherwise, return the provided default.
@@ -17,7 +18,7 @@ public fun <T> validateOrUseDefault(
 ): T = if (validator(value)) {
     value
 } else {
-    sdkErrorHandler.onError(
+    sdkErrorHandler.reportError(
         SdkError.ApiMisuse(
             api,
             "$value is not a valid value for $configParameterName. $default used instead.",

--- a/sdk-common/src/commonMain/kotlin/io/opentelemetry/kotlin/error/Guard.kt
+++ b/sdk-common/src/commonMain/kotlin/io/opentelemetry/kotlin/error/Guard.kt
@@ -53,19 +53,27 @@ public suspend fun <T> SdkErrorHandler.guardOrDefaultSuspend(
 }
 
 /**
+ * Reports [error] to this handler. A handler that throws in response must not take down the
+ * caller, so any such failure is swallowed.
+ */
+public fun SdkErrorHandler.reportError(error: SdkError) {
+    try {
+        onError(error)
+    } catch (ignored: Throwable) {
+        // swallow
+    }
+}
+
+/**
  * Reports [exc] to this handler as a [SdkError.UserCodeError]. A handler that throws in response
  * must not take down the guard that called it, so any such failure is swallowed.
  */
 public fun SdkErrorHandler.reportUserCodeError(exc: Throwable, details: String?) {
-    try {
-        onError(
-            SdkError.UserCodeError(
-                exc,
-                details ?: DEFAULT_DETAILS,
-                SdkErrorSeverity.WARNING
-            )
+    reportError(
+        SdkError.UserCodeError(
+            exc,
+            details ?: DEFAULT_DETAILS,
+            SdkErrorSeverity.WARNING
         )
-    } catch (ignored: Throwable) {
-        // swallow
-    }
+    )
 }

--- a/sdk-common/src/commonMain/kotlin/io/opentelemetry/kotlin/export/BatchExportOperation.kt
+++ b/sdk-common/src/commonMain/kotlin/io/opentelemetry/kotlin/export/BatchExportOperation.kt
@@ -1,8 +1,8 @@
 package io.opentelemetry.kotlin.export
 
-import io.opentelemetry.kotlin.error.SdkError
 import io.opentelemetry.kotlin.error.SdkErrorHandler
-import io.opentelemetry.kotlin.error.SdkErrorSeverity
+import io.opentelemetry.kotlin.error.guardOrDefault
+import io.opentelemetry.kotlin.error.guardOrDefaultSuspend
 
 /**
  * Performs an export operation on each element in a List and returns a success code if each
@@ -16,19 +16,13 @@ public fun <T> batchExportOperation(
     var success = true
 
     elements.forEach {
-        try {
-            val exportResult = action(it)
-            success = success && exportResult == OperationResultCode.Success
-        } catch (exc: Throwable) {
-            success = false
-            sdkErrorHandler.onError(
-                SdkError.UserCodeError(
-                    exc,
-                    "Export operation failed",
-                    SdkErrorSeverity.WARNING
-                )
-            )
+        val exportResult = sdkErrorHandler.guardOrDefault(
+            OperationResultCode.Failure,
+            "Export operation failed",
+        ) {
+            action(it)
         }
+        success = success && exportResult == OperationResultCode.Success
     }
     return when {
         success -> OperationResultCode.Success
@@ -48,19 +42,13 @@ public suspend fun <T> batchExportOperationSuspend(
     var success = true
 
     elements.forEach {
-        try {
-            val exportResult = action(it)
-            success = success && exportResult == OperationResultCode.Success
-        } catch (exc: Throwable) {
-            success = false
-            sdkErrorHandler.onError(
-                SdkError.UserCodeError(
-                    exc,
-                    "Export operation failed",
-                    SdkErrorSeverity.WARNING
-                )
-            )
+        val exportResult = sdkErrorHandler.guardOrDefaultSuspend(
+            OperationResultCode.Failure,
+            "Export operation failed",
+        ) {
+            action(it)
         }
+        success = success && exportResult == OperationResultCode.Success
     }
     return when {
         success -> OperationResultCode.Success

--- a/sdk-common/src/commonMain/kotlin/io/opentelemetry/kotlin/export/TelemetryExceptionHandler.kt
+++ b/sdk-common/src/commonMain/kotlin/io/opentelemetry/kotlin/export/TelemetryExceptionHandler.kt
@@ -1,8 +1,7 @@
 package io.opentelemetry.kotlin.export
 
-import io.opentelemetry.kotlin.error.SdkError
 import io.opentelemetry.kotlin.error.SdkErrorHandler
-import io.opentelemetry.kotlin.error.SdkErrorSeverity
+import io.opentelemetry.kotlin.error.reportUserCodeError
 import kotlinx.coroutines.CoroutineExceptionHandler
 
 /**
@@ -18,11 +17,5 @@ import kotlinx.coroutines.CoroutineExceptionHandler
  */
 public fun telemetryExceptionHandler(context: String, sdkErrorHandler: SdkErrorHandler): CoroutineExceptionHandler =
     CoroutineExceptionHandler { _, throwable ->
-        sdkErrorHandler.onError(
-            SdkError.UserCodeError(
-                cause = throwable,
-                message = "$context coroutine failed",
-                severity = SdkErrorSeverity.WARNING,
-            )
-        )
+        sdkErrorHandler.reportUserCodeError(throwable, "$context coroutine failed")
     }

--- a/sdk-common/src/commonMain/kotlin/io/opentelemetry/kotlin/resource/ResourceDetection.kt
+++ b/sdk-common/src/commonMain/kotlin/io/opentelemetry/kotlin/resource/ResourceDetection.kt
@@ -3,6 +3,7 @@ package io.opentelemetry.kotlin.resource
 import io.opentelemetry.kotlin.error.SdkError
 import io.opentelemetry.kotlin.error.SdkErrorHandler
 import io.opentelemetry.kotlin.error.SdkErrorSeverity
+import io.opentelemetry.kotlin.error.reportError
 import io.opentelemetry.kotlin.factory.ResourceFactory
 
 /**
@@ -23,7 +24,7 @@ public fun List<ResourceDetector>.detectResource(
         try {
             detected.merge(with(detector) { factory.detect() })
         } catch (exc: Throwable) {
-            errorHandler.onError(
+            errorHandler.reportError(
                 SdkError.UserCodeError(
                     exc,
                     "Resource detector '${detector.name}' failed",
@@ -45,7 +46,7 @@ private fun List<ResourceDetector>.reportDuplicateNames(errorHandler: SdkErrorHa
         .filterValues { it.size > 1 }
         .keys
         .forEach { name ->
-            errorHandler.onError(
+            errorHandler.reportError(
                 SdkError.ApiMisuse(
                     "ResourceDetector",
                     "Multiple resource detectors are named '$name'",


### PR DESCRIPTION
## Goal
Report SDK errors through Guard.kt (reportError / reportUserCodeError / guard) so a throwing SdkErrorHandler cannot crash the host. ApiMisuse stays ApiMisuse.

## Testing
Added GuardTest coverage for reportError. Ran targeted sdk-common, implementation, and exporters-core jvmTest.

Fixes #866