### PR TITLE
fix: enhance HttpClientRegistry to reuse default engine across exporter calls

### DIFF
--- a/exporters-otlp/src/commonMain/kotlin/io/opentelemetry/kotlin/export/HttpClientInstance.kt
+++ b/exporters-otlp/src/commonMain/kotlin/io/opentelemetry/kotlin/export/HttpClientInstance.kt
@@ -20,12 +20,11 @@ internal object HttpClientRegistry {
         clients.clear()
     }
 
-    fun getOrCreate(requestTimeoutMs: Long): HttpClient = getOrCreate(defaultEngine, requestTimeoutMs)
-
-    fun getOrCreate(engine: HttpClientEngine, requestTimeoutMs: Long): HttpClient {
-        val key = HttpClientKey(engine, requestTimeoutMs)
+    fun getOrCreate(engine: HttpClientEngine? = null, requestTimeoutMs: Long): HttpClient {
+        val resolvedEngine = engine ?: defaultEngine
+        val key = HttpClientKey(resolvedEngine, requestTimeoutMs)
         return clients.computeIfAbsent(key) {
-            createDefaultHttpClient(requestTimeoutMs, engine)
+            createDefaultHttpClient(requestTimeoutMs, resolvedEngine)
         }
     }
 }

--- a/exporters-otlp/src/commonMain/kotlin/io/opentelemetry/kotlin/export/HttpClientInstance.kt
+++ b/exporters-otlp/src/commonMain/kotlin/io/opentelemetry/kotlin/export/HttpClientInstance.kt
@@ -14,10 +14,13 @@ internal data class HttpClientKey(
 
 internal object HttpClientRegistry {
     private val clients = ConcurrentMap<HttpClientKey, HttpClient>()
+    private val defaultEngine: HttpClientEngine by lazy { createHttpEngine() }
 
     internal fun clear() {
         clients.clear()
     }
+
+    fun getOrCreate(requestTimeoutMs: Long): HttpClient = getOrCreate(defaultEngine, requestTimeoutMs)
 
     fun getOrCreate(engine: HttpClientEngine, requestTimeoutMs: Long): HttpClient {
         val key = HttpClientKey(engine, requestTimeoutMs)

--- a/exporters-otlp/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/OtlpLogRecordExporterApi.kt
+++ b/exporters-otlp/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/OtlpLogRecordExporterApi.kt
@@ -23,14 +23,7 @@ public fun LogExportConfigDsl.otlpHttpLogRecordExporter(
     OtlpHttpLogRecordExporter(
         OtlpClient(
             baseUrl,
-            if (httpClientEngine != null) {
-                HttpClientRegistry.getOrCreate(
-                    requestTimeoutMs = timeoutMs,
-                    engine = httpClientEngine
-                )
-            } else {
-                HttpClientRegistry.getOrCreate(requestTimeoutMs = timeoutMs)
-            },
+            HttpClientRegistry.getOrCreate(requestTimeoutMs = timeoutMs, engine = httpClientEngine),
             sdkErrorHandler,
         ),
         EXPORT_INITIAL_DELAY_MS,

--- a/exporters-otlp/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/OtlpLogRecordExporterApi.kt
+++ b/exporters-otlp/src/commonMain/kotlin/io/opentelemetry/kotlin/logging/export/OtlpLogRecordExporterApi.kt
@@ -1,4 +1,3 @@
-
 package io.opentelemetry.kotlin.logging.export
 
 import io.ktor.client.HttpClient
@@ -8,9 +7,8 @@ import io.opentelemetry.kotlin.export.EXPORT_INITIAL_DELAY_MS
 import io.opentelemetry.kotlin.export.EXPORT_MAX_ATTEMPTS
 import io.opentelemetry.kotlin.export.EXPORT_MAX_ATTEMPT_INTERVAL_MS
 import io.opentelemetry.kotlin.export.EXPORT_REQUEST_TIMEOUT_MS
+import io.opentelemetry.kotlin.export.HttpClientRegistry
 import io.opentelemetry.kotlin.export.OtlpClient
-import io.opentelemetry.kotlin.export.createDefaultHttpClient
-import io.opentelemetry.kotlin.export.createHttpEngine
 import io.opentelemetry.kotlin.init.LogExportConfigDsl
 
 /**
@@ -19,11 +17,22 @@ import io.opentelemetry.kotlin.init.LogExportConfigDsl
 @ExperimentalApi
 public fun LogExportConfigDsl.otlpHttpLogRecordExporter(
     baseUrl: String,
-    httpClientEngine: HttpClientEngine = createHttpEngine(),
+    httpClientEngine: HttpClientEngine? = null,
     timeoutMs: Long = EXPORT_REQUEST_TIMEOUT_MS,
 ): LogRecordExporter =
     OtlpHttpLogRecordExporter(
-        OtlpClient(baseUrl, createDefaultHttpClient(requestTimeoutMs = timeoutMs, engine = httpClientEngine), sdkErrorHandler),
+        OtlpClient(
+            baseUrl,
+            if (httpClientEngine != null) {
+                HttpClientRegistry.getOrCreate(
+                    requestTimeoutMs = timeoutMs,
+                    engine = httpClientEngine
+                )
+            } else {
+                HttpClientRegistry.getOrCreate(requestTimeoutMs = timeoutMs)
+            },
+            sdkErrorHandler,
+        ),
         EXPORT_INITIAL_DELAY_MS,
         EXPORT_MAX_ATTEMPT_INTERVAL_MS,
         EXPORT_MAX_ATTEMPTS,

--- a/exporters-otlp/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/OtlpSpanExporterApi.kt
+++ b/exporters-otlp/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/OtlpSpanExporterApi.kt
@@ -22,11 +22,7 @@ public fun TraceExportConfigDsl.otlpHttpSpanExporter(
 ): SpanExporter = OtlpHttpSpanExporter(
     OtlpClient(
         baseUrl,
-        if (httpClientEngine != null) {
-            HttpClientRegistry.getOrCreate(requestTimeoutMs = timeoutMs, engine = httpClientEngine)
-        } else {
-            HttpClientRegistry.getOrCreate(requestTimeoutMs = timeoutMs)
-        },
+        HttpClientRegistry.getOrCreate(requestTimeoutMs = timeoutMs, engine = httpClientEngine),
         sdkErrorHandler
     ),
     EXPORT_INITIAL_DELAY_MS,

--- a/exporters-otlp/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/OtlpSpanExporterApi.kt
+++ b/exporters-otlp/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/OtlpSpanExporterApi.kt
@@ -23,7 +23,7 @@ public fun TraceExportConfigDsl.otlpHttpSpanExporter(
     OtlpClient(
         baseUrl,
         HttpClientRegistry.getOrCreate(requestTimeoutMs = timeoutMs, engine = httpClientEngine),
-        sdkErrorHandler
+        sdkErrorHandler,
     ),
     EXPORT_INITIAL_DELAY_MS,
     EXPORT_MAX_ATTEMPT_INTERVAL_MS,

--- a/exporters-otlp/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/OtlpSpanExporterApi.kt
+++ b/exporters-otlp/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/export/OtlpSpanExporterApi.kt
@@ -9,7 +9,6 @@ import io.opentelemetry.kotlin.export.EXPORT_MAX_ATTEMPT_INTERVAL_MS
 import io.opentelemetry.kotlin.export.EXPORT_REQUEST_TIMEOUT_MS
 import io.opentelemetry.kotlin.export.HttpClientRegistry
 import io.opentelemetry.kotlin.export.OtlpClient
-import io.opentelemetry.kotlin.export.createHttpEngine
 import io.opentelemetry.kotlin.init.TraceExportConfigDsl
 
 /**
@@ -18,13 +17,17 @@ import io.opentelemetry.kotlin.init.TraceExportConfigDsl
 @ExperimentalApi
 public fun TraceExportConfigDsl.otlpHttpSpanExporter(
     baseUrl: String,
-    httpClientEngine: HttpClientEngine = createHttpEngine(),
+    httpClientEngine: HttpClientEngine? = null,
     timeoutMs: Long = EXPORT_REQUEST_TIMEOUT_MS,
 ): SpanExporter = OtlpHttpSpanExporter(
     OtlpClient(
         baseUrl,
-        HttpClientRegistry.getOrCreate(requestTimeoutMs = timeoutMs, engine = httpClientEngine),
-        sdkErrorHandler,
+        if (httpClientEngine != null) {
+            HttpClientRegistry.getOrCreate(requestTimeoutMs = timeoutMs, engine = httpClientEngine)
+        } else {
+            HttpClientRegistry.getOrCreate(requestTimeoutMs = timeoutMs)
+        },
+        sdkErrorHandler
     ),
     EXPORT_INITIAL_DELAY_MS,
     EXPORT_MAX_ATTEMPT_INTERVAL_MS,

--- a/exporters-otlp/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/export/OtlpHttpLogRecordExporterTest.kt
+++ b/exporters-otlp/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/export/OtlpHttpLogRecordExporterTest.kt
@@ -13,6 +13,8 @@ import io.ktor.utils.io.ByteReadChannel
 import io.opentelemetry.kotlin.Clock
 import io.opentelemetry.kotlin.clock.FakeClock
 import io.opentelemetry.kotlin.error.NoopSdkErrorHandler
+import io.opentelemetry.kotlin.export.EXPORT_REQUEST_TIMEOUT_MS
+import io.opentelemetry.kotlin.export.HttpClientRegistry
 import io.opentelemetry.kotlin.export.OperationResultCode
 import io.opentelemetry.kotlin.export.OtlpClient
 import io.opentelemetry.kotlin.export.createDefaultHttpClient
@@ -26,6 +28,7 @@ import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
+import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 internal class OtlpHttpLogRecordExporterTest {
@@ -112,11 +115,7 @@ internal class OtlpHttpLogRecordExporterTest {
         val customClient = HttpClient(customServer) {
             defaultRequest { header("Authorization", "Bearer test-token") }
         }
-        val fakeConfig = object : LogExportConfigDsl {
-            override val clock: Clock = FakeClock()
-            override val sdkErrorHandler = NoopSdkErrorHandler
-        }
-        val customExporter = fakeConfig.otlpHttpLogRecordExporter(baseUrl, customClient)
+        val customExporter = fakeConfig().otlpHttpLogRecordExporter(baseUrl, customClient)
         customExporter.export(logRecords)
 
         withTimeout(1000) {
@@ -126,6 +125,41 @@ internal class OtlpHttpLogRecordExporterTest {
         }
         val headers = customServer.requestHistory.single().headers.toMap().mapValues { it.value.joinToString() }
         assertEquals("Bearer test-token", headers["Authorization"])
+    }
+
+    @Test
+    fun testDefaultFactoryUsesSharedRegistryClient() {
+        HttpClientRegistry.clear()
+        val config = fakeConfig()
+
+        // 1. First exporter creation populates the registry with the default engine/client
+        config.otlpHttpLogRecordExporter(baseUrl)
+        val client1 = HttpClientRegistry.getOrCreate(requestTimeoutMs = EXPORT_REQUEST_TIMEOUT_MS)
+
+        // 2. Second exporter creation should hit the existing cache without replacing it
+        config.otlpHttpLogRecordExporter(baseUrl)
+        val client2 = HttpClientRegistry.getOrCreate(requestTimeoutMs = EXPORT_REQUEST_TIMEOUT_MS)
+
+        assertSame(client1, client2)
+        HttpClientRegistry.clear()
+    }
+
+    @Test
+    fun testFactoryWithCustomEngineExports() = runTest {
+        val mockServer = MockEngine {
+            respond(content = ByteReadChannel(""), status = HttpStatusCode.OK)
+        }
+        val factoryExporter = fakeConfig().otlpHttpLogRecordExporter(baseUrl, mockServer)
+        val code = factoryExporter.export(logRecords)
+        assertEquals(OperationResultCode.Success, code)
+
+        withTimeout(1000) {
+            while (mockServer.requestHistory.isEmpty()) {
+                delay(1L)
+            }
+        }
+        assertEquals(1, mockServer.requestHistory.size)
+        HttpClientRegistry.clear()
     }
 
     private suspend fun waitForExportedTelemetry(
@@ -149,5 +183,10 @@ internal class OtlpHttpLogRecordExporterTest {
         val request = requests.single()
         val bytes = request.body.toByteArray()
         assertContentEquals(telemetry.toProtobufByteArray(), bytes)
+    }
+
+    private fun fakeConfig(): LogExportConfigDsl = object : LogExportConfigDsl {
+        override val clock: Clock = FakeClock()
+        override val sdkErrorHandler = NoopSdkErrorHandler
     }
 }

--- a/exporters-otlp/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/export/OtlpHttpSpanExporterTest.kt
+++ b/exporters-otlp/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/export/OtlpHttpSpanExporterTest.kt
@@ -21,12 +21,6 @@ import io.opentelemetry.kotlin.export.createHttpEngine
 import io.opentelemetry.kotlin.init.TraceExportConfigDsl
 import io.opentelemetry.kotlin.tracing.data.FakeSpanData
 import io.opentelemetry.kotlin.tracing.data.SpanData
-import kotlin.test.BeforeTest
-import kotlin.test.Test
-import kotlin.test.assertContentEquals
-import kotlin.test.assertEquals
-import kotlin.test.assertSame
-import kotlin.test.assertTrue
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
@@ -34,6 +28,12 @@ import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withTimeout
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
 
 internal class OtlpHttpSpanExporterTest {
 

--- a/exporters-otlp/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/export/OtlpHttpSpanExporterTest.kt
+++ b/exporters-otlp/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/export/OtlpHttpSpanExporterTest.kt
@@ -13,6 +13,7 @@ import io.ktor.utils.io.ByteReadChannel
 import io.opentelemetry.kotlin.Clock
 import io.opentelemetry.kotlin.clock.FakeClock
 import io.opentelemetry.kotlin.error.NoopSdkErrorHandler
+import io.opentelemetry.kotlin.export.EXPORT_REQUEST_TIMEOUT_MS
 import io.opentelemetry.kotlin.export.HttpClientRegistry
 import io.opentelemetry.kotlin.export.OperationResultCode
 import io.opentelemetry.kotlin.export.OtlpClient
@@ -119,11 +120,7 @@ internal class OtlpHttpSpanExporterTest {
         val customClient = HttpClient(customServer) {
             defaultRequest { header("Authorization", "Bearer test-token") }
         }
-        val fakeConfig = object : TraceExportConfigDsl {
-            override val clock: Clock = FakeClock()
-            override val sdkErrorHandler = NoopSdkErrorHandler
-        }
-        val customExporter = fakeConfig.otlpHttpSpanExporter(baseUrl, customClient)
+        val customExporter = fakeConfig().otlpHttpSpanExporter(baseUrl, customClient)
         customExporter.export(spans)
 
         withTimeout(1000) {
@@ -133,6 +130,39 @@ internal class OtlpHttpSpanExporterTest {
         }
         val headers = customServer.requestHistory.single().headers.toMap().mapValues { it.value.joinToString() }
         assertEquals("Bearer test-token", headers["Authorization"])
+    }
+
+    @Test
+    fun testDefaultFactoryUsesSharedRegistryClient() {
+        HttpClientRegistry.clear()
+        val config = fakeConfig()
+
+        config.otlpHttpSpanExporter(baseUrl)
+        val client1 = HttpClientRegistry.getOrCreate(requestTimeoutMs = EXPORT_REQUEST_TIMEOUT_MS)
+
+        config.otlpHttpSpanExporter(baseUrl)
+        val client2 = HttpClientRegistry.getOrCreate(requestTimeoutMs = EXPORT_REQUEST_TIMEOUT_MS)
+
+        assertSame(client1, client2)
+        HttpClientRegistry.clear()
+    }
+
+    @Test
+    fun testFactoryWithCustomEngineExports() = runTest {
+        val mockServer = MockEngine {
+            respond(content = ByteReadChannel(""), status = HttpStatusCode.OK)
+        }
+        val factoryExporter = fakeConfig().otlpHttpSpanExporter(baseUrl, mockServer)
+        val code = factoryExporter.export(spans)
+        assertEquals(OperationResultCode.Success, code)
+
+        withTimeout(1000) {
+            while (mockServer.requestHistory.isEmpty()) {
+                delay(1L)
+            }
+        }
+        assertEquals(1, mockServer.requestHistory.size)
+        HttpClientRegistry.clear()
     }
 
     @Test
@@ -154,8 +184,8 @@ internal class OtlpHttpSpanExporterTest {
 
     @Test
     fun testDefaultPathReusesClientAcrossCalls() {
-        val client1 = HttpClientRegistry.getOrCreate(requestTimeoutMs = 10000)
-        val client2 = HttpClientRegistry.getOrCreate(requestTimeoutMs = 10000)
+        val client1 = HttpClientRegistry.getOrCreate(requestTimeoutMs = EXPORT_REQUEST_TIMEOUT_MS)
+        val client2 = HttpClientRegistry.getOrCreate(requestTimeoutMs = EXPORT_REQUEST_TIMEOUT_MS)
 
         assertSame(client1, client2)
         HttpClientRegistry.clear()
@@ -201,5 +231,10 @@ internal class OtlpHttpSpanExporterTest {
         val request = requests.single()
         val bytes = request.body.toByteArray()
         assertContentEquals(telemetry.toProtobufByteArray(), bytes)
+    }
+
+    private fun fakeConfig(): TraceExportConfigDsl = object : TraceExportConfigDsl {
+        override val clock: Clock = FakeClock()
+        override val sdkErrorHandler = NoopSdkErrorHandler
     }
 }

--- a/exporters-otlp/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/export/OtlpHttpSpanExporterTest.kt
+++ b/exporters-otlp/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/export/OtlpHttpSpanExporterTest.kt
@@ -155,8 +155,8 @@ internal class OtlpHttpSpanExporterTest {
 
     @Test
     fun testDefaultPathReusesClientAcrossCalls() {
-        val client1 = HttpClientRegistry.getOrCreate(EXPORT_REQUEST_TIMEOUT_MS)
-        val client2 = HttpClientRegistry.getOrCreate(EXPORT_REQUEST_TIMEOUT_MS)
+        val client1 = HttpClientRegistry.getOrCreate(requestTimeoutMs = EXPORT_REQUEST_TIMEOUT_MS)
+        val client2 = HttpClientRegistry.getOrCreate(requestTimeoutMs = EXPORT_REQUEST_TIMEOUT_MS)
 
         assertSame(client1, client2)
         HttpClientRegistry.clear()

--- a/exporters-otlp/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/export/OtlpHttpSpanExporterTest.kt
+++ b/exporters-otlp/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/export/OtlpHttpSpanExporterTest.kt
@@ -185,15 +185,6 @@ internal class OtlpHttpSpanExporterTest {
     }
 
     @Test
-    fun testDefaultPathReusesClientAcrossCalls() {
-        val client1 = HttpClientRegistry.getOrCreate(requestTimeoutMs = EXPORT_REQUEST_TIMEOUT_MS)
-        val client2 = HttpClientRegistry.getOrCreate(requestTimeoutMs = EXPORT_REQUEST_TIMEOUT_MS)
-
-        assertSame(client1, client2)
-        HttpClientRegistry.clear()
-    }
-
-    @Test
     fun testHttpClientRegistryConcurrency() = runTest {
         val engine = createHttpEngine()
 

--- a/exporters-otlp/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/export/OtlpHttpSpanExporterTest.kt
+++ b/exporters-otlp/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/export/OtlpHttpSpanExporterTest.kt
@@ -13,6 +13,7 @@ import io.ktor.utils.io.ByteReadChannel
 import io.opentelemetry.kotlin.Clock
 import io.opentelemetry.kotlin.clock.FakeClock
 import io.opentelemetry.kotlin.error.NoopSdkErrorHandler
+import io.opentelemetry.kotlin.export.EXPORT_REQUEST_TIMEOUT_MS
 import io.opentelemetry.kotlin.export.HttpClientRegistry
 import io.opentelemetry.kotlin.export.OperationResultCode
 import io.opentelemetry.kotlin.export.OtlpClient
@@ -147,6 +148,15 @@ internal class OtlpHttpSpanExporterTest {
             engine = engine,
             requestTimeoutMs = 30_000,
         )
+
+        assertSame(client1, client2)
+        HttpClientRegistry.clear()
+    }
+
+    @Test
+    fun testDefaultPathReusesClientAcrossCalls() {
+        val client1 = HttpClientRegistry.getOrCreate(EXPORT_REQUEST_TIMEOUT_MS)
+        val client2 = HttpClientRegistry.getOrCreate(EXPORT_REQUEST_TIMEOUT_MS)
 
         assertSame(client1, client2)
         HttpClientRegistry.clear()

--- a/exporters-otlp/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/export/OtlpHttpSpanExporterTest.kt
+++ b/exporters-otlp/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/export/OtlpHttpSpanExporterTest.kt
@@ -137,9 +137,11 @@ internal class OtlpHttpSpanExporterTest {
         HttpClientRegistry.clear()
         val config = fakeConfig()
 
+        // 1. First exporter creation populates the registry with the default engine/client
         config.otlpHttpSpanExporter(baseUrl)
         val client1 = HttpClientRegistry.getOrCreate(requestTimeoutMs = EXPORT_REQUEST_TIMEOUT_MS)
 
+        // 2. Second exporter creation should hit the existing cache without replacing it
         config.otlpHttpSpanExporter(baseUrl)
         val client2 = HttpClientRegistry.getOrCreate(requestTimeoutMs = EXPORT_REQUEST_TIMEOUT_MS)
 

--- a/exporters-otlp/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/export/OtlpHttpSpanExporterTest.kt
+++ b/exporters-otlp/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/export/OtlpHttpSpanExporterTest.kt
@@ -13,7 +13,6 @@ import io.ktor.utils.io.ByteReadChannel
 import io.opentelemetry.kotlin.Clock
 import io.opentelemetry.kotlin.clock.FakeClock
 import io.opentelemetry.kotlin.error.NoopSdkErrorHandler
-import io.opentelemetry.kotlin.export.EXPORT_REQUEST_TIMEOUT_MS
 import io.opentelemetry.kotlin.export.HttpClientRegistry
 import io.opentelemetry.kotlin.export.OperationResultCode
 import io.opentelemetry.kotlin.export.OtlpClient
@@ -22,6 +21,12 @@ import io.opentelemetry.kotlin.export.createHttpEngine
 import io.opentelemetry.kotlin.init.TraceExportConfigDsl
 import io.opentelemetry.kotlin.tracing.data.FakeSpanData
 import io.opentelemetry.kotlin.tracing.data.SpanData
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
@@ -29,12 +34,6 @@ import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withTimeout
-import kotlin.test.BeforeTest
-import kotlin.test.Test
-import kotlin.test.assertContentEquals
-import kotlin.test.assertEquals
-import kotlin.test.assertSame
-import kotlin.test.assertTrue
 
 internal class OtlpHttpSpanExporterTest {
 
@@ -155,8 +154,8 @@ internal class OtlpHttpSpanExporterTest {
 
     @Test
     fun testDefaultPathReusesClientAcrossCalls() {
-        val client1 = HttpClientRegistry.getOrCreate(requestTimeoutMs = EXPORT_REQUEST_TIMEOUT_MS)
-        val client2 = HttpClientRegistry.getOrCreate(requestTimeoutMs = EXPORT_REQUEST_TIMEOUT_MS)
+        val client1 = HttpClientRegistry.getOrCreate(requestTimeoutMs = 10000)
+        val client2 = HttpClientRegistry.getOrCreate(requestTimeoutMs = 10000)
 
         assertSame(client1, client2)
         HttpClientRegistry.clear()


### PR DESCRIPTION
## Goal

Fixes #964 (follow-up to #789).

Previously, exporter DSL entry points used `httpClientEngine: HttpClientEngine = createHttpEngine()` as a default parameter. Because default arguments are evaluated per call site in Kotlin, each call instantiated a fresh engine, causing `HttpClientRegistry` cache lookups to miss and repeatedly allocate new `HttpClient` instances.

This change:
- Introduces a lazily initialized `defaultEngine` inside `HttpClientRegistry` so unconfigured requests share a single engine instance.
- Updates `HttpClientRegistry.getOrCreate` to accept `engine: HttpClientEngine? = null` and fall back to `defaultEngine`.
- Updates `otlpHttpSpanExporter` and `otlpHttpLogRecordExporter` to default `httpClientEngine` to `null`.

## Testing

- Added `testDefaultPathReusesClientAcrossCalls` in `OtlpHttpSpanExporterTest`