### PR TITLE
fix: construct SpanContext from bytes without a hex round trip

### DIFF
--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/factory/SpanContextFactoryImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/factory/SpanContextFactoryImpl.kt
@@ -27,24 +27,13 @@ internal class SpanContextFactoryImpl(
         traceFlags: TraceFlags,
         traceState: TraceState,
         isRemote: Boolean,
-    ): SpanContext {
-        val isValidTraceId = isValidTraceId(traceId)
-        val isValidSpanId = isValidSpanId(spanId)
-
-        return SpanContextImpl(
-            traceIdBytes = when {
-                isValidTraceId -> traceId.hexToByteArray()
-                else -> idGenerator.invalidTraceId
-            },
-            spanIdBytes = when {
-                isValidSpanId -> spanId.hexToByteArray()
-                else -> idGenerator.invalidSpanId
-            },
-            traceFlags = traceFlags,
-            isRemote = isRemote,
-            traceState = traceState
-        )
-    }
+    ): SpanContext = create(
+        traceId.hexToByteArray(),
+        spanId.hexToByteArray(),
+        traceFlags,
+        traceState,
+        isRemote,
+    )
 
     override fun create(
         traceIdBytes: ByteArray,
@@ -52,41 +41,19 @@ internal class SpanContextFactoryImpl(
         traceFlags: TraceFlags,
         traceState: TraceState,
         isRemote: Boolean,
-    ): SpanContext = create(
-        traceIdBytes.toHexString(),
-        spanIdBytes.toHexString(),
-        traceFlags,
-        traceState,
-        isRemote,
+    ): SpanContext = SpanContextImpl(
+        traceIdBytes = if (traceIdBytes.isValidTraceIdBytes()) {
+            traceIdBytes
+        } else {
+            idGenerator.invalidTraceId
+        },
+        spanIdBytes = if (spanIdBytes.isValidSpanIdBytes()) {
+            spanIdBytes
+        } else {
+            idGenerator.invalidSpanId
+        },
+        traceFlags = traceFlags,
+        isRemote = isRemote,
+        traceState = traceState,
     )
-
-    private fun isValidTraceId(traceId: String): Boolean {
-        // Must be 32 hex characters (16 bytes)
-        if (traceId.length != TRACE_ID_HEX_LENGTH) {
-            return false
-        }
-
-        // Must be valid hex
-        if (!traceId.isValidHex()) {
-            return false
-        }
-
-        // Must have at least one non-zero byte (not all zeros)
-        return !traceId.isAllZerosHex()
-    }
-
-    private fun isValidSpanId(spanId: String): Boolean {
-        // Must be 16 hex characters (8 bytes)
-        if (spanId.length != SPAN_ID_HEX_LENGTH) {
-            return false
-        }
-
-        // Must be valid hex
-        if (!spanId.isValidHex()) {
-            return false
-        }
-
-        // Must have at least one non-zero byte (not all zeros)
-        return !spanId.isAllZerosHex()
-    }
 }

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/factory/SpanContextFactoryImplTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/factory/SpanContextFactoryImplTest.kt
@@ -183,6 +183,59 @@ internal class SpanContextFactoryImplTest {
     }
 
     @Test
+    internal fun testCreateBytesWithValidIds() {
+        val traceId = "12345678901234567890123456789012"
+        val spanId = "1234567890123456"
+        val traceIdBytes = traceId.hexToByteArray()
+        val spanIdBytes = spanId.hexToByteArray()
+
+        val spanContext = factory.create(
+            traceIdBytes,
+            spanIdBytes,
+            traceFlagsFactory.default,
+            traceStateFactory.default,
+            false,
+        )
+
+        assertEquals(traceId, spanContext.traceId)
+        assertEquals(spanId, spanContext.spanId)
+        assertTrue(spanContext.isValid)
+        assertFalse(spanContext.isRemote)
+    }
+
+    @Test
+    internal fun testCreateBytesWithAllZeroIdsIsInvalid() {
+        val spanContext = factory.create(
+            ByteArray(16),
+            ByteArray(8),
+            traceFlagsFactory.default,
+            traceStateFactory.default,
+            false,
+        )
+
+        assertEquals("00000000000000000000000000000000", spanContext.traceId)
+        assertEquals("0000000000000000", spanContext.spanId)
+        assertFalse(spanContext.isValid)
+    }
+
+    @Test
+    internal fun testCreateBytesWithWrongLengthIdsAreZeroed() {
+        val spanContext = factory.create(
+            ByteArray(4) { 1 },
+            ByteArray(0),
+            traceFlagsFactory.default,
+            traceStateFactory.default,
+            false,
+        )
+
+        assertEquals("00000000000000000000000000000000", spanContext.traceId)
+        assertEquals("0000000000000000", spanContext.spanId)
+        assertEquals(16, spanContext.traceIdBytes.size)
+        assertEquals(8, spanContext.spanIdBytes.size)
+        assertFalse(spanContext.isValid)
+    }
+
+    @Test
     internal fun testStatePreservedWithInvalidIds() {
         val invalidTraceId = "invalid"
         val invalidSpanId = "bad"


### PR DESCRIPTION
## Goal
Stop SpanContextFactoryImpl's ByteArray create() from round-tripping through
hex. Bytes construct SpanContextImpl directly; hex strings convert with
hexToByteArray and delegate. Invalid IDs still become the generator's
all-zero IDs.

## Testing
Existing string create tests still cover valid/invalid/uppercase hex.
Added ByteArray cases for valid, all-zero, and wrong-length IDs. Ran
implementation jvmTest for SpanContextFactoryImpl / SpanContextImpl /
TracerInvalidIdTest plus detekt.

Fixes #968