### PR TITLE
feat: add sampler DSL for tracer provider configuration

### DIFF
--- a/config-dsl/src/commonMain/kotlin/io/opentelemetry/kotlin/config/dsl/SamplerConfigDslImpl.kt
+++ b/config-dsl/src/commonMain/kotlin/io/opentelemetry/kotlin/config/dsl/SamplerConfigDslImpl.kt
@@ -1,0 +1,37 @@
+package io.opentelemetry.kotlin.config.dsl
+
+import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.behavior.SamplerBehavior
+
+@ExperimentalApi
+class SamplerConfigDslImpl {
+
+    private var chosen: SamplerBehavior? = null
+
+    fun toBehavior(): SamplerBehavior? = chosen
+
+    fun alwaysOn(): SamplerBehavior = record(SamplerBehavior.AlwaysOn)
+
+    fun alwaysOff(): SamplerBehavior = record(SamplerBehavior.AlwaysOff)
+
+    fun parentBased(
+        root: SamplerBehavior? = null,
+        remoteParentSampled: SamplerBehavior? = null,
+        remoteParentNotSampled: SamplerBehavior? = null,
+        localParentSampled: SamplerBehavior? = null,
+        localParentNotSampled: SamplerBehavior? = null,
+    ): SamplerBehavior = record(
+        SamplerBehavior.ParentBased(
+            root = root,
+            remoteParentSampled = remoteParentSampled,
+            remoteParentNotSampled = remoteParentNotSampled,
+            localParentSampled = localParentSampled,
+            localParentNotSampled = localParentNotSampled
+        )
+    )
+
+    private fun record(value: SamplerBehavior): SamplerBehavior {
+        chosen = value
+        return value
+    }
+}

--- a/config-dsl/src/commonMain/kotlin/io/opentelemetry/kotlin/config/dsl/SamplerConfigDslImpl.kt
+++ b/config-dsl/src/commonMain/kotlin/io/opentelemetry/kotlin/config/dsl/SamplerConfigDslImpl.kt
@@ -3,16 +3,19 @@ package io.opentelemetry.kotlin.config.dsl
 import io.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.kotlin.behavior.SamplerBehavior
 
+/**
+ * Captures the sampler configured programmatically, and maps it onto a behavior.
+ */
 @ExperimentalApi
 class SamplerConfigDslImpl {
 
-    private var chosen: SamplerBehavior? = null
+    private var sampler: SamplerBehavior? = null
 
-    fun toBehavior(): SamplerBehavior? = chosen
+    fun toBehavior(): SamplerBehavior? = sampler
 
-    fun alwaysOn(): SamplerBehavior = record(SamplerBehavior.AlwaysOn)
+    fun alwaysOn(): SamplerBehavior = SamplerBehavior.AlwaysOn.also { sampler = it }
 
-    fun alwaysOff(): SamplerBehavior = record(SamplerBehavior.AlwaysOff)
+    fun alwaysOff(): SamplerBehavior = SamplerBehavior.AlwaysOff.also { sampler = it }
 
     fun parentBased(
         root: SamplerBehavior? = null,
@@ -20,18 +23,12 @@ class SamplerConfigDslImpl {
         remoteParentNotSampled: SamplerBehavior? = null,
         localParentSampled: SamplerBehavior? = null,
         localParentNotSampled: SamplerBehavior? = null,
-    ): SamplerBehavior = record(
+    ): SamplerBehavior =
         SamplerBehavior.ParentBased(
             root = root,
             remoteParentSampled = remoteParentSampled,
             remoteParentNotSampled = remoteParentNotSampled,
             localParentSampled = localParentSampled,
             localParentNotSampled = localParentNotSampled
-        )
-    )
-
-    private fun record(value: SamplerBehavior): SamplerBehavior {
-        chosen = value
-        return value
-    }
+        ).also { sampler = it }
 }

--- a/config-dsl/src/commonMain/kotlin/io/opentelemetry/kotlin/config/dsl/TracerProviderConfigDslImpl.kt
+++ b/config-dsl/src/commonMain/kotlin/io/opentelemetry/kotlin/config/dsl/TracerProviderConfigDslImpl.kt
@@ -1,6 +1,7 @@
 package io.opentelemetry.kotlin.config.dsl
 
 import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.behavior.SamplerBehavior
 import io.opentelemetry.kotlin.behavior.SpanProcessorBehavior
 import io.opentelemetry.kotlin.behavior.TracerProviderBehavior
 import io.opentelemetry.kotlin.init.TraceExportConfigDsl
@@ -13,12 +14,19 @@ import io.opentelemetry.kotlin.tracing.export.SpanProcessor
 class TracerProviderConfigDslImpl : BehaviorSupplier<TracerProviderBehavior> {
 
     private var processor: SpanProcessorBehavior? = null
+    private var sampler: SamplerBehavior? = null
 
     @Suppress("UnusedParameter")
     fun export(action: TraceExportConfigDsl.() -> SpanProcessor) {
         processor = SpanProcessorBehavior()
     }
 
+    fun sampler(action: SamplerConfigDslImpl.() -> Unit) {
+        val impl = SamplerConfigDslImpl()
+        impl.action()
+        sampler = impl.toBehavior()
+    }
+
     override fun toBehavior(): TracerProviderBehavior =
-        TracerProviderBehavior(processor = processor)
+        TracerProviderBehavior(processor = processor, sampler = sampler)
 }

