### PR TITLE
Alter stale labelling workflows

### DIFF
--- a/.github/workflows/add-stale-label.yaml
+++ b/.github/workflows/add-stale-label.yaml
@@ -18,18 +18,20 @@ jobs:
       - uses: actions/stale@4391f3da665fdf50b6810c1a66712fb9ba21aa93 # v11.0.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          days-before-stale: 21
+          days-before-stale: 14
           days-before-close: 14
+          # increase limit to avoid silent failures if default 30 operations is exceeded
+          operations-per-run: 100
           only-labels: "needs author feedback"
           stale-issue-label: stale
           stale-issue-message: >
             This has been automatically marked as stale because it has been marked
-            as needing author feedback and has not had any activity for 21 days.
+            as needing author feedback and has not had any activity for 14 days.
             It will be closed automatically if there is no response from the author
             within 14 additional days from this comment.
           stale-pr-label: stale
           stale-pr-message: >
             This has been automatically marked as stale because it has been marked
-            as needing author feedback and has not had any activity for 21 days.
+            as needing author feedback and has not had any activity for 14 days.
             It will be closed automatically if there is no response from the author
             within 14 additional days from this comment.

--- a/.github/workflows/remove-needs-author-feedback.yaml
+++ b/.github/workflows/remove-needs-author-feedback.yaml
@@ -3,28 +3,40 @@ name: Issue management - remove labels as needed
 on:
   issue_comment:
     types: [created]
+  pull_request_review:
+    types: [submitted]
+  pull_request_review_comment:
+    types: [created]
 
 permissions:
   contents: read
 
 jobs:
-  issue_comment:
+  remove_labels:
     permissions:
-      contents: read
-      issues: write
+      issues: write         # for gh to remove labels from issues
+      pull-requests: write  # for gh to remove labels from pull requests
     if: >
-      contains(github.event.issue.labels.*.name, 'needs author feedback') &&
-      github.event.comment.user.login == github.event.issue.user.login
+      (
+        github.event_name == 'issue_comment' &&
+        contains(github.event.issue.labels.*.name, 'needs author feedback') &&
+        github.event.comment.user.login == github.event.issue.user.login
+      ) || (
+        github.event_name == 'pull_request_review' &&
+        contains(github.event.pull_request.labels.*.name, 'needs author feedback') &&
+        github.event.review.user.login == github.event.pull_request.user.login
+      ) || (
+        github.event_name == 'pull_request_review_comment' &&
+        contains(github.event.pull_request.labels.*.name, 'needs author feedback') &&
+        github.event.comment.user.login == github.event.pull_request.user.login
+      )
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-
       - name: Remove labels
         env:
-          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
+          GH_REPO: ${{ github.repository }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh issue edit --remove-label "needs author feedback" $ISSUE_NUMBER
-          gh issue edit --remove-label "stale" $ISSUE_NUMBER
+          gh issue edit --remove-label "needs author feedback" "$ISSUE_NUMBER" || true
+          gh issue edit --remove-label "stale" "$ISSUE_NUMBER" || true


### PR DESCRIPTION
## Goal

Alters the github workflows that mark PRs as needing author feedback/stale so that they have the correct permissions to write labels. Additionally I've altered the workflows so that they respond when comments are added as replies on a PR.

I've decreased the stale limit to 14 days as this gives 28 days in total after feedback was requested before the PR auto-closes, which feels reasonable given the current pace of the project.