### PR TITLE
fix: stop swallowing coroutine CancellationException

### DIFF
--- a/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/export/BatchTelemetryProcessor.kt
+++ b/exporters-core/src/commonMain/kotlin/io/opentelemetry/kotlin/export/BatchTelemetryProcessor.kt
@@ -1,5 +1,6 @@
 package io.opentelemetry.kotlin.export
 
+import io.opentelemetry.kotlin.error.guardOrDefaultSuspend
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -9,7 +10,6 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
-import kotlinx.coroutines.withTimeout
 
 internal class BatchTelemetryProcessor<T>(
     private val config: BatchTelemetryConfig,
@@ -69,12 +69,11 @@ internal class BatchTelemetryProcessor<T>(
                 return
             }
 
-            try {
-                withTimeout(config.exportTimeoutMs) {
-                    exportAction(batch)
-                }
-            } catch (ignored: Throwable) {
-                // drop, continue as normal.
+            config.sdkErrorHandler.guardOrDefaultSuspend(
+                OperationResultCode.Failure,
+                "Batch export failed",
+            ) {
+                runWithTimeout(config.exportTimeoutMs) { exportAction(batch) }
             }
         }
     }

--- a/exporters-persistence/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/PersistingLogRecordProcessor.kt
+++ b/exporters-persistence/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/PersistingLogRecordProcessor.kt
@@ -4,6 +4,7 @@ import io.opentelemetry.kotlin.InstrumentationScopeInfo
 import io.opentelemetry.kotlin.context.Context
 import io.opentelemetry.kotlin.error.SdkErrorHandler
 import io.opentelemetry.kotlin.error.guard
+import io.opentelemetry.kotlin.error.guardOrDefaultSuspend
 import io.opentelemetry.kotlin.export.MutableShutdownState
 import io.opentelemetry.kotlin.export.OperationResultCode
 import io.opentelemetry.kotlin.export.OperationResultCode.Failure
@@ -14,6 +15,7 @@ import io.opentelemetry.kotlin.export.TelemetryCloseable
 import io.opentelemetry.kotlin.export.TelemetryFileSystem
 import io.opentelemetry.kotlin.export.TelemetryRepositoryImpl
 import io.opentelemetry.kotlin.export.TimeoutTelemetryCloseable
+import io.opentelemetry.kotlin.export.runWithTimeout
 import io.opentelemetry.kotlin.export.telemetryExceptionHandler
 import io.opentelemetry.kotlin.init.LogExportConfigDsl
 import io.opentelemetry.kotlin.logging.SeverityNumber
