### PR TITLE
fix: ignore Unset when setting span status

### DIFF
--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/model/SpanModel.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/model/SpanModel.kt
@@ -93,6 +93,7 @@ internal class SpanModel(
     }
 
     override fun setStatus(status: StatusData) {
+        if (status is StatusData.Unset) return
         mutate("Span.setStatus failed") {
             if (statusImpl !is StatusData.Ok) {
                 statusImpl = status

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/model/SpanModel.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/model/SpanModel.kt
@@ -93,7 +93,9 @@ internal class SpanModel(
     }
 
     override fun setStatus(status: StatusData) {
-        if (status is StatusData.Unset) return
+        if (status is StatusData.Unset) {
+            return
+        }
         mutate("Span.setStatus failed") {
             if (statusImpl !is StatusData.Ok) {
                 statusImpl = status

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/SpanSimplePropertiesTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/SpanSimplePropertiesTest.kt
@@ -113,6 +113,17 @@ internal class SpanSimplePropertiesTest {
     }
 
     @Test
+    fun testSpanStatusErrorCanBeOverriddenByOk() {
+        val span = tracer.startSpan("test")
+        span.setStatus(StatusData.Error("Whoops"))
+        span.setStatus(StatusData.Ok)
+        assertEquals(StatusData.Ok, (span.toReadableSpan()).status)
+
+        span.setStatus(StatusData.Error("Whoops"))
+        assertEquals(StatusData.Ok, (span.toReadableSpan()).status)
+    }
+
+    @Test
     fun testSpanKind() {
         val span = tracer.startSpan("test")
         assertEquals(SpanKind.INTERNAL, (span.toReadableSpan()).spanKind)

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/SpanSimplePropertiesTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/SpanSimplePropertiesTest.kt
@@ -104,12 +104,12 @@ internal class SpanSimplePropertiesTest {
     }
 
     @Test
-    fun testSpanStatusErrorCanBeOverridden() {
+    fun testSpanStatusErrorCannotBeOverriddenByUnset() {
         val span = tracer.startSpan("test")
-        span.setStatus(StatusData.Error("Whoops"))
-        val unset = StatusData.Unset
-        span.setStatus(unset)
-        assertEquals(unset, (span.toReadableSpan()).status)
+        val error = StatusData.Error("Whoops")
+        span.setStatus(error)
+        span.setStatus(StatusData.Unset)
+        assertEquals(error, (span.toReadableSpan()).status)
     }
 
     @Test


### PR DESCRIPTION
## Goal
Ignore Span.setStatus(Unset) so Unset cannot overwrite Error, matching the spec (Ok > Error > Unset).

## Testing
Updated SpanSimplePropertiesTest so Error then Unset stays Error. Ran :implementation:jvmTest for SpanSimplePropertiesTest.

Fixes #857