### PR TITLE
fix: enhance scopeCacheKey to support attributes for deduplication

### DIFF
--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/logging/LoggerProviderAdapter.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/logging/LoggerProviderAdapter.kt
@@ -18,7 +18,7 @@ internal class LoggerProviderAdapter(private val impl: OtelJavaLoggerProvider) :
         schemaUrl: String?,
         attributes: (AttributesMutator.() -> Unit)?
     ): Logger {
-        return map.getOrPut(scopeCacheKey(name, version, schemaUrl)) {
+        return map.getOrPut(scopeCacheKey(name, version, schemaUrl, attributes)) {
             val builder = impl.loggerBuilder(name)
 
             if (schemaUrl != null) {

--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/metrics/MeterProviderAdapter.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/metrics/MeterProviderAdapter.kt
@@ -22,7 +22,7 @@ internal class MeterProviderAdapter(
         schemaUrl: String?,
         attributes: (AttributesMutator.() -> Unit)?,
     ): Meter {
-        return map.getOrPut(scopeCacheKey(name, version, schemaUrl)) {
+        return map.getOrPut(scopeCacheKey(name, version, schemaUrl, attributes)) {
             val builder = impl.meterBuilder(name)
             schemaUrl?.let(builder::setSchemaUrl)
             version?.let(builder::setInstrumentationVersion)

--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/scope/InstrumentationScopeInfoExt.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/scope/InstrumentationScopeInfoExt.kt
@@ -3,6 +3,8 @@ package io.opentelemetry.kotlin.scope
 import io.opentelemetry.kotlin.InstrumentationScopeInfo
 import io.opentelemetry.kotlin.InstrumentationScopeInfoImpl
 import io.opentelemetry.kotlin.aliases.OtelJavaInstrumentationScopeInfo
+import io.opentelemetry.kotlin.attributes.AttributesMutator
+import io.opentelemetry.kotlin.attributes.CompatAttributesModel
 import io.opentelemetry.kotlin.attributes.attrsFromMap
 import io.opentelemetry.kotlin.attributes.convertToMap
 
@@ -24,12 +26,16 @@ internal fun OtelJavaInstrumentationScopeInfo.toOtelKotlinInstrumentationScopeIn
 
 /**
  * Builds the cache key used by the provider adapters to dedupe tracers/loggers/meters.
- *
- * Scope attributes are deliberately excluded because opentelemetry-java doesn't currently support
- * them.
  */
 internal fun scopeCacheKey(
     name: String,
     version: String?,
-    schemaUrl: String?
-): InstrumentationScopeInfo = InstrumentationScopeInfoImpl(name, version, schemaUrl, emptyMap())
+    schemaUrl: String?,
+    attributes: (AttributesMutator.() -> Unit)? = null,
+): InstrumentationScopeInfo {
+    val container = CompatAttributesModel()
+    if (attributes != null) {
+        attributes(container)
+    }
+    return InstrumentationScopeInfoImpl(name, version, schemaUrl, container.attributes)
+}

--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/tracing/TracerProviderAdapter.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/tracing/TracerProviderAdapter.kt
@@ -24,7 +24,7 @@ internal class TracerProviderAdapter(
         schemaUrl: String?,
         attributes: (AttributesMutator.() -> Unit)?
     ): Tracer {
-        return map.getOrPut(scopeCacheKey(name, version, schemaUrl)) {
+        return map.getOrPut(scopeCacheKey(name, version, schemaUrl, attributes)) {
             val tracerBuilder = tracerProvider.tracerBuilder(name)
 
             schemaUrl?.let(tracerBuilder::setSchemaUrl)

--- a/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/logging/LoggerProviderAdapterTest.kt
+++ b/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/logging/LoggerProviderAdapterTest.kt
@@ -2,11 +2,28 @@ package io.opentelemetry.kotlin.logging
 
 import io.opentelemetry.kotlin.aliases.OtelJavaSdkLoggerProvider
 import kotlin.test.Test
+import kotlin.test.assertNotEquals
 import kotlin.test.assertNotSame
+import kotlin.test.assertSame
 
 internal class LoggerProviderAdapterTest {
 
     private val adapter = LoggerProviderAdapter(OtelJavaSdkLoggerProvider.builder().build())
+
+    @Test
+    fun testDupeLoggerProviderAttributes() {
+        val first = adapter.getLogger(name = "name") {
+            setStringAttribute("key", "value")
+        }
+        val second = adapter.getLogger(name = "name") {
+            setStringAttribute("key", "value")
+        }
+        val third = adapter.getLogger(name = "name") {
+            setStringAttribute("foo", "bar")
+        }
+        assertSame(first, second)
+        assertNotEquals(first, third)
+    }
 
     @Test
     fun testScopePropertyBoundaryCollision() {

--- a/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/metrics/MeterProviderAdapterTest.kt
+++ b/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/metrics/MeterProviderAdapterTest.kt
@@ -44,6 +44,21 @@ internal class MeterProviderAdapterTest {
     }
 
     @Test
+    fun testDupeMeterProviderAttributes() {
+        val first = adapter.getMeter(name = "name") {
+            setStringAttribute("key", "value")
+        }
+        val second = adapter.getMeter(name = "name") {
+            setStringAttribute("key", "value")
+        }
+        val third = adapter.getMeter(name = "name") {
+            setStringAttribute("foo", "bar")
+        }
+        assertSame(first, second)
+        assertNotEquals(first, third)
+    }
+
+    @Test
     fun testScopePropertyBoundaryCollision() {
         val first = adapter.getMeter(name = "ab", version = "c")
         val second = adapter.getMeter(name = "a", version = "bc")

--- a/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/tracing/TracerProviderAdapterTest.kt
+++ b/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/tracing/TracerProviderAdapterTest.kt
@@ -4,7 +4,9 @@ import io.opentelemetry.kotlin.aliases.OtelJavaSdkTracerProvider
 import io.opentelemetry.kotlin.clock.FakeClock
 import io.opentelemetry.kotlin.init.CompatSpanLimitsConfig
 import kotlin.test.Test
+import kotlin.test.assertNotEquals
 import kotlin.test.assertNotSame
+import kotlin.test.assertSame
 
 internal class TracerProviderAdapterTest {
 
@@ -13,6 +15,21 @@ internal class TracerProviderAdapterTest {
         FakeClock(),
         CompatSpanLimitsConfig()
     )
+
+    @Test
+    fun testDupeTracerProviderAttributes() {
+        val first = adapter.getTracer(name = "name") {
+            setStringAttribute("key", "value")
+        }
+        val second = adapter.getTracer(name = "name") {
+            setStringAttribute("key", "value")
+        }
+        val third = adapter.getTracer(name = "name") {
+            setStringAttribute("foo", "bar")
+        }
+        assertSame(first, second)
+        assertNotEquals(first, third)
+    }
 
     @Test
     fun testScopePropertyBoundaryCollision() {


### PR DESCRIPTION
## Goal

`LoggerProviderAdapter` doesn't use attributes as part of the scope key, whereas `LoggerProviderImpl` does. Added fixed compat implementation for logs/traces/metrics so their adapters use attributes as part of their scope key. 

Fixes #930 

## Testing

- Compiled for all platforms. Detekt, apiCheck, and Android test compilation passed.
