### PR TITLE
metrics: add DoubleUpDownCounter API (#382)

### DIFF
--- a/api/api/jvm/api.api
+++ b/api/api/jvm/api.api
@@ -248,6 +248,14 @@ public final class io/opentelemetry/kotlin/metrics/DoubleHistogram$DefaultImpls 
 	public static synthetic fun record$default (Lio/opentelemetry/kotlin/metrics/DoubleHistogram;DLio/opentelemetry/kotlin/context/Context;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
 }
 
+public abstract interface class io/opentelemetry/kotlin/metrics/DoubleUpDownCounter : io/opentelemetry/kotlin/metrics/SynchronousInstrument {
+	public abstract fun add (DLkotlin/jvm/functions/Function1;)V
+}
+
+public final class io/opentelemetry/kotlin/metrics/DoubleUpDownCounter$DefaultImpls {
+	public static synthetic fun add$default (Lio/opentelemetry/kotlin/metrics/DoubleUpDownCounter;DLkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+}
+
 public abstract interface class io/opentelemetry/kotlin/metrics/Instrument {
 	public abstract fun getDescription ()Ljava/lang/String;
 	public abstract fun getName ()Ljava/lang/String;
@@ -263,6 +271,11 @@ public final class io/opentelemetry/kotlin/metrics/LongHistogram$DefaultImpls {
 }
 
 public abstract interface class io/opentelemetry/kotlin/metrics/Meter {
+	public abstract fun createDoubleUpDownCounter (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lio/opentelemetry/kotlin/metrics/DoubleUpDownCounter;
+}
+
+public final class io/opentelemetry/kotlin/metrics/Meter$DefaultImpls {
+	public static synthetic fun createDoubleUpDownCounter$default (Lio/opentelemetry/kotlin/metrics/Meter;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/opentelemetry/kotlin/metrics/DoubleUpDownCounter;
 }
 
 public abstract interface class io/opentelemetry/kotlin/metrics/MeterProvider {

--- a/api/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/DoubleUpDownCounter.kt
+++ b/api/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/DoubleUpDownCounter.kt
@@ -1,0 +1,28 @@
+package io.opentelemetry.kotlin.metrics
+
+import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.ThreadSafe
+import io.opentelemetry.kotlin.attributes.AttributesMutator
+
+/**
+ * A synchronous [Instrument] which supports increments and decrements.
+ *
+ * If the value is monotonically increasing, use a Counter instead.
+ *
+ * Example uses: the number of active requests, the number of items in a queue.
+ *
+ * https://opentelemetry.io/docs/specs/otel/metrics/api/#updowncounter
+ */
+@ExperimentalApi
+@ThreadSafe
+public interface DoubleUpDownCounter : SynchronousInstrument {
+
+    /**
+     * Increments or decrements this counter by [value], optionally associating [attributes]
+     * with the measurement.
+     *
+     * [value] may be positive, negative, or zero.
+     */
+    @ThreadSafe
+    public fun add(value: Double, attributes: AttributesMutator.() -> Unit = {})
+}

--- a/api/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/Meter.kt
+++ b/api/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/Meter.kt
@@ -15,4 +15,21 @@ import io.opentelemetry.kotlin.ThreadSafe
  */
 @ExperimentalApi
 @ThreadSafe
-public interface Meter
+public interface Meter {
+
+    /**
+     * Creates a [DoubleUpDownCounter] for recording signed floating-point increments and decrements.
+     *
+     * [name] is required and should conform to the
+     * [instrument name syntax](https://opentelemetry.io/docs/specs/otel/metrics/api/#instrument-name-syntax).
+     * [unit] and [description] are optional.
+     *
+     * https://opentelemetry.io/docs/specs/otel/metrics/api/#updowncounter-creation
+     */
+    @ThreadSafe
+    public fun createDoubleUpDownCounter(
+        name: String,
+        unit: String? = null,
+        description: String? = null,
+    ): DoubleUpDownCounter
+}

--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/metrics/DoubleUpDownCounterAdapter.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/metrics/DoubleUpDownCounterAdapter.kt
@@ -1,0 +1,22 @@
+package io.opentelemetry.kotlin.metrics
+
+import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.aliases.OtelJavaDoubleUpDownCounter
+import io.opentelemetry.kotlin.attributes.AttributesMutator
+import io.opentelemetry.kotlin.attributes.CompatAttributesModel
+
+@ExperimentalApi
+internal class DoubleUpDownCounterAdapter(
+    private val impl: OtelJavaDoubleUpDownCounter,
+    override val name: String,
+    override val unit: String?,
+    override val description: String?,
+) : DoubleUpDownCounter {
+    override fun enabled(): Boolean = impl.isEnabled()
+
+    override fun add(value: Double, attributes: AttributesMutator.() -> Unit) {
+        val container = CompatAttributesModel()
+        attributes(container)
+        impl.add(value, container.otelJavaAttributes())
+    }
+}

--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/metrics/MeterAdapter.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/metrics/MeterAdapter.kt
@@ -5,5 +5,16 @@ import io.opentelemetry.kotlin.aliases.OtelJavaMeter
 
 @ExperimentalApi
 internal class MeterAdapter(
-    @Suppress("UnusedPrivateProperty") private val impl: OtelJavaMeter,
-) : Meter
+    private val impl: OtelJavaMeter,
+) : Meter {
+    override fun createDoubleUpDownCounter(
+        name: String,
+        unit: String?,
+        description: String?,
+    ): DoubleUpDownCounter {
+        val builder = impl.upDownCounterBuilder(name).ofDoubles()
+        unit?.let(builder::setUnit)
+        description?.let(builder::setDescription)
+        return DoubleUpDownCounterAdapter(builder.build(), name, unit, description)
+    }
+}

--- a/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/metrics/MeterAdapterUpDownCounterTest.kt
+++ b/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/metrics/MeterAdapterUpDownCounterTest.kt
@@ -1,0 +1,30 @@
+package io.opentelemetry.kotlin.metrics
+
+import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.aliases.OtelJavaSdkMeterProvider
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalApi::class)
+internal class MeterAdapterUpDownCounterTest {
+
+    private val adapter = MeterProviderAdapter(OtelJavaSdkMeterProvider.builder().build())
+        .getMeter("test")
+
+    @Test
+    fun createDoubleUpDownCounterDelegatesAdd() {
+        val counter = adapter.createDoubleUpDownCounter(
+            name = "queue.depth",
+            unit = "{item}",
+            description = "queue size",
+        )
+        assertEquals("queue.depth", counter.name)
+        assertEquals("{item}", counter.unit)
+        assertEquals("queue size", counter.description)
+        counter.enabled()
+        counter.add(1.0)
+        counter.add(-1.0)
+        counter.add(0.0)
+        counter.add(2.5) { setStringAttribute("account.type", "residential") }
+    }
+}

--- a/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/metrics/MeterAdapterUpDownCounterTest.kt
+++ b/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/metrics/MeterAdapterUpDownCounterTest.kt
@@ -27,4 +27,13 @@ internal class MeterAdapterUpDownCounterTest {
         counter.add(0.0)
         counter.add(2.5) { setStringAttribute("account.type", "residential") }
     }
+
+    @Test
+    fun createDoubleUpDownCounterOmitsNullUnitAndDescription() {
+        val counter = adapter.createDoubleUpDownCounter("queue.depth")
+        assertEquals("queue.depth", counter.name)
+        assertEquals(null, counter.unit)
+        assertEquals(null, counter.description)
+        counter.add(1.0)
+    }
 }

--- a/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/metrics/OtelJavaMeterBuilderAdapterTest.kt
+++ b/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/metrics/OtelJavaMeterBuilderAdapterTest.kt
@@ -78,7 +78,7 @@ internal class OtelJavaMeterBuilderAdapterTest {
             capturedName = name
             capturedVersion = version
             capturedSchemaUrl = schemaUrl
-            return object : Meter {}
+            return FakeMeter(name)
         }
     }
 }

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/DoubleUpDownCounterImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/DoubleUpDownCounterImpl.kt
@@ -1,0 +1,12 @@
+package io.opentelemetry.kotlin.metrics
+
+import io.opentelemetry.kotlin.attributes.AttributesMutator
+
+internal class DoubleUpDownCounterImpl(
+    override val name: String,
+    override val unit: String?,
+    override val description: String?,
+) : DoubleUpDownCounter {
+    override fun enabled(): Boolean = true
+    override fun add(value: Double, attributes: AttributesMutator.() -> Unit) {}
+}

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/DoubleUpDownCounterImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/DoubleUpDownCounterImpl.kt
@@ -8,5 +8,5 @@ internal class DoubleUpDownCounterImpl(
     override val description: String?,
 ) : DoubleUpDownCounter {
     override fun enabled(): Boolean = true
-    override fun add(value: Double, attributes: AttributesMutator.() -> Unit) {}
+    override fun add(value: Double, attributes: AttributesMutator.() -> Unit) = Unit
 }

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/MeterImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/MeterImpl.kt
@@ -6,4 +6,10 @@ import io.opentelemetry.kotlin.resource.Resource
 internal class MeterImpl(
     val instrumentationScopeInfo: InstrumentationScopeInfo,
     val resource: Resource,
-) : Meter
+) : Meter {
+    override fun createDoubleUpDownCounter(
+        name: String,
+        unit: String?,
+        description: String?,
+    ): DoubleUpDownCounter = DoubleUpDownCounterImpl(name, unit, description)
+}

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/metrics/FakeUpDownCounterTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/metrics/FakeUpDownCounterTest.kt
@@ -1,0 +1,39 @@
+package io.opentelemetry.kotlin.metrics
+
+import io.opentelemetry.kotlin.ExperimentalApi
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalApi::class)
+internal class FakeUpDownCounterTest {
+
+    @Test
+    fun doubleAddRecordsValueAndAttributes() {
+        val meter = FakeMeter("test")
+        val counter = meter.createDoubleUpDownCounter(
+            name = "queue.depth",
+            unit = "{item}",
+            description = "queue size",
+        ) as FakeDoubleUpDownCounter
+
+        counter.add(1.5)
+        counter.add(-0.5) { setStringAttribute("material", "steel") }
+
+        assertEquals("queue.depth", counter.name)
+        assertEquals("{item}", counter.unit)
+        assertEquals("queue size", counter.description)
+        assertTrue(counter.enabled())
+        assertEquals(listOf(1.5 to emptyMap(), -0.5 to mapOf("material" to "steel")), counter.adds)
+        assertEquals(1, meter.doubleUpDownCounters.size)
+    }
+
+    @Test
+    fun enabledResultCanChange() {
+        val counter = FakeDoubleUpDownCounter("n")
+        assertTrue(counter.enabled())
+        counter.enabledResult = { false }
+        assertFalse(counter.enabled())
+    }
+}

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/metrics/UpDownCounterImplTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/metrics/UpDownCounterImplTest.kt
@@ -1,0 +1,57 @@
+package io.opentelemetry.kotlin.metrics
+
+import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.attributes.AttributesModel
+import io.opentelemetry.kotlin.error.NoopSdkErrorHandler
+import io.opentelemetry.kotlin.init.config.MetricsConfig
+import io.opentelemetry.kotlin.resource.ResourceImpl
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalApi::class)
+internal class UpDownCounterImplTest {
+
+    private lateinit var meter: Meter
+
+    @BeforeTest
+    fun setup() {
+        meter = MeterProviderImpl(
+            MetricsConfig(
+                resource = ResourceImpl(AttributesModel(), null),
+                sdkErrorHandler = NoopSdkErrorHandler,
+            )
+        ).getMeter("test")
+    }
+
+    @Test
+    fun createDoubleUpDownCounterExposesIdentity() {
+        val counter = meter.createDoubleUpDownCounter(
+            name = "queue.depth",
+            unit = "{item}",
+            description = "queue size",
+        )
+        assertEquals("queue.depth", counter.name)
+        assertEquals("{item}", counter.unit)
+        assertEquals("queue size", counter.description)
+        assertTrue(counter.enabled())
+    }
+
+    @Test
+    fun doubleAddAcceptsPositiveNegativeAndZero() {
+        val counter = meter.createDoubleUpDownCounter("grocery.customers")
+        counter.add(1.5)
+        counter.add(-1.5)
+        counter.add(0.0)
+        counter.add(2.0) { setStringAttribute("account.type", "residential") }
+    }
+
+    @Test
+    fun createUsesNullUnitAndDescriptionByDefault() {
+        val counter = meter.createDoubleUpDownCounter("grocery.customers")
+        assertEquals("grocery.customers", counter.name)
+        assertEquals(null, counter.unit)
+        assertEquals(null, counter.description)
+    }
+}

