### PR TITLE
Discard Span.setStatus calls with Unset status

### DIFF
--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/model/SpanModel.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/model/SpanModel.kt
@@ -94,7 +94,8 @@ internal class SpanModel(
 
     override fun setStatus(status: StatusData) {
         mutate("Span.setStatus failed") {
-            if (statusImpl !is StatusData.Ok) {
+            // per the OTel spec, Unset MUST be ignored, and Ok is final once set.
+            if (status !is StatusData.Unset && statusImpl !is StatusData.Ok) {
                 statusImpl = status
             }
         }

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/SpanSimplePropertiesTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/SpanSimplePropertiesTest.kt
@@ -104,12 +104,20 @@ internal class SpanSimplePropertiesTest {
     }
 
     @Test
-    fun testSpanStatusErrorCanBeOverridden() {
+    fun testSpanStatusErrorCannotBeOverriddenByUnset() {
+        val span = tracer.startSpan("test")
+        val error = StatusData.Error("Whoops")
+        span.setStatus(error)
+        span.setStatus(StatusData.Unset)
+        assertEquals(error, (span.toReadableSpan()).status)
+    }
+
+    @Test
+    fun testSpanStatusErrorCanBeOverriddenByOk() {
         val span = tracer.startSpan("test")
         span.setStatus(StatusData.Error("Whoops"))
-        val unset = StatusData.Unset
-        span.setStatus(unset)
-        assertEquals(unset, (span.toReadableSpan()).status)
+        span.setStatus(StatusData.Ok)
+        assertEquals(StatusData.Ok, (span.toReadableSpan()).status)
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Per the [OTel trace API spec](https://opentelemetry.io/docs/specs/otel/trace/api/#set-status), an attempt to set span status to `Unset` SHOULD be ignored.
- `SpanModel.setStatus` previously allowed `Unset` to overwrite a previously-set `Error` status, which contradicts the spec's total order (`Ok > Error > Unset`).
- Added a guard so `Unset` is discarded, alongside the existing rule that `Ok` is final.
- Updated `SpanSimplePropertiesTest` to reflect the corrected behavior (renamed the test that previously asserted the wrong behavior, and added a coverage case for `Error` being overridden by `Ok`).

Fixes #857

## Test plan
- [x] `./gradlew :implementation:jvmTest` — all tests pass, including new/updated status tests
- [x] `./gradlew detekt` — no lint violations