### PR TITLE
Introduce internal Metrics API foundation

### DIFF
--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/MetricDescriptor.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/MetricDescriptor.kt
@@ -1,0 +1,63 @@
+package io.opentelemetry.kotlin.metrics
+
+import io.opentelemetry.kotlin.metrics.instrument.InstrumentDescriptor
+import io.opentelemetry.kotlin.metrics.view.AttributesProcessor
+import io.opentelemetry.kotlin.metrics.view.View
+
+/**
+ * SDK configuration for a metric stream after applying an instrument-matching View.
+ *
+ * One instrument may produce multiple independently configured streams when multiple Views match.
+ *
+ * https://opentelemetry.io/docs/specs/otel/metrics/sdk/#measurement-processing
+ */
+internal class MetricDescriptor private constructor(
+    val name: String,
+    val description: String?,
+    val sourceInstrument: InstrumentDescriptor,
+    val view: View,
+    val attributesProcessor: AttributesProcessor,
+    val cardinalityLimit: Int,
+) {
+    val unit: String? = sourceInstrument.unit
+
+    override fun equals(other: Any?): Boolean =
+        this === other ||
+            other is MetricDescriptor &&
+            name.equals(other.name, ignoreCase = true) &&
+            description == other.description &&
+            sourceInstrument == other.sourceInstrument &&
+            view.aggregation == other.view.aggregation &&
+            attributesProcessor == other.attributesProcessor &&
+            cardinalityLimit == other.cardinalityLimit
+
+    override fun hashCode(): Int {
+        var result = name.lowercase().hashCode()
+        result = 31 * result + description.hashCode()
+        result = 31 * result + sourceInstrument.hashCode()
+        result = 31 * result + view.aggregation.hashCode()
+        result = 31 * result + attributesProcessor.hashCode()
+        result = 31 * result + cardinalityLimit
+        return result
+    }
+
+    override fun toString(): String =
+        "MetricDescriptor(name=$name, description=$description, sourceInstrument=$sourceInstrument, " +
+            "view=$view, cardinalityLimit=$cardinalityLimit)"
+
+    companion object {
+        fun create(
+            sourceInstrument: InstrumentDescriptor,
+            view: View,
+            attributesProcessor: AttributesProcessor = view.attributesProcessor,
+            cardinalityLimit: Int = view.cardinalityLimit,
+        ): MetricDescriptor = MetricDescriptor(
+            name = view.name ?: sourceInstrument.name,
+            description = view.description ?: sourceInstrument.description,
+            sourceInstrument = sourceInstrument,
+            view = view,
+            attributesProcessor = attributesProcessor,
+            cardinalityLimit = cardinalityLimit,
+        )
+    }
+}

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/MetricDescriptor.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/MetricDescriptor.kt
@@ -5,9 +5,15 @@ import io.opentelemetry.kotlin.metrics.view.AttributesProcessor
 import io.opentelemetry.kotlin.metrics.view.View
 
 /**
- * SDK configuration for a metric stream after applying an instrument-matching View.
+ * Resolved SDK configuration for a metric stream after applying an instrument-matching View.
  *
  * One instrument may produce multiple independently configured streams when multiple Views match.
+ *
+ * This is a plain class rather than a data class because equality represents the resolved stream
+ * configuration rather than the complete [View]. Names are compared case-insensitively to preserve
+ * instrument identity, as specified by the specification:
+ *
+ * https://opentelemetry.io/docs/specs/semconv/general/naming
  *
  * https://opentelemetry.io/docs/specs/otel/metrics/sdk/#measurement-processing
  */
@@ -21,6 +27,7 @@ internal class MetricDescriptor private constructor(
 ) {
     val unit: String? = sourceInstrument.unit
 
+    /** Uses case-insensitive version of [name]. */
     override fun equals(other: Any?): Boolean =
         this === other ||
             other is MetricDescriptor &&
@@ -31,6 +38,7 @@ internal class MetricDescriptor private constructor(
             attributesProcessor == other.attributesProcessor &&
             cardinalityLimit == other.cardinalityLimit
 
+    /** Uses case-insensitive version of [name]. */
     override fun hashCode(): Int {
         var result = name.lowercase().hashCode()
         result = 31 * result + description.hashCode()

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/MetricDescriptor.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/MetricDescriptor.kt
@@ -65,7 +65,8 @@ internal class MetricDescriptor private constructor(
             sourceInstrument = sourceInstrument,
             view = view,
             attributesProcessor = attributesProcessor,
-            cardinalityLimit = cardinalityLimit,
+            cardinalityLimit = cardinalityLimit.takeIf { it > 0 }
+                ?: MetricStorage.DEFAULT_MAX_CARDINALITY,
         )
     }
 }

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/MetricStorage.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/MetricStorage.kt
@@ -1,0 +1,35 @@
+package io.opentelemetry.kotlin.metrics
+
+import io.opentelemetry.kotlin.InstrumentationScopeInfo
+import io.opentelemetry.kotlin.metrics.data.MetricData
+import io.opentelemetry.kotlin.resource.Resource
+
+/**
+ * Aggregation state for one resolved stream and MetricReader pipeline.
+ *
+ * Storage persistence across collections depends on instrument synchronicity and the reader's
+ * selected temporality.
+ *
+ * https://opentelemetry.io/docs/specs/otel/metrics/sdk/#metricreader
+ */
+internal interface MetricStorage {
+    val descriptor: MetricDescriptor
+
+    /**
+     * Collects the metric data currently retained by this storage.
+     *
+     * Delta storage advances its interval after collection; cumulative storage retains its start
+     * timestamp and previously observed synchronous series.
+     */
+    fun collect(
+        resource: Resource,
+        instrumentationScopeInfo: InstrumentationScopeInfo,
+        timestampEpochNanos: Long,
+    ): MetricData
+
+    fun setEnabled(enabled: Boolean)
+
+    companion object {
+        const val DEFAULT_MAX_CARDINALITY: Int = 2_000
+    }
+}

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/MetricStorage.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/MetricStorage.kt
@@ -14,6 +14,7 @@ import io.opentelemetry.kotlin.resource.Resource
  */
 internal interface MetricStorage {
     val descriptor: MetricDescriptor
+    var isEnabled: Boolean
 
     /**
      * Collects the metric data currently retained by this storage.
@@ -26,8 +27,6 @@ internal interface MetricStorage {
         instrumentationScopeInfo: InstrumentationScopeInfo,
         timestampEpochNanos: Long,
     ): MetricData
-
-    fun setEnabled(enabled: Boolean)
 
     companion object {
         const val DEFAULT_MAX_CARDINALITY: Int = 2_000

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/WritableMetricStorage.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/WritableMetricStorage.kt
@@ -1,0 +1,26 @@
+package io.opentelemetry.kotlin.metrics
+
+import io.opentelemetry.kotlin.attributes.AttributesModel
+import io.opentelemetry.kotlin.context.Context
+
+/**
+ * Records synchronous measurements together with attributes and the Context used for exemplar
+ * sampling.
+ *
+ * https://opentelemetry.io/docs/specs/otel/metrics/api/#synchronous-instrument-api
+ */
+internal interface WritableMetricStorage {
+    val isEnabled: Boolean
+
+    fun recordLong(
+        value: Long,
+        attributes: AttributesModel,
+        context: Context,
+    )
+
+    fun recordDouble(
+        value: Double,
+        attributes: AttributesModel,
+        context: Context,
+    )
+}

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/aggregation/Aggregation.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/aggregation/Aggregation.kt
@@ -1,0 +1,11 @@
+package io.opentelemetry.kotlin.metrics.aggregation
+
+/**
+ * A decomposable operation and its configuration overrides for converting measurements into
+ * metric points.
+ *
+ * https://opentelemetry.io/docs/specs/otel/metrics/sdk/#aggregation
+ */
+internal sealed interface Aggregation {
+    val name: String
+}

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/aggregation/AggregationResolver.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/aggregation/AggregationResolver.kt
@@ -1,0 +1,17 @@
+package io.opentelemetry.kotlin.metrics.aggregation
+
+import io.opentelemetry.kotlin.metrics.instrument.InstrumentDescriptor
+
+/**
+ * Internal strategy for resolving a MetricReader's concrete default aggregation for an
+ * instrument, including relevant instrument advice.
+ *
+ * This resolver is an implementation-specific abstraction, not an entity defined by the
+ * OpenTelemetry Metrics SDK. It separates reader-specific default selection from View and metric
+ * stream resolution.
+ *
+ * https://opentelemetry.io/docs/specs/otel/metrics/sdk/#default-aggregation
+ */
+internal fun interface AggregationResolver {
+    fun resolve(instrument: InstrumentDescriptor): Aggregation
+}

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/instrument/Advice.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/instrument/Advice.kt
@@ -1,0 +1,35 @@
+package io.opentelemetry.kotlin.metrics.instrument
+
+/**
+ * Optional recommendations supplied by instrumentation to influence metric stream configuration.
+ *
+ * Advice is not part of instrument identity, implementations may ignore it, and an explicit View
+ * setting takes precedence over advice for the same aspect of a stream.
+ *
+ * https://opentelemetry.io/docs/specs/otel/metrics/api/#instrument-advisory-parameters
+ */
+internal sealed interface Advice {
+
+    /** Recommended allow-list of attribute keys, or `null` when no recommendation was supplied. */
+    val attributeKeys: Set<String>?
+
+    data object Empty : Advice {
+        override val attributeKeys: Set<String>? = null
+    }
+
+    /** Recommended attribute keys to retain when no matching View configures an allow-list. */
+    data class Attributes(
+        override val attributeKeys: Set<String>
+    ) : Advice
+
+    data class Histogram(
+        override val attributeKeys: Set<String>?,
+
+        /**
+         * Recommended explicit bucket boundaries used when no View matches or a matching View
+         * selects default aggregation. A View selecting explicit-bucket histogram aggregation
+         * overrides this advice even when it does not configure boundaries.
+         */
+        val explicitBucketBoundaries: List<Double>?,
+    ) : Advice
+}

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/instrument/InstrumentDescriptor.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/instrument/InstrumentDescriptor.kt
@@ -1,0 +1,42 @@
+package io.opentelemetry.kotlin.metrics.instrument
+
+/**
+ * Identifying parameters captured when a Meter creates an instrument.
+ *
+ * Instrument names are compared case-insensitively. Kind, unit, description, and numeric value
+ * type are identifying; [advice] is not, so the first advice registered for otherwise identical
+ * instruments is retained by the Meter.
+ *
+ * https://opentelemetry.io/docs/specs/otel/metrics/api/#instrument
+ */
+internal class InstrumentDescriptor(
+    val name: String,
+    val unit: String?,
+    val description: String?,
+    val kind: InstrumentKind,
+    val valueType: InstrumentValueType,
+    val advice: Advice = Advice.Empty,
+) {
+
+    override fun equals(other: Any?): Boolean =
+        this === other ||
+            other is InstrumentDescriptor &&
+            name.equals(other.name, ignoreCase = true) &&
+            unit == other.unit &&
+            description == other.description &&
+            kind == other.kind &&
+            valueType == other.valueType
+
+    override fun hashCode(): Int {
+        var result = name.lowercase().hashCode()
+        result = 31 * result + unit.hashCode()
+        result = 31 * result + description.hashCode()
+        result = 31 * result + kind.hashCode()
+        result = 31 * result + valueType.hashCode()
+        return result
+    }
+
+    override fun toString(): String =
+        "InstrumentDescriptor(name=$name, unit=$unit, description=$description, " +
+            "kind=$kind, valueType=$valueType, advice=$advice)"
+}

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/instrument/InstrumentDescriptor.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/instrument/InstrumentDescriptor.kt
@@ -3,9 +3,9 @@ package io.opentelemetry.kotlin.metrics.instrument
 /**
  * Identifying parameters captured when a Meter creates an instrument.
  *
- * Instrument names are compared case-insensitively. Kind, unit, description, and numeric value
- * type are identifying; [advice] is not, so the first advice registered for otherwise identical
- * instruments is retained by the Meter.
+ * This is a plain class rather than a data class because equality represents instrument identity
+ * rather than all properties. Names are compared case-insensitively, and [advice] is excluded from
+ * the identity.
  *
  * https://opentelemetry.io/docs/specs/otel/metrics/api/#instrument
  */
@@ -18,6 +18,10 @@ internal class InstrumentDescriptor(
     val advice: Advice = Advice.Empty,
 ) {
 
+    /**
+     * Uses case-insensitive version of [name], ignores [advice] (since advice is not part of
+     * instrument identity).
+     */
     override fun equals(other: Any?): Boolean =
         this === other ||
             other is InstrumentDescriptor &&
@@ -27,6 +31,10 @@ internal class InstrumentDescriptor(
             kind == other.kind &&
             valueType == other.valueType
 
+    /**
+     * Uses case-insensitive version of [name], ignores [advice] (since advice is not part of
+     * instrument identity).
+     */
     override fun hashCode(): Int {
         var result = name.lowercase().hashCode()
         result = 31 * result + unit.hashCode()

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/instrument/SdkInstrument.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/instrument/SdkInstrument.kt
@@ -1,0 +1,28 @@
+package io.opentelemetry.kotlin.metrics.instrument
+
+import io.opentelemetry.kotlin.metrics.Instrument
+
+/**
+ * Internal bridge between an API instrument and SDK measurement processing.
+ *
+ * Concrete SDK instruments implement this interface alongside their corresponding recording API.
+ * They use [descriptor] to match Views and resolve metric streams, then forward measurements to
+ * the writable storages created for those streams.
+ *
+ * This interface is an implementation detail; the Metrics SDK specification defines the required
+ * instrument behavior but does not define an `SdkInstrument` type.
+ *
+ * https://opentelemetry.io/docs/specs/otel/metrics/sdk/#measurement-processing
+ */
+internal interface SdkInstrument : Instrument {
+    val descriptor: InstrumentDescriptor
+
+    override val name: String
+        get() = descriptor.name
+
+    override val unit: String?
+        get() = descriptor.unit
+
+    override val description: String?
+        get() = descriptor.description
+}

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/view/AttributesProcessor.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/view/AttributesProcessor.kt
@@ -1,0 +1,20 @@
+package io.opentelemetry.kotlin.metrics.view
+
+import io.opentelemetry.kotlin.attributes.AttributesModel
+
+/**
+ * Applies a View's attribute filtering before attributes form an aggregation key.
+ *
+ * Cardinality limits are evaluated after this processing so excluded attributes cannot create
+ * additional metric points.
+ *
+ * https://opentelemetry.io/docs/specs/otel/metrics/sdk/#stream-configuration
+ */
+internal sealed interface AttributesProcessor {
+
+    fun process(attributes: AttributesModel): AttributesModel
+
+    data object Noop : AttributesProcessor {
+        override fun process(attributes: AttributesModel): AttributesModel = attributes
+    }
+}

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/view/InstrumentSelector.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/view/InstrumentSelector.kt
@@ -1,0 +1,16 @@
+package io.opentelemetry.kotlin.metrics.view
+
+import io.opentelemetry.kotlin.InstrumentationScopeInfo
+import io.opentelemetry.kotlin.metrics.instrument.InstrumentDescriptor
+
+/**
+ * Evaluates the additive instrument and instrumentation-scope criteria of a View.
+ *
+ * https://opentelemetry.io/docs/specs/otel/metrics/sdk/#instrument-selection-criteria
+ */
+internal fun interface InstrumentSelector {
+    fun matches(
+        descriptor: InstrumentDescriptor,
+        instrumentationScopeInfo: InstrumentationScopeInfo,
+    ): Boolean
+}

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/view/View.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/view/View.kt
@@ -1,0 +1,26 @@
+package io.opentelemetry.kotlin.metrics.view
+
+import io.opentelemetry.kotlin.metrics.MetricStorage
+import io.opentelemetry.kotlin.metrics.aggregation.Aggregation
+
+/**
+ * Instrument selection criteria and the stream configuration applied to every matching
+ * instrument independently of other Views.
+ *
+ * An explicitly configured stream setting overrides advice for the same aspect. A null
+ * [aggregation] delegates aggregation selection to the MetricReader default.
+ *
+ * https://opentelemetry.io/docs/specs/otel/metrics/sdk/#view
+ */
+internal data class View(
+    val selector: InstrumentSelector,
+    val name: String? = null,
+    val description: String? = null,
+    val aggregation: Aggregation? = null,
+    val attributesProcessor: AttributesProcessor = AttributesProcessor.Noop,
+    val cardinalityLimit: Int = MetricStorage.DEFAULT_MAX_CARDINALITY,
+) {
+    init {
+        require(cardinalityLimit > 0) { "cardinalityLimit must be positive" }
+    }
+}

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/view/View.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/view/View.kt
@@ -10,6 +10,9 @@ import io.opentelemetry.kotlin.metrics.aggregation.Aggregation
  * An explicitly configured stream setting overrides advice for the same aspect. A null
  * [aggregation] delegates aggregation selection to the MetricReader default.
  *
+ * [cardinalityLimit] should be positive. Non-positive values fall back to
+ * [MetricStorage.DEFAULT_MAX_CARDINALITY] when the metric stream is resolved.
+ *
  * https://opentelemetry.io/docs/specs/otel/metrics/sdk/#view
  */
 internal data class View(
@@ -19,8 +22,4 @@ internal data class View(
     val aggregation: Aggregation? = null,
     val attributesProcessor: AttributesProcessor = AttributesProcessor.Noop,
     val cardinalityLimit: Int = MetricStorage.DEFAULT_MAX_CARDINALITY,
-) {
-    init {
-        require(cardinalityLimit > 0) { "cardinalityLimit must be positive" }
-    }
-}
+)

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/metrics/MetricDescriptorTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/metrics/MetricDescriptorTest.kt
@@ -1,0 +1,69 @@
+package io.opentelemetry.kotlin.metrics
+
+import io.opentelemetry.kotlin.metrics.instrument.InstrumentDescriptor
+import io.opentelemetry.kotlin.metrics.instrument.InstrumentKind
+import io.opentelemetry.kotlin.metrics.instrument.InstrumentValueType
+import io.opentelemetry.kotlin.metrics.view.InstrumentSelector
+import io.opentelemetry.kotlin.metrics.view.View
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+internal class MetricDescriptorTest {
+
+    @Test
+    fun `uses instrument name and description when the view omits them`() {
+        val descriptor = MetricDescriptor.create(
+            sourceInstrument = instrument,
+            view = view(),
+        )
+
+        assertEquals(instrument.name, descriptor.name)
+        assertEquals(instrument.description, descriptor.description)
+    }
+
+    @Test
+    fun `uses name and description configured by the view`() {
+        val descriptor = MetricDescriptor.create(
+            sourceInstrument = instrument,
+            view = view(name = "view-name", description = "view-description"),
+        )
+
+        assertEquals("view-name", descriptor.name)
+        assertEquals("view-description", descriptor.description)
+    }
+
+    @Test
+    fun `selector does not participate in resolved descriptor equality`() {
+        val first = MetricDescriptor.create(
+            sourceInstrument = instrument,
+            view = view(selector = { _, _ -> true }),
+        )
+        val second = MetricDescriptor.create(
+            sourceInstrument = instrument,
+            view = view(selector = { _, _ -> true }),
+        )
+
+        assertEquals(first, second)
+        assertEquals(first.hashCode(), second.hashCode())
+    }
+
+    private fun view(
+        selector: InstrumentSelector = InstrumentSelector { _, _ -> true },
+        name: String? = null,
+        description: String? = null,
+    ): View = View(
+        selector = selector,
+        name = name,
+        description = description,
+    )
+
+    private companion object {
+        val instrument = InstrumentDescriptor(
+            name = "instrument-name",
+            unit = "ms",
+            description = "instrument-description",
+            kind = InstrumentKind.HISTOGRAM,
+            valueType = InstrumentValueType.DOUBLE,
+        )
+    }
+}

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/metrics/MetricDescriptorTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/metrics/MetricDescriptorTest.kt
@@ -62,14 +62,28 @@ internal class MetricDescriptorTest {
         assertEquals(first.hashCode(), second.hashCode())
     }
 
+    @Test
+    fun `invalid cardinality limit falls back to the SDK default`() {
+        listOf(0, -1).forEach { invalidLimit ->
+            val descriptor = MetricDescriptor.create(
+                sourceInstrument = instrument,
+                view = view(cardinalityLimit = invalidLimit),
+            )
+
+            assertEquals(MetricStorage.DEFAULT_MAX_CARDINALITY, descriptor.cardinalityLimit)
+        }
+    }
+
     private fun view(
         selector: InstrumentSelector = InstrumentSelector { _, _ -> true },
         name: String? = null,
         description: String? = null,
+        cardinalityLimit: Int = MetricStorage.DEFAULT_MAX_CARDINALITY,
     ): View = View(
         selector = selector,
         name = name,
         description = description,
+        cardinalityLimit = cardinalityLimit,
     )
 
     private companion object {

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/metrics/MetricDescriptorTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/metrics/MetricDescriptorTest.kt
@@ -47,6 +47,21 @@ internal class MetricDescriptorTest {
         assertEquals(first.hashCode(), second.hashCode())
     }
 
+    @Test
+    fun `metric name comparison is case insensitive`() {
+        val first = MetricDescriptor.create(
+            sourceInstrument = instrument,
+            view = view(name = "http.server.request.duration"),
+        )
+        val second = MetricDescriptor.create(
+            sourceInstrument = instrument,
+            view = view(name = "HTTP.SERVER.REQUEST.DURATION"),
+        )
+
+        assertEquals(first, second)
+        assertEquals(first.hashCode(), second.hashCode())
+    }
+
     private fun view(
         selector: InstrumentSelector = InstrumentSelector { _, _ -> true },
         name: String? = null,

--- a/sdk-api/api/jvm/sdk-api.api
+++ b/sdk-api/api/jvm/sdk-api.api
@@ -386,6 +386,21 @@ public abstract interface class io/opentelemetry/kotlin/metrics/data/SumData$Dou
 public abstract interface class io/opentelemetry/kotlin/metrics/data/SumData$LongSumData : io/opentelemetry/kotlin/metrics/data/SumData {
 }
 
+public final class io/opentelemetry/kotlin/metrics/instrument/InstrumentKind : java/lang/Enum {
+	public static final field HISTOGRAM Lio/opentelemetry/kotlin/metrics/instrument/InstrumentKind;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lio/opentelemetry/kotlin/metrics/instrument/InstrumentKind;
+	public static fun values ()[Lio/opentelemetry/kotlin/metrics/instrument/InstrumentKind;
+}
+
+public final class io/opentelemetry/kotlin/metrics/instrument/InstrumentValueType : java/lang/Enum {
+	public static final field DOUBLE Lio/opentelemetry/kotlin/metrics/instrument/InstrumentValueType;
+	public static final field LONG Lio/opentelemetry/kotlin/metrics/instrument/InstrumentValueType;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lio/opentelemetry/kotlin/metrics/instrument/InstrumentValueType;
+	public static fun values ()[Lio/opentelemetry/kotlin/metrics/instrument/InstrumentValueType;
+}
+
 public abstract interface class io/opentelemetry/kotlin/resource/MutableResource {
 	public abstract fun getAttributes ()Ljava/util/Map;
 	public abstract fun getSchemaUrl ()Ljava/lang/String;

--- a/sdk-api/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/instrument/InstrumentKind.kt
+++ b/sdk-api/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/instrument/InstrumentKind.kt
@@ -1,0 +1,13 @@
+package io.opentelemetry.kotlin.metrics.instrument
+
+import io.opentelemetry.kotlin.ExperimentalApi
+
+/**
+ * Classification of a metric instrument used to capture measurements.
+ *
+ * https://opentelemetry.io/docs/specs/otel/metrics/api/#instrument
+ */
+@ExperimentalApi
+public enum class InstrumentKind {
+    HISTOGRAM,
+}

--- a/sdk-api/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/instrument/InstrumentValueType.kt
+++ b/sdk-api/src/commonMain/kotlin/io/opentelemetry/kotlin/metrics/instrument/InstrumentValueType.kt
@@ -1,0 +1,17 @@
+package io.opentelemetry.kotlin.metrics.instrument
+
+import io.opentelemetry.kotlin.ExperimentalApi
+
+/**
+ * Language-level numeric type recorded by an instrument.
+ *
+ * Numeric type participates in instrument identity even though integer and floating-point values
+ * do not create distinct OTLP metric-stream identities.
+ *
+ * https://opentelemetry.io/docs/specs/otel/metrics/api/#instrument
+ */
+@ExperimentalApi
+public enum class InstrumentValueType {
+    DOUBLE,
+    LONG,
+}


### PR DESCRIPTION
## GOAL

Created the internal Metrics SDK foundations for configuring and storing metric streams. Addresses https://github.com/open-telemetry/opentelemetry-kotlin/issues/952 and https://github.com/open-telemetry/opentelemetry-kotlin/issues/954

Added Aggregation and View contracts, instrument and metric descriptors, attribute processing, aggregation resolution, and readable/writable MetricStorage APIs.

Concrete aggregation and instrument implementations will be added in subsequent PRs.

## Testing

Compiled for all platforms. Detekt, apiCheck, and Android test compilation passed.