--- a/java-typealiases/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/aliases/Aliases.kt
+++ b/java-typealiases/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/aliases/Aliases.kt
@@ -16,6 +16,7 @@ import io.opentelemetry.api.logs.Logger
 import io.opentelemetry.api.logs.LoggerBuilder
 import io.opentelemetry.api.logs.LoggerProvider
 import io.opentelemetry.api.logs.Severity
+import io.opentelemetry.api.metrics.DoubleUpDownCounter
 import io.opentelemetry.api.metrics.Meter
 import io.opentelemetry.api.metrics.MeterBuilder
 import io.opentelemetry.api.metrics.MeterProvider
@@ -134,6 +135,7 @@ typealias OtelJavaScopeConfigurator<T> = ScopeConfigurator<T>
 typealias OtelJavaMeterProvider = MeterProvider
 typealias OtelJavaMeterBuilder = MeterBuilder
 typealias OtelJavaMeter = Meter
+typealias OtelJavaDoubleUpDownCounter = DoubleUpDownCounter
 typealias OtelJavaObservableMeasurement = ObservableMeasurement
 typealias OtelJavaObservableLongMeasurement = ObservableLongMeasurement
 typealias OtelJavaObservableDoubleMeasurement = ObservableDoubleMeasurement

--- a/noop/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/NoopDoubleUpDownCounter.kt
+++ b/noop/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/NoopDoubleUpDownCounter.kt
@@ -1,0 +1,17 @@
+package io.opentelemetry.kotlin.metrics
+
+import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.attributes.AttributesMutator
+
+/**
+ * No-op implementation of [DoubleUpDownCounter].
+ */
+@ExperimentalApi
+internal class NoopDoubleUpDownCounter(
+    override val name: String,
+    override val unit: String?,
+    override val description: String?,
+) : DoubleUpDownCounter {
+    override fun enabled(): Boolean = false
+    override fun add(value: Double, attributes: AttributesMutator.() -> Unit) {}
+}

