### PR TITLE
[FEAT] : Replace copies of collections in SpanModel and LogRecordModel with a read-only view  

### DIFF
--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/attributes/AttributesModel.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/attributes/AttributesModel.kt
@@ -1,10 +1,14 @@
 package io.opentelemetry.kotlin.attributes
 
+import io.opentelemetry.kotlin.collections.ReadOnlyMapView
+
 internal class AttributesModel(
     private val attributeLimit: Int = DEFAULT_ATTRIBUTE_LIMIT,
     private val attributeValueLengthLimit: Int = DEFAULT_ATTRIBUTE_VALUE_LENGTH_LIMIT,
     private val attrs: MutableMap<String, Any> = mutableMapOf()
 ) : AttributesMutator, AttributeContainer {
+
+    internal val readOnlyAttributes: Map<String, Any> = ReadOnlyMapView(attrs)
 
     /**
      * True when [attributeValueLengthLimit] doesn't truncate anything, which is the default.

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/collections/ReadOnlyViews.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/collections/ReadOnlyViews.kt
@@ -1,0 +1,17 @@
+package io.opentelemetry.kotlin.collections
+
+internal class ReadOnlyListView<T>(
+    private val delegate: List<T>
+) : AbstractList<T>() {
+    override val size: Int
+        get() = delegate.size
+
+    override fun get(index: Int): T = delegate[index]
+}
+
+internal class ReadOnlyMapView<K, V>(
+    private val delegate: Map<K, V>
+) : AbstractMap<K, V>() {
+    override val entries: Set<Map.Entry<K, V>>
+        get() = delegate.entries
+}

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/model/LogRecordModel.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/model/LogRecordModel.kt
@@ -126,7 +126,7 @@ internal class LogRecordModel(
 
     override val attributes: Map<String, Any>
         get() = lock.read {
-            attrs.attributes.toMap()
+            attrs.readOnlyAttributes
         }
 
     override val droppedAttributesCount: Int
@@ -214,7 +214,7 @@ internal class LogRecordModel(
         body,
         eventName,
         spanContext,
-        attributes,
+        attributes.toMap(),
         resource,
         instrumentationScopeInfo,
         droppedAttributesCount

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/model/SpanModel.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/model/SpanModel.kt
@@ -6,6 +6,7 @@ import io.opentelemetry.kotlin.ReentrantReadWriteLock
 import io.opentelemetry.kotlin.attributes.AnyValue
 import io.opentelemetry.kotlin.attributes.AttributesModel
 import io.opentelemetry.kotlin.attributes.AttributesMutator
+import io.opentelemetry.kotlin.collections.ReadOnlyListView
 import io.opentelemetry.kotlin.error.SdkErrorHandler
 import io.opentelemetry.kotlin.error.guard
 import io.opentelemetry.kotlin.error.guardOrDefault
@@ -147,11 +148,13 @@ internal class SpanModel(
 
     private val eventsList = mutableListOf<SpanEventData>()
 
+    private val eventsView: List<SpanEventData> = ReadOnlyListView(eventsList)
+
     private var droppedEventsCountImpl = 0
 
     override val events: List<SpanEventData>
         get() = lock.read {
-            eventsList.toList()
+            eventsView
         }
 
     override val droppedEventsCount: Int
@@ -161,11 +164,13 @@ internal class SpanModel(
 
     private val linksList = initialLinks.toMutableList<SpanLinkData>()
 
+    private val linksView: List<SpanLinkData> = ReadOnlyListView(linksList)
+
     private var droppedLinksCountImpl = initialDroppedLinksCount
 
     override val links: List<SpanLinkData>
         get() = lock.read {
-            linksList.toList()
+            linksView
         }
 
     override val droppedLinksCount: Int
@@ -252,7 +257,7 @@ internal class SpanModel(
 
     override val attributes: Map<String, Any>
         get() = lock.read {
-            attrs.attributes
+            attrs.readOnlyAttributes
         }
 
     override val droppedAttributesCount: Int

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/collections/ReadOnlyListViewTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/collections/ReadOnlyListViewTest.kt
@@ -1,0 +1,37 @@
+package io.opentelemetry.kotlin.collections
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+internal class ReadOnlyListViewTest {
+
+    @Test
+    fun reflectsDelegateContents() {
+        val delegate = mutableListOf("a", "b")
+        val view = ReadOnlyListView(delegate)
+
+        assertEquals(listOf("a", "b"), view)
+    }
+
+    @Test
+    fun reflectsLiveUpdatesToDelegate() {
+        val delegate = mutableListOf("a")
+        val view = ReadOnlyListView(delegate)
+
+        delegate.add("b")
+
+        assertEquals(listOf("a", "b"), view)
+    }
+
+    @Test
+    fun isNotAMutableList() {
+        val delegate = mutableListOf("a")
+        val view = ReadOnlyListView(delegate)
+
+        assertFailsWith<ClassCastException> {
+            @Suppress("UNCHECKED_CAST")
+            view as MutableList<String>
+        }
+    }
+}

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/collections/ReadOnlyMapViewTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/collections/ReadOnlyMapViewTest.kt
@@ -1,0 +1,37 @@
+package io.opentelemetry.kotlin.collections
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+internal class ReadOnlyMapViewTest {
+
+    @Test
+    fun reflectsDelegateContents() {
+        val delegate = mutableMapOf("key" to "value")
+        val view = ReadOnlyMapView(delegate)
+
+        assertEquals(mapOf("key" to "value"), view)
+    }
+
+    @Test
+    fun reflectsLiveUpdatesToDelegate() {
+        val delegate = mutableMapOf("key" to "value")
+        val view = ReadOnlyMapView(delegate)
+
+        delegate["key2"] = "value2"
+
+        assertEquals(mapOf("key" to "value", "key2" to "value2"), view)
+    }
+
+    @Test
+    fun isNotAMutableMap() {
+        val delegate = mutableMapOf("key" to "value")
+        val view = ReadOnlyMapView(delegate)
+
+        assertFailsWith<ClassCastException> {
+            @Suppress("UNCHECKED_CAST")
+            view as MutableMap<String, String>
+        }
+    }
+}


### PR DESCRIPTION
## Goal

Replace copies of collections in SpanModel and LogRecordModel with a read-only view - to prevent new copies. We added a separate package for reusable classes for views - `ReadOnlyListView` and `ReadOnlyMapView`. This addresses #808 

## Testing

added the tests for Read only views : `ReadOnlyMapViewTest.kt` and `ReadOnlyListViewTest.kt` to check functionality  