### PR TITLE
fix: enable gzip compression for OTLP HTTP requests

### DIFF
--- a/exporters-otlp/src/commonMain/kotlin/io/opentelemetry/kotlin/export/HttpClientInstance.kt
+++ b/exporters-otlp/src/commonMain/kotlin/io/opentelemetry/kotlin/export/HttpClientInstance.kt
@@ -4,6 +4,7 @@ import io.ktor.client.HttpClient
 import io.ktor.client.engine.HttpClientEngine
 import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.plugins.compression.ContentEncoding
+import io.ktor.client.plugins.compression.ContentEncodingConfig
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.util.collections.ConcurrentMap
 
@@ -38,6 +39,7 @@ internal fun createDefaultHttpClient(
     }
     install(ContentNegotiation)
     install(ContentEncoding) {
+        mode = ContentEncodingConfig.Mode.All
         gzip()
         deflate()
     }

--- a/exporters-otlp/src/commonTest/kotlin/io/opentelemetry/kotlin/export/OtlpClientTest.kt
+++ b/exporters-otlp/src/commonTest/kotlin/io/opentelemetry/kotlin/export/OtlpClientTest.kt
@@ -2,15 +2,17 @@ package io.opentelemetry.kotlin.export
 
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
-import io.ktor.client.engine.mock.toByteReadPacket
+import io.ktor.client.engine.mock.toByteArray
 import io.ktor.client.plugins.HttpTimeoutConfig.Companion.INFINITE_TIMEOUT_MS
 import io.ktor.http.Headers
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpMethod
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.headersOf
+import io.ktor.util.GZipEncoder
 import io.ktor.util.toMap
 import io.ktor.utils.io.ByteReadChannel
+import io.ktor.utils.io.toByteArray
 import io.opentelemetry.kotlin.error.FakeSdkErrorHandler
 import io.opentelemetry.kotlin.error.NoopSdkErrorHandler
 import io.opentelemetry.kotlin.logging.data.FakeLogRecordData
