### PR TITLE
Don't include untrusted values in B3Propagator error messages

### DIFF
--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/propagation/B3Propagator.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/propagation/B3Propagator.kt
@@ -100,7 +100,7 @@ internal class B3Propagator(
             sdkErrorHandler.reportError(
                 SdkError.ApiMisuse(
                     api = "B3Propagator.extractSingle",
-                    message = "B3 single header has wrong number of parts: $header",
+                    message = "B3 single header has wrong number of parts",
                     severity = SdkErrorSeverity.WARNING,
                 )
             )
@@ -110,7 +110,7 @@ internal class B3Propagator(
             sdkErrorHandler.reportError(
                 SdkError.ApiMisuse(
                     api = "B3Propagator.extractSingle",
-                    message = "B3 invalid traceId in single header: ${parts[0]}",
+                    message = "B3 invalid traceId in single header",
                     severity = SdkErrorSeverity.WARNING,
                 )
             )
@@ -124,7 +124,7 @@ internal class B3Propagator(
             sdkErrorHandler.reportError(
                 SdkError.ApiMisuse(
                     api = "B3Propagator.extractSingle",
-                    message = "B3 invalid spanId in single header: $rawSpanId",
+                    message = "B3 invalid spanId in single header",
                     severity = SdkErrorSeverity.WARNING,
                 )
             )
@@ -143,7 +143,7 @@ internal class B3Propagator(
                 sdkErrorHandler.reportError(
                     SdkError.ApiMisuse(
                         api = "B3Propagator.extractMulti",
-                        message = "B3 invalid traceId in multi header: $rawTraceId",
+                        message = "B3 invalid traceId in multi header",
                         severity = SdkErrorSeverity.WARNING,
                     )
                 )
@@ -157,7 +157,7 @@ internal class B3Propagator(
             sdkErrorHandler.reportError(
                 SdkError.ApiMisuse(
                     api = "B3Propagator.extractMulti",
-                    message = "B3 invalid spanId in multi header: $rawSpanId",
+                    message = "B3 invalid spanId in multi header",
                     severity = SdkErrorSeverity.WARNING,
                 )
             )

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/propagation/B3PropagatorErrorReportingTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/propagation/B3PropagatorErrorReportingTest.kt
@@ -60,7 +60,7 @@ internal class B3PropagatorErrorReportingTest {
         assertEquals(1, handler.apiMisuses.size)
         val error = handler.apiMisuses.single()
         assertEquals("B3Propagator.extractSingle", error.api)
-        assertEquals("B3 single header has wrong number of parts: $traceId", error.message)
+        assertEquals("B3 single header has wrong number of parts", error.message)
         assertEquals(SdkErrorSeverity.WARNING, error.severity)
     }
 
@@ -75,7 +75,7 @@ internal class B3PropagatorErrorReportingTest {
         assertEquals(1, handler.apiMisuses.size)
         val error = handler.apiMisuses.single()
         assertEquals("B3Propagator.extractSingle", error.api)
-        assertEquals("B3 invalid traceId in single header: ${"0".repeat(32)}", error.message)
+        assertEquals("B3 invalid traceId in single header", error.message)
     }
 
     @Test
@@ -89,7 +89,7 @@ internal class B3PropagatorErrorReportingTest {
         assertEquals(1, handler.apiMisuses.size)
         val error = handler.apiMisuses.single()
         assertEquals("B3Propagator.extractSingle", error.api)
-        assertEquals("B3 invalid spanId in single header: ${"0".repeat(16)}", error.message)
+        assertEquals("B3 invalid spanId in single header", error.message)
     }
 
     @Test
@@ -107,7 +107,7 @@ internal class B3PropagatorErrorReportingTest {
         assertEquals(1, handler.apiMisuses.size)
         val error = handler.apiMisuses.single()
         assertEquals("B3Propagator.extractMulti", error.api)
-        assertEquals("B3 invalid traceId in multi header: not-a-valid-trace-id", error.message)
+        assertEquals("B3 invalid traceId in multi header", error.message)
     }
 
     @Test
@@ -125,6 +125,6 @@ internal class B3PropagatorErrorReportingTest {
         assertEquals(1, handler.apiMisuses.size)
         val error = handler.apiMisuses.single()
         assertEquals("B3Propagator.extractMulti", error.api)
-        assertEquals("B3 invalid spanId in multi header: short", error.message)
+        assertEquals("B3 invalid spanId in multi header", error.message)
     }
 }


### PR DESCRIPTION
## Summary
- `B3Propagator.extractSingle` / `extractMulti` embedded the raw header/traceId/spanId value directly in the `ApiMisuse` error messages reported to `SdkErrorHandler`.
- That data comes from an untrusted carrier (an inbound request header) and is unbounded, so including it can explode error-reporting cardinality and leak untrusted input into logs/metrics.
- Removed the embedded value from all 5 call sites, matching the existing convention already used in `TraceParent.create`/`decode`, which reports a fixed description of the constraint violated rather than the offending value.
- Updated `B3PropagatorErrorReportingTest` assertions to match the new (value-free) messages.

Fixes #967

## AI usage disclosure
This change was written with Claude Code (Anthropic) under my direction and review: I selected the issue, Claude located the code and the existing `TraceParent` convention to follow, made the edit, and ran the test/lint suite. I reviewed the diff and verification output before opening this PR, per this repo's `AGENTS.md` AI contribution guidance.

## Test plan
- [x] `./gradlew :implementation:jvmTest --tests "*B3Propagator*"` — `B3PropagatorErrorReportingTest` (5/5) and `B3PropagatorTest` (32/32) pass
- [x] `./gradlew detekt` — no violations