### PR TITLE
feat: add compat mode sdk obeys config

### DIFF
--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/OpenTelemetryCompatEntrypoint.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/OpenTelemetryCompatEntrypoint.kt
@@ -35,8 +35,9 @@ public fun createCompatOpenTelemetry(
     val resolvedIdGenerator = cfg.resolveIdGenerator()
     val base = cfg.buildGlobalResource()
     val globalLimits = cfg.resolveAttributeLimits()
+    val spanLimits = cfg.resolveSpanLimits()
     return CompatOpenTelemetryImpl(
-        tracerProvider = cfg.tracerProviderConfig.build(clock, resolvedIdGenerator, base, globalLimits),
+        tracerProvider = cfg.tracerProviderConfig.build(clock, resolvedIdGenerator, base, globalLimits, spanLimits),
         loggerProvider = cfg.loggerProviderConfig.build(clock, base, globalLimits),
         meterProvider = cfg.meterProviderConfig.build(clock, base),
         clock = clock,

--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/init/CompatOpenTelemetryConfig.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/init/CompatOpenTelemetryConfig.kt
@@ -8,6 +8,7 @@ import io.opentelemetry.kotlin.attributes.CompatAttributesModel
 import io.opentelemetry.kotlin.attributes.setTypedAttributes
 import io.opentelemetry.kotlin.behavior.AttributeLimitsBehavior
 import io.opentelemetry.kotlin.behavior.OpenTelemetryBehavior
+import io.opentelemetry.kotlin.behavior.SpanLimitsBehavior
 import io.opentelemetry.kotlin.config.dsl.AttributeLimitsConfigDslImpl
 import io.opentelemetry.kotlin.error.GuardedSdkErrorHandler
 import io.opentelemetry.kotlin.error.NoopSdkErrorHandler
@@ -115,10 +116,16 @@ internal class CompatOpenTelemetryConfig(
     private val resolvedBehavior: OpenTelemetryBehavior by lazy {
         behaviorReader.read(
             configFilePath = configFilePath,
-            dsl = OpenTelemetryBehavior(attributeLimits = globalAttributeLimits.toBehavior()),
+            dsl = OpenTelemetryBehavior(
+                attributeLimits = globalAttributeLimits.toBehavior(),
+                tracerProvider = tracerProviderConfig.toBehavior(),
+            ),
         )
     }
 
     internal fun resolveAttributeLimits(): AttributeLimitsBehavior =
         resolvedBehavior.attributeLimits ?: AttributeLimitsBehavior()
+
+    internal fun resolveSpanLimits(): SpanLimitsBehavior =
+        resolvedBehavior.tracerProvider?.spanLimits ?: SpanLimitsBehavior()
 }

--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/init/CompatTracerProviderConfig.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/init/CompatTracerProviderConfig.kt
@@ -14,6 +14,9 @@ import io.opentelemetry.kotlin.attributes.CompatAttributesModel
 import io.opentelemetry.kotlin.attributes.attrsFromMap
 import io.opentelemetry.kotlin.attributes.setTypedAttributes
 import io.opentelemetry.kotlin.behavior.AttributeLimitsBehavior
+import io.opentelemetry.kotlin.behavior.SpanLimitsBehavior
+import io.opentelemetry.kotlin.behavior.TracerProviderBehavior
+import io.opentelemetry.kotlin.config.dsl.SpanLimitsConfigDslImpl
 import io.opentelemetry.kotlin.error.SdkErrorHandler
 import io.opentelemetry.kotlin.factory.CompatSpanContextFactory
 import io.opentelemetry.kotlin.factory.CompatSpanFactory
@@ -40,10 +43,10 @@ internal class CompatTracerProviderConfig(
 
     private val builder: OtelJavaSdkTracerProviderBuilder = OtelJavaSdkTracerProvider.builder()
     internal val spanLimitsConfig = CompatSpanLimitsConfig()
-    private var spanLimitsAction: (SpanLimitsConfigDsl.() -> Unit)? = null
     private var tracerConfigurator: TracerConfigurator? = null
     private val resourceAttrs = CompatAttributesModel()
     private var resourceSchemaUrl: String? = null
+    private val spanLimitsDsl = SpanLimitsConfigDslImpl()
 
     override var serviceName: String? = null
         set(value) {
@@ -61,7 +64,7 @@ internal class CompatTracerProviderConfig(
     }
 
     override fun spanLimits(action: SpanLimitsConfigDsl.() -> Unit) {
-        spanLimitsAction = action
+        spanLimitsDsl.action()
     }
 
     override fun export(action: TraceExportConfigDsl.() -> SpanProcessor) {
@@ -101,6 +104,7 @@ internal class CompatTracerProviderConfig(
         idGenerator: IdGenerator,
         baseResource: Resource = ResourceAdapter(OtelJavaResource.builder().build()),
         globalLimits: AttributeLimitsBehavior,
+        spanLimits: SpanLimitsBehavior,
     ): TracerProvider {
         builder.setIdGenerator(
             when (idGenerator) {
@@ -108,11 +112,14 @@ internal class CompatTracerProviderConfig(
                 else -> OtelJavaIdGeneratorAdapter(idGenerator)
             }
         )
-        spanLimitsAction?.invoke(spanLimitsConfig)
         spanLimitsConfig.attributeCountLimit =
-            spanLimitsConfig.attributeCountLimit ?: globalLimits.attributeCountLimit
+            spanLimits.attributeCountLimit ?: globalLimits.attributeCountLimit
         spanLimitsConfig.attributeValueLengthLimit =
-            spanLimitsConfig.attributeValueLengthLimit ?: globalLimits.attributeValueLengthLimit
+            spanLimits.attributeValueLengthLimit ?: globalLimits.attributeValueLengthLimit
+        spanLimitsConfig.linkCountLimit = spanLimits.linkCountLimit
+        spanLimitsConfig.eventCountLimit = spanLimits.eventCountLimit
+        spanLimitsConfig.attributeCountPerEventLimit = spanLimits.attributeCountPerEventLimit
+        spanLimitsConfig.attributeCountPerLinkLimit = spanLimits.attributeCountPerLinkLimit
         builder.setSpanLimits(spanLimitsConfig.build())
         tracerConfigurator?.let(::applyTracerConfigurator)
         val resource = ResourceAdapter(
@@ -126,6 +133,11 @@ internal class CompatTracerProviderConfig(
         builder.setClock(OtelJavaClockWrapper(clock))
         return TracerProviderAdapter(builder.build(), clock, spanLimitsConfig)
     }
+
+    fun toBehavior(): TracerProviderBehavior =
+        TracerProviderBehavior(
+            spanLimits = spanLimitsDsl.toBehavior()
+        )
 
     private class TraceExportConfigCompat(
         override val clock: Clock,

--- a/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/init/CompatOpenTelemetryConfigTest.kt
+++ b/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/init/CompatOpenTelemetryConfigTest.kt
@@ -1,0 +1,33 @@
+package io.opentelemetry.kotlin.init
+
+import io.opentelemetry.kotlin.clock.FakeClock
+import org.junit.Test
+import kotlin.test.assertEquals
+
+internal class CompatOpenTelemetryConfigTest {
+
+    private val clock = FakeClock()
+
+    @Test
+    fun `span limits dsl is reflected in resolved behavior`() {
+        val cfg = CompatOpenTelemetryConfig(clock)
+        cfg.tracerProvider {
+            spanLimits {
+                attributeCountLimit = 8
+                attributeValueLengthLimit = 16
+                linkCountLimit = 32
+                eventCountLimit = 64
+                attributeCountPerEventLimit = 128
+                attributeCountPerLinkLimit = 512
+            }
+        }
+
+        val spanLimits = cfg.resolveSpanLimits()
+        assertEquals(8, spanLimits.attributeCountLimit)
+        assertEquals(16, spanLimits.attributeValueLengthLimit)
+        assertEquals(32, spanLimits.linkCountLimit)
+        assertEquals(64, spanLimits.eventCountLimit)
+        assertEquals(128, spanLimits.attributeCountPerEventLimit)
+        assertEquals(512, spanLimits.attributeCountPerLinkLimit)
+    }
+}

--- a/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/init/CompatTracerProviderSamplerTest.kt
+++ b/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/init/CompatTracerProviderSamplerTest.kt
@@ -2,6 +2,7 @@ package io.opentelemetry.kotlin.init
 
 import io.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.kotlin.behavior.AttributeLimitsBehavior
+import io.opentelemetry.kotlin.behavior.SpanLimitsBehavior
 import io.opentelemetry.kotlin.clock.FakeClock
 import io.opentelemetry.kotlin.createCompatOpenTelemetry
 import io.opentelemetry.kotlin.error.NoopSdkErrorHandler
@@ -30,12 +31,13 @@ internal class CompatTracerProviderSamplerTest {
 
     private val idGenerator = CompatIdGenerator()
     private val noGlobalLimits = AttributeLimitsBehavior()
+    private val noSpanLimits = SpanLimitsBehavior()
 
     @Test
     fun `default sampler records and samples spans`() {
         val clock = FakeClock()
         val config = CompatTracerProviderConfig(clock, NoopSdkErrorHandler)
-        val provider = config.build(clock, idGenerator, globalLimits = noGlobalLimits)
+        val provider = config.build(clock, idGenerator, globalLimits = noGlobalLimits, spanLimits = noSpanLimits)
         val span = provider.getTracer("test").startSpan("span")
         assertTrue(span.isRecording())
         assertTrue(span.spanContext.traceFlags.isSampled)
@@ -47,7 +49,12 @@ internal class CompatTracerProviderSamplerTest {
         val config = CompatTracerProviderConfig(clock, NoopSdkErrorHandler).apply {
             sampler { alwaysOn() }
         }
-        val span = config.build(clock, idGenerator, globalLimits = noGlobalLimits).getTracer("test").startSpan("span")
+        val span = config.build(
+            clock,
+            idGenerator,
+            globalLimits = noGlobalLimits,
+            spanLimits = noSpanLimits
+        ).getTracer("test").startSpan("span")
         assertTrue(span.isRecording())
         assertTrue(span.spanContext.traceFlags.isSampled)
     }
@@ -58,7 +65,12 @@ internal class CompatTracerProviderSamplerTest {
         val config = CompatTracerProviderConfig(clock, NoopSdkErrorHandler).apply {
             sampler { FakeSampler(SamplingResult.Decision.DROP) }
         }
-        val span = config.build(clock, idGenerator, globalLimits = noGlobalLimits).getTracer("test").startSpan("span")
+        val span = config.build(
+            clock,
+            idGenerator,
+            globalLimits = noGlobalLimits,
+            spanLimits = noSpanLimits
+        ).getTracer("test").startSpan("span")
         assertFalse(span.isRecording())
     }
 
@@ -68,7 +80,12 @@ internal class CompatTracerProviderSamplerTest {
         val config = CompatTracerProviderConfig(clock, NoopSdkErrorHandler).apply {
             sampler { FakeSampler(SamplingResult.Decision.RECORD_AND_SAMPLE) }
         }
-        val span = config.build(clock, idGenerator, globalLimits = noGlobalLimits).getTracer("test").startSpan("span")
+        val span = config.build(
+            clock,
+            idGenerator,
+            globalLimits = noGlobalLimits,
+            spanLimits = noSpanLimits
+        ).getTracer("test").startSpan("span")
         assertTrue(span.isRecording())
         assertTrue(span.spanContext.traceFlags.isSampled)
     }
@@ -79,7 +96,12 @@ internal class CompatTracerProviderSamplerTest {
         val config = CompatTracerProviderConfig(clock, NoopSdkErrorHandler).apply {
             sampler { alwaysOff() }
         }
-        val span = config.build(clock, idGenerator, globalLimits = noGlobalLimits).getTracer("test").startSpan("span")
+        val span = config.build(
+            clock,
+            idGenerator,
+            globalLimits = noGlobalLimits,
+            spanLimits = noSpanLimits
+        ).getTracer("test").startSpan("span")
         assertFalse(span.isRecording())
         assertFalse(span.spanContext.traceFlags.isSampled)
     }
@@ -103,7 +125,12 @@ internal class CompatTracerProviderSamplerTest {
         val config = CompatTracerProviderConfig(clock, NoopSdkErrorHandler).apply {
             sampler { parentBased(root = alwaysOn()) }
         }
-        val span = config.build(clock, idGenerator, globalLimits = noGlobalLimits).getTracer("test").startSpan("span")
+        val span = config.build(
+            clock,
+            idGenerator,
+            globalLimits = noGlobalLimits,
+            spanLimits = noSpanLimits
+        ).getTracer("test").startSpan("span")
         assertTrue(span.isRecording())
         assertTrue(span.spanContext.traceFlags.isSampled)
     }
@@ -114,7 +141,12 @@ internal class CompatTracerProviderSamplerTest {
         val config = CompatTracerProviderConfig(clock, NoopSdkErrorHandler).apply {
             sampler { parentBased(root = alwaysOff()) }
         }
-        val span = config.build(clock, idGenerator, globalLimits = noGlobalLimits).getTracer("test").startSpan("span")
+        val span = config.build(
+            clock,
+            idGenerator,
+            globalLimits = noGlobalLimits,
+            spanLimits = noSpanLimits
+        ).getTracer("test").startSpan("span")
         assertFalse(span.isRecording())
         assertFalse(span.spanContext.traceFlags.isSampled)
     }
@@ -140,7 +172,12 @@ internal class CompatTracerProviderSamplerTest {
         val config = CompatTracerProviderConfig(clock, NoopSdkErrorHandler).apply {
             sampler { composite { composableAlwaysOn() } }
         }
-        val span = config.build(clock, idGenerator, globalLimits = noGlobalLimits).getTracer("test").startSpan("span")
+        val span = config.build(
+            clock,
+            idGenerator,
+            globalLimits = noGlobalLimits,
+            spanLimits = noSpanLimits
+        ).getTracer("test").startSpan("span")
         assertTrue(span.isRecording())
         assertTrue(span.spanContext.traceFlags.isSampled)
     }
@@ -151,7 +188,12 @@ internal class CompatTracerProviderSamplerTest {
         val config = CompatTracerProviderConfig(clock, NoopSdkErrorHandler).apply {
             sampler { composite { composableAlwaysOff() } }
         }
-        val span = config.build(clock, idGenerator, globalLimits = noGlobalLimits).getTracer("test").startSpan("span")
+        val span = config.build(
+            clock,
+            idGenerator,
+            globalLimits = noGlobalLimits,
+            spanLimits = noSpanLimits
+        ).getTracer("test").startSpan("span")
         assertFalse(span.isRecording())
         assertFalse(span.spanContext.traceFlags.isSampled)
     }
@@ -162,7 +204,12 @@ internal class CompatTracerProviderSamplerTest {
         val config = CompatTracerProviderConfig(clock, NoopSdkErrorHandler).apply {
             sampler { composite { composableProbability(1.0) } }
         }
-        val span = config.build(clock, idGenerator, globalLimits = noGlobalLimits).getTracer("test").startSpan("span")
+        val span = config.build(
+            clock,
+            idGenerator,
+            globalLimits = noGlobalLimits,
+            spanLimits = noSpanLimits
+        ).getTracer("test").startSpan("span")
         assertTrue(span.isRecording())
         assertTrue(span.spanContext.traceFlags.isSampled)
     }
@@ -173,7 +220,12 @@ internal class CompatTracerProviderSamplerTest {
         val config = CompatTracerProviderConfig(clock, NoopSdkErrorHandler).apply {
             sampler { composite { composableProbability(0.0) } }
         }
-        val span = config.build(clock, idGenerator, globalLimits = noGlobalLimits).getTracer("test").startSpan("span")
+        val span = config.build(
+            clock,
+            idGenerator,
+            globalLimits = noGlobalLimits,
+            spanLimits = noSpanLimits
+        ).getTracer("test").startSpan("span")
         assertFalse(span.isRecording())
         assertFalse(span.spanContext.traceFlags.isSampled)
     }
@@ -184,7 +236,12 @@ internal class CompatTracerProviderSamplerTest {
         val config = CompatTracerProviderConfig(clock, NoopSdkErrorHandler).apply {
             sampler { composite { composableParentThreshold(root = composableAlwaysOn()) } }
         }
-        val span = config.build(clock, idGenerator, globalLimits = noGlobalLimits).getTracer("test").startSpan("span")
+        val span = config.build(
+            clock,
+            idGenerator,
+            globalLimits = noGlobalLimits,
+            spanLimits = noSpanLimits
+        ).getTracer("test").startSpan("span")
         assertTrue(span.isRecording())
         assertTrue(span.spanContext.traceFlags.isSampled)
     }
@@ -195,7 +252,12 @@ internal class CompatTracerProviderSamplerTest {
         val config = CompatTracerProviderConfig(clock, NoopSdkErrorHandler).apply {
             sampler { composite { composableParentThreshold(root = composableAlwaysOff()) } }
         }
-        val span = config.build(clock, idGenerator, globalLimits = noGlobalLimits).getTracer("test").startSpan("span")
+        val span = config.build(
+            clock,
+            idGenerator,
+            globalLimits = noGlobalLimits,
+            spanLimits = noSpanLimits
+        ).getTracer("test").startSpan("span")
         assertFalse(span.isRecording())
         assertFalse(span.spanContext.traceFlags.isSampled)
     }
@@ -253,7 +315,12 @@ internal class CompatTracerProviderSamplerTest {
                 }
             }
         }
-        val span = config.build(clock, idGenerator, globalLimits = noGlobalLimits).getTracer("test").startSpan("span")
+        val span = config.build(
+            clock,
+            idGenerator,
+            globalLimits = noGlobalLimits,
+            spanLimits = noSpanLimits
+        ).getTracer("test").startSpan("span")
         assertTrue(span.isRecording())
         assertTrue(span.spanContext.traceFlags.isSampled)
     }
@@ -270,7 +337,12 @@ internal class CompatTracerProviderSamplerTest {
                 }
             }
         }
-        val span = config.build(clock, idGenerator, globalLimits = noGlobalLimits).getTracer("test").startSpan("span")
+        val span = config.build(
+            clock,
+            idGenerator,
+            globalLimits = noGlobalLimits,
+            spanLimits = noSpanLimits
+        ).getTracer("test").startSpan("span")
         assertFalse(span.isRecording())
         assertFalse(span.spanContext.traceFlags.isSampled)
     }
@@ -281,7 +353,12 @@ internal class CompatTracerProviderSamplerTest {
         val config = CompatTracerProviderConfig(clock, NoopSdkErrorHandler).apply {
             sampler { composite { composableRuleBased { } } }
         }
-        val span = config.build(clock, idGenerator, globalLimits = noGlobalLimits).getTracer("test").startSpan("span")
+        val span = config.build(
+            clock,
+            idGenerator,
+            globalLimits = noGlobalLimits,
+            spanLimits = noSpanLimits
+        ).getTracer("test").startSpan("span")
         assertFalse(span.isRecording())
         assertFalse(span.spanContext.traceFlags.isSampled)
     }
@@ -299,7 +376,12 @@ internal class CompatTracerProviderSamplerTest {
                 }
             }
         }
-        val span = config.build(clock, idGenerator, globalLimits = noGlobalLimits).getTracer("test").startSpan("span")
+        val span = config.build(
+            clock,
+            idGenerator,
+            globalLimits = noGlobalLimits,
+            spanLimits = noSpanLimits
+        ).getTracer("test").startSpan("span")
         assertTrue(span.isRecording())
         assertTrue(span.spanContext.traceFlags.isSampled)
     }

--- a/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/init/GlobalAttributeLimitsConfigTest.kt
+++ b/compat/src/jvmTest/kotlin/io/opentelemetry/kotlin/init/GlobalAttributeLimitsConfigTest.kt
@@ -3,6 +3,7 @@ package io.opentelemetry.kotlin.init
 import io.opentelemetry.kotlin.aliases.OtelJavaLogLimits
 import io.opentelemetry.kotlin.aliases.OtelJavaSpanLimits
 import io.opentelemetry.kotlin.behavior.AttributeLimitsBehavior
+import io.opentelemetry.kotlin.behavior.SpanLimitsBehavior
 import io.opentelemetry.kotlin.clock.FakeClock
 import io.opentelemetry.kotlin.config.dsl.AttributeLimitsConfigDslImpl
 import io.opentelemetry.kotlin.error.NoopSdkErrorHandler
@@ -16,13 +17,14 @@ internal class GlobalAttributeLimitsConfigTest {
     private val clock = FakeClock()
     private val idGenerator = CompatIdGenerator()
     private val noGlobalLimits = AttributeLimitsBehavior()
+    private val noSpanLimits = SpanLimitsBehavior()
 
     @Test
     fun `global only - applies to spans and logs`() {
         val globalLimits = AttributeLimitsBehavior(attributeCountLimit = 64)
 
         val tracerConfig = CompatTracerProviderConfig(clock, NoopSdkErrorHandler)
-        tracerConfig.build(clock, idGenerator, globalLimits = globalLimits)
+        tracerConfig.build(clock, idGenerator, globalLimits = globalLimits, spanLimits = noSpanLimits)
         assertEquals(64, tracerConfig.spanLimitsConfig.attributeCountLimit)
 
         val loggerConfig = CompatLoggerProviderConfig(clock, NoopSdkErrorHandler)
@@ -33,11 +35,10 @@ internal class GlobalAttributeLimitsConfigTest {
     @Test
     fun `signal-specific overrides global`() {
         val globalLimits = AttributeLimitsBehavior(attributeCountLimit = 64)
+        val spanLimits = SpanLimitsBehavior(attributeCountLimit = 32)
 
-        val tracerConfig = CompatTracerProviderConfig(clock, NoopSdkErrorHandler).apply {
-            spanLimits { attributeCountLimit = 32 }
-        }
-        tracerConfig.build(clock, idGenerator, globalLimits = globalLimits)
+        val tracerConfig = CompatTracerProviderConfig(clock, NoopSdkErrorHandler)
+        tracerConfig.build(clock, idGenerator, globalLimits = globalLimits, spanLimits = spanLimits)
         assertEquals(32, tracerConfig.spanLimitsConfig.attributeCountLimit)
 
         val loggerConfig = CompatLoggerProviderConfig(clock, NoopSdkErrorHandler).apply {
@@ -50,11 +51,10 @@ internal class GlobalAttributeLimitsConfigTest {
     @Test
     fun `a signal-specific zero is not treated as unset`() {
         val globalLimits = AttributeLimitsBehavior(attributeCountLimit = 64)
+        val spanLimits = SpanLimitsBehavior(attributeCountLimit = 0)
 
-        val tracerConfig = CompatTracerProviderConfig(clock, NoopSdkErrorHandler).apply {
-            spanLimits { attributeCountLimit = 0 }
-        }
-        tracerConfig.build(clock, idGenerator, globalLimits = globalLimits)
+        val tracerConfig = CompatTracerProviderConfig(clock, NoopSdkErrorHandler)
+        tracerConfig.build(clock, idGenerator, globalLimits = globalLimits, spanLimits = spanLimits)
         assertEquals(0, tracerConfig.spanLimitsConfig.attributeCountLimit)
 
         val loggerConfig = CompatLoggerProviderConfig(clock, NoopSdkErrorHandler).apply {
@@ -67,11 +67,10 @@ internal class GlobalAttributeLimitsConfigTest {
     @Test
     fun `partial signal override - other global properties still apply`() {
         val globalLimits = AttributeLimitsBehavior(attributeCountLimit = 64)
+        val spanLimits = SpanLimitsBehavior(attributeValueLengthLimit = 256)
 
-        val tracerConfig = CompatTracerProviderConfig(clock, NoopSdkErrorHandler).apply {
-            spanLimits { attributeValueLengthLimit = 256 }
-        }
-        tracerConfig.build(clock, idGenerator, globalLimits = globalLimits)
+        val tracerConfig = CompatTracerProviderConfig(clock, NoopSdkErrorHandler)
+        tracerConfig.build(clock, idGenerator, globalLimits = globalLimits, spanLimits = spanLimits)
         assertEquals(64, tracerConfig.spanLimitsConfig.attributeCountLimit)
         assertEquals(256, tracerConfig.spanLimitsConfig.attributeValueLengthLimit)
     }
@@ -79,7 +78,7 @@ internal class GlobalAttributeLimitsConfigTest {
     @Test
     fun `no global - limits stay unset so the Java SDK applies its own defaults`() {
         val tracerConfig = CompatTracerProviderConfig(clock, NoopSdkErrorHandler)
-        tracerConfig.build(clock, idGenerator, globalLimits = noGlobalLimits)
+        tracerConfig.build(clock, idGenerator, globalLimits = noGlobalLimits, spanLimits = noSpanLimits)
         assertNull(tracerConfig.spanLimitsConfig.attributeCountLimit)
         assertNull(tracerConfig.spanLimitsConfig.attributeValueLengthLimit)
         assertEquals(OtelJavaSpanLimits.getDefault(), tracerConfig.spanLimitsConfig.build())
@@ -96,7 +95,7 @@ internal class GlobalAttributeLimitsConfigTest {
         val globalLimits = AttributeLimitsBehavior(attributeCountLimit = 64)
 
         val tracerConfig = CompatTracerProviderConfig(clock, NoopSdkErrorHandler)
-        tracerConfig.build(clock, idGenerator, globalLimits = globalLimits)
+        tracerConfig.build(clock, idGenerator, globalLimits = globalLimits, spanLimits = noSpanLimits)
         assertEquals(64, tracerConfig.spanLimitsConfig.effectiveAttributeCountLimit)
     }
 
@@ -108,7 +107,7 @@ internal class GlobalAttributeLimitsConfigTest {
         }.toBehavior()
 
         val tracerConfig = CompatTracerProviderConfig(clock, NoopSdkErrorHandler)
-        tracerConfig.build(clock, idGenerator, globalLimits = globalLimits)
+        tracerConfig.build(clock, idGenerator, globalLimits = globalLimits, spanLimits = noSpanLimits)
         assertNull(tracerConfig.spanLimitsConfig.attributeCountLimit)
         assertNull(tracerConfig.spanLimitsConfig.attributeValueLengthLimit)
         assertEquals(OtelJavaSpanLimits.getDefault(), tracerConfig.spanLimitsConfig.build())


### PR DESCRIPTION
## Goal

Route span limits through `SpanLimitsBehavior` in the compat SDK, following the implementation SDK changes in #1017.

Include the tracer provider's DSL span limits in behavior resolution, then apply the resolved values to the Java SDK and compat adapters. Preserve fallback to global attribute limits and existing defaults.

Refs https://github.com/open-telemetry/opentelemetry-kotlin/issues/906

## Testing

- Verify all six DSL-configured span limits reach the resolved behavior.
- Update existing tests to pass `SpanLimitsBehavior` explicitly, preserving coverage for defaults, global attribute limit fallback, partial overrides, and zero-value precedence.