--- a/config-dsl/src/commonTest/kotlin/io/opentelemetry/kotlin/config/dsl/SamplerConfigDslImplTest.kt
+++ b/config-dsl/src/commonTest/kotlin/io/opentelemetry/kotlin/config/dsl/SamplerConfigDslImplTest.kt
@@ -1,0 +1,65 @@
+package io.opentelemetry.kotlin.config.dsl
+
+import io.opentelemetry.kotlin.behavior.SamplerBehavior
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+internal class SamplerConfigDslImplTest {
+
+    @Test
+    fun startsUnset() {
+        assertNull(SamplerConfigDslImpl().toBehavior())
+    }
+
+    @Test
+    fun mapsAlwaysOn() {
+        val dsl = SamplerConfigDslImpl()
+        dsl.alwaysOn()
+        assertEquals(SamplerBehavior.AlwaysOn, dsl.toBehavior())
+    }
+
+    @Test
+    fun mapsAlwaysOff() {
+        val dsl = SamplerConfigDslImpl()
+        dsl.alwaysOff()
+        assertEquals(SamplerBehavior.AlwaysOff, dsl.toBehavior())
+    }
+
+    @Test
+    fun lastSuccessfulCallWins() {
+        val dsl = SamplerConfigDslImpl()
+        dsl.alwaysOn()
+        dsl.alwaysOff()
+        assertEquals(SamplerBehavior.AlwaysOff, dsl.toBehavior())
+    }
+
+    @Test
+    fun mapsEveryParentBasedChild() {
+        val dsl = SamplerConfigDslImpl()
+        dsl.parentBased(
+            root = dsl.alwaysOff(),
+            remoteParentSampled = dsl.alwaysOn(),
+            remoteParentNotSampled = dsl.alwaysOff(),
+            localParentSampled = dsl.alwaysOn(),
+            localParentNotSampled = dsl.alwaysOff(),
+        )
+        assertEquals(
+            SamplerBehavior.ParentBased(
+                root = SamplerBehavior.AlwaysOff,
+                remoteParentSampled = SamplerBehavior.AlwaysOn,
+                remoteParentNotSampled = SamplerBehavior.AlwaysOff,
+                localParentSampled = SamplerBehavior.AlwaysOn,
+                localParentNotSampled = SamplerBehavior.AlwaysOff,
+            ),
+            dsl.toBehavior()
+        )
+    }
+
+    @Test
+    fun emptyParentBasedLeavesChildrenUnset() {
+        val dsl = SamplerConfigDslImpl()
+        dsl.parentBased()
+        assertEquals(SamplerBehavior.ParentBased(), dsl.toBehavior())
+    }
+}

--- a/config-dsl/src/commonTest/kotlin/io/opentelemetry/kotlin/config/dsl/TracerProviderConfigDslImplTest.kt
+++ b/config-dsl/src/commonTest/kotlin/io/opentelemetry/kotlin/config/dsl/TracerProviderConfigDslImplTest.kt
@@ -1,5 +1,6 @@
 package io.opentelemetry.kotlin.config.dsl
 
+import io.opentelemetry.kotlin.behavior.SamplerBehavior
 import io.opentelemetry.kotlin.behavior.SpanProcessorBehavior
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -10,6 +11,39 @@ internal class TracerProviderConfigDslImplTest {
     @Test
     fun processorStartsUnset() {
         assertNull(TracerProviderConfigDslImpl().toBehavior().processor)
+    }
+
+    @Test
+    fun samplerStartsUnset() {
+        assertNull(TracerProviderConfigDslImpl().toBehavior().sampler)
+    }
+
+    @Test
+    fun samplerCallSetsSampler() {
+        val dsl = TracerProviderConfigDslImpl()
+        dsl.sampler { alwaysOn() }
+        assertEquals(SamplerBehavior.AlwaysOn, dsl.toBehavior().sampler)
+    }
+
+    @Test
+    fun samplerMapsParentBased() {
+        val dsl = TracerProviderConfigDslImpl()
+        dsl.sampler { parentBased(root = alwaysOff()) }
+        assertEquals(
+            SamplerBehavior.ParentBased(root = SamplerBehavior.AlwaysOff),
+            dsl.toBehavior().sampler
+        )
+    }
+
+    @Test
+    fun samplerDoesNotDropProcessor() {
+        val dsl = TracerProviderConfigDslImpl()
+        dsl.export { error("behavior mapping does not run the export lambda") }
+        dsl.sampler { alwaysOff() }
+
+        val behavior = dsl.toBehavior()
+        assertEquals(SpanProcessorBehavior(), behavior.processor)
+        assertEquals(SamplerBehavior.AlwaysOff, behavior.sampler)
     }
 
     @Test


### PR DESCRIPTION
Part of #913 
Related #1010

## Goal

Introduce the DSL configuration layer for trace samplers and map them to their corresponding `SamplerBehavior` models.

* **`SamplerConfigDslImpl`**
* **`TracerProviderConfigDslImpl`**

## Testing

Add tests in:
* **`SamplerConfigDslImplTest`**
* **`TracerProviderConfigDslImplTest`**