### PR TITLE
fix: call onEnding after releasing the span write lock

### DIFF
--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/model/SpanModel.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/tracing/model/SpanModel.kt
@@ -119,15 +119,21 @@ internal class SpanModel(
     @Suppress("NOTHING_TO_INLINE")
     private inline fun endInternal(timestamp: Long) {
         sdkErrorHandler.guard("Span.end failed") {
-            val toExport = lock.write {
+            val shouldEnd = lock.write {
                 if (state != State.STARTED) {
-                    return@write null
+                    return@write false
                 }
                 state = State.ENDING
                 endTimestampImpl = timestamp
-                sdkErrorHandler.guard {
-                    processor?.onEnding(ReadWriteSpanImpl(this))
-                }
+                true
+            }
+            if (!shouldEnd) {
+                return
+            }
+            sdkErrorHandler.guard {
+                processor?.onEnding(ReadWriteSpanImpl(this))
+            }
+            val toExport = lock.write {
                 state = State.ENDED
                 // take a snapshot so that processors retain plain data rather than this
                 // model, releasing its properties once the span

--- a/implementation/src/jvmTest/kotlin/io/opentelemetry/kotlin/tracing/SpanOnEndingOtherThreadTest.kt
+++ b/implementation/src/jvmTest/kotlin/io/opentelemetry/kotlin/tracing/SpanOnEndingOtherThreadTest.kt
@@ -1,0 +1,57 @@
+package io.opentelemetry.kotlin.tracing
+
+import io.opentelemetry.kotlin.InstrumentationScopeInfoImpl
+import io.opentelemetry.kotlin.clock.FakeClock
+import io.opentelemetry.kotlin.error.NoopSdkErrorHandler
+import io.opentelemetry.kotlin.export.MutableShutdownState
+import io.opentelemetry.kotlin.factory.FakeContextFactory
+import io.opentelemetry.kotlin.factory.FakeIdGenerator
+import io.opentelemetry.kotlin.factory.FakeSpanContextFactory
+import io.opentelemetry.kotlin.factory.FakeTraceFlagsFactory
+import io.opentelemetry.kotlin.resource.FakeResource
+import io.opentelemetry.kotlin.tracing.export.FakeSpanProcessor
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+
+internal class SpanOnEndingOtherThreadTest {
+
+    @Test
+    fun onEndingCanMutateFromAnotherThreadWithoutDeadlock() {
+        val processor = FakeSpanProcessor()
+        processor.endingAction = { span ->
+            val worker = Thread {
+                span.setName("from-other-thread")
+                span.setStringAttribute("key", "value")
+            }
+            worker.start()
+            worker.join(JOIN_TIMEOUT_MS)
+            assertFalse(worker.isAlive)
+        }
+
+        val tracer = TracerImpl(
+            clock = FakeClock(),
+            processor = processor,
+            contextFactory = FakeContextFactory(),
+            spanContextFactory = FakeSpanContextFactory(),
+            traceFlagsFactory = FakeTraceFlagsFactory(),
+            scope = InstrumentationScopeInfoImpl("key", null, null, emptyMap()),
+            resource = FakeResource(),
+            spanLimitConfig = fakeSpanLimitsConfig,
+            idGenerator = FakeIdGenerator(),
+            shutdownState = MutableShutdownState(),
+            sdkErrorHandler = NoopSdkErrorHandler,
+        )
+
+        tracer.startSpan("test").end()
+
+        with(processor.endCalls.single()) {
+            assertEquals("from-other-thread", name)
+            assertEquals(mapOf("key" to "value"), attributes)
+        }
+    }
+
+    private companion object {
+        const val JOIN_TIMEOUT_MS = 5_000L
+    }
+}


### PR DESCRIPTION
## Goal
Call SpanProcessor.onEnding after releasing SpanModel’s write lock so a processor that hands the ReadWriteSpan to another thread cannot deadlock. endInternal still runs once via STARTED → ENDING → ENDED; onEnd stays outside the lock and still sees onEnding mutations.

## Testing
Existing span-end / onEnding tests plus a JVM test that mutates the span from another thread during onEnding. Ran implementation jvmTest and detekt.

Fixes #970