@@ -25,7 +27,6 @@ import io.opentelemetry.proto.collector.trace.v1.ExportTracePartialSuccess
 import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceResponse
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.test.runTest
-import kotlinx.io.readByteArray
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
@@ -50,6 +51,7 @@ internal class OtlpClientTest {
     private var mockResponseBody: ByteArray = ByteArray(0)
     private var serverDelayMs: Long = 0
     private var serverThrows: Boolean = false
+    private var compressedRequestBody: ByteArray = ByteArray(0)
 
     @BeforeTest
     fun setUp() {
@@ -58,6 +60,9 @@ internal class OtlpClientTest {
             if (serverThrows) {
                 error("network unreachable")
             }
+            // gzip compression is lazy and tied to the request context, so capture the body here;
+            // reading it later fails after the request completes.
+            compressedRequestBody = it.body.toByteArray()
             if (serverDelayMs > 0) {
                 delay(serverDelayMs.milliseconds)
             }
@@ -417,11 +422,13 @@ internal class OtlpClientTest {
         val contentType = checkNotNull(request.body.contentType)
         assertEquals("application/x-protobuf", contentType.toString())
 
-        val headers = request.headers.toMap().mapValues { it.value.joinToString() }
-        assertEquals("gzip,deflate", headers["Accept-Encoding"])
+        assertEquals("gzip,deflate", request.headers[HttpHeaders.AcceptEncoding])
 
-        val bytes = request.body.toByteReadPacket().readByteArray()
-        return bytes
+        assertEquals("gzip", request.body.headers[HttpHeaders.ContentEncoding])
+
+        val uncompressedBytes = GZipEncoder.decode(ByteReadChannel(compressedRequestBody))
+            .toByteArray()
+        return uncompressedBytes
     }
 
     private fun useRequestTimeout() {

--- a/exporters-otlp/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/export/OtlpHttpLogRecordExporterTest.kt
+++ b/exporters-otlp/src/commonTest/kotlin/io/opentelemetry/kotlin/logging/export/OtlpHttpLogRecordExporterTest.kt
@@ -5,11 +5,12 @@ import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
 import io.ktor.client.engine.mock.toByteArray
 import io.ktor.client.plugins.defaultRequest
-import io.ktor.client.request.HttpRequestData
 import io.ktor.client.request.header
 import io.ktor.http.HttpStatusCode
+import io.ktor.util.GZipEncoder
 import io.ktor.util.toMap
 import io.ktor.utils.io.ByteReadChannel
+import io.ktor.utils.io.toByteArray
 import io.opentelemetry.kotlin.Clock
 import io.opentelemetry.kotlin.clock.FakeClock
 import io.opentelemetry.kotlin.error.NoopSdkErrorHandler
@@ -21,8 +22,10 @@ import io.opentelemetry.kotlin.export.createDefaultHttpClient
 import io.opentelemetry.kotlin.init.LogExportConfigDsl
 import io.opentelemetry.kotlin.logging.data.FakeLogRecordData
 import io.opentelemetry.kotlin.logging.data.LogRecordData
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -41,10 +44,14 @@ internal class OtlpHttpLogRecordExporterTest {
     private lateinit var mockResponseStatus: HttpStatusCode
     private lateinit var exporter: OtlpHttpLogRecordExporter
     private var serverDelayMs: Long = 0
+    private var compressedRequestBody: ByteArray = ByteArray(0)
 
     @BeforeTest
     fun setUp() {
         server = MockEngine {
+            // gzip compression is lazy and tied to the request context, so capture the body here;
+            // reading it later fails after the request completes.
+            compressedRequestBody = it.body.toByteArray()
             delay(serverDelayMs)
             respond(
                 content = ByteReadChannel(""),
@@ -67,7 +74,7 @@ internal class OtlpHttpLogRecordExporterTest {
         mockResponseStatus = HttpStatusCode.OK
         val code = exporter.export(logRecords)
         assertEquals(OperationResultCode.Success, code)
-        assertTelemetryExported(logRecords)
+        waitAndAssertExportedTelemetry(logRecords)
     }
 
     @Test
@@ -97,7 +104,7 @@ internal class OtlpHttpLogRecordExporterTest {
         serverDelayMs = 2
         val code = exporter.export(logRecords)
         assertEquals(OperationResultCode.Success, code)
-        assertTelemetryExported(logRecords)
+        waitAndAssertExportedTelemetry(logRecords)
     }
 
     @Test
@@ -118,9 +125,12 @@ internal class OtlpHttpLogRecordExporterTest {
         val customExporter = fakeConfig().otlpHttpLogRecordExporter(baseUrl, customClient)
         customExporter.export(logRecords)
 
-        withTimeout(1000) {
-            while (customServer.requestHistory.isEmpty()) {
-                delay(1L)
+        // use real time because the exporter runs on Dispatchers.Default.
+        withContext(Dispatchers.Default.limitedParallelism(1)) {
+            withTimeout(1000) {
+                while (customServer.requestHistory.isEmpty()) {
+                    delay(1L)
+                }
             }
         }
         val headers = customServer.requestHistory.single().headers.toMap().mapValues { it.value.joinToString() }
@@ -162,26 +172,24 @@ internal class OtlpHttpLogRecordExporterTest {
         HttpClientRegistry.clear()
     }
 
-    private suspend fun waitForExportedTelemetry(
-        telemetrySize: Int = 1,
-        timeoutMs: Long = 1000,
-    ): List<HttpRequestData> {
-        withTimeout(timeoutMs) {
-            while (server.requestHistory.size < telemetrySize) {
-                delay(1L)
+    private suspend fun waitAndAssertExportedTelemetry(
+        telemetry: List<LogRecordData>,
+        timeoutMs: Long = 1000
+    ) {
+        // use real time because the exporter runs on Dispatchers.Default.
+        withContext(Dispatchers.Default.limitedParallelism(1)) {
+            withTimeout(timeoutMs) {
+                while (server.requestHistory.isEmpty()) {
+                    delay(1L)
+                }
             }
         }
         val requests = server.requestHistory
-        check(requests.size == telemetrySize) {
+        check(server.requestHistory.size == 1) {
             "Expected 1 request, got ${requests.size}"
         }
-        return requests
-    }
-
-    private suspend fun assertTelemetryExported(telemetry: List<LogRecordData>) {
-        val requests = waitForExportedTelemetry()
-        val request = requests.single()
-        val bytes = request.body.toByteArray()
+        val bytes = GZipEncoder.decode(ByteReadChannel(compressedRequestBody))
+            .toByteArray()
         assertContentEquals(telemetry.toProtobufByteArray(), bytes)
     }
 

--- a/exporters-otlp/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/export/OtlpHttpSpanExporterTest.kt
+++ b/exporters-otlp/src/commonTest/kotlin/io/opentelemetry/kotlin/tracing/export/OtlpHttpSpanExporterTest.kt
@@ -5,11 +5,12 @@ import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
 import io.ktor.client.engine.mock.toByteArray
 import io.ktor.client.plugins.defaultRequest
-import io.ktor.client.request.HttpRequestData
 import io.ktor.client.request.header
 import io.ktor.http.HttpStatusCode
+import io.ktor.util.GZipEncoder
 import io.ktor.util.toMap
 import io.ktor.utils.io.ByteReadChannel
+import io.ktor.utils.io.toByteArray
 import io.opentelemetry.kotlin.Clock
 import io.opentelemetry.kotlin.clock.FakeClock
 import io.opentelemetry.kotlin.error.NoopSdkErrorHandler
@@ -28,6 +29,7 @@ import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -46,10 +48,14 @@ internal class OtlpHttpSpanExporterTest {
     private lateinit var mockResponseStatus: HttpStatusCode
     private lateinit var exporter: OtlpHttpSpanExporter
     private var serverDelayMs: Long = 0
+    private var compressedRequestBody: ByteArray = ByteArray(0)
 
     @BeforeTest
     fun setUp() {
         server = MockEngine {
+            // gzip compression is lazy and tied to the request context, so capture the body here;
+            // reading it later fails after the request completes.
+            compressedRequestBody = it.body.toByteArray()
             delay(serverDelayMs)
             respond(
                 content = ByteReadChannel(""),
@@ -72,7 +78,7 @@ internal class OtlpHttpSpanExporterTest {
         mockResponseStatus = HttpStatusCode.OK
         val code = exporter.export(spans)
         assertEquals(OperationResultCode.Success, code)
-        assertTelemetryExported(spans)
+        waitAndAssertExportedTelemetry(spans)
     }
 
     @Test
@@ -102,7 +108,7 @@ internal class OtlpHttpSpanExporterTest {
         serverDelayMs = 2
         val code = exporter.export(spans)
         assertEquals(OperationResultCode.Success, code)
-        assertTelemetryExported(spans)
+        waitAndAssertExportedTelemetry(spans)
     }
 
     @Test
@@ -123,9 +129,12 @@ internal class OtlpHttpSpanExporterTest {
         val customExporter = fakeConfig().otlpHttpSpanExporter(baseUrl, customClient)
         customExporter.export(spans)
 
-        withTimeout(1000) {
-            while (customServer.requestHistory.isEmpty()) {
-                delay(1L)
+        // use real time because the exporter runs on Dispatchers.Default.
+        withContext(Dispatchers.Default.limitedParallelism(1)) {
+            withTimeout(1000) {
+                while (customServer.requestHistory.isEmpty()) {
+                    delay(1L)
+                }
             }
         }
         val headers = customServer.requestHistory.single().headers.toMap().mapValues { it.value.joinToString() }
@@ -203,26 +212,24 @@ internal class OtlpHttpSpanExporterTest {
         HttpClientRegistry.clear()
     }
 
-    private suspend fun waitForExportedTelemetry(
-        telemetrySize: Int = 1,
-        timeoutMs: Long = 1000,
-    ): List<HttpRequestData> {
-        withTimeout(timeoutMs) {
-            while (server.requestHistory.size < telemetrySize) {
-                delay(1L)
+    private suspend fun waitAndAssertExportedTelemetry(
+        telemetry: List<SpanData>,
+        timeoutMs: Long = 1000
+    ) {
+        // use real time because the exporter runs on Dispatchers.Default.
+        withContext(Dispatchers.Default.limitedParallelism(1)) {
+            withTimeout(timeoutMs) {
+                while (server.requestHistory.isEmpty()) {
+                    delay(1L)
+                }
             }
         }
         val requests = server.requestHistory
-        check(requests.size == telemetrySize) {
+        check(server.requestHistory.size == 1) {
             "Expected 1 request, got ${requests.size}"
         }
-        return requests
-    }
-
-    private suspend fun assertTelemetryExported(telemetry: List<SpanData>) {
-        val requests = waitForExportedTelemetry()
-        val request = requests.single()
-        val bytes = request.body.toByteArray()
+        val bytes = GZipEncoder.decode(ByteReadChannel(compressedRequestBody))
+            .toByteArray()
         assertContentEquals(telemetry.toProtobufByteArray(), bytes)
     }
 

--- a/smoke-test/src/commonTest/kotlin/io/opentelemetry/kotlin/smoketest/FakeOtlpServer.kt
+++ b/smoke-test/src/commonTest/kotlin/io/opentelemetry/kotlin/smoketest/FakeOtlpServer.kt
@@ -4,7 +4,9 @@ import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
 import io.ktor.client.engine.mock.toByteArray
 import io.ktor.http.HttpStatusCode
+import io.ktor.util.GZipEncoder
 import io.ktor.utils.io.ByteReadChannel
+import io.ktor.utils.io.toByteArray
 import io.opentelemetry.kotlin.logging.data.LogRecordData
 import io.opentelemetry.kotlin.logging.export.toLogRecordDataList
 import io.opentelemetry.kotlin.tracing.data.SpanData
@@ -28,7 +30,9 @@ class FakeOtlpServer {
      * Mock HTTP engine that intercepts OTLP requests and collects telemetry data.
      */
     val mockEngine = MockEngine { request ->
-        val body = request.body.toByteArray()
+        val compressedBody = request.body.toByteArray()
+        val body = GZipEncoder.decode(ByteReadChannel(compressedBody))
+            .toByteArray()
         val path = request.url.encodedPath
 
         when {


### PR DESCRIPTION
## Goal

  Fixes #977.

  The default OTLP HTTP client already registers gzip and calls `compress("gzip")`, but
  Ktor's `ContentEncoding` plugin defaults to response decompression only. This change
  configures it with `Mode.All`, enabling request compression while preserving response
  decompression.

  OTLP HTTP requests now include `Content-Encoding: gzip` and send gzip-compressed protobuf
  payloads.

  While updating the tests, two implementation details had to be handled:

  - Ktor produces the compressed request body lazily and ties it to the request execution
  context. Reading it later through `MockEngine.requestHistory` fails after that context
  completes, so tests now capture the body inside the mock handler.
  - Exporters run on `Dispatchers.Default` using real time, while `runTest` uses virtual
  time. Telemetry polling now runs on `Dispatchers.Default.limitedParallelism(1)` so its
  delays and timeouts use real time as well.

  The fake OTLP server used by smoke tests now decompresses request bodies before decoding
  protobuf telemetry.

  ## Testing

  - Added assertions for `Content-Encoding: gzip`.
  - Verified that decompressed request bodies match the original protobuf payloads.
  - Updated exporter and smoke tests to consume compressed request bodies.
  - Ran `./gradlew build -Psigning.skip=true`.