### PR TITLE
Allow supplying clock param

### DIFF
--- a/compat/api/jvm/compat.api
+++ b/compat/api/jvm/compat.api
@@ -8,7 +8,8 @@ public final class io/opentelemetry/kotlin/OpenTelemetryCompatExtKt {
 }
 
 public final class io/opentelemetry/kotlin/OtelJavaOpenTelemetryExtKt {
-	public static final fun toOtelKotlinApi (Lio/opentelemetry/api/OpenTelemetry;)Lio/opentelemetry/kotlin/OpenTelemetry;
+	public static final fun toOtelKotlinApi (Lio/opentelemetry/api/OpenTelemetry;Lio/opentelemetry/kotlin/Clock;)Lio/opentelemetry/kotlin/OpenTelemetry;
+	public static synthetic fun toOtelKotlinApi$default (Lio/opentelemetry/api/OpenTelemetry;Lio/opentelemetry/kotlin/Clock;ILjava/lang/Object;)Lio/opentelemetry/kotlin/OpenTelemetry;
 }
 
 public final class io/opentelemetry/kotlin/context/ContextExtKt {

--- a/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/OtelJavaOpenTelemetryExt.kt
+++ b/compat/src/jvmAndAndroidMain/kotlin/io/opentelemetry/kotlin/OtelJavaOpenTelemetryExt.kt
@@ -33,14 +33,15 @@ import io.opentelemetry.kotlin.tracing.TracerProviderAdapter
  * generally be encouraged to migrate to [createCompatOpenTelemetry] as a long-term goal.
  */
 @ExperimentalApi
-public fun OtelJavaOpenTelemetry.toOtelKotlinApi(): OpenTelemetry {
+public fun OtelJavaOpenTelemetry.toOtelKotlinApi(
+    clock: Clock = ClockAdapter(OtelJavaClock.getDefault())
+): OpenTelemetry {
     val idGenerator = CompatIdGenerator()
     val traceFlags = CompatTraceFlagsFactory()
     val traceState = CompatTraceStateFactory()
     val spanContext = CompatSpanContextFactory()
     val contextFactory = CompatContextFactory()
     val span = CompatSpanFactory(spanContext)
-    val clock = ClockAdapter(OtelJavaClock.getDefault())
     return CompatOpenTelemetryImpl(
         tracerProvider = TracerProviderAdapter(unobfuscatedTracerProvider(), clock, CompatSpanLimitsConfig()),
         loggerProvider = LoggerProviderAdapter(unobfuscatedLoggerProvider()),


### PR DESCRIPTION
## Goal

When calling `toOtelKotlinApi` it should be possible to pass in the `Clock` instance if this is known, rather than assuming the default is used. This is not the case for opentelemetry-android, for example, which uses a custom implementation, and we have no way to obtain it from this project so require users to specify a parameter if they care about this.

We still supply the default clock instance if nothing is supplied.
