### PR TITLE
fix: enforce W3C baggage size limits on extract

### DIFF
--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/propagation/W3CBaggagePropagator.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/propagation/W3CBaggagePropagator.kt
@@ -85,19 +85,44 @@ internal object W3CBaggagePropagator : TextMapPropagator {
 
     private fun decode(header: String): Baggage? {
         var baggage: Baggage = BaggageImpl.EMPTY
-        for (rawElement in header.split(ENTRY_DELIMITER)) {
-            val parsed = parseElement(rawElement) ?: continue
-            baggage = baggage.set(parsed.key, parsed.value, BaggageEntryMetadataImpl(parsed.metadata))
+        var currentLength = 0
+        var start = 0
+        var headerFull = false
+        while (start <= header.length && !headerFull) {
+            val comma = header.indexOf(ENTRY_DELIMITER, start)
+            val end = if (comma < 0) {
+                header.length
+            } else {
+                comma
+            }
+            val element = header.substring(start, end).trim(SPACE, HTAB)
+            start = if (comma < 0) {
+                header.length + 1
+            } else {
+                comma + 1
+            }
+            if (element.isNotEmpty() && element.length <= MAX_ENTRY_BYTES) {
+                val separator = if (currentLength == 0) {
+                    0
+                } else {
+                    1
+                }
+                if (currentLength + separator + element.length > MAX_HEADER_BYTES) {
+                    headerFull = true
+                } else {
+                    val parsed = decodeEntry(element)
+                    if (parsed != null) {
+                        currentLength += separator + element.length
+                        baggage = baggage.set(
+                            parsed.key,
+                            parsed.value,
+                            BaggageEntryMetadataImpl(parsed.metadata),
+                        )
+                    }
+                }
+            }
         }
         return baggage.takeIf { it !== BaggageImpl.EMPTY }
-    }
-
-    private fun parseElement(rawElement: String): ParsedEntry? {
-        val element = rawElement.trim(SPACE, HTAB)
-        if (element.isEmpty()) {
-            return null
-        }
-        return decodeEntry(element)
     }
 
     private fun decodeEntry(element: String): ParsedEntry? {

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/propagation/W3CBaggagePropagator.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/propagation/W3CBaggagePropagator.kt
@@ -85,44 +85,58 @@ internal object W3CBaggagePropagator : TextMapPropagator {
 
     private fun decode(header: String): Baggage? {
         var baggage: Baggage = BaggageImpl.EMPTY
-        var currentLength = 0
-        var start = 0
-        var headerFull = false
-        while (start <= header.length && !headerFull) {
-            val comma = header.indexOf(ENTRY_DELIMITER, start)
-            val end = if (comma < 0) {
-                header.length
-            } else {
-                comma
-            }
-            val element = header.substring(start, end).trim(SPACE, HTAB)
-            start = if (comma < 0) {
-                header.length + 1
-            } else {
-                comma + 1
-            }
-            if (element.isNotEmpty() && element.length <= MAX_ENTRY_BYTES) {
-                val separator = if (currentLength == 0) {
-                    0
-                } else {
-                    1
-                }
-                if (currentLength + separator + element.length > MAX_HEADER_BYTES) {
-                    headerFull = true
-                } else {
-                    val parsed = decodeEntry(element)
-                    if (parsed != null) {
-                        currentLength += separator + element.length
-                        baggage = baggage.set(
-                            parsed.key,
-                            parsed.value,
-                            BaggageEntryMetadataImpl(parsed.metadata),
-                        )
-                    }
-                }
-            }
+        val budget = HeaderBudget(MAX_HEADER_BYTES)
+        for (rawElement in header.split(ENTRY_DELIMITER)) {
+            val parsed = parseElementIfFits(rawElement, budget) ?: continue
+            baggage = baggage.set(parsed.key, parsed.value, BaggageEntryMetadataImpl(parsed.metadata))
         }
         return baggage.takeIf { it !== BaggageImpl.EMPTY }
+    }
+
+    /**
+     * Trims and decodes [rawElement], honoring the per-entry size limit and [budget] for the
+     * whole header. Returns `null` for elements that are empty, malformed, or too large.
+     * Malformed entries do not consume any of the header's budget, but an oversized element
+     * permanently exhausts [budget] so later, smaller elements are skipped too -- matching how a
+     * real client would stop appending once the header is full.
+     */
+    private fun parseElementIfFits(rawElement: String, budget: HeaderBudget): ParsedEntry? {
+        val element = rawElement.trim(SPACE, HTAB)
+        if (element.isEmpty() || element.length > MAX_ENTRY_BYTES) {
+            return null
+        }
+        if (!budget.hasRoomFor(element.length)) {
+            budget.exhaust()
+            return null
+        }
+        val parsed = decodeEntry(element) ?: return null
+        budget.reserve(element.length)
+        return parsed
+    }
+
+    /** Tracks how many bytes of [MAX_HEADER_BYTES] remain as baggage entries are accumulated. */
+    private class HeaderBudget(private var remainingBytes: Int) {
+        private var hasEntries = false
+
+        private val separatorBytes: Int
+            get() = when {
+                hasEntries -> 1
+                else -> 0
+            }
+
+        /** Whether an entry of [entryLength] bytes, plus its delimiter, still fits. */
+        fun hasRoomFor(entryLength: Int): Boolean = separatorBytes + entryLength <= remainingBytes
+
+        /** Commits the space for an entry already confirmed to fit via [hasRoomFor]. */
+        fun reserve(entryLength: Int) {
+            remainingBytes -= separatorBytes + entryLength
+            hasEntries = true
+        }
+
+        /** Permanently blocks any further entries from fitting. */
+        fun exhaust() {
+            remainingBytes = 0
+        }
     }
 
     private fun decodeEntry(element: String): ParsedEntry? {

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/propagation/W3CBaggagePropagatorTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/propagation/W3CBaggagePropagatorTest.kt
@@ -117,6 +117,41 @@ internal class W3CBaggagePropagatorTest {
     }
 
     @Test
+    fun `extract skips entry whose serialized form exceeds per-entry limit`() {
+        val header = "ok=v,big=" + "x".repeat(5000) + ",keep=g"
+        val baggage = extract(header)
+        assertEquals("v", baggage.getValue("ok"))
+        assertEquals("g", baggage.getValue("keep"))
+        assertNull(baggage.getValue("big"))
+        assertEquals(2, baggage.asMap().size)
+    }
+
+    @Test
+    fun `extract stops when total header would exceed 8192 bytes`() {
+        val header = (0 until 20).joinToString(",") { idx ->
+            "k$idx=" + "v".repeat(500)
+        }
+        assertTrue(header.length > 8192)
+        val baggage = extract(header)
+        assertNotNull(baggage.getValue("k0"))
+        assertNull(baggage.getValue("k19"))
+        assertTrue(baggage.asMap().size < 20)
+        assertTrue(extractedHeaderSize(baggage) <= 8192)
+    }
+
+    @Test
+    fun `extract accepts a header of exactly 8192 bytes`() {
+        val first = "a=" + "x".repeat(4094)
+        val second = "b=" + "y".repeat(4093)
+        val header = "$first,$second"
+        assertEquals(8192, header.length)
+        val baggage = extract(header)
+        assertEquals("x".repeat(4094), baggage.getValue("a"))
+        assertEquals("y".repeat(4093), baggage.getValue("b"))
+        assertEquals(2, baggage.asMap().size)
+    }
+
+    @Test
     fun `inject caps at 180 entries even when bytes remain`() {
         val baggage = (0 until 181).fold(BaggageImpl.EMPTY) { acc, idx ->
             acc.set("k$idx", "v")
@@ -304,6 +339,9 @@ internal class W3CBaggagePropagatorTest {
         )
         return ctx.extractBaggage()
     }
+
+    private fun extractedHeaderSize(baggage: Baggage): Int =
+        injectInto(baggage)["baggage"]?.length ?: 0
 
     private object MultiValueMapTextMapGetter : TextMapGetter<Map<String, List<String>>> {
         override fun keys(carrier: Map<String, List<String>>): Collection<String> = carrier.keys


### PR DESCRIPTION
## Goal
Apply the same W3C baggage size limits on extract as on inject (4096 bytes per list-member, 8192 bytes total) so decode cannot accept unbounded headers.

## Testing
Added W3CBaggagePropagatorTest cases for oversized members and headers over 8192 bytes. Ran :implementation:jvmTest for W3CBaggagePropagatorTest.

Fixes #853