### PR TITLE
feat: map console exporter YAML and env vars to processor behavior

### DIFF
--- a/config-envar/src/commonMain/kotlin/io/opentelemetry/kotlin/config/envar/OpenTelemetryEnvVars.kt
+++ b/config-envar/src/commonMain/kotlin/io/opentelemetry/kotlin/config/envar/OpenTelemetryEnvVars.kt
@@ -5,8 +5,10 @@ import io.opentelemetry.kotlin.behavior.LoggerProviderBehavior
 import io.opentelemetry.kotlin.behavior.OpenTelemetryBehavior
 import io.opentelemetry.kotlin.behavior.TracerProviderBehavior
 import io.opentelemetry.kotlin.config.envar.logging.LogLimitsEnvVars
+import io.opentelemetry.kotlin.config.envar.logging.LogsExporterEnvVars
 import io.opentelemetry.kotlin.config.envar.tracing.SamplerEnvVars
 import io.opentelemetry.kotlin.config.envar.tracing.SpanLimitsEnvVars
+import io.opentelemetry.kotlin.config.envar.tracing.TracesExporterEnvVars
 
 /**
  * Maps every environment variable this SDK understands onto [OpenTelemetryBehavior].
@@ -20,10 +22,12 @@ class OpenTelemetryEnvVars(private val reader: EnvVarReader) {
         attributeLimits = AttributeLimitsEnvVars(reader).toBehavior(),
         tracerProvider = TracerProviderBehavior(
             spanLimits = SpanLimitsEnvVars(reader).toBehavior(),
-            sampler = SamplerEnvVars(reader).toBehavior()
+            sampler = SamplerEnvVars(reader).toBehavior(),
+            processor = TracesExporterEnvVars(reader).toBehavior(),
         ),
         loggerProvider = LoggerProviderBehavior(
             logLimits = LogLimitsEnvVars(reader).toBehavior(),
+            processor = LogsExporterEnvVars(reader).toBehavior(),
         ),
     )
 }

--- a/config-envar/src/commonMain/kotlin/io/opentelemetry/kotlin/config/envar/logging/LogsExporterEnvVars.kt
+++ b/config-envar/src/commonMain/kotlin/io/opentelemetry/kotlin/config/envar/logging/LogsExporterEnvVars.kt
@@ -1,0 +1,36 @@
+package io.opentelemetry.kotlin.config.envar.logging
+
+import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.behavior.ConsoleExporterBehavior
+import io.opentelemetry.kotlin.behavior.LogRecordProcessorBehavior
+import io.opentelemetry.kotlin.config.envar.EnvVarReader
+
+/**
+ * Maps `OTEL_LOGS_EXPORTER` onto processor behavior. Console is the only exporter this mapper
+ * understands. Unrecognized exporter names are ignored (and reported via [onWarning]).
+ *
+ * https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#exporter-selection
+ */
+@ExperimentalApi
+class LogsExporterEnvVars(
+    private val reader: EnvVarReader,
+    private val onWarning: (String) -> Unit = {},
+) {
+    fun toBehavior(): LogRecordProcessorBehavior? {
+        val name = reader.readString(EXPORTER)?.takeIf { it.isNotEmpty() } ?: return null
+        return when (name.lowercase()) {
+            CONSOLE -> LogRecordProcessorBehavior(console = ConsoleExporterBehavior())
+            OTLP, LOGGING, NONE, OTLP_STDOUT -> null
+            else -> null.also { onWarning("Unknown OTEL_LOGS_EXPORTER value '$name'; ignoring") }
+        }
+    }
+
+    private companion object {
+        const val EXPORTER = "OTEL_LOGS_EXPORTER"
+        const val CONSOLE = "console"
+        const val OTLP = "otlp"
+        const val LOGGING = "logging"
+        const val NONE = "none"
+        const val OTLP_STDOUT = "otlp/stdout"
+    }
+}

