### PR TITLE
fix: release span lock before processor.onEnd

### DIFF
--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/model/SpanModel.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/model/SpanModel.kt
@@ -116,20 +116,21 @@ internal class SpanModel(
     @Suppress("NOTHING_TO_INLINE")
     private inline fun endInternal(timestamp: Long) {
         sdkErrorHandler.guard("Span.end failed") {
-            lock.write {
-                if (state == State.STARTED) {
-                    state = State.ENDING
-                    endTimestampImpl = timestamp
-                    sdkErrorHandler.guard {
-                        processor?.onEnding(ReadWriteSpanImpl(this))
-                    }
-                    state = State.ENDED
-                    sdkErrorHandler.guard {
-                        // take a snapshot so that processors retain plain data rather than this
-                        // model, releasing its properties once the span
-                        // has ended. Only built if a processor needs it.
-                        processor?.takeIf(SpanProcessor::isEndRequired)?.onEnd(toSpanData())
-                    }
+            val snapshot = lock.write {
+                if (state != State.STARTED) return@write null
+                state = State.ENDING
+                endTimestampImpl = timestamp
+                sdkErrorHandler.guard {
+                    processor?.onEnding(ReadWriteSpanImpl(this))
+                }
+                state = State.ENDED
+                // Snapshot under the lock so processors retain plain data rather than this
+                // model. onEnd is invoked after release — the snapshot is immutable.
+                processor?.takeIf(SpanProcessor::isEndRequired)?.let { toSpanData() }
+            }
+            if (snapshot != null) {
+                sdkErrorHandler.guard {
+                    processor?.onEnd(snapshot)
                 }
             }
         }

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/model/SpanModel.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/model/SpanModel.kt
@@ -116,7 +116,7 @@ internal class SpanModel(
     @Suppress("NOTHING_TO_INLINE")
     private inline fun endInternal(timestamp: Long) {
         sdkErrorHandler.guard("Span.end failed") {
-            val snapshot = lock.write {
+            val toExport = lock.write {
                 if (state != State.STARTED) {
                     return@write null
                 }
@@ -129,11 +129,14 @@ internal class SpanModel(
                 // take a snapshot so that processors retain plain data rather than this
                 // model, releasing its properties once the span
                 // has ended. Only built if a processor needs it.
-                processor?.takeIf(SpanProcessor::isEndRequired)?.let { toSpanData() }
+                processor?.takeIf(SpanProcessor::isEndRequired)?.let { endProcessor ->
+                    endProcessor to toSpanData()
+                }
             }
-            if (snapshot != null) {
+            if (toExport != null) {
+                val (endProcessor, snapshot) = toExport
                 sdkErrorHandler.guard {
-                    processor?.onEnd(snapshot)
+                    endProcessor.onEnd(snapshot)
                 }
             }
         }

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/model/SpanModel.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/model/SpanModel.kt
@@ -117,15 +117,18 @@ internal class SpanModel(
     private inline fun endInternal(timestamp: Long) {
         sdkErrorHandler.guard("Span.end failed") {
             val snapshot = lock.write {
-                if (state != State.STARTED) return@write null
+                if (state != State.STARTED) {
+                    return@write null
+                }
                 state = State.ENDING
                 endTimestampImpl = timestamp
                 sdkErrorHandler.guard {
                     processor?.onEnding(ReadWriteSpanImpl(this))
                 }
                 state = State.ENDED
-                // Snapshot under the lock so processors retain plain data rather than this
-                // model. onEnd is invoked after release — the snapshot is immutable.
+                // take a snapshot so that processors retain plain data rather than this
+                // model, releasing its properties once the span
+                // has ended. Only built if a processor needs it.
                 processor?.takeIf(SpanProcessor::isEndRequired)?.let { toSpanData() }
             }
             if (snapshot != null) {


### PR DESCRIPTION
## Goal
Release SpanModel’s write lock before SpanProcessor.onEnd so export is not serialized behind span mutation. Keep onEnding under the lock so processors can still mutate the span.

## Testing
Ran :implementation:jvmTest for SpanEndTest, SpanProcessorErrorHandlingTest, SpanModelTest, and the SpanProcess* onEnd/onEnding tests.

Fixes #865