### PR TITLE
fix: apply W3C tracestate 512-character limit on decode

### DIFF
--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/propagation/TraceStateMarshaller.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/propagation/TraceStateMarshaller.kt
@@ -4,6 +4,9 @@ import io.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.kotlin.factory.TraceStateFactory
 import io.opentelemetry.kotlin.tracing.TraceState
 
+internal const val MAX_TRACESTATE_CHARS = 512
+internal const val LARGE_MEMBER_CHARS = 128
+
 /**
  * Implementation of a W3C `tracestate` header.
  *
@@ -16,7 +19,7 @@ internal class TraceStateMarshaller(internal val traceState: TraceState) {
         traceState.asMap()
     }
 
-    fun encode(): String = W3CTraceStateCodec.encode(state)
+    fun encode(): String = W3CTraceStateCodec.encode(state.truncatedToHeaderLimit())
 
     companion object {
         fun decode(header: String, traceStateFactory: TraceStateFactory): TraceStateMarshaller {
@@ -27,7 +30,37 @@ internal class TraceStateMarshaller(internal val traceState: TraceState) {
                     state = next
                 }
             }
+            val truncated = state.asMap().truncatedToHeaderLimit()
+            state = truncated.entries.fold(traceStateFactory.default) { acc, (key, value) ->
+                acc.put(key, value)
+            }
             return TraceStateMarshaller(state)
         }
     }
+}
+
+/**
+ * Drops whole list-members until the encoded header is at most [MAX_TRACESTATE_CHARS].
+ * Members longer than [LARGE_MEMBER_CHARS] are removed first, then members from the end.
+ *
+ * https://www.w3.org/TR/trace-context-2/#tracestate-limits
+ */
+private fun Map<String, String>.truncatedToHeaderLimit(): Map<String, String> {
+    if (W3CTraceStateCodec.encode(this).length <= MAX_TRACESTATE_CHARS) {
+        return this
+    }
+    val result = LinkedHashMap(this)
+    while (result.isNotEmpty() &&
+        W3CTraceStateCodec.encode(result).length > MAX_TRACESTATE_CHARS
+    ) {
+        val largeKey = result.entries.findLast { (key, value) ->
+            key.length + 1 + value.length > LARGE_MEMBER_CHARS
+        }?.key
+        if (largeKey != null) {
+            result.remove(largeKey)
+        } else {
+            result.remove(result.keys.last())
+        }
+    }
+    return result
 }

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/propagation/TraceStateMarshaller.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/propagation/TraceStateMarshaller.kt
@@ -4,9 +4,6 @@ import io.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.kotlin.factory.TraceStateFactory
 import io.opentelemetry.kotlin.tracing.TraceState
 