--- a/config-envar/src/commonMain/kotlin/io/opentelemetry/kotlin/config/envar/tracing/TracesExporterEnvVars.kt
+++ b/config-envar/src/commonMain/kotlin/io/opentelemetry/kotlin/config/envar/tracing/TracesExporterEnvVars.kt
@@ -20,7 +20,7 @@ class TracesExporterEnvVars(
         val name = reader.readString(EXPORTER)?.takeIf { it.isNotEmpty() } ?: return null
         return when (name.lowercase()) {
             CONSOLE -> SpanProcessorBehavior(console = ConsoleExporterBehavior())
-            OTLP, ZIPKIN, LOGGING, NONE, OTLP_STDOUT -> null
+            OTLP, LOGGING, NONE, OTLP_STDOUT -> null
             else -> null.also { onWarning("Unknown OTEL_TRACES_EXPORTER value '$name'; ignoring") }
         }
     }
@@ -29,7 +29,6 @@ class TracesExporterEnvVars(
         const val EXPORTER = "OTEL_TRACES_EXPORTER"
         const val CONSOLE = "console"
         const val OTLP = "otlp"
-        const val ZIPKIN = "zipkin"
         const val LOGGING = "logging"
         const val NONE = "none"
         const val OTLP_STDOUT = "otlp/stdout"

--- a/config-envar/src/commonMain/kotlin/io/opentelemetry/kotlin/config/envar/tracing/TracesExporterEnvVars.kt
+++ b/config-envar/src/commonMain/kotlin/io/opentelemetry/kotlin/config/envar/tracing/TracesExporterEnvVars.kt
@@ -1,0 +1,37 @@
+package io.opentelemetry.kotlin.config.envar.tracing
+
+import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.behavior.ConsoleExporterBehavior
+import io.opentelemetry.kotlin.behavior.SpanProcessorBehavior
+import io.opentelemetry.kotlin.config.envar.EnvVarReader
+
+/**
+ * Maps `OTEL_TRACES_EXPORTER` onto processor behavior. Console is the only exporter this mapper
+ * understands. Unrecognized exporter names are ignored (and reported via [onWarning]).
+ *
+ * https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#exporter-selection
+ */
+@ExperimentalApi
+class TracesExporterEnvVars(
+    private val reader: EnvVarReader,
+    private val onWarning: (String) -> Unit = {},
+) {
+    fun toBehavior(): SpanProcessorBehavior? {
+        val name = reader.readString(EXPORTER)?.takeIf { it.isNotEmpty() } ?: return null
+        return when (name.lowercase()) {
+            CONSOLE -> SpanProcessorBehavior(console = ConsoleExporterBehavior())
+            OTLP, ZIPKIN, LOGGING, NONE, OTLP_STDOUT -> null
+            else -> null.also { onWarning("Unknown OTEL_TRACES_EXPORTER value '$name'; ignoring") }
+        }
+    }
+
+    private companion object {
+        const val EXPORTER = "OTEL_TRACES_EXPORTER"
+        const val CONSOLE = "console"
+        const val OTLP = "otlp"
+        const val ZIPKIN = "zipkin"
+        const val LOGGING = "logging"
+        const val NONE = "none"
+        const val OTLP_STDOUT = "otlp/stdout"
+    }
+}

--- a/config-envar/src/commonTest/kotlin/io/opentelemetry/kotlin/config/envar/OpenTelemetryEnvVarsTest.kt
+++ b/config-envar/src/commonTest/kotlin/io/opentelemetry/kotlin/config/envar/OpenTelemetryEnvVarsTest.kt
@@ -1,11 +1,14 @@
 package io.opentelemetry.kotlin.config.envar
 
 import io.opentelemetry.kotlin.behavior.AttributeLimitsBehavior
+import io.opentelemetry.kotlin.behavior.ConsoleExporterBehavior
 import io.opentelemetry.kotlin.behavior.LogLimitsBehavior
+import io.opentelemetry.kotlin.behavior.LogRecordProcessorBehavior
 import io.opentelemetry.kotlin.behavior.LoggerProviderBehavior
 import io.opentelemetry.kotlin.behavior.OpenTelemetryBehavior
 import io.opentelemetry.kotlin.behavior.SamplerBehavior
 import io.opentelemetry.kotlin.behavior.SpanLimitsBehavior
+import io.opentelemetry.kotlin.behavior.SpanProcessorBehavior
 import io.opentelemetry.kotlin.behavior.TracerProviderBehavior
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -104,6 +107,25 @@ internal class OpenTelemetryEnvVarsTest {
     @Test
     fun `should leave sampler unset when OTEL_TRACES_SAMPLER is unset`() {
         assertEquals(null, toBehavior { null }.tracerProvider?.sampler)
+    }
+
+    @Test
+    fun `should map console exporter env vars onto processor behavior`() {
+        val env = mapOf(
+            "OTEL_TRACES_EXPORTER" to "console",
+            "OTEL_LOGS_EXPORTER" to "console",
+        )
+        val behavior = toBehavior(env::get)
+        val console = ConsoleExporterBehavior()
+        assertEquals(SpanProcessorBehavior(console = console), behavior.tracerProvider?.processor)
+        assertEquals(LogRecordProcessorBehavior(console = console), behavior.loggerProvider?.processor)
+    }
+
+    @Test
+    fun `should leave processor unset when exporter env vars are unset`() {
+        val behavior = toBehavior { null }
+        assertEquals(null, behavior.tracerProvider?.processor)
+        assertEquals(null, behavior.loggerProvider?.processor)
     }
 
     private fun behaviorFrom(vars: Map<String, String>) =

--- a/config-envar/src/commonTest/kotlin/io/opentelemetry/kotlin/config/envar/logging/LogsExporterEnvVarsTest.kt
+++ b/config-envar/src/commonTest/kotlin/io/opentelemetry/kotlin/config/envar/logging/LogsExporterEnvVarsTest.kt
@@ -1,0 +1,67 @@
+package io.opentelemetry.kotlin.config.envar.logging
+
+import io.opentelemetry.kotlin.behavior.ConsoleExporterBehavior
+import io.opentelemetry.kotlin.behavior.LogRecordProcessorBehavior
+import io.opentelemetry.kotlin.config.envar.EnvVarReader
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+internal class LogsExporterEnvVarsTest {
+
+    @Test
+    fun `should leave unset env vars unset`() {
+        assertNull(toBehavior { null })
+    }
+
+    @Test
+    fun `should map console`() {
+        assertEquals(
+            LogRecordProcessorBehavior(console = ConsoleExporterBehavior()),
+            toBehavior(env("console")),
+        )
+    }
+
+    @Test
+    fun `should leave known non-console exporters unset`() {
+        listOf("otlp", "logging", "none", "otlp/stdout", "").forEach { name ->
+            assertNull(toBehavior(env(name)), "<$name> should not configure a processor")
+        }
+    }
+
+    @Test
+    fun `should leave unknown exporter unset`() {
+        assertNull(toBehavior(env("not_an_exporter")))
+    }
+
+    @Test
+    fun `should warn on unknown exporter`() {
+        val warnings = mutableListOf<String>()
+        LogsExporterEnvVars(EnvVarReader(env("not_an_exporter")), warnings::add).toBehavior()
+        assertEquals(1, warnings.size)
+    }
+
+    @Test
+    fun `should not warn when exporter is unset`() {
+        val warnings = mutableListOf<String>()
+        LogsExporterEnvVars(EnvVarReader { null }, warnings::add).toBehavior()
+        assertEquals(emptyList(), warnings)
+    }
+
+    @Test
+    fun `should not warn on known non-console exporters`() {
+        val warnings = mutableListOf<String>()
+        LogsExporterEnvVars(EnvVarReader(env("otlp")), warnings::add).toBehavior()
+        assertEquals(emptyList(), warnings)
+    }
+
+    private fun env(exporter: String): (String) -> String? {
+        val values = buildMap {
+            put("OTEL_LOGS_EXPORTER", exporter)
+        }
+        return values::get
+    }
+
+    private fun toBehavior(getEnvVar: (String) -> String?) =
+        LogsExporterEnvVars(EnvVarReader(getEnvVar)).toBehavior()
+}

--- a/config-envar/src/commonTest/kotlin/io/opentelemetry/kotlin/config/envar/tracing/TracesExporterEnvVarsTest.kt
+++ b/config-envar/src/commonTest/kotlin/io/opentelemetry/kotlin/config/envar/tracing/TracesExporterEnvVarsTest.kt
@@ -1,0 +1,67 @@
+package io.opentelemetry.kotlin.config.envar.tracing
+
+import io.opentelemetry.kotlin.behavior.ConsoleExporterBehavior
+import io.opentelemetry.kotlin.behavior.SpanProcessorBehavior
+import io.opentelemetry.kotlin.config.envar.EnvVarReader
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+internal class TracesExporterEnvVarsTest {
+
+    @Test
+    fun `should leave unset env vars unset`() {
+        assertNull(toBehavior { null })
+    }
+
+    @Test
+    fun `should map console`() {
+        assertEquals(
+            SpanProcessorBehavior(console = ConsoleExporterBehavior()),
+            toBehavior(env("console")),
+        )
+    }
+
+    @Test
+    fun `should leave known non-console exporters unset`() {
+        listOf("otlp", "zipkin", "logging", "none", "otlp/stdout", "").forEach { name ->
+            assertNull(toBehavior(env(name)), "<$name> should not configure a processor")
+        }
+    }
+
+    @Test
+    fun `should leave unknown exporter unset`() {
+        assertNull(toBehavior(env("not_an_exporter")))
+    }
+
+    @Test
+    fun `should warn on unknown exporter`() {
+        val warnings = mutableListOf<String>()
+        TracesExporterEnvVars(EnvVarReader(env("not_an_exporter")), warnings::add).toBehavior()
+        assertEquals(1, warnings.size)
+    }
+
+    @Test
+    fun `should not warn when exporter is unset`() {
+        val warnings = mutableListOf<String>()
+        TracesExporterEnvVars(EnvVarReader { null }, warnings::add).toBehavior()
+        assertEquals(emptyList(), warnings)
+    }
+
+    @Test
+    fun `should not warn on known non-console exporters`() {
+        val warnings = mutableListOf<String>()
+        TracesExporterEnvVars(EnvVarReader(env("otlp")), warnings::add).toBehavior()
+        assertEquals(emptyList(), warnings)
+    }
+
+    private fun env(exporter: String): (String) -> String? {
+        val values = buildMap {
+            put("OTEL_TRACES_EXPORTER", exporter)
+        }
+        return values::get
+    }
+
+    private fun toBehavior(getEnvVar: (String) -> String?) =
+        TracesExporterEnvVars(EnvVarReader(getEnvVar)).toBehavior()
+}

--- a/config-envar/src/commonTest/kotlin/io/opentelemetry/kotlin/config/envar/tracing/TracesExporterEnvVarsTest.kt
+++ b/config-envar/src/commonTest/kotlin/io/opentelemetry/kotlin/config/envar/tracing/TracesExporterEnvVarsTest.kt
@@ -24,21 +24,25 @@ internal class TracesExporterEnvVarsTest {
 
     @Test
     fun `should leave known non-console exporters unset`() {
-        listOf("otlp", "zipkin", "logging", "none", "otlp/stdout", "").forEach { name ->
+        listOf("otlp", "logging", "none", "otlp/stdout", "").forEach { name ->
             assertNull(toBehavior(env(name)), "<$name> should not configure a processor")
         }
     }
 
     @Test
     fun `should leave unknown exporter unset`() {
-        assertNull(toBehavior(env("not_an_exporter")))
+        listOf("not_an_exporter", "zipkin").forEach { name ->
+            assertNull(toBehavior(env(name)), "<$name> should not configure a processor")
+        }
     }
 
     @Test
     fun `should warn on unknown exporter`() {
-        val warnings = mutableListOf<String>()
-        TracesExporterEnvVars(EnvVarReader(env("not_an_exporter")), warnings::add).toBehavior()
-        assertEquals(1, warnings.size)
+        listOf("not_an_exporter", "zipkin").forEach { name ->
+            val warnings = mutableListOf<String>()
+            TracesExporterEnvVars(EnvVarReader(env(name)), warnings::add).toBehavior()
+            assertEquals(1, warnings.size, "<$name> should warn")
+        }
     }
 
     @Test

--- a/config-yaml/src/commonMain/kotlin/io/opentelemetry/kotlin/config/yaml/LogRecordProcessorMapper.kt
+++ b/config-yaml/src/commonMain/kotlin/io/opentelemetry/kotlin/config/yaml/LogRecordProcessorMapper.kt
@@ -1,0 +1,21 @@
+package io.opentelemetry.kotlin.config.yaml
+
+import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.behavior.ConsoleExporterBehavior
+import io.opentelemetry.kotlin.behavior.LogRecordProcessorBehavior
+import io.opentelemetry.kotlin.config.schema.model.LogRecordProcessor
+
+/**
+ * Maps `logger_provider.processors` onto processor behavior. Console is the only exporter this
+ * mapper understands: selecting it in any simple or batch processor is the whole configuration.
+ * Anything else is left unset.
+ */
+@ExperimentalApi
+fun List<LogRecordProcessor>.toBehavior(): LogRecordProcessorBehavior? {
+    val consoleSelected = any { processor ->
+        processor.simple?.exporter?.console != null ||
+            processor.batch?.exporter?.console != null
+    }
+    if (!consoleSelected) return null
+    return LogRecordProcessorBehavior(console = ConsoleExporterBehavior())
+}

--- a/config-yaml/src/commonMain/kotlin/io/opentelemetry/kotlin/config/yaml/LogRecordProcessorMapper.kt
+++ b/config-yaml/src/commonMain/kotlin/io/opentelemetry/kotlin/config/yaml/LogRecordProcessorMapper.kt
@@ -16,6 +16,8 @@ fun List<LogRecordProcessor>.toBehavior(): LogRecordProcessorBehavior? {
         processor.simple?.exporter?.console != null ||
             processor.batch?.exporter?.console != null
     }
-    if (!consoleSelected) return null
+    if (!consoleSelected) {
+        return null
+    }
     return LogRecordProcessorBehavior(console = ConsoleExporterBehavior())
 }

--- a/config-yaml/src/commonMain/kotlin/io/opentelemetry/kotlin/config/yaml/OpenTelemetryConfigurationMapper.kt
+++ b/config-yaml/src/commonMain/kotlin/io/opentelemetry/kotlin/config/yaml/OpenTelemetryConfigurationMapper.kt
@@ -15,10 +15,14 @@ fun OpenTelemetryConfiguration.toBehavior(): OpenTelemetryBehavior = OpenTelemet
     tracerProvider = tracerProvider?.let {
         TracerProviderBehavior(
             spanLimits = it.limits?.toBehavior(),
-            sampler = it.sampler?.toBehavior()
+            processor = it.processors.toBehavior(),
+            sampler = it.sampler?.toBehavior(),
         )
     },
     loggerProvider = loggerProvider?.let {
-        LoggerProviderBehavior(logLimits = it.limits?.toBehavior())
+        LoggerProviderBehavior(
+            logLimits = it.limits?.toBehavior(),
+            processor = it.processors.toBehavior(),
+        )
     },
 )

--- a/config-yaml/src/commonMain/kotlin/io/opentelemetry/kotlin/config/yaml/SpanProcessorMapper.kt
+++ b/config-yaml/src/commonMain/kotlin/io/opentelemetry/kotlin/config/yaml/SpanProcessorMapper.kt
@@ -16,6 +16,8 @@ fun List<SpanProcessor>.toBehavior(): SpanProcessorBehavior? {
         processor.simple?.exporter?.console != null ||
             processor.batch?.exporter?.console != null
     }
-    if (!consoleSelected) return null
+    if (!consoleSelected) {
+        return null
+    }
     return SpanProcessorBehavior(console = ConsoleExporterBehavior())
 }

--- a/config-yaml/src/commonMain/kotlin/io/opentelemetry/kotlin/config/yaml/SpanProcessorMapper.kt
+++ b/config-yaml/src/commonMain/kotlin/io/opentelemetry/kotlin/config/yaml/SpanProcessorMapper.kt
@@ -1,0 +1,21 @@
+package io.opentelemetry.kotlin.config.yaml
+
+import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.behavior.ConsoleExporterBehavior
+import io.opentelemetry.kotlin.behavior.SpanProcessorBehavior
+import io.opentelemetry.kotlin.config.schema.model.SpanProcessor
+
+/**
+ * Maps `tracer_provider.processors` onto processor behavior. Console is the only exporter this
+ * mapper understands: selecting it in any simple or batch processor is the whole configuration.
+ * Anything else is left unset.
+ */
+@ExperimentalApi
+fun List<SpanProcessor>.toBehavior(): SpanProcessorBehavior? {
+    val consoleSelected = any { processor ->
+        processor.simple?.exporter?.console != null ||
+            processor.batch?.exporter?.console != null
+    }
+    if (!consoleSelected) return null
+    return SpanProcessorBehavior(console = ConsoleExporterBehavior())
+}

--- a/config-yaml/src/commonTest/kotlin/io/opentelemetry/kotlin/config/yaml/LogRecordProcessorMapperTest.kt
+++ b/config-yaml/src/commonTest/kotlin/io/opentelemetry/kotlin/config/yaml/LogRecordProcessorMapperTest.kt
@@ -1,0 +1,52 @@
+package io.opentelemetry.kotlin.config.yaml
+
+import io.opentelemetry.kotlin.behavior.ConsoleExporterBehavior
+import io.opentelemetry.kotlin.behavior.LogRecordProcessorBehavior
+import io.opentelemetry.kotlin.config.schema.model.BatchLogRecordProcessor
+import io.opentelemetry.kotlin.config.schema.model.ConsoleExporter
+import io.opentelemetry.kotlin.config.schema.model.LogRecordExporter
+import io.opentelemetry.kotlin.config.schema.model.LogRecordProcessor
+import io.opentelemetry.kotlin.config.schema.model.SimpleLogRecordProcessor
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+internal class LogRecordProcessorMapperTest {
+
+    @Test
+    fun emptyProcessorsLeaveBehaviorUnset() {
+        assertNull(emptyList<LogRecordProcessor>().toBehavior())
+    }
+
+    @Test
+    fun mapsConsoleFromASimpleProcessor() {
+        val processors = listOf(
+            LogRecordProcessor(simple = SimpleLogRecordProcessor(exporter = consoleExporter())),
+        )
+        assertEquals(
+            LogRecordProcessorBehavior(console = ConsoleExporterBehavior()),
+            processors.toBehavior(),
+        )
+    }
+
+    @Test
+    fun mapsConsoleFromABatchProcessor() {
+        val processors = listOf(
+            LogRecordProcessor(batch = BatchLogRecordProcessor(exporter = consoleExporter())),
+        )
+        assertEquals(
+            LogRecordProcessorBehavior(console = ConsoleExporterBehavior()),
+            processors.toBehavior(),
+        )
+    }
+
+    @Test
+    fun leavesProcessorsWithoutConsoleUnset() {
+        val processors = listOf(
+            LogRecordProcessor(simple = SimpleLogRecordProcessor(exporter = LogRecordExporter())),
+        )
+        assertNull(processors.toBehavior())
+    }
+
+    private fun consoleExporter() = LogRecordExporter(console = ConsoleExporter())
+}

--- a/config-yaml/src/commonTest/kotlin/io/opentelemetry/kotlin/config/yaml/OpenTelemetryConfigurationMapperTest.kt
+++ b/config-yaml/src/commonTest/kotlin/io/opentelemetry/kotlin/config/yaml/OpenTelemetryConfigurationMapperTest.kt
@@ -1,20 +1,32 @@
 package io.opentelemetry.kotlin.config.yaml
 
 import io.opentelemetry.kotlin.behavior.AttributeLimitsBehavior
+import io.opentelemetry.kotlin.behavior.ConsoleExporterBehavior
 import io.opentelemetry.kotlin.behavior.LogLimitsBehavior
+import io.opentelemetry.kotlin.behavior.LogRecordProcessorBehavior
 import io.opentelemetry.kotlin.behavior.LoggerProviderBehavior
 import io.opentelemetry.kotlin.behavior.OpenTelemetryBehavior
 import io.opentelemetry.kotlin.behavior.SamplerBehavior
 import io.opentelemetry.kotlin.behavior.SpanLimitsBehavior
+import io.opentelemetry.kotlin.behavior.SpanProcessorBehavior
 import io.opentelemetry.kotlin.behavior.TracerProviderBehavior
 import io.opentelemetry.kotlin.config.schema.model.AlwaysOffSampler
+import io.opentelemetry.kotlin.config.schema.model.ConsoleExporter
+import io.opentelemetry.kotlin.config.schema.model.LogRecordExporter
+import io.opentelemetry.kotlin.config.schema.model.LogRecordProcessor
+import io.opentelemetry.kotlin.config.schema.model.LoggerProvider
 import io.opentelemetry.kotlin.config.schema.model.OpenTelemetryConfiguration
 import io.opentelemetry.kotlin.config.schema.model.Sampler
+import io.opentelemetry.kotlin.config.schema.model.SimpleLogRecordProcessor
+import io.opentelemetry.kotlin.config.schema.model.SimpleSpanProcessor
+import io.opentelemetry.kotlin.config.schema.model.SpanExporter
 import io.opentelemetry.kotlin.config.schema.model.SpanLimits
+import io.opentelemetry.kotlin.config.schema.model.SpanProcessor
 import io.opentelemetry.kotlin.config.schema.model.TracerProvider
 import io.opentelemetry.kotlin.framework.loadTestFixture
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 
 internal class OpenTelemetryConfigurationMapperTest {
 
@@ -51,17 +63,47 @@ internal class OpenTelemetryConfigurationMapperTest {
 
     @Test
     fun leavesLimitsTheSpecDisallowsUnset() {
-        val config = OpenTelemetryConfiguration(
+        val behavior = OpenTelemetryConfiguration(
             fileFormat = FILE_FORMAT,
             tracerProvider = TracerProvider(
                 processors = emptyList(),
                 limits = SpanLimits(attributeCountLimit = -1),
             ),
+        ).toBehavior()
+
+        assertEquals(SpanLimitsBehavior(), behavior.tracerProvider?.spanLimits)
+        assertNull(behavior.tracerProvider?.processor)
+    }
+
+    @Test
+    fun mapsConsoleExportersOntoProcessorBehavior() {
+        val console = ConsoleExporterBehavior()
+        val config = OpenTelemetryConfiguration(
+            fileFormat = FILE_FORMAT,
+            tracerProvider = TracerProvider(
+                processors = listOf(
+                    SpanProcessor(simple = SimpleSpanProcessor(exporter = SpanExporter(console = ConsoleExporter()))),
+                ),
+            ),
+            loggerProvider = LoggerProvider(
+                processors = listOf(
+                    LogRecordProcessor(
+                        simple = SimpleLogRecordProcessor(exporter = LogRecordExporter(console = ConsoleExporter())),
+                    ),
+                ),
+            ),
         )
 
         assertEquals(
-            SpanLimitsBehavior(),
-            config.toBehavior().tracerProvider?.spanLimits,
+            OpenTelemetryBehavior(
+                tracerProvider = TracerProviderBehavior(
+                    processor = SpanProcessorBehavior(console = console),
+                ),
+                loggerProvider = LoggerProviderBehavior(
+                    processor = LogRecordProcessorBehavior(console = console),
+                ),
+            ),
+            config.toBehavior(),
         )
     }
 

--- a/config-yaml/src/commonTest/kotlin/io/opentelemetry/kotlin/config/yaml/SpanProcessorMapperTest.kt
+++ b/config-yaml/src/commonTest/kotlin/io/opentelemetry/kotlin/config/yaml/SpanProcessorMapperTest.kt
@@ -1,0 +1,46 @@
+package io.opentelemetry.kotlin.config.yaml
+
+import io.opentelemetry.kotlin.behavior.ConsoleExporterBehavior
+import io.opentelemetry.kotlin.behavior.SpanProcessorBehavior
+import io.opentelemetry.kotlin.config.schema.model.BatchSpanProcessor
+import io.opentelemetry.kotlin.config.schema.model.ConsoleExporter
+import io.opentelemetry.kotlin.config.schema.model.SimpleSpanProcessor
+import io.opentelemetry.kotlin.config.schema.model.SpanExporter
+import io.opentelemetry.kotlin.config.schema.model.SpanProcessor
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+internal class SpanProcessorMapperTest {
+
+    @Test
+    fun emptyProcessorsLeaveBehaviorUnset() {
+        assertNull(emptyList<SpanProcessor>().toBehavior())
+    }
+
+    @Test
+    fun mapsConsoleFromASimpleProcessor() {
+        val processors = listOf(
+            SpanProcessor(simple = SimpleSpanProcessor(exporter = consoleExporter())),
+        )
+        assertEquals(SpanProcessorBehavior(console = ConsoleExporterBehavior()), processors.toBehavior())
+    }
+
+    @Test
+    fun mapsConsoleFromABatchProcessor() {
+        val processors = listOf(
+            SpanProcessor(batch = BatchSpanProcessor(exporter = consoleExporter())),
+        )
+        assertEquals(SpanProcessorBehavior(console = ConsoleExporterBehavior()), processors.toBehavior())
+    }
+
+    @Test
+    fun leavesProcessorsWithoutConsoleUnset() {
+        val processors = listOf(
+            SpanProcessor(simple = SimpleSpanProcessor(exporter = SpanExporter())),
+        )
+        assertNull(processors.toBehavior())
+    }
+
+    private fun consoleExporter() = SpanExporter(console = ConsoleExporter())
+}


### PR DESCRIPTION
## Goal

Map ConsoleExporter from declarative YAML and environment variables onto `processor.console` on tracer and logger providers. Part of #924.

YAML: if any simple or batch processor has `exporter.console`, set `SpanProcessorBehavior` / `LogRecordProcessorBehavior` with `ConsoleExporterBehavior`. Other processors/exporters are left unset.

Env: `OTEL_TRACES_EXPORTER=console` and `OTEL_LOGS_EXPORTER=console` do the same. Known values that this MVP does not map (`otlp`, `zipkin`, `none`, `logging`, `otlp/stdout`) leave the processor unset. Unknown values are ignored and reported via `onWarning`.

This does not make `implementation` or `compat` obey the resolved behavior.

## Testing

`./gradlew :config-yaml:jvmTest :config-envar:jvmTest`