### PR TITLE
fix: remove LoggerImpl contextFactory shadowing

### DIFF
--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/LoggerImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/LoggerImpl.kt
@@ -21,7 +21,7 @@ import io.opentelemetry.kotlin.tracing.SpanContext
 internal class LoggerImpl(
     private val clock: Clock,
     private val processor: LogRecordProcessor?,
-    contextFactory: ContextFactory,
+    private val contextFactory: ContextFactory,
     spanContextFactory: SpanContextFactory,
     private val key: InstrumentationScopeInfo,
     private val resource: Resource,
@@ -31,7 +31,6 @@ internal class LoggerImpl(
     private val sdkErrorHandler: SdkErrorHandler,
 ) : Logger {
 
-    private val contextFactory = contextFactory
     private val root = contextFactory.root()
     private val invalidSpanContext = spanContextFactory.invalid
 


### PR DESCRIPTION
## Goal

`LoggerImpl` copied the `contextFactory` constructor parameter into a property of the same name (`private val contextFactory = contextFactory`). That extra assignment is unnecessary and shadows the parameter.

This change declares the constructor parameter as `private val contextFactory: ContextFactory` and removes the redundant class-body property. `private val root = contextFactory.root()` is unchanged.

There is no intended behavior or public API change.

Fixes #861.

## Testing

```text
./gradlew :implementation:jvmTest
# BUILD SUCCESSFUL
# 813 tests, 0 failures, 0 errors, 0 skipped

./gradlew :implementation:detektMetadataCommonMain
# BUILD SUCCESSFUL

git diff --check
# no whitespace errors
```

`compileKotlinJvm` succeeded with `allWarningsAsErrors`, so the previous name-shadowing warning is gone.

Android instrumentation tests and iOS simulator tests were not run here: this environment has no Android SDK and is Linux, so those targets cannot execute locally. The full `./gradlew build` was not attempted for the same reason.