### PR TITLE
fix: default stdout exporters to platformLog

### DIFF
--- a/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/CoreLogRecordExporterApi.kt
+++ b/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/CoreLogRecordExporterApi.kt
@@ -8,6 +8,7 @@ import io.opentelemetry.kotlin.error.reportError
 import io.opentelemetry.kotlin.export.BatchTelemetryDefaults
 import io.opentelemetry.kotlin.export.telemetryExceptionHandler
 import io.opentelemetry.kotlin.init.LogExportConfigDsl
+import io.opentelemetry.kotlin.platformLog
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -85,12 +86,12 @@ public fun LogExportConfigDsl.batchLogRecordProcessor(
 
 /**
  * Creates a log record exporter that outputs log records to stdout. The destination is configurable
- * via a parameter that defaults to [println].
+ * via a parameter that defaults to [platformLog].
  *
  * This exporter is intended for debugging and learning purposes. It is not recommended for
  * production use. The output format is not standardized and can change at any time.
  */
 @ExperimentalApi
 public fun LogExportConfigDsl.stdoutLogRecordExporter(
-    logger: (String) -> Unit = ::println
+    logger: (String) -> Unit = ::platformLog
 ): LogRecordExporter = StdoutLogRecordExporter(logger)

--- a/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/CoreSpanExporterApi.kt
+++ b/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/CoreSpanExporterApi.kt
@@ -7,6 +7,7 @@ import io.opentelemetry.kotlin.error.reportError
 import io.opentelemetry.kotlin.export.BatchTelemetryDefaults
 import io.opentelemetry.kotlin.export.telemetryExceptionHandler
 import io.opentelemetry.kotlin.init.TraceExportConfigDsl
+import io.opentelemetry.kotlin.platformLog
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -84,12 +85,12 @@ public fun TraceExportConfigDsl.batchSpanProcessor(
 
 /**
  * Creates a span exporter that outputs span data to stdout. The destination is configurable
- * via a parameter that defaults to [println].
+ * via a parameter that defaults to [platformLog].
  *
  * This exporter is intended for debugging and learning purposes. It is not recommended for
  * production use. The output format is not standardized and can change at any time.
  */
 @ExperimentalApi
 public fun TraceExportConfigDsl.stdoutSpanExporter(
-    logger: (String) -> Unit = ::println
+    logger: (String) -> Unit = ::platformLog
 ): SpanExporter = StdoutSpanExporter(logger)


### PR DESCRIPTION
## Goal
Default stdoutSpanExporter and stdoutLogRecordExporter to platformLog so debug stdout export uses the platform logger instead of println.

## Testing
Ran :exporters-core:jvmTest for StdoutSpanExporterTest and StdoutLogRecordExporterTest.

Fixes #860