### PR TITLE
fix: return snapshots from in-memory exporters

### DIFF
--- a/exporters-in-memory/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/InMemoryLogRecordExporterImpl.kt
+++ b/exporters-in-memory/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/InMemoryLogRecordExporterImpl.kt
@@ -10,7 +10,7 @@ internal class InMemoryLogRecordExporterImpl : InMemoryLogRecordExporter {
     private val shutdownState = MutableShutdownState()
 
     override val exportedLogRecords: List<LogRecordData>
-        get() = impl
+        get() = impl.toList()
 
     override suspend fun export(telemetry: List<LogRecordData>): OperationResultCode =
         shutdownState.ifActive {

--- a/exporters-in-memory/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/InMemorySpanExporterImpl.kt
+++ b/exporters-in-memory/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/InMemorySpanExporterImpl.kt
@@ -10,7 +10,7 @@ internal class InMemorySpanExporterImpl : InMemorySpanExporter {
     private val shutdownState = MutableShutdownState()
 
     override val exportedSpans: List<SpanData>
-        get() = impl
+        get() = impl.toList()
 
     override suspend fun export(telemetry: List<SpanData>): OperationResultCode =
         shutdownState.ifActive {

--- a/exporters-in-memory/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/export/InMemoryLogRecordExporterTest.kt
+++ b/exporters-in-memory/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/export/InMemoryLogRecordExporterTest.kt
@@ -35,6 +35,17 @@ internal class InMemoryLogRecordExporterTest {
     }
 
     @Test
+    fun testExportedRecordsAreSnapshots() = runTest {
+        exporter.export(fakeTelemetry)
+        val firstSnapshot = exporter.exportedLogRecords
+
+        exporter.export(fakeTelemetry)
+
+        assertEquals(fakeTelemetry, firstSnapshot)
+        assertEquals(fakeTelemetry + fakeTelemetry, exporter.exportedLogRecords)
+    }
+
+    @Test
     fun testExportReturnsFailureAfterShutdown() = runTest {
         exporter.shutdown()
         val result = exporter.export(fakeTelemetry)

--- a/exporters-in-memory/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/export/InMemorySpanExporterTest.kt
+++ b/exporters-in-memory/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/export/InMemorySpanExporterTest.kt
@@ -35,6 +35,17 @@ internal class InMemorySpanExporterTest {
     }
 
     @Test
+    fun testExportedSpansAreSnapshots() = runTest {
+        exporter.export(fakeTelemetry)
+        val firstSnapshot = exporter.exportedSpans
+
+        exporter.export(fakeTelemetry)
+
+        assertEquals(fakeTelemetry, firstSnapshot)
+        assertEquals(fakeTelemetry + fakeTelemetry, exporter.exportedSpans)
+    }
+
+    @Test
     fun testExportReturnsFailureAfterShutdown() = runTest {
         exporter.shutdown()
         val result = exporter.export(fakeTelemetry)


### PR DESCRIPTION
## Goal

Return defensive snapshots from `exportedLogRecords` and `exportedSpans` instead of exposing their mutable backing lists. Add common regression tests proving that previously returned results do not change after later exports.

Closes #864

## Testing

- `./gradlew :exporters-in-memory:jvmTest :exporters-in-memory:jsNodeTest`
- `./gradlew :exporters-in-memory:allTests`
- `./gradlew :exporters-in-memory:apiCheck`
- `./gradlew detekt -x detektAndroidMain`, plus all non-Android `exporters-in-memory` Detekt source-set tasks

The full build and Android assembly were attempted, but the local SDK lacks accepted licenses for Android SDK 36. The same pre-compilation failure reproduces on an unmodified `upstream/main` worktree.