--- a/noop/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/NoopDoubleUpDownCounter.kt
+++ b/noop/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/NoopDoubleUpDownCounter.kt
@@ -13,5 +13,5 @@ internal class NoopDoubleUpDownCounter(
     override val description: String?,
 ) : DoubleUpDownCounter {
     override fun enabled(): Boolean = false
-    override fun add(value: Double, attributes: AttributesMutator.() -> Unit) {}
+    override fun add(value: Double, attributes: AttributesMutator.() -> Unit) = Unit
 }

--- a/noop/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/NoopMeter.kt
+++ b/noop/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/NoopMeter.kt
@@ -8,4 +8,10 @@ import io.opentelemetry.kotlin.ExperimentalApi
  * This implementation should induce as close to zero overhead as possible.
  */
 @ExperimentalApi
-internal object NoopMeter : Meter
+internal object NoopMeter : Meter {
+    override fun createDoubleUpDownCounter(
+        name: String,
+        unit: String?,
+        description: String?,
+    ): DoubleUpDownCounter = NoopDoubleUpDownCounter(name, unit, description)
+}

--- a/noop/src/commonTest/kotlin/io/opentelemetry/kotlin/NoopTests.kt
+++ b/noop/src/commonTest/kotlin/io/opentelemetry/kotlin/NoopTests.kt
@@ -284,6 +284,23 @@ internal class NoopTests {
         assertSame(emptySet(), NoopConfigProperties.propertyKeys)
     }
 
