### PR TITLE
fix: match span event bridge IDs by bytes, not hex

### DIFF
--- a/span-event-bridge/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/SpanEventBridgeLogRecordProcessor.kt
+++ b/span-event-bridge/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/SpanEventBridgeLogRecordProcessor.kt
@@ -55,6 +55,6 @@ internal class SpanEventBridgeLogRecordProcessor : LogRecordProcessor {
     }
 
     private fun SpanContext.identifies(span: Span): Boolean = isValid &&
-        traceId == span.spanContext.traceId &&
-        spanId == span.spanContext.spanId
+        traceIdBytes.contentEquals(span.spanContext.traceIdBytes) &&
+        spanIdBytes.contentEquals(span.spanContext.spanIdBytes)
 }

--- a/span-event-bridge/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/export/SpanEventBridgeLogRecordProcessorTest.kt
+++ b/span-event-bridge/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/export/SpanEventBridgeLogRecordProcessorTest.kt
@@ -70,6 +70,21 @@ internal class SpanEventBridgeLogRecordProcessorTest {
     }
 
     @Test
+    fun testEventBridgedWhenIdsMatchByContentNotIdentity() {
+        val span = FakeSpan(spanContext = FakeSpanContext.VALID)
+        val log = eventLogRecord(
+            spanContext = FakeSpanContext(
+                traceIdBytes = FakeSpanContext.VALID.traceIdBytes.copyOf(),
+                spanIdBytes = FakeSpanContext.VALID.spanIdBytes.copyOf(),
+            ),
+        )
+
+        SpanEventBridgeLogRecordProcessor().onEmit(log, FakeContext(span = span))
+
+        assertEquals("my_event", span.events.single().name)
+    }
+
+    @Test
     fun testLogRecordWithoutEventNameNotBridged() {
         assertNotBridged(eventLogRecord(eventName = null))
     }


### PR DESCRIPTION
## Goal
Match log records to the current span by comparing traceIdBytes and
spanIdBytes instead of hex strings, so emit does not force lazy hex
encoding of four IDs per record.

## Testing
Existing bridge/mismatch tests still pass. Added a case with copied
ID byte arrays so matching is by content, not array identity. Ran
span-event-bridge jvmTest plus detekt.

Fixes #969