### PR TITLE
Remove unnecessary composite processor locks

### DIFF
--- a/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/CompositeLogRecordProcessor.kt
+++ b/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/CompositeLogRecordProcessor.kt
@@ -1,7 +1,6 @@
 package io.opentelemetry.kotlin.logging.export
 
 import io.opentelemetry.kotlin.InstrumentationScopeInfo
-import io.opentelemetry.kotlin.ReentrantReadWriteLock
 import io.opentelemetry.kotlin.context.Context
 import io.opentelemetry.kotlin.error.SdkErrorHandler
 import io.opentelemetry.kotlin.export.CompositeTelemetryCloseable
@@ -20,17 +19,13 @@ internal class CompositeLogRecordProcessor(
     ),
 ) : LogRecordProcessor, TelemetryCloseable by telemetryCloseable {
 
-    private val lock = ReentrantReadWriteLock()
-
     override fun onEmit(log: ReadWriteLogRecord, context: Context) {
-        lock.write {
-            batchExportOperation(
-                processors,
-                sdkErrorHandler
-            ) {
-                it.onEmit(log, context)
-                OperationResultCode.Success
-            }
+        batchExportOperation(
+            processors,
+            sdkErrorHandler
+        ) {
+            it.onEmit(log, context)
+            OperationResultCode.Success
         }
     }
 
@@ -41,8 +36,6 @@ internal class CompositeLogRecordProcessor(
         eventName: String?,
     ): Boolean {
         // returns true if _any_ of the processors are enabled.
-        return lock.read {
-            processors.any { it.enabled(context, instrumentationScopeInfo, severityNumber, eventName) }
-        }
+        return processors.any { it.enabled(context, instrumentationScopeInfo, severityNumber, eventName) }
     }
 }

--- a/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/CompositeSpanProcessor.kt
+++ b/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/CompositeSpanProcessor.kt
@@ -1,6 +1,5 @@
 package io.opentelemetry.kotlin.tracing.export
 
-import io.opentelemetry.kotlin.ReentrantReadWriteLock
 import io.opentelemetry.kotlin.context.Context
 import io.opentelemetry.kotlin.error.SdkErrorHandler
 import io.opentelemetry.kotlin.export.CompositeTelemetryCloseable
@@ -19,50 +18,42 @@ internal class CompositeSpanProcessor(
     ),
 ) : SpanProcessor, TelemetryCloseable by telemetryCloseable {
 
-    private val lock = ReentrantReadWriteLock()
-
     override fun onStart(
         span: ReadWriteSpan,
         parentContext: Context
     ) {
-        lock.write {
-            batchExportOperation(
-                processors,
-                sdkErrorHandler
-            ) {
-                if (it.isStartRequired()) {
-                    it.onStart(span, parentContext)
-                }
-                OperationResultCode.Success
+        batchExportOperation(
+            processors,
+            sdkErrorHandler
+        ) {
+            if (it.isStartRequired()) {
+                it.onStart(span, parentContext)
             }
+            OperationResultCode.Success
         }
     }
 
     override fun onEnding(span: ReadWriteSpan) {
-        lock.write {
-            batchExportOperation(
-                processors,
-                sdkErrorHandler
-            ) {
-                if (it.isEndRequired()) {
-                    it.onEnding(span)
-                }
-                OperationResultCode.Success
+        batchExportOperation(
+            processors,
+            sdkErrorHandler
+        ) {
+            if (it.isEndRequired()) {
+                it.onEnding(span)
             }
+            OperationResultCode.Success
         }
     }
 
     override fun onEnd(span: ReadableSpan) {
-        lock.write {
-            batchExportOperation(
-                processors,
-                sdkErrorHandler
-            ) {
-                if (it.isEndRequired()) {
-                    it.onEnd(span)
-                }
-                OperationResultCode.Success
+        batchExportOperation(
+            processors,
+            sdkErrorHandler
+        ) {
+            if (it.isEndRequired()) {
+                it.onEnd(span)
             }
+            OperationResultCode.Success
         }
     }
 


### PR DESCRIPTION
## Goal

Fixes #867 by removing the read/write locks from the composite span and log record processors. Processor implementations are already required to be thread safe, so serializing every composite callback is unnecessary and prevents independent telemetry calls from running concurrently.

The processor iteration and error-handling behavior are unchanged.

## Testing

- `./gradlew :exporters-core:jvmTest --no-configuration-cache -Porg.gradle.java.installations.paths=<JDK_11_HOME>`
- `./gradlew :exporters-core:detektMetadataCommonMain --no-configuration-cache -Porg.gradle.java.installations.paths=<JDK_11_HOME>`
