### PR TITLE
[FIX] : close http client on telemetry exporter shutdown + hard limits enforcement 

### DIFF
--- a/exporters-otlp/src/commonMain/kotlin/io/opentelemetry/kotlin/export/OtlpClient.kt
+++ b/exporters-otlp/src/commonMain/kotlin/io/opentelemetry/kotlin/export/OtlpClient.kt
@@ -96,6 +96,10 @@ internal class OtlpClient(
         return header.toLongOrNull()?.takeIf { it >= 0 }?.let { it * 1000L }
     }
 
+    internal fun close() {
+        httpClient.close()
+    }
+
     private companion object {
         const val MAX_ERROR_BODY_BYTES: Long = 4 * 1024 * 1024
     }

--- a/exporters-otlp/src/commonMain/kotlin/io/opentelemetry/kotlin/export/TelemetryExporter.kt
+++ b/exporters-otlp/src/commonMain/kotlin/io/opentelemetry/kotlin/export/TelemetryExporter.kt
@@ -9,9 +9,12 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlin.coroutines.CoroutineContext
+import kotlin.math.min
 import kotlin.random.Random
 
 private const val SHUTDOWN_TIMEOUT_MS = 5000L
+private const val MAX_RETRY_AFTER_MS = 60_000L
+private const val MAX_ATTEMPTS = 4
 
 internal class TelemetryExporter<T>(
     private val initialDelayMs: Long,
@@ -21,11 +24,17 @@ internal class TelemetryExporter<T>(
     coroutineContext: CoroutineContext = Dispatchers.Default,
     private val random: Random = Random.Default,
     private val exportAction: suspend (telemetry: List<T>) -> OtlpResponse,
+    private val shutdownAction: suspend () -> Unit,
 ) : TelemetryCloseable {
 
     private val shutdownState: MutableShutdownState = MutableShutdownState()
     private val scope: CoroutineScope =
-        CoroutineScope(SupervisorJob() + coroutineContext + telemetryExceptionHandler("OTLP exporter", sdkErrorHandler))
+        CoroutineScope(
+            SupervisorJob() + coroutineContext + telemetryExceptionHandler(
+                "OTLP exporter",
+                sdkErrorHandler
+            )
+        )
 
     /**
      * Exports telemetry via coroutines and uses exponential backoff when a failure
@@ -43,7 +52,9 @@ internal class TelemetryExporter<T>(
 
     private suspend fun exportTelemetry(telemetry: List<T>) {
         var delayMs = initialDelayMs
-        repeat(maxAttempts) {
+        val effectiveMaxAttemptsIntervalMs = min(maxAttemptIntervalMs, MAX_RETRY_AFTER_MS)
+        val effectiveMaxAttempts = min(maxAttempts, MAX_ATTEMPTS)
+        repeat(effectiveMaxAttempts) {
             when (val response = exportAction(telemetry)) {
                 is OtlpResponse.Success -> {
                     return
@@ -60,13 +71,17 @@ internal class TelemetryExporter<T>(
                 }
 
                 is OtlpResponse.RetryableError -> {
-                    delay(response.retryAfterMs ?: jittered(delayMs))
-                    delayMs = (delayMs * 2).coerceAtMost(maxAttemptIntervalMs)
+                    delay(
+                        (response.retryAfterMs ?: jittered(delayMs)).coerceAtMost(
+                            effectiveMaxAttemptsIntervalMs
+                        )
+                    )
+                    delayMs = (delayMs * 2).coerceAtMost(effectiveMaxAttemptsIntervalMs)
                 }
 
                 is OtlpResponse.ServerError, is OtlpResponse.Unknown -> {
                     delay(jittered(delayMs))
-                    delayMs = (delayMs * 2).coerceAtMost(maxAttemptIntervalMs)
+                    delayMs = (delayMs * 2).coerceAtMost(effectiveMaxAttemptsIntervalMs)
                 }
             }
         }
@@ -87,6 +102,7 @@ internal class TelemetryExporter<T>(
     override suspend fun shutdown(): OperationResultCode =
         shutdownState.shutdown(SHUTDOWN_TIMEOUT_MS) {
             scope.cancel()
+            shutdownAction()
             Success
         }
 }

--- a/exporters-otlp/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/OtlpHttpLogRecordExporter.kt
+++ b/exporters-otlp/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/OtlpHttpLogRecordExporter.kt
@@ -1,6 +1,5 @@
 package io.opentelemetry.kotlin.logging.export
 
-
 import io.opentelemetry.kotlin.error.SdkErrorHandler
 import io.opentelemetry.kotlin.export.OperationResultCode
 import io.opentelemetry.kotlin.export.OtlpClient
@@ -25,7 +24,8 @@ internal class OtlpHttpLogRecordExporter(
         },
         shutdownAction = {
             otlpClient.close()
-        })
+        }
+    )
 
     override suspend fun export(telemetry: List<LogRecordData>): OperationResultCode {
         return exporter.export(telemetry)

--- a/exporters-otlp/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/OtlpHttpLogRecordExporter.kt
+++ b/exporters-otlp/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/OtlpHttpLogRecordExporter.kt
@@ -1,5 +1,6 @@
 package io.opentelemetry.kotlin.logging.export
 
+
 import io.opentelemetry.kotlin.error.SdkErrorHandler
 import io.opentelemetry.kotlin.export.OperationResultCode
 import io.opentelemetry.kotlin.export.OtlpClient
@@ -19,9 +20,12 @@ internal class OtlpHttpLogRecordExporter(
         maxAttemptIntervalMs,
         maxAttempts,
         sdkErrorHandler,
-    ) {
-        otlpClient.exportLogs(it)
-    }
+        exportAction = {
+            otlpClient.exportLogs(it)
+        },
+        shutdownAction = {
+            otlpClient.close()
+        })
 
     override suspend fun export(telemetry: List<LogRecordData>): OperationResultCode {
         return exporter.export(telemetry)

--- a/exporters-otlp/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/OtlpHttpSpanExporter.kt
+++ b/exporters-otlp/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/OtlpHttpSpanExporter.kt
@@ -19,9 +19,13 @@ internal class OtlpHttpSpanExporter(
         maxAttemptIntervalMs,
         maxAttempts,
         sdkErrorHandler,
-    ) {
-        otlpClient.exportTraces(it)
-    }
+        exportAction = {
+            otlpClient.exportTraces(it)
+        },
+        shutdownAction = {
+            otlpClient.close()
+        }
+    )
 
     override suspend fun export(telemetry: List<SpanData>): OperationResultCode {
         return exporter.export(telemetry)

--- a/exporters-otlp/src/commonTest/kotlin/io/opentelemetry/kotlin/export/TelemetryExporterTest.kt
+++ b/exporters-otlp/src/commonTest/kotlin/io/opentelemetry/kotlin/export/TelemetryExporterTest.kt
@@ -16,15 +16,18 @@ import kotlin.test.assertTrue
 internal class TelemetryExporterTest {
 
     private lateinit var exporter: TelemetryExporter<String>
+    private var shutdownActionCalls = 0
 
     @BeforeTest
     fun setup() {
+        shutdownActionCalls = 0
         exporter = TelemetryExporter(
             initialDelayMs = 100,
             maxAttemptIntervalMs = 1000,
             maxAttempts = 3,
             sdkErrorHandler = NoopSdkErrorHandler,
             exportAction = { OtlpResponse.Success },
+            shutdownAction = { shutdownActionCalls++ },
         )
     }
 
@@ -38,6 +41,12 @@ internal class TelemetryExporterTest {
     fun testShutdownReturnsSuccessOnSecondCall() = runTest {
         assertEquals(OperationResultCode.Success, exporter.shutdown())
         assertEquals(OperationResultCode.Success, exporter.shutdown())
+    }
+
+    @Test
+    fun testShutdownInvokesShutdownAction() = runTest {
+        assertEquals(OperationResultCode.Success, exporter.shutdown())
+        assertEquals(1, shutdownActionCalls)
     }
 
     @Test
@@ -60,10 +69,12 @@ internal class TelemetryExporterTest {
             maxAttempts = 3,
             sdkErrorHandler = NoopSdkErrorHandler,
             coroutineContext = StandardTestDispatcher(testScheduler),
-        ) {
-            attempts++
-            OtlpResponse.ClientError(400, null)
-        }
+            exportAction = {
+                attempts++
+                OtlpResponse.ClientError(400, null)
+            },
+            shutdownAction = {},
+        )
         exporter.export(listOf("data"))
         advanceUntilIdle()
         assertEquals(1, attempts)
@@ -78,10 +89,12 @@ internal class TelemetryExporterTest {
             maxAttempts = 3,
             sdkErrorHandler = NoopSdkErrorHandler,
             coroutineContext = StandardTestDispatcher(testScheduler),
-        ) {
-            attempts++
-            OtlpResponse.Success
-        }
+            exportAction = {
+                attempts++
+                OtlpResponse.Success
+            },
+            shutdownAction = {},
+        )
         exporter.export(listOf("data"))
         advanceUntilIdle()
         assertEquals(1, attempts)
@@ -100,10 +113,12 @@ internal class TelemetryExporterTest {
             sdkErrorHandler = NoopSdkErrorHandler,
             coroutineContext = StandardTestDispatcher(testScheduler),
             random = Random(0),
-        ) {
-            timestamps += testScheduler.currentTime
-            OtlpResponse.RetryableError(503, retryAfterMs = null, errorMessage = null)
-        }
+            exportAction = {
+                timestamps += testScheduler.currentTime
+                OtlpResponse.RetryableError(503, retryAfterMs = null, errorMessage = null)
+            },
+            shutdownAction = {},
+        )
         exporter.export(listOf("data"))
         advanceUntilIdle()
 
@@ -132,14 +147,16 @@ internal class TelemetryExporterTest {
             coroutineContext = StandardTestDispatcher(testScheduler),
             random = Random(0),
             sdkErrorHandler = NoopSdkErrorHandler,
-        ) {
-            timestamps += testScheduler.currentTime
-            if (attempts++ == 0) {
-                OtlpResponse.RetryableError(429, retryAfterMs = retryAfterMs, errorMessage = null)
-            } else {
-                OtlpResponse.Success
-            }
-        }
+            exportAction = {
+                timestamps += testScheduler.currentTime
+                if (attempts++ == 0) {
+                    OtlpResponse.RetryableError(429, retryAfterMs = retryAfterMs, errorMessage = null)
+                } else {
+                    OtlpResponse.Success
+                }
+            },
+            shutdownAction = {},
+        )
         exporter.export(listOf("data"))
         advanceUntilIdle()
 
@@ -154,6 +171,7 @@ internal class TelemetryExporterTest {
             maxAttempts = 1,
             sdkErrorHandler = NoopSdkErrorHandler,
             exportAction = { error("network unreachable") },
+            shutdownAction = {},
         )
         // The failure occurs on a background coroutine whose scope has a CoroutineExceptionHandler,
         // so it must not propagate to the caller nor crash the process.

--- a/exporters-otlp/src/commonTest/kotlin/io/opentelemetry/kotlin/export/TelemetryExporterTest.kt
+++ b/exporters-otlp/src/commonTest/kotlin/io/opentelemetry/kotlin/export/TelemetryExporterTest.kt
@@ -142,7 +142,7 @@ internal class TelemetryExporterTest {
         var attempts = 0
         val exporter = TelemetryExporter<String>(
             initialDelayMs = 100,
-            maxAttemptIntervalMs = 1000,
+            maxAttemptIntervalMs = 5000,
             maxAttempts = 3,
             coroutineContext = StandardTestDispatcher(testScheduler),
             random = Random(0),

--- a/exporters-otlp/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/export/OtlpHttpSpanExporterTest.kt
+++ b/exporters-otlp/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/export/OtlpHttpSpanExporterTest.kt
@@ -12,10 +12,13 @@ import io.ktor.util.toMap
 import io.ktor.utils.io.ByteReadChannel
 import io.opentelemetry.kotlin.Clock
 import io.opentelemetry.kotlin.clock.FakeClock
+import io.opentelemetry.kotlin.error.FakeSdkErrorHandler
 import io.opentelemetry.kotlin.error.NoopSdkErrorHandler
 import io.opentelemetry.kotlin.export.HttpClientRegistry
 import io.opentelemetry.kotlin.export.OperationResultCode
 import io.opentelemetry.kotlin.export.OtlpClient
+import io.opentelemetry.kotlin.export.OtlpResponse
+import io.opentelemetry.kotlin.export.TelemetryExporter
 import io.opentelemetry.kotlin.export.createDefaultHttpClient
 import io.opentelemetry.kotlin.export.createHttpEngine
 import io.opentelemetry.kotlin.init.TraceExportConfigDsl
@@ -131,7 +134,8 @@ internal class OtlpHttpSpanExporterTest {
                 delay(1L)
             }
         }
-        val headers = customServer.requestHistory.single().headers.toMap().mapValues { it.value.joinToString() }
+        val headers = customServer.requestHistory.single().headers.toMap()
+            .mapValues { it.value.joinToString() }
         assertEquals("Bearer test-token", headers["Authorization"])
     }
 
@@ -169,6 +173,29 @@ internal class OtlpHttpSpanExporterTest {
 
         assertTrue(clients.all { it === clients.first() })
         HttpClientRegistry.clear()
+    }
+
+    @Test
+    fun testShutdownOtlpClient() = runTest {
+        var shutdownCount = 0
+
+        val exporter = TelemetryExporter<SpanData>(
+            initialDelayMs = 1L,
+            maxAttemptIntervalMs = 100L,
+            maxAttempts = 5,
+            sdkErrorHandler = FakeSdkErrorHandler(),
+            exportAction = {
+                OtlpResponse.Success
+            },
+            shutdownAction = {
+                shutdownCount++
+            },
+        )
+
+        exporter.shutdown()
+        exporter.shutdown()
+
+        assertEquals(1, shutdownCount)
     }
 
     private suspend fun waitForExportedTelemetry(


### PR DESCRIPTION
## Goal

Add a separate suspend function inside of telemetry exporter to have `httpClient` closed . Added hard limits for `MAX_ATTEMPTS` and `MAX_RETRY_AFTER_MS` to prevent memory overload - when retrying. Addresses issue : #784 

## Testing

Test functions added to test `shutdownAction` in `TelemetryExporter.kt` and `OtlpHttpSpanExporterTest.kt`