+    @OptIn(ExperimentalApi::class)
+    @Test
+    fun testNoopMetrics() {
+        val counter = NoopOpenTelemetry.meterProvider.getMeter("test-meter")
+            .createDoubleUpDownCounter(
+                name = "queue.depth",
+                unit = "{item}",
+                description = "queue size",
+            )
+        assertEquals("queue.depth", counter.name)
+        assertEquals("{item}", counter.unit)
+        assertEquals("queue size", counter.description)
+        assertFalse(counter.enabled())
+        counter.add(1.0)
+        counter.add(-1.0) { setStringAttribute("account.type", "commercial") }
+    }
+
     private fun verifySpanOperationsAreNoop(span: NoopSpan) {
         // Test primitive attributes
         span.setStringAttribute("key", "value")

--- a/test-fakes/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/FakeDoubleUpDownCounter.kt
+++ b/test-fakes/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/FakeDoubleUpDownCounter.kt
@@ -1,0 +1,20 @@
+package io.opentelemetry.kotlin.metrics
+
+import io.opentelemetry.kotlin.attributes.AttributesMutator
+import io.opentelemetry.kotlin.attributes.FakeAttributesMutator
+
+class FakeDoubleUpDownCounter(
+    override val name: String,
+    override val unit: String? = null,
+    override val description: String? = null,
+    var enabledResult: () -> Boolean = { true },
+) : DoubleUpDownCounter {
+
+    val adds: MutableList<Pair<Double, Map<String, Any>>> = mutableListOf()
+
+    override fun enabled(): Boolean = enabledResult()
+
+    override fun add(value: Double, attributes: AttributesMutator.() -> Unit) {
+        adds.add(value to FakeAttributesMutator().apply(attributes).attributes)
+    }
+}

--- a/test-fakes/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/FakeMeter.kt
+++ b/test-fakes/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/FakeMeter.kt
@@ -2,4 +2,15 @@ package io.opentelemetry.kotlin.metrics
 
 class FakeMeter(
     val name: String
-) : Meter
+) : Meter {
+
+    val doubleUpDownCounters: MutableList<FakeDoubleUpDownCounter> = mutableListOf()
+
+    override fun createDoubleUpDownCounter(
+        name: String,
+        unit: String?,
+        description: String?,
+    ): DoubleUpDownCounter = FakeDoubleUpDownCounter(name, unit, description).also {
+        doubleUpDownCounters.add(it)
+    }
+}


### PR DESCRIPTION
## Goal

Add the synchronous `DoubleUpDownCounter` API from the [metrics spec](https://opentelemetry.io/docs/specs/otel/metrics/api/#updowncounter). Partially addresses https://github.com/open-telemetry/opentelemetry-kotlin/issues/382.

## Testing

- Unit tests cover instrument identity (`name` / `unit` / `description`), `enabled()`, and that `add` accepts signed values with and without attributes
- Fakes record `add` calls; the dummy impl does not aggregate
- Compat tests cover Java SDK → Kotlin `DoubleUpDownCounter` wiring