-internal const val MAX_TRACESTATE_CHARS = 512
-internal const val LARGE_MEMBER_CHARS = 128
-
 /**
  * Implementation of a W3C `tracestate` header.
  *
@@ -19,7 +16,7 @@ internal class TraceStateMarshaller(internal val traceState: TraceState) {
         traceState.asMap()
     }
 
-    fun encode(): String = W3CTraceStateCodec.encode(state.truncatedToHeaderLimit())
+    fun encode(): String = W3CTraceStateCodec.encode(state)
 
     companion object {
         fun decode(header: String, traceStateFactory: TraceStateFactory): TraceStateMarshaller {
@@ -30,37 +27,7 @@ internal class TraceStateMarshaller(internal val traceState: TraceState) {
                     state = next
                 }
             }
-            val truncated = state.asMap().truncatedToHeaderLimit()
-            state = truncated.entries.fold(traceStateFactory.default) { acc, (key, value) ->
-                acc.put(key, value)
-            }
             return TraceStateMarshaller(state)
         }
     }
-}
-
-/**
- * Drops whole list-members until the encoded header is at most [MAX_TRACESTATE_CHARS].
- * Members longer than [LARGE_MEMBER_CHARS] are removed first, then members from the end.
- *
- * https://www.w3.org/TR/trace-context-2/#tracestate-limits
- */
-private fun Map<String, String>.truncatedToHeaderLimit(): Map<String, String> {
-    if (W3CTraceStateCodec.encode(this).length <= MAX_TRACESTATE_CHARS) {
-        return this
-    }
-    val result = LinkedHashMap(this)
-    while (result.isNotEmpty() &&
-        W3CTraceStateCodec.encode(result).length > MAX_TRACESTATE_CHARS
-    ) {
-        val largeKey = result.entries.findLast { (key, value) ->
-            key.length + 1 + value.length > LARGE_MEMBER_CHARS
-        }?.key
-        if (largeKey != null) {
-            result.remove(largeKey)
-        } else {
-            result.remove(result.keys.last())
-        }
-    }
-    return result
 }

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/propagation/TraceStateMarshallerTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/propagation/TraceStateMarshallerTest.kt
@@ -162,7 +162,7 @@ internal class TraceStateMarshallerTest {
     @Test
     fun `decode keeps a combined header of exactly 512 characters`() {
         val header = exactly512Header()
-        assertEquals(MAX_TRACESTATE_CHARS, header.length)
+        assertEquals(512, header.length)
         val ts = TraceStateMarshaller.decode(header, factory)
         assertEquals(header, ts.encode())
     }
@@ -171,7 +171,7 @@ internal class TraceStateMarshallerTest {
     fun `encode keeps a combined header of exactly 512 characters`() {
         val header = exactly512Header()
         val ts = TraceStateMarshaller.decode(header, factory)
-        assertEquals(MAX_TRACESTATE_CHARS, ts.encode().length)
+        assertEquals(512, ts.encode().length)
         assertEquals(header, ts.encode())
     }
 
@@ -179,7 +179,7 @@ internal class TraceStateMarshallerTest {
     fun `decode drops members longer than 128 before dropping from the end`() {
         val ts = TraceStateMarshaller.decode(oversizedHeaderWithTrailingLargeMember(), factory)
         assertEquals(truncatedOversizedHeader(), ts.encode())
-        assertTrue(ts.encode().length <= MAX_TRACESTATE_CHARS)
+        assertTrue(ts.encode().length <= 512)
     }
 
     @Test
@@ -192,10 +192,10 @@ internal class TraceStateMarshallerTest {
     fun `decode drops members from the end when all members are at most 128 characters`() {
         val members = (0 until 11).map { "a$it=" + "x".repeat(47) }
         val header = members.joinToString(",")
-        assertTrue(header.length > MAX_TRACESTATE_CHARS)
+        assertTrue(header.length > 512)
         val ts = TraceStateMarshaller.decode(header, factory)
         val encoded = ts.encode()
-        assertTrue(encoded.length <= MAX_TRACESTATE_CHARS)
+        assertTrue(encoded.length <= 512)
         assertEquals(members.dropLast(1).joinToString(","), encoded)
     }
 

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/propagation/TraceStateMarshallerTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/propagation/TraceStateMarshallerTest.kt
@@ -4,6 +4,7 @@ import io.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.kotlin.factory.TraceStateFactoryImpl
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 /**
  * Asserts behaviour against the W3C `tracestate` spec:
@@ -156,5 +157,63 @@ internal class TraceStateMarshallerTest {
         val expected = (1..32).joinToString(",") { "k$it=v$it" }
         val ts = TraceStateMarshaller.decode(header, factory)
         assertEquals(expected, ts.encode())
+    }
+
+    @Test
+    fun `decode keeps a combined header of exactly 512 characters`() {
+        val header = exactly512Header()
+        assertEquals(MAX_TRACESTATE_CHARS, header.length)
+        val ts = TraceStateMarshaller.decode(header, factory)
+        assertEquals(header, ts.encode())
+    }
+
+    @Test
+    fun `encode keeps a combined header of exactly 512 characters`() {
+        val header = exactly512Header()
+        val ts = TraceStateMarshaller.decode(header, factory)
+        assertEquals(MAX_TRACESTATE_CHARS, ts.encode().length)
+        assertEquals(header, ts.encode())
+    }
+
+    @Test
+    fun `decode drops members longer than 128 before dropping from the end`() {
+        val ts = TraceStateMarshaller.decode(oversizedHeaderWithTrailingLargeMember(), factory)
+        assertEquals(truncatedOversizedHeader(), ts.encode())
+        assertTrue(ts.encode().length <= MAX_TRACESTATE_CHARS)
+    }
+
+    @Test
+    fun `encode drops members longer than 128 before dropping from the end`() {
+        val ts = TraceStateMarshaller.decode(oversizedHeaderWithTrailingLargeMember(), factory)
+        assertEquals(truncatedOversizedHeader(), ts.encode())
+    }
+
+    @Test
+    fun `decode drops members from the end when all members are at most 128 characters`() {
+        val members = (0 until 11).map { "a$it=" + "x".repeat(47) }
+        val header = members.joinToString(",")
+        assertTrue(header.length > MAX_TRACESTATE_CHARS)
+        val ts = TraceStateMarshaller.decode(header, factory)
+        val encoded = ts.encode()
+        assertTrue(encoded.length <= MAX_TRACESTATE_CHARS)
+        assertEquals(members.dropLast(1).joinToString(","), encoded)
+    }
+
+    private fun exactly512Header(): String {
+        val first = "a=" + "x".repeat(254)
+        val second = "b=" + "x".repeat(253)
+        return "$first,$second"
+    }
+
+    private fun oversizedHeaderWithTrailingLargeMember(): String {
+        val small = "keep=ok"
+        val large = (0 until 4).joinToString(",") { "k$it=" + "x".repeat(126) }
+        return "$small,$large"
+    }
+
+    private fun truncatedOversizedHeader(): String {
+        val small = "keep=ok"
+        val large = (0 until 3).joinToString(",") { "k$it=" + "x".repeat(126) }
+        return "$small,$large"
     }
 }

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/propagation/W3CTraceContextPropagatorTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/propagation/W3CTraceContextPropagatorTest.kt
@@ -260,7 +260,7 @@ internal class W3CTraceContextPropagatorTest {
         assertEquals(traceId, sc.traceId)
         assertEquals("ok", sc.traceState.get("keep"))
         assertEquals(null, sc.traceState.get("k3"))
-        assertTrue(W3CTraceStateCodec.encode(sc.traceState.asMap()).length <= MAX_TRACESTATE_CHARS)
+        assertTrue(W3CTraceStateCodec.encode(sc.traceState.asMap()).length <= 512)
     }
 
     @Test

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/propagation/W3CTraceContextPropagatorTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/propagation/W3CTraceContextPropagatorTest.kt
@@ -246,6 +246,24 @@ internal class W3CTraceContextPropagatorTest {
     }
 
     @Test
+    fun `extract still succeeds when tracestate exceeds the combined header limit`() {
+        val large = (0 until 4).joinToString(",") { "k$it=" + "x".repeat(126) }
+        val carrier = mapOf(
+            "traceparent" to "00-$traceId-$spanId-01",
+            "tracestate" to "keep=ok,$large",
+        )
+        val result = propagator.extract(contextFactory.root(), carrier, MapTextMapGetter)
+        val sc = result.extractSpan().spanContext
+
+        assertTrue(sc.isValid)
+        assertTrue(sc.isRemote)
+        assertEquals(traceId, sc.traceId)
+        assertEquals("ok", sc.traceState.get("keep"))
+        assertEquals(null, sc.traceState.get("k3"))
+        assertTrue(W3CTraceStateCodec.encode(sc.traceState.asMap()).length <= MAX_TRACESTATE_CHARS)
+    }
+
+    @Test
     fun `inject and extract round-trip preserves traceId spanId flags and tracestate`() {
         val state = traceStateFactory.default.put("vendor", "value")
         val original = spanContext(

--- a/sdk-common/src/commonMain/kotlin/io/opentelemetry/kotlin/propagation/W3CTraceStateCodec.kt
+++ b/sdk-common/src/commonMain/kotlin/io/opentelemetry/kotlin/propagation/W3CTraceStateCodec.kt
@@ -5,9 +5,9 @@ package io.opentelemetry.kotlin.propagation
  *
  * https://www.w3.org/TR/trace-context-2/#tracestate-header
  *
- * This handles the structure of the list only: splitting on the list-member separator, trimming
- * optional whitespace, and locating the key/value separator. Validating the characters of a key or
- * value, and capping the number of entries, is the responsibility of the `TraceState`
+ * This handles the structure of the list: splitting on the list-member separator, trimming
+ * optional whitespace, locating the key/value separator, and applying the spec size limits.
+ * Validating the characters of a key or value is the responsibility of the `TraceState`
  * implementation.
  */
 public object W3CTraceStateCodec {
@@ -17,10 +17,82 @@ public object W3CTraceStateCodec {
     private const val OWS_SPACE = ' '
     private const val OWS_HTAB = '\t'
 
+    /** https://www.w3.org/TR/trace-context-2/#tracestate-header-field-values */
+    private const val MAX_LIST_MEMBERS = 32
+
+    /** https://www.w3.org/TR/trace-context-2/#tracestate-limits */
+    private const val MAX_HEADER_CHARS = 512
+    private const val LARGE_MEMBER_CHARS = 128
+
     /**
      * Encodes [entries] as a `tracestate` header value, preserving iteration order.
+     *
+     * At most 32 members are written. If the combined header would exceed 512 characters,
+     * whole members longer than 128 characters are dropped first, then members from the end,
+     * until the result fits.
      */
-    public fun encode(entries: Map<String, String>): String = buildString {
+    public fun encode(entries: Map<String, String>): String = join(sanitize(entries))
+
+    /**
+     * Decodes a `tracestate` header value into its entries, preserving the order in which they
+     * appear in [header].
+     *
+     * Malformed list members are skipped rather than failing the whole header, and where a key is
+     * repeated the first occurrence wins. At most 32 members are kept; combined length is then
+     * truncated using the same rules as [encode]. This never throws.
+     */
+    public fun decode(header: String): Map<String, String> {
+        val entries = LinkedHashMap<String, String>()
+        header.split(LIST_MEMBER_SEPARATOR).forEach { raw ->
+            val member = raw.trim(OWS_SPACE, OWS_HTAB)
+            val eq = member.indexOf(KEY_VALUE_SEPARATOR)
+            if (eq <= 0 || eq == member.length - 1) {
+                // skip empty/invalid members
+                return@forEach
+            }
+            val key = member.substring(0, eq)
+            if (!entries.containsKey(key) && entries.size < MAX_LIST_MEMBERS) {
+                entries[key] = member.substring(eq + 1)
+            }
+        }
+        truncateToCharLimit(entries)
+        return entries
+    }
+
+    private fun sanitize(entries: Map<String, String>): Map<String, String> {
+        if (entries.size <= MAX_LIST_MEMBERS && encodedChars(entries) <= MAX_HEADER_CHARS) {
+            return entries
+        }
+        val result = LinkedHashMap<String, String>()
+        for ((key, value) in entries) {
+            if (result.size >= MAX_LIST_MEMBERS) {
+                break
+            }
+            result[key] = value
+        }
+        truncateToCharLimit(result)
+        return result
+    }
+
+    /**
+     * Drops whole list-members until the encoded header is at most [MAX_HEADER_CHARS].
+     * Members longer than [LARGE_MEMBER_CHARS] are removed first (from the end), then members
+     * from the end.
+     */
+    private fun truncateToCharLimit(entries: MutableMap<String, String>) {
+        while (entries.isNotEmpty() && encodedChars(entries) > MAX_HEADER_CHARS) {
+            val largeKey = entries.entries.findLast { (key, value) ->
+                memberChars(key, value) > LARGE_MEMBER_CHARS
+            }?.key
+            if (largeKey != null) {
+                entries.remove(largeKey)
+            } else {
+                entries.remove(entries.keys.last())
+            }
+        }
+    }
+
+    private fun join(entries: Map<String, String>): String = buildString {
         entries.forEach {
             if (isNotEmpty()) {
                 append(LIST_MEMBER_SEPARATOR)
@@ -31,27 +103,16 @@ public object W3CTraceStateCodec {
         }
     }
 
-    /**
-     * Decodes a `tracestate` header value into its entries, preserving the order in which they
-     * appear in [header].
-     *
-     * Malformed list members are skipped rather than failing the whole header, and where a key is
-     * repeated the first occurrence wins. This never throws.
-     */
-    public fun decode(header: String): Map<String, String> {
-        val entries = mutableMapOf<String, String>()
-        header.split(LIST_MEMBER_SEPARATOR).forEach { raw ->
-            val member = raw.trim(OWS_SPACE, OWS_HTAB)
-            val eq = member.indexOf(KEY_VALUE_SEPARATOR)
-            if (eq <= 0 || eq == member.length - 1) {
-                // skip empty/invalid members
-                return@forEach
-            }
-            val key = member.substring(0, eq)
-            if (!entries.containsKey(key)) {
-                entries[key] = member.substring(eq + 1)
-            }
+    private fun memberChars(key: String, value: String): Int = key.length + 1 + value.length
+
+    private fun encodedChars(entries: Map<String, String>): Int {
+        if (entries.isEmpty()) {
+            return 0
         }
-        return entries
+        var chars = entries.size - 1
+        entries.forEach { (key, value) ->
+            chars += memberChars(key, value)
+        }
+        return chars
     }
 }

--- a/sdk-common/src/commonMain/kotlin/io/opentelemetry/kotlin/propagation/W3CTraceStateValidator.kt
+++ b/sdk-common/src/commonMain/kotlin/io/opentelemetry/kotlin/propagation/W3CTraceStateValidator.kt
@@ -6,7 +6,8 @@ package io.opentelemetry.kotlin.propagation
  *
  * https://www.w3.org/TR/trace-context/#tracestate-header
  *
- * This complements [W3CTraceStateCodec], which handles the structure of the list only.
+ * This complements [W3CTraceStateCodec], which handles the list structure and combined-header
+ * size limits. This type validates key/value characters and whether a new entry may be put.
  */
 public object W3CTraceStateValidator {
 

--- a/sdk-common/src/commonTest/kotlin/io/opentelemetry/kotlin/propagation/W3CTraceStateCodecTest.kt
+++ b/sdk-common/src/commonTest/kotlin/io/opentelemetry/kotlin/propagation/W3CTraceStateCodecTest.kt
@@ -2,6 +2,7 @@ package io.opentelemetry.kotlin.propagation
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 /**
  * Asserts the structure of the W3C `tracestate` list format:
@@ -114,5 +115,79 @@ internal class W3CTraceStateCodecTest {
     fun testDecodeThenEncodeRoundTrips() {
         val header = "foo=1,bar=2,baz=3"
         assertEquals(header, W3CTraceStateCodec.encode(W3CTraceStateCodec.decode(header)))
+    }
+
+    @Test
+    fun testDecodeKeepsAtMost32Members() {
+        val header = (1..33).joinToString(",") { "k$it=v$it" }
+        val decoded = W3CTraceStateCodec.decode(header)
+        assertEquals((1..32).map { "k$it" }, decoded.keys.toList())
+    }
+
+    @Test
+    fun testEncodeKeepsAtMost32Members() {
+        val entries = (1..33).associate { "k$it" to "v$it" }
+        val expected = (1..32).joinToString(",") { "k$it=v$it" }
+        assertEquals(expected, W3CTraceStateCodec.encode(entries))
+    }
+
+    @Test
+    fun testDecodeKeepsAHeaderOfExactly512Characters() {
+        val header = exactly512Header()
+        assertEquals(512, header.length)
+        assertEquals(header, W3CTraceStateCodec.encode(W3CTraceStateCodec.decode(header)))
+    }
+
+    @Test
+    fun testEncodeKeepsAHeaderOfExactly512Characters() {
+        val header = exactly512Header()
+        val entries = linkedMapOf(
+            "a" to "x".repeat(254),
+            "b" to "x".repeat(253),
+        )
+        assertEquals(header, W3CTraceStateCodec.encode(entries))
+    }
+
+    @Test
+    fun testDecodeDropsMembersLongerThan128BeforeDroppingFromTheEnd() {
+        assertEquals(
+            truncatedOversizedHeader(),
+            W3CTraceStateCodec.encode(W3CTraceStateCodec.decode(oversizedHeaderWithTrailingLargeMember())),
+        )
+    }
+
+    @Test
+    fun testEncodeDropsMembersLongerThan128BeforeDroppingFromTheEnd() {
+        val entries = linkedMapOf("keep" to "ok")
+        (0 until 4).forEach { entries["k$it"] = "x".repeat(126) }
+        assertEquals(truncatedOversizedHeader(), W3CTraceStateCodec.encode(entries))
+    }
+
+    @Test
+    fun testDecodeDropsMembersFromTheEndWhenAllMembersAreAtMost128Characters() {
+        val members = (0 until 11).map { "a$it=" + "x".repeat(47) }
+        val header = members.joinToString(",")
+        assertTrue(header.length > 512)
+        val encoded = W3CTraceStateCodec.encode(W3CTraceStateCodec.decode(header))
+        assertTrue(encoded.length <= 512)
+        assertEquals(members.dropLast(1).joinToString(","), encoded)
+    }
+
+    private fun exactly512Header(): String {
+        val first = "a=" + "x".repeat(254)
+        val second = "b=" + "x".repeat(253)
+        return "$first,$second"
+    }
+
+    private fun oversizedHeaderWithTrailingLargeMember(): String {
+        val small = "keep=ok"
+        val large = (0 until 4).joinToString(",") { "k$it=" + "x".repeat(126) }
+        return "$small,$large"
+    }
+
+    private fun truncatedOversizedHeader(): String {
+        val small = "keep=ok"
+        val large = (0 until 3).joinToString(",") { "k$it=" + "x".repeat(126) }
+        return "$small,$large"
     }
 }


### PR DESCRIPTION
## Goal
Apply W3C tracestate combined-header limits (512 characters; drop members longer than 128 first, then from the end) on decode, not only via the 32-entry put cap. Encode uses the same truncation so inject and extract stay consistent. Invalid members are still skipped; a bad tracestate does not fail traceparent extract.

## Testing
Added TraceStateMarshaller tests for the 512/128 truncation on encode and decode, plus a W3CTraceContextPropagator extract case with an oversized tracestate. Ran implementation jvmTest for those classes plus detekt.

Fixes #965