@@ -28,7 +30,6 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
-import kotlinx.coroutines.withTimeout
 
 /**
  * Creates a processor that persists telemetry before exporting it. This effectively glues
@@ -138,10 +139,11 @@ internal class PersistingLogRecordProcessor(
                     repository.delete(record)
                     return@forEach
                 }
-                val result = try {
-                    withTimeout(exportTimeoutMs) { exporter.export(telemetry) }
-                } catch (e: Throwable) {
-                    Failure
+                val result = sdkErrorHandler.guardOrDefaultSuspend(
+                    Failure,
+                    "Persisted export failed",
+                ) {
+                    runWithTimeout(exportTimeoutMs) { exporter.export(telemetry) }
                 }
                 if (result == Success) {
                     repository.delete(record)

--- a/exporters-persistence/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/PersistingSpanProcessor.kt
+++ b/exporters-persistence/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/PersistingSpanProcessor.kt
@@ -3,6 +3,7 @@ package io.opentelemetry.kotlin.tracing.export
 import io.opentelemetry.kotlin.context.Context
 import io.opentelemetry.kotlin.error.SdkErrorHandler
 import io.opentelemetry.kotlin.error.guard
+import io.opentelemetry.kotlin.error.guardOrDefaultSuspend
 import io.opentelemetry.kotlin.export.MutableShutdownState
 import io.opentelemetry.kotlin.export.OperationResultCode
 import io.opentelemetry.kotlin.export.OperationResultCode.Failure
@@ -13,6 +14,7 @@ import io.opentelemetry.kotlin.export.TelemetryCloseable
 import io.opentelemetry.kotlin.export.TelemetryFileSystem
 import io.opentelemetry.kotlin.export.TelemetryRepositoryImpl
 import io.opentelemetry.kotlin.export.TimeoutTelemetryCloseable
+import io.opentelemetry.kotlin.export.runWithTimeout
 import io.opentelemetry.kotlin.export.telemetryExceptionHandler
 import io.opentelemetry.kotlin.init.TraceExportConfigDsl
 import io.opentelemetry.kotlin.tracing.data.SpanData
@@ -27,7 +29,6 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
-import kotlinx.coroutines.withTimeout
 
 /**
  * Creates a processor that persists telemetry before exporting it. This effectively glues
@@ -143,10 +144,11 @@ internal class PersistingSpanProcessor(
                     repository.delete(record)
                     return@forEach
                 }
-                val result = try {
-                    withTimeout(exportTimeoutMs) { exporter.export(telemetry) }
-                } catch (e: Throwable) {
-                    Failure
+                val result = sdkErrorHandler.guardOrDefaultSuspend(
+                    Failure,
+                    "Persisted export failed",
+                ) {
+                    runWithTimeout(exportTimeoutMs) { exporter.export(telemetry) }
                 }
                 if (result == Success) {
                     repository.delete(record)

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/OpenTelemetryImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/OpenTelemetryImpl.kt
@@ -5,6 +5,7 @@ import io.opentelemetry.kotlin.export.OperationResultCode
 import io.opentelemetry.kotlin.export.OperationResultCode.Failure
 import io.opentelemetry.kotlin.export.OperationResultCode.Success
 import io.opentelemetry.kotlin.export.TelemetryCloseable
+import io.opentelemetry.kotlin.export.runWithTimeout
 import io.opentelemetry.kotlin.factory.BaggageFactory
 import io.opentelemetry.kotlin.factory.ContextFactory
 import io.opentelemetry.kotlin.factory.IdGenerator
@@ -17,7 +18,6 @@ import io.opentelemetry.kotlin.logging.LoggerProvider
 import io.opentelemetry.kotlin.metrics.MeterProvider
 import io.opentelemetry.kotlin.propagation.TextMapPropagator
 import io.opentelemetry.kotlin.tracing.TracerProvider
-import kotlinx.coroutines.withTimeout
 
 internal class OpenTelemetryImpl(
     override val tracerProvider: TracerProvider,
@@ -74,11 +74,7 @@ internal class OpenTelemetryImpl(
         }
 
     private suspend fun withOverallTimeout(action: suspend () -> OperationResultCode): OperationResultCode =
-        try {
-            withTimeout(timeoutMs) { action() }
-        } catch (_: Throwable) {
-            Failure
-        }
+        runWithTimeout(timeoutMs, action)
 
     private fun combineResults(vararg results: OperationResultCode): OperationResultCode =
         when {

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/error/GuardTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/error/GuardTest.kt
@@ -1,7 +1,10 @@
 package io.opentelemetry.kotlin.error
 
+import kotlinx.coroutines.test.runTest
+import kotlin.coroutines.cancellation.CancellationException
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertSame
 import kotlin.test.assertTrue
@@ -46,5 +49,35 @@ internal class GuardTest {
         throwingHandler.reportError(
             SdkError.ApiMisuse("TestApi", "boom", SdkErrorSeverity.WARNING)
         )
+    }
+
+    @Test
+    fun testGuardRethrowsCancellationException() {
+        val cancelled = CancellationException("cancelled")
+        val thrown = assertFailsWith<CancellationException> {
+            handler.guard("should not be used") { throw cancelled }
+        }
+        assertSame(cancelled, thrown)
+        assertFalse(handler.hasErrors())
+    }
+
+    @Test
+    fun testGuardOrDefaultRethrowsCancellationException() {
+        val cancelled = CancellationException("cancelled")
+        val thrown = assertFailsWith<CancellationException> {
+            handler.guardOrDefault("default", "should not be used") { throw cancelled }
+        }
+        assertSame(cancelled, thrown)
+        assertFalse(handler.hasErrors())
+    }
+
+    @Test
+    fun testGuardOrDefaultSuspendRethrowsCancellationException() = runTest {
+        val cancelled = CancellationException("cancelled")
+        val thrown = assertFailsWith<CancellationException> {
+            handler.guardOrDefaultSuspend("default", "should not be used") { throw cancelled }
+        }
+        assertSame(cancelled, thrown)
+        assertFalse(handler.hasErrors())
     }
 }

--- a/sdk-common/src/commonMain/kotlin/io/opentelemetry/kotlin/error/Guard.kt
+++ b/sdk-common/src/commonMain/kotlin/io/opentelemetry/kotlin/error/Guard.kt
@@ -8,13 +8,16 @@ private const val DEFAULT_DETAILS = "Operation failed"
  * Runs [action], which may be user-supplied code.
  *
  * If [action] completes normally nothing happens. If it throws, the failure is reported to this
- * handler as a [SdkError.UserCodeError] and swallowed.
+ * handler as a [SdkError.UserCodeError] and swallowed. [CancellationException] is rethrown so
+ * coroutine cancellation keeps propagating.
  *
  * @param details optional description of what was being attempted, used as the error message.
  */
 public inline fun SdkErrorHandler.guard(details: String? = null, action: () -> Unit) {
     try {
         action()
+    } catch (exc: CancellationException) {
+        throw exc
     } catch (exc: Throwable) {
         reportUserCodeError(exc, details)
     }
@@ -22,7 +25,7 @@ public inline fun SdkErrorHandler.guard(details: String? = null, action: () -> U
 
 /**
  * As [guard], but for user-supplied code that returns a value. Returns [default] if [action]
- * throws.
+ * throws. [CancellationException] is rethrown rather than reported.
  */
 public inline fun <T> SdkErrorHandler.guardOrDefault(
     default: T,
@@ -30,6 +33,8 @@ public inline fun <T> SdkErrorHandler.guardOrDefault(
     action: () -> T,
 ): T = try {
     action()
+} catch (exc: CancellationException) {
+    throw exc
 } catch (exc: Throwable) {
     reportUserCodeError(exc, details)
     default


### PR DESCRIPTION
## Goal
Stop swallowing coroutine CancellationException in timeout/export catch-alls. Use runWithTimeout for timeouts and guardOrDefaultSuspend for other failures so parent cancellation still propagates.

## Testing
Added GuardTest coverage that CancellationException is rethrown. Ran OpenTelemetryImplTest, GuardTest, BatchTelemetryProcessorTest, and persisting processor tests.

Fixes #870