### PR TITLE
Always imply snapshot when publishing to maven local.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,7 +24,15 @@ plugins.withType<YarnPlugin> {
 group = "io.opentelemetry.kotlin"
 version = project.version
 
-if (project.hasProperty("snapshotPublish")) {
+val publishingToMavenLocal = gradle.startParameter.taskNames.any {
+    it.substringAfterLast(':') == "publishToMavenLocal"
+}
+val snapshotPublish = project.findProperty("snapshotPublish")
+    ?.toString()
+    ?.toBoolean()
+    ?: publishingToMavenLocal
+
+if (snapshotPublish) {
     allprojects {
         version = "${version}-SNAPSHOT"
     }


### PR DESCRIPTION
Related to #998.

When developers are building locally and want to publish to maven local for testing, lets make that easier thank requiring them to supply `-PsnpashotPublish=true`.