### PR TITLE
fix: make DefaultImplicitContextStorage.current volatile

### DIFF
--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/context/DefaultImplicitContextStorage.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/context/DefaultImplicitContextStorage.kt
@@ -1,4 +1,7 @@
 package io.opentelemetry.kotlin.context
+
+import kotlin.concurrent.Volatile
+
 /**
  * A simple implementation of [ImplicitContextStorage] that only allows one context at any time,
  * and doesn't use thread locals/coroutine context to distinguish between what is current.
@@ -8,6 +11,8 @@ internal class DefaultImplicitContextStorage(
 ) : ImplicitContextStorage {
 
     private val root by lazy { rootSupplier() }
+
+    @Volatile
     private var current: Context? = null
 
     override fun setImplicitContext(context: Context) {


### PR DESCRIPTION
## Goal
Make GLOBAL implicit-context storage visible across threads by marking
DefaultImplicitContextStorage.current @ Volatile. A plain var can leave
another thread seeing a stale context.

## Testing
Existing DefaultImplicitContextStorageImplTest covers set/get. Ran
implementation jvmTest for context storage/scope plus detekt.

Fixes #962