### PR TITLE
Alter default propagator to W3cBaggage and TraceContext

### DIFF
--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/propagation/CompatPropagatorConfigImpl.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/propagation/CompatPropagatorConfigImpl.kt
@@ -12,34 +12,40 @@ import io.opentelemetry.extension.trace.propagation.B3Propagator as JavaB3Propag
 @OptIn(ExperimentalApi::class)
 internal class CompatPropagatorConfigImpl : PropagatorConfigDsl {
 
-    private var configured: TextMapPropagator = TextMapPropagatorAdapter(OtelJavaTextMapPropagator.noop())
+    private var configured: TextMapPropagator? = null
 
     override fun composite(vararg propagators: TextMapPropagator): TextMapPropagator {
         val javaPropagators = propagators.map { it.toOtelJavaTextMapPropagator() }
-        configured = TextMapPropagatorAdapter(composite(javaPropagators))
-        return configured
+        return TextMapPropagatorAdapter(composite(javaPropagators)).also { configured = it }
     }
 
-    override fun w3cBaggage(): TextMapPropagator {
-        configured = TextMapPropagatorAdapter(W3CBaggagePropagator.getInstance())
-        return configured
-    }
+    override fun w3cBaggage(): TextMapPropagator =
+        TextMapPropagatorAdapter(W3CBaggagePropagator.getInstance()).also { configured = it }
 
-    override fun w3cTraceContext(): TextMapPropagator {
-        configured = TextMapPropagatorAdapter(W3CTraceContextPropagator.getInstance())
-        return configured
-    }
+    override fun w3cTraceContext(): TextMapPropagator =
+        TextMapPropagatorAdapter(W3CTraceContextPropagator.getInstance()).also { configured = it }
 
     override fun b3(format: B3Format): TextMapPropagator {
         val javaPropagator = when (format) {
             B3Format.SINGLE -> JavaB3Propagator.injectingSingleHeader()
             B3Format.MULTI -> JavaB3Propagator.injectingMultiHeaders()
         }
-        configured = TextMapPropagatorAdapter(javaPropagator)
-        return configured
+        return TextMapPropagatorAdapter(javaPropagator).also { configured = it }
     }
 
-    internal fun buildPropagator(): TextMapPropagator = configured
+    override fun none(): TextMapPropagator =
+        TextMapPropagatorAdapter(OtelJavaTextMapPropagator.noop()).also { configured = it }
+
+    internal fun buildPropagator(): TextMapPropagator = configured ?: defaultPropagator()
+
+    /**
+     * The `tracecontext,baggage` default mandated by the OTel spec.
+     *
+     * https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#general-sdk-configuration
+     */
+    private fun defaultPropagator(): TextMapPropagator = TextMapPropagatorAdapter(
+        composite(listOf(W3CTraceContextPropagator.getInstance(), W3CBaggagePropagator.getInstance()))
+    )
 
     private fun TextMapPropagator.toOtelJavaTextMapPropagator(): OtelJavaTextMapPropagator =
         (this as? TextMapPropagatorAdapter)?.impl ?: OtelJavaTextMapPropagatorAdapter(this)

--- a/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/propagation/CompatPropagatorApiTest.kt
+++ b/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/propagation/CompatPropagatorApiTest.kt
@@ -132,6 +132,37 @@ internal class CompatPropagatorApiTest {
         val captured = dsl.w3cTraceContext()
         assertSame(captured, dsl.buildPropagator())
     }
+
+    @Test
+    fun `default propagator is w3c trace context and baggage`() {
+        val propagator = dsl.buildPropagator()
+        assertEquals(listOf("traceparent", "tracestate", "baggage"), propagator.fields().toList())
+    }
+
+    @Test
+    fun `default propagator round-trips a traceparent header through inject and extract`() {
+        val propagator = dsl.buildPropagator()
+        val incoming = mapOf("traceparent" to "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01")
+        val extracted = propagator.extract(contextFactory.root(), incoming, MapTextMapGetter)
+
+        val outgoing = mutableMapOf<String, String>()
+        propagator.inject(extracted, outgoing, MapTextMapSetter)
+        assertEquals(incoming["traceparent"], outgoing["traceparent"])
+    }
+
+    @Test
+    fun `none disables propagation`() {
+        val captured = dsl.none()
+        assertSame(captured, dsl.buildPropagator())
+        assertTrue(captured.fields().isEmpty())
+
+        val incoming = mapOf("traceparent" to "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01")
+        val extracted = captured.extract(contextFactory.root(), incoming, MapTextMapGetter)
+
+        val outgoing = mutableMapOf<String, String>()
+        captured.inject(extracted, outgoing, MapTextMapSetter)
+        assertTrue(outgoing.isEmpty())
+    }
 }
 
 @OptIn(ExperimentalApi::class)

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/PropagatorConfigImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/PropagatorConfigImpl.kt
@@ -20,7 +20,7 @@ import kotlin.concurrent.Volatile
 @OptIn(ExperimentalApi::class)
 internal class PropagatorConfigImpl : PropagatorConfigDsl {
 
-    private var configured: TextMapPropagator = NoopOpenTelemetry.propagator
+    private var configured: TextMapPropagator? = null
 
     @Volatile private var w3cTraceContextImpl: TextMapPropagator = NoopOpenTelemetry.propagator
 
@@ -29,13 +29,14 @@ internal class PropagatorConfigImpl : PropagatorConfigDsl {
     @Volatile private var b3MultiImpl: TextMapPropagator = NoopOpenTelemetry.propagator
 
     override fun composite(vararg propagators: TextMapPropagator): TextMapPropagator {
-        configured = CompositeTextMapPropagator(propagators.toList())
-        return configured
+        val composite = CompositeTextMapPropagator(propagators.toList())
+        configured = composite
+        return composite
     }
 
     override fun w3cBaggage(): TextMapPropagator {
         configured = W3CBaggagePropagator
-        return configured
+        return W3CBaggagePropagator
     }
 
     override fun w3cTraceContext(): TextMapPropagator {
@@ -51,6 +52,12 @@ internal class PropagatorConfigImpl : PropagatorConfigDsl {
         }
         configured = forwarder
         return forwarder
+    }
+
+    override fun none(): TextMapPropagator {
+        val noop = NoopOpenTelemetry.propagator
+        configured = noop
+        return noop
     }
 
     // Factories are constructed after user config is applied, so we install them once available.
@@ -86,7 +93,16 @@ internal class PropagatorConfigImpl : PropagatorConfigDsl {
         )
     }
 
-    internal fun buildPropagator(): TextMapPropagator = configured
+    internal fun buildPropagator(): TextMapPropagator = configured ?: defaultPropagator()
+
+    /**
+     * The `tracecontext,baggage` default mandated by the OTel spec.
+     *
+     * https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#general-sdk-configuration
+     */
+    private fun defaultPropagator(): TextMapPropagator = CompositeTextMapPropagator(
+        listOf(ForwardingPropagator { w3cTraceContextImpl }, W3CBaggagePropagator)
+    )
 }
 
 @OptIn(ExperimentalApi::class)

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/init/OpenTelemetryConfigImplTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/init/OpenTelemetryConfigImplTest.kt
@@ -36,6 +36,14 @@ internal class OpenTelemetryConfigImplTest {
         assertNull(cfg.generateTracingConfig().processor)
         assertNull(cfg.generateLoggingConfig().processor)
         assertNull(cfg.contextConfig.storageMode)
+        assertIs<CompositeTextMapPropagator>(cfg.propagatorCfg.buildPropagator())
+    }
+
+    @Test
+    fun testPropagatorNone() {
+        val cfg = OpenTelemetryConfigImpl(clock).apply {
+            propagator { none() }
+        }
         assertSame(NoopOpenTelemetry.propagator, cfg.propagatorCfg.buildPropagator())
     }
 

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/propagation/CorePropagatorApiTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/propagation/CorePropagatorApiTest.kt
@@ -1,6 +1,7 @@
 package io.opentelemetry.kotlin.propagation
 
 import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.NoopOpenTelemetry
 import io.opentelemetry.kotlin.context.Context
 import io.opentelemetry.kotlin.context.ContextKey
 import io.opentelemetry.kotlin.error.NoopSdkErrorHandler
@@ -12,9 +13,11 @@ import io.opentelemetry.kotlin.factory.TraceFlagsFactoryImpl
 import io.opentelemetry.kotlin.factory.TraceStateFactoryImpl
 import io.opentelemetry.kotlin.init.B3Format
 import io.opentelemetry.kotlin.init.PropagatorConfigImpl
+import io.opentelemetry.kotlin.tracing.FakeSpanContext
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
+import kotlin.test.assertNotSame
 import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
@@ -124,6 +127,61 @@ internal class CorePropagatorApiTest {
     fun `b3 call captures result and buildPropagator returns it`() {
         val captured = dsl.b3(B3Format.SINGLE)
         assertSame(captured, dsl.buildPropagator())
+    }
+
+    @Test
+    fun `default propagator is w3c trace context and baggage`() {
+        installFactories()
+        val propagator = dsl.buildPropagator()
+        assertIs<CompositeTextMapPropagator>(propagator)
+        assertEquals(listOf("traceparent", "tracestate", "baggage"), propagator.fields().toList())
+    }
+
+    @Test
+    fun `default propagator injects traceparent for the current span`() {
+        installFactories()
+        val span = spanFactory.fromSpanContext(FakeSpanContext.VALID)
+        val carrier = mutableMapOf<String, String>()
+        dsl.buildPropagator().inject(contextFactory.root().storeSpan(span), carrier, MapTextMapSetter)
+        assertTrue(carrier.containsKey("traceparent"))
+    }
+
+    @Test
+    fun `default propagator extracts an incoming traceparent`() {
+        installFactories()
+        val result = dsl.buildPropagator().extract(
+            context = contextFactory.root(),
+            carrier = mapOf("traceparent" to "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"),
+            getter = MapTextMapGetter,
+        )
+        assertNotSame(contextFactory.root(), result)
+    }
+
+    @Test
+    fun `none returns the noop propagator and buildPropagator returns it`() {
+        val captured = dsl.none()
+        assertSame(NoopOpenTelemetry.propagator, captured)
+        assertSame(captured, dsl.buildPropagator())
+    }
+
+    @Test
+    fun `none disables injection and extraction`() {
+        dsl.none()
+        installFactories()
+        val propagator = dsl.buildPropagator()
+        assertTrue(propagator.fields().isEmpty())
+
+        val span = spanFactory.fromSpanContext(FakeSpanContext.VALID)
+        val carrier = mutableMapOf<String, String>()
+        propagator.inject(contextFactory.root().storeSpan(span), carrier, MapTextMapSetter)
+        assertTrue(carrier.isEmpty())
+
+        val result = propagator.extract(
+            context = contextFactory.root(),
+            carrier = mapOf("traceparent" to "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"),
+            getter = MapTextMapGetter,
+        )
+        assertSame(contextFactory.root(), result)
     }
 
     private fun installFactories() {

--- a/sdk-api/api/jvm/sdk-api.api
+++ b/sdk-api/api/jvm/sdk-api.api
@@ -180,6 +180,7 @@ public abstract interface class io/opentelemetry/kotlin/init/OpenTelemetryConfig
 public abstract interface class io/opentelemetry/kotlin/init/PropagatorConfigDsl {
 	public abstract fun b3 (Lio/opentelemetry/kotlin/init/B3Format;)Lio/opentelemetry/kotlin/propagation/TextMapPropagator;
 	public abstract fun composite ([Lio/opentelemetry/kotlin/propagation/TextMapPropagator;)Lio/opentelemetry/kotlin/propagation/TextMapPropagator;
+	public abstract fun none ()Lio/opentelemetry/kotlin/propagation/TextMapPropagator;
 	public abstract fun w3cBaggage ()Lio/opentelemetry/kotlin/propagation/TextMapPropagator;
 	public abstract fun w3cTraceContext ()Lio/opentelemetry/kotlin/propagation/TextMapPropagator;
 }

--- a/sdk-api/src/commonMain/kotlin/io/opentelemetry/kotlin/init/PropagatorConfigDsl.kt
+++ b/sdk-api/src/commonMain/kotlin/io/opentelemetry/kotlin/init/PropagatorConfigDsl.kt
@@ -43,4 +43,9 @@ public interface PropagatorConfigDsl {
      * https://github.com/openzipkin/b3-propagation
      */
     public fun b3(format: B3Format = B3Format.SINGLE): TextMapPropagator
+
+    /**
+     * Disables context propagation entirely by returning a no-op value.
+     */
+    public fun none(): TextMapPropagator
 }


### PR DESCRIPTION
## Goal

Alters the SDK's default propagator to W3cBaggage and TraceContext, as written in the spec. Previously the default was for no propagators to be configured which resulted in the SDK dropping trace context/baggage when the SDK was enabled.

## Testing

Added unit tests.
