### PR TITLE
Metrics API: Introduce data model types

### DIFF
--- a/sdk-api/api/jvm/sdk-api.api
+++ b/sdk-api/api/jvm/sdk-api.api
@@ -271,6 +271,99 @@ public abstract interface class io/opentelemetry/kotlin/logging/model/ReadableLo
 	public abstract fun getTimestamp ()Ljava/lang/Long;
 }
 
+public final class io/opentelemetry/kotlin/metrics/data/AggregationTemporality : java/lang/Enum {
+	public static final field CUMULATIVE Lio/opentelemetry/kotlin/metrics/data/AggregationTemporality;
+	public static final field DELTA Lio/opentelemetry/kotlin/metrics/data/AggregationTemporality;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lio/opentelemetry/kotlin/metrics/data/AggregationTemporality;
+	public static fun values ()[Lio/opentelemetry/kotlin/metrics/data/AggregationTemporality;
+}
+
+public abstract interface class io/opentelemetry/kotlin/metrics/data/Data {
+	public abstract fun getPoints ()Ljava/util/List;
+}
+
+public abstract interface class io/opentelemetry/kotlin/metrics/data/DoublePoint : io/opentelemetry/kotlin/metrics/data/PointData {
+	public abstract fun getValue ()D
+}
+
+public abstract interface class io/opentelemetry/kotlin/metrics/data/ExponentialHistogramBuckets {
+	public abstract fun getBucketCounts ()Ljava/util/List;
+	public abstract fun getOffset ()I
+}
+
+public abstract interface class io/opentelemetry/kotlin/metrics/data/ExponentialHistogramData : io/opentelemetry/kotlin/metrics/data/Data {
+	public abstract fun getAggregationTemporality ()Lio/opentelemetry/kotlin/metrics/data/AggregationTemporality;
+}
+
+public abstract interface class io/opentelemetry/kotlin/metrics/data/ExponentialHistogramPoint : io/opentelemetry/kotlin/metrics/data/PointData {
+	public abstract fun getCount ()J
+	public abstract fun getMax ()Ljava/lang/Double;
+	public abstract fun getMin ()Ljava/lang/Double;
+	public abstract fun getNegativeBuckets ()Lio/opentelemetry/kotlin/metrics/data/ExponentialHistogramBuckets;
+	public abstract fun getPositiveBuckets ()Lio/opentelemetry/kotlin/metrics/data/ExponentialHistogramBuckets;
+	public abstract fun getScale ()I
+	public abstract fun getSum ()Ljava/lang/Double;
+	public abstract fun getZeroCount ()J
+	public abstract fun getZeroThreshold ()D
+}
+
+public abstract interface class io/opentelemetry/kotlin/metrics/data/GaugeData : io/opentelemetry/kotlin/metrics/data/Data {
+}
+
+public abstract interface class io/opentelemetry/kotlin/metrics/data/GaugeData$DoubleGaugeData : io/opentelemetry/kotlin/metrics/data/GaugeData {
+}
+
+public abstract interface class io/opentelemetry/kotlin/metrics/data/GaugeData$LongGaugeData : io/opentelemetry/kotlin/metrics/data/GaugeData {
+}
+
+public abstract interface class io/opentelemetry/kotlin/metrics/data/HistogramData : io/opentelemetry/kotlin/metrics/data/Data {
+	public abstract fun getAggregationTemporality ()Lio/opentelemetry/kotlin/metrics/data/AggregationTemporality;
+}
+
+public abstract interface class io/opentelemetry/kotlin/metrics/data/HistogramPoint : io/opentelemetry/kotlin/metrics/data/PointData {
+	public abstract fun getBoundaries ()Ljava/util/List;
+	public abstract fun getCount ()J
+	public abstract fun getCounts ()Ljava/util/List;
+	public abstract fun getMax ()Ljava/lang/Double;
+	public abstract fun getMin ()Ljava/lang/Double;
+	public abstract fun getSum ()Ljava/lang/Double;
+}
+
+public abstract interface class io/opentelemetry/kotlin/metrics/data/LongPoint : io/opentelemetry/kotlin/metrics/data/PointData {
+	public abstract fun getValue ()J
+}
+
+public abstract interface class io/opentelemetry/kotlin/metrics/data/MetricData {
+	public abstract fun getData ()Lio/opentelemetry/kotlin/metrics/data/Data;
+	public abstract fun getDescription ()Ljava/lang/String;
+	public abstract fun getInstrumentationScopeInfo ()Lio/opentelemetry/kotlin/InstrumentationScopeInfo;
+	public abstract fun getName ()Ljava/lang/String;
+	public abstract fun getResource ()Lio/opentelemetry/kotlin/resource/Resource;
+	public abstract fun getUnit ()Ljava/lang/String;
+	public abstract fun isEmpty ()Z
+}
+
+public final class io/opentelemetry/kotlin/metrics/data/MetricData$DefaultImpls {
+	public static fun isEmpty (Lio/opentelemetry/kotlin/metrics/data/MetricData;)Z
+}
+
+public abstract interface class io/opentelemetry/kotlin/metrics/data/PointData : io/opentelemetry/kotlin/attributes/AttributeContainer {
+	public abstract fun getEpochNanos ()J
+	public abstract fun getStartEpochNanos ()J
+}
+
+public abstract interface class io/opentelemetry/kotlin/metrics/data/SumData : io/opentelemetry/kotlin/metrics/data/Data {
+	public abstract fun getAggregationTemporality ()Lio/opentelemetry/kotlin/metrics/data/AggregationTemporality;
+	public abstract fun isMonotonic ()Z
+}
+
+public abstract interface class io/opentelemetry/kotlin/metrics/data/SumData$DoubleSumData : io/opentelemetry/kotlin/metrics/data/SumData {
+}
+
+public abstract interface class io/opentelemetry/kotlin/metrics/data/SumData$LongSumData : io/opentelemetry/kotlin/metrics/data/SumData {
+}
+
 public abstract interface class io/opentelemetry/kotlin/resource/MutableResource {
 	public abstract fun getAttributes ()Ljava/util/Map;
 	public abstract fun getSchemaUrl ()Ljava/lang/String;

--- a/sdk-api/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/data/AggregationTemporality.kt
+++ b/sdk-api/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/data/AggregationTemporality.kt
@@ -1,0 +1,18 @@
+package io.opentelemetry.kotlin.metrics.data
+
+import io.opentelemetry.kotlin.ExperimentalApi
+
+/**
+ * Defines how successive points relate to the measurements observed during their time intervals.
+ *
+ * https://opentelemetry.io/docs/specs/otel/metrics/data-model/#temporality
+ */
+@ExperimentalApi
+public enum class AggregationTemporality {
+
+    /** Each point covers only measurements recorded since the previous collection. */
+    DELTA,
+
+    /** Each point covers measurements recorded since a fixed start time. */
+    CUMULATIVE,
+}

--- a/sdk-api/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/data/Data.kt
+++ b/sdk-api/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/data/Data.kt
@@ -1,0 +1,16 @@
+package io.opentelemetry.kotlin.metrics.data
+
+import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.ThreadSafe
+
+/**
+ * The points in a metric stream, with at most one point for each distinct attribute set in a
+ * collection cycle.
+ *
+ * https://opentelemetry.io/docs/specs/otel/metrics/data-model/#opentelemetry-protocol-data-model
+ */
+@ExperimentalApi
+@ThreadSafe
+public sealed interface Data<out T : PointData> {
+    public val points: List<T>
+}

--- a/sdk-api/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/data/DoublePoint.kt
+++ b/sdk-api/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/data/DoublePoint.kt
@@ -1,0 +1,10 @@
+package io.opentelemetry.kotlin.metrics.data
+
+import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.ThreadSafe
+
+@ExperimentalApi
+@ThreadSafe
+public interface DoublePoint : PointData {
+    public val value: Double
+}

--- a/sdk-api/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/data/ExponentialHistogramBuckets.kt
+++ b/sdk-api/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/data/ExponentialHistogramBuckets.kt
@@ -1,0 +1,23 @@
+package io.opentelemetry.kotlin.metrics.data
+
+import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.ThreadSafe
+
+/**
+ * A dense range of positive or negative base-2 exponential histogram buckets.
+ *
+ * Element `i` of [bucketCounts] records the count for bucket index `offset + i`.
+ * Bucket boundaries are derived from that index and the containing point's scale.
+ *
+ * https://opentelemetry.io/docs/specs/otel/metrics/data-model/#exponential-buckets
+ */
+@ExperimentalApi
+@ThreadSafe
+public interface ExponentialHistogramBuckets {
+
+    /** Index of the first bucket represented by [bucketCounts]. */
+    public val offset: Int
+
+    /** Counts for the contiguous bucket indexes beginning at [offset]. */
+    public val bucketCounts: List<Long>
+}

--- a/sdk-api/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/data/ExponentialHistogramData.kt
+++ b/sdk-api/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/data/ExponentialHistogramData.kt
@@ -1,0 +1,16 @@
+package io.opentelemetry.kotlin.metrics.data
+
+import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.ThreadSafe
+
+/**
+ * Exponential histogram points that share an [aggregationTemporality]. Their bucket boundaries
+ * are calculated from a base-2 exponential mapping rather than transmitted explicitly.
+ *
+ * https://opentelemetry.io/docs/specs/otel/metrics/data-model/#exponentialhistogram
+ */
+@ExperimentalApi
+@ThreadSafe
+public interface ExponentialHistogramData : Data<ExponentialHistogramPoint> {
+    public val aggregationTemporality: AggregationTemporality
+}

--- a/sdk-api/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/data/ExponentialHistogramPoint.kt
+++ b/sdk-api/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/data/ExponentialHistogramPoint.kt
@@ -1,0 +1,46 @@
+package io.opentelemetry.kotlin.metrics.data
+
+import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.ThreadSafe
+
+/**
+ * A population of measurements aggregated into base-2 exponential buckets over this point's
+ * time interval.
+ *
+ * Bucket boundaries are determined by [scale], while positive and negative measurements are
+ * recorded separately in [positiveBuckets] and [negativeBuckets].
+ *
+ * https://opentelemetry.io/docs/specs/otel/metrics/data-model/#exponentialhistogram
+ */
+@ExperimentalApi
+@ThreadSafe
+public interface ExponentialHistogramPoint : PointData {
+
+    /**
+     * Resolution used to derive the histogram base as `2 ** (2 ** -scale)`; larger values
+     * provide greater precision.
+     */
+    public val scale: Int
+
+    public val count: Long
+
+    /** Sum of represented measurements, or `null` when the aggregation did not collect it. */
+    public val sum: Double?
+
+    /** Minimum represented measurement, or `null` when min was not collected. */
+    public val min: Double?
+
+    /** Maximum represented measurement, or `null` when max was not collected. */
+    public val max: Double?
+
+    /** Number of measurements whose absolute value is at most [zeroThreshold]. */
+    public val zeroCount: Long
+
+    /** Inclusive absolute-value threshold used by the zero bucket. */
+    public val zeroThreshold: Double
+
+    public val positiveBuckets: ExponentialHistogramBuckets
+
+    /** Negative measurements bucketed by absolute value. */
+    public val negativeBuckets: ExponentialHistogramBuckets
+}

--- a/sdk-api/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/data/GaugeData.kt
+++ b/sdk-api/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/data/GaugeData.kt
@@ -1,0 +1,25 @@
+package io.opentelemetry.kotlin.metrics.data
+
+import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.ThreadSafe
+
+/**
+ * The last sampled measurement for each attribute set in a collection cycle.
+ *
+ * Gauge streams do not carry aggregation temporality because their points describe values at a
+ * sampling time rather than additive changes over an interval.
+ *
+ * https://opentelemetry.io/docs/specs/otel/metrics/data-model/#gauge
+ */
+@ExperimentalApi
+@ThreadSafe
+public sealed interface GaugeData<out T : PointData> : Data<T> {
+
+    @ExperimentalApi
+    @ThreadSafe
+    public interface LongGaugeData : GaugeData<LongPoint>
+
+    @ExperimentalApi
+    @ThreadSafe
+    public interface DoubleGaugeData : GaugeData<DoublePoint>
+}

--- a/sdk-api/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/data/HistogramData.kt
+++ b/sdk-api/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/data/HistogramData.kt
@@ -1,0 +1,16 @@
+package io.opentelemetry.kotlin.metrics.data
+
+import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.ThreadSafe
+
+/**
+ * Histogram points that compress a population into count, sum, and optional explicit buckets over
+ * intervals described by [aggregationTemporality].
+ *
+ * https://opentelemetry.io/docs/specs/otel/metrics/data-model/#histogram
+ */
+@ExperimentalApi
+@ThreadSafe
+public interface HistogramData : Data<HistogramPoint> {
+    public val aggregationTemporality: AggregationTemporality
+}

--- a/sdk-api/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/data/HistogramPoint.kt
+++ b/sdk-api/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/data/HistogramPoint.kt
@@ -1,0 +1,35 @@
+package io.opentelemetry.kotlin.metrics.data
+
+import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.ThreadSafe
+
+/**
+ * A population of measurements aggregated into explicit-boundary buckets over this point's
+ * time interval.
+ *
+ * When bucket data is present for `N` boundaries, [counts] contains `N + 1` entries covering
+ * `(-inf, boundaries[0]]`, each adjacent `(boundaries[i - 1], boundaries[i]]` interval, and
+ * `(boundaries[N - 1], +inf)`. Empty [boundaries] and [counts] represent omitted buckets.
+ *
+ * https://opentelemetry.io/docs/specs/otel/metrics/data-model/#histogram
+ */
+@ExperimentalApi
+@ThreadSafe
+public interface HistogramPoint : PointData {
+
+    public val count: Long
+
+    /** Sum of represented measurements, or `null` when the aggregation did not collect it. */
+    public val sum: Double?
+
+    /** Minimum represented measurement, or `null` when min was not collected. */
+    public val min: Double?
+
+    /** Maximum represented measurement, or `null` when max was not collected. */
+    public val max: Double?
+
+    /** Strictly increasing upper bounds; each bound is inclusive for its bucket. */
+    public val boundaries: List<Double>
+
+    public val counts: List<Long>
+}

--- a/sdk-api/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/data/LongPoint.kt
+++ b/sdk-api/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/data/LongPoint.kt
@@ -1,0 +1,10 @@
+package io.opentelemetry.kotlin.metrics.data
+
+import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.ThreadSafe
+
+@ExperimentalApi
+@ThreadSafe
+public interface LongPoint : PointData {
+    public val value: Long
+}

--- a/sdk-api/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/data/MetricData.kt
+++ b/sdk-api/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/data/MetricData.kt
@@ -1,0 +1,28 @@
+package io.opentelemetry.kotlin.metrics.data
+
+import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.InstrumentationScopeInfo
+import io.opentelemetry.kotlin.ThreadSafe
+import io.opentelemetry.kotlin.resource.Resource
+
+/**
+ * One OTLP metric stream produced by an instrumentation scope and resource.
+ *
+ * A stream is identified by its resource, instrumentation scope, name, point kind, unit, and
+ * intrinsic point properties such as temporality and monotonicity. Description is intentionally
+ * non-identifying.
+ *
+ * https://opentelemetry.io/docs/specs/otel/metrics/data-model/#opentelemetry-protocol-data-model
+ */
+@ExperimentalApi
+@ThreadSafe
+public interface MetricData {
+    public val resource: Resource
+    public val instrumentationScopeInfo: InstrumentationScopeInfo
+    public val name: String
+    public val description: String?
+    public val unit: String?
+    public val data: Data<PointData>
+    public val isEmpty: Boolean
+        get() = data.points.isEmpty()
+}

--- a/sdk-api/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/data/PointData.kt
+++ b/sdk-api/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/data/PointData.kt
@@ -1,0 +1,25 @@
+package io.opentelemetry.kotlin.metrics.data
+
+import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.ThreadSafe
+import io.opentelemetry.kotlin.attributes.AttributeContainer
+
+/**
+ * A metric point for one attribute set, with timestamps describing when its value applies.
+ *
+ * For interval points, the covered range is `(startEpochNanos, epochNanos]`. The start timestamp
+ * represents the earliest time at which a measurement contributing to the series could have been
+ * recorded.
+ *
+ * https://opentelemetry.io/docs/specs/otel/metrics/data-model/#metric-points
+ */
+@ExperimentalApi
+@ThreadSafe
+public sealed interface PointData : AttributeContainer {
+
+    /** Start of the point's interval as Unix epoch nanoseconds, or zero when unspecified. */
+    public val startEpochNanos: Long
+
+    /** Time at which the point took effect as Unix epoch nanoseconds. */
+    public val epochNanos: Long
+}

--- a/sdk-api/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/data/SumData.kt
+++ b/sdk-api/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/data/SumData.kt
@@ -1,0 +1,30 @@
+package io.opentelemetry.kotlin.metrics.data
+
+import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.ThreadSafe
+
+/**
+ * Additive points whose values are interpreted according to [aggregationTemporality].
+ *
+ * Monotonic sums model non-decreasing quantities such as request counts; non-monotonic sums can
+ * increase or decrease.
+ *
+ * https://opentelemetry.io/docs/specs/otel/metrics/data-model/#sums
+ */
+@ExperimentalApi
+@ThreadSafe
+public sealed interface SumData<out T : PointData> : Data<T> {
+
+    /** Whether the sum is expected to increase monotonically. */
+    public val isMonotonic: Boolean
+
+    public val aggregationTemporality: AggregationTemporality
+
+    @ExperimentalApi
+    @ThreadSafe
+    public interface LongSumData : SumData<LongPoint>
+
+    @ExperimentalApi
+    @ThreadSafe
+    public interface DoubleSumData : SumData<DoublePoint>
+}


### PR DESCRIPTION
## GOAL

Introduce public interfaces representing the core OpenTelemetry Metrics Data Model to be used by MetricStorage.

Addresses this issue : [#952](https://github.com/open-telemetry/opentelemetry-kotlin/issues/952)

Added data types for Gauge, Sum, Histogram, and Exponential Histogram metric streams, including their corresponding point representations, aggregation temporality, timestamps, attributes, and histogram bucket data.

[The legacy Summary data model](https://opentelemetry.io/docs/specs/otel/metrics/data-model/#summary-legacy) was intentionally excluded because it is not recommended for new OpenTelemetry applications.

MetricStorage and related API, including InstrumentDescriptors, Aggregation, AttributeProcessing, and View, will be introduced in the subsequent PRs.

## Testing

Compiled for all platforms. Detekt and apiCheck passed.