### PR TITLE
fix: back in-memory exporters with threadSafeList

### DIFF
--- a/exporters-in-memory/build.gradle.kts
+++ b/exporters-in-memory/build.gradle.kts
@@ -13,6 +13,7 @@ kotlin {
             dependencies {
                 implementation(project(":sdk-api"))
                 implementation(project(":sdk-common"))
+                implementation(project(":platform-implementations"))
             }
         }
         val commonTest by getting {

--- a/exporters-in-memory/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/InMemoryLogRecordExporterImpl.kt
+++ b/exporters-in-memory/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/InMemoryLogRecordExporterImpl.kt
@@ -3,10 +3,11 @@ package io.opentelemetry.kotlin.logging.export
 import io.opentelemetry.kotlin.export.MutableShutdownState
 import io.opentelemetry.kotlin.export.OperationResultCode
 import io.opentelemetry.kotlin.logging.data.LogRecordData
+import io.opentelemetry.kotlin.threadSafeList
 
 internal class InMemoryLogRecordExporterImpl : InMemoryLogRecordExporter {
 
-    private val impl = mutableListOf<LogRecordData>()
+    private val impl = threadSafeList<LogRecordData>()
     private val shutdownState = MutableShutdownState()
 
     override val exportedLogRecords: List<LogRecordData>

--- a/exporters-in-memory/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/InMemorySpanExporterImpl.kt
+++ b/exporters-in-memory/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/InMemorySpanExporterImpl.kt
@@ -2,11 +2,12 @@ package io.opentelemetry.kotlin.tracing.export
 
 import io.opentelemetry.kotlin.export.MutableShutdownState
 import io.opentelemetry.kotlin.export.OperationResultCode
+import io.opentelemetry.kotlin.threadSafeList
 import io.opentelemetry.kotlin.tracing.data.SpanData
 
 internal class InMemorySpanExporterImpl : InMemorySpanExporter {
 
-    private val impl = mutableListOf<SpanData>()
+    private val impl = threadSafeList<SpanData>()
     private val shutdownState = MutableShutdownState()
 
     override val exportedSpans: List<SpanData>


### PR DESCRIPTION
## Goal
Back in-memory span and log exporters with threadSafeList so concurrent
export/read does not hit an unsynchronised ArrayList.

## Testing
Existing InMemorySpanExporterTest and InMemoryLogRecordExporterTest cover
export, snapshots, and shutdown. Ran exporters-in-memory jvmTest plus detekt.

Fixes #966