### PR TITLE
fix: set schema_url on ResourceSpans and ResourceLogs

### DIFF
--- a/exporters-protobuf/src/commonMain/kotlin/io/opentelemetry/kotlin/export/conversion/CommonProtobufConversion.kt
+++ b/exporters-protobuf/src/commonMain/kotlin/io/opentelemetry/kotlin/export/conversion/CommonProtobufConversion.kt
@@ -30,8 +30,13 @@ internal fun InstrumentationScope.toInstrumentationScopeInfo(
     attributes = attributes.toAttributeMap()
 )
 
-internal fun io.opentelemetry.proto.resource.v1.Resource.toResource(): Resource =
-    DeserializedResource(attributes = attributes.toAttributeMap())
+internal fun io.opentelemetry.proto.resource.v1.Resource.toResource(
+    schemaUrl: String? = null,
+): Resource =
+    DeserializedResource(
+        attributes = attributes.toAttributeMap(),
+        schemaUrl = schemaUrl?.ifEmpty { null },
+    )
 
 internal fun TraceFlags.toFlagsInt(): Int = hex.toInt(16)
 

--- a/exporters-protobuf/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/ExportLogsServiceRequestCreator.kt
+++ b/exporters-protobuf/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/ExportLogsServiceRequestCreator.kt
@@ -14,7 +14,7 @@ fun List<LogRecordData>.toProtobufByteArray(): ByteArray =
 fun ByteArray.toLogRecordDataList(): List<LogRecordData> {
     val request = ExportLogsServiceRequest.ADAPTER.decode(this)
     return request.resource_logs.flatMap { resourceLogs ->
-        val resource = resourceLogs.resource?.toResource()
+        val resource = resourceLogs.resource?.toResource(resourceLogs.schema_url)
             ?: return@flatMap emptyList()
         resourceLogs.scope_logs.flatMap { scopeLogs ->
             val scopeInfo = scopeLogs.scope?.toInstrumentationScopeInfo(scopeLogs.schema_url)
@@ -42,5 +42,6 @@ private fun List<LogRecordData>.toResourceLogs(): List<ResourceLogs> =
                     schema_url = scope.schemaUrl ?: "",
                 )
             },
+            schema_url = resource.schemaUrl ?: "",
         )
     }

--- a/exporters-protobuf/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/ExportTracesServiceRequestCreator.kt
+++ b/exporters-protobuf/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/ExportTracesServiceRequestCreator.kt
@@ -14,7 +14,7 @@ fun List<SpanData>.toProtobufByteArray() =
 fun ByteArray.toSpanDataList(): List<SpanData> {
     val request = ExportTraceServiceRequest.ADAPTER.decode(this)
     return request.resource_spans.flatMap { resourceSpans ->
-        val resource = resourceSpans.resource?.toResource()
+        val resource = resourceSpans.resource?.toResource(resourceSpans.schema_url)
             ?: return@flatMap emptyList()
         resourceSpans.scope_spans.flatMap { scopeSpans ->
             val scopeInfo = scopeSpans.scope?.toInstrumentationScopeInfo(scopeSpans.schema_url)
@@ -40,5 +40,6 @@ private fun List<SpanData>.toResourceSpan(): List<ResourceSpans> =
                     schema_url = scope.schemaUrl ?: "",
                 )
             },
+            schema_url = resource.schemaUrl ?: "",
         )
     }

--- a/exporters-protobuf/src/commonTest/kotlin/io/opentelemetry/kotlin/export/conversion/CommonProtobufConversionTest.kt
+++ b/exporters-protobuf/src/commonTest/kotlin/io/opentelemetry/kotlin/export/conversion/CommonProtobufConversionTest.kt
@@ -110,6 +110,24 @@ class CommonProtobufConversionTest {
     }
 
     @Test
+    fun testResourceDeserialization_usesSchemaUrl() {
+        val proto = io.opentelemetry.proto.resource.v1.Resource(
+            attributes = emptyList()
+        )
+        val resource = proto.toResource("https://example.com/schema")
+        assertEquals("https://example.com/schema", resource.schemaUrl)
+    }
+
+    @Test
+    fun testResourceDeserialization_emptySchemaUrlIsNull() {
+        val proto = io.opentelemetry.proto.resource.v1.Resource(
+            attributes = emptyList()
+        )
+        val resource = proto.toResource("")
+        assertNull(resource.schemaUrl)
+    }
+
+    @Test
     fun testResourceDeserialization_asNewResource() {
         val resource = deserializedResource()
 

--- a/exporters-protobuf/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/export/ExportLogsServiceRequestTest.kt
+++ b/exporters-protobuf/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/export/ExportLogsServiceRequestTest.kt
@@ -199,4 +199,32 @@ class ExportLogsServiceRequestTest {
 
         assertEquals("", request.resource_logs[0].scope_logs[0].schema_url)
     }
+
+    @Test
+    fun testUsesResourceSchemaUrlOnResourceLogs() {
+        val request = listOf(
+            FakeLogRecordData(resource = FakeResource(schemaUrl = "https://example.com/resource")),
+        ).toExportLogsServiceRequest()
+
+        assertEquals("https://example.com/resource", request.resource_logs[0].schema_url)
+    }
+
+    @Test
+    fun testUsesEmptySchemaUrlWhenResourceHasNone() {
+        val request = listOf(
+            FakeLogRecordData(resource = FakeResource(schemaUrl = null)),
+        ).toExportLogsServiceRequest()
+
+        assertEquals("", request.resource_logs[0].schema_url)
+    }
+
+    @Test
+    fun testRoundTripPreservesResourceSchemaUrl() {
+        val original = listOf(
+            FakeLogRecordData(resource = FakeResource(schemaUrl = "https://example.com/resource")),
+        )
+        val result = original.toProtobufByteArray().toLogRecordDataList()
+
+        assertEquals("https://example.com/resource", result.single().resource.schemaUrl)
+    }
 }

--- a/exporters-protobuf/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/export/ExportTraceServiceRequestCreatorTest.kt
+++ b/exporters-protobuf/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/export/ExportTraceServiceRequestCreatorTest.kt
@@ -274,4 +274,32 @@ class ExportTraceServiceRequestCreatorTest {
 
         assertEquals("", request.resource_spans[0].scope_spans[0].schema_url)
     }
+
+    @Test
+    fun testUsesResourceSchemaUrlOnResourceSpans() {
+        val request = listOf(
+            FakeSpanData(resource = FakeResource(schemaUrl = "https://example.com/resource")),
+        ).toExportTraceServiceRequest()
+
+        assertEquals("https://example.com/resource", request.resource_spans[0].schema_url)
+    }
+
+    @Test
+    fun testUsesEmptySchemaUrlWhenResourceHasNone() {
+        val request = listOf(
+            FakeSpanData(resource = FakeResource(schemaUrl = null)),
+        ).toExportTraceServiceRequest()
+
+        assertEquals("", request.resource_spans[0].schema_url)
+    }
+
+    @Test
+    fun testRoundTripPreservesResourceSchemaUrl() {
+        val original = listOf(
+            FakeSpanData(resource = FakeResource(schemaUrl = "https://example.com/resource")),
+        )
+        val result = original.toProtobufByteArray().toSpanDataList()
+
+        assertEquals("https://example.com/resource", result.single().resource.schemaUrl)
+    }
 }


### PR DESCRIPTION
## Goal
Set schema_url on ResourceSpans and ResourceLogs from Resource.schemaUrl
(empty string when unset), matching ScopeSpans/ScopeLogs and the OTLP
schema spec. Decode restores the URL onto the Resource.

## Testing
Added encode tests for set and empty resource schema URLs on traces and
logs. Ran exporters-protobuf jvmTest for the request creators and
CommonProtobufConversion plus detekt.

Fixes #973