### PR TITLE
feat: Configuration LogRecordLimits add implementation mode sdk obeys config

### DIFF
--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/LoggerProviderConfigImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/LoggerProviderConfigImpl.kt
@@ -2,6 +2,8 @@ package io.opentelemetry.kotlin.init
 
 import io.opentelemetry.kotlin.Clock
 import io.opentelemetry.kotlin.behavior.AttributeLimitsBehavior
+import io.opentelemetry.kotlin.behavior.LogLimitsBehavior
+import io.opentelemetry.kotlin.behavior.LoggerProviderBehavior
 import io.opentelemetry.kotlin.config.dsl.LogLimitsConfigDslImpl
 import io.opentelemetry.kotlin.error.SdkError
 import io.opentelemetry.kotlin.error.SdkErrorHandler
@@ -20,7 +22,7 @@ internal class LoggerProviderConfigImpl(
 ) : LoggerProviderConfigDsl, ResourceConfigDsl by resourceConfigImpl {
 
     private var processor: LogRecordProcessor? = null
-    private var logLimitsAction: LogLimitsConfigDsl.() -> Unit = {}
+    private val logLimits = LogLimitsConfigDslImpl()
     private val defaultLoggerConfig = LoggerConfigImpl(true)
     private var loggerConfigurator: LoggerConfigurator = LoggerConfigurator {
         defaultLoggerConfig
@@ -41,7 +43,7 @@ internal class LoggerProviderConfigImpl(
     }
 
     override fun logLimits(action: LogLimitsConfigDsl.() -> Unit) {
-        logLimitsAction = action
+        logLimits.action()
     }
 
     override fun loggerConfigurator(configurator: LoggerConfigurator) {
@@ -51,21 +53,28 @@ internal class LoggerProviderConfigImpl(
     fun generateLoggingConfig(
         base: Resource,
         globalLimits: AttributeLimitsBehavior,
+        logLimits: LogLimitsBehavior,
     ): LoggingConfig = LoggingConfig(
         processor = processor,
-        logLimits = generateLogLimitsConfig(globalLimits),
+        logLimits = generateLogLimitsConfig(globalLimits, logLimits),
         resource = base.merge(resourceConfigImpl.generateResource()),
         sdkErrorHandler = sdkErrorHandler,
         loggerConfigurator = loggerConfigurator,
     )
 
+    fun toBehavior(): LoggerProviderBehavior =
+        LoggerProviderBehavior(
+            logLimits = logLimits.toBehavior()
+        )
+
     /**
      * A limit left unset by the log limits falls back to the global attribute limits, then to the
      * default this SDK applies.
      */
-    private fun generateLogLimitsConfig(globalLimits: AttributeLimitsBehavior): AttributeLimitsBehavior {
-        val impl = LogLimitsConfigDslImpl()
-        logLimitsAction(impl)
-        return globalLimits.mergeWith(impl.toBehavior())
+    private fun generateLogLimitsConfig(
+        globalLimits: AttributeLimitsBehavior,
+        logLimits: LogLimitsBehavior
+    ): AttributeLimitsBehavior {
+        return globalLimits.mergeWith(logLimits)
     }
 }

--- a/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/OpenTelemetryConfigImpl.kt
+++ b/implementation/src/commonMain/kotlin/io/opentelemetry/kotlin/init/OpenTelemetryConfigImpl.kt
@@ -2,6 +2,7 @@ package io.opentelemetry.kotlin.init
 
 import io.opentelemetry.kotlin.Clock
 import io.opentelemetry.kotlin.behavior.AttributeLimitsBehavior
+import io.opentelemetry.kotlin.behavior.LogLimitsBehavior
 import io.opentelemetry.kotlin.behavior.OpenTelemetryBehavior
 import io.opentelemetry.kotlin.behavior.SpanLimitsBehavior
 import io.opentelemetry.kotlin.config.dsl.AttributeLimitsConfigDslImpl
@@ -100,6 +101,7 @@ internal class OpenTelemetryConfigImpl(
             dsl = OpenTelemetryBehavior(
                 attributeLimits = globalAttributeLimits.toBehavior(),
                 tracerProvider = tracingConfig.toBehavior(),
+                loggerProvider = loggingConfig.toBehavior(),
             ),
         )
     }
@@ -110,11 +112,14 @@ internal class OpenTelemetryConfigImpl(
     private fun resolveSpanLimits(): SpanLimitsBehavior =
         resolvedBehavior.tracerProvider?.spanLimits ?: SpanLimitsBehavior()
 
+    private fun resolveLogLimits(): LogLimitsBehavior =
+        resolvedBehavior.loggerProvider?.logLimits ?: LogLimitsBehavior()
+
     internal fun generateTracingConfig() =
         tracingConfig.generateTracingConfig(baseResource, resolveAttributeLimits(), resolveSpanLimits())
 
     internal fun generateLoggingConfig() =
-        loggingConfig.generateLoggingConfig(baseResource, resolveAttributeLimits())
+        loggingConfig.generateLoggingConfig(baseResource, resolveAttributeLimits(), resolveLogLimits())
 
     internal fun generateMetricsConfig() =
         metricsConfig.generateMetricsConfig(baseResource)

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/init/LoggerProviderConfigImplTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/init/LoggerProviderConfigImplTest.kt
@@ -2,6 +2,7 @@ package io.opentelemetry.kotlin.init
 
 import io.opentelemetry.kotlin.attributes.DEFAULT_ATTRIBUTE_LIMIT
 import io.opentelemetry.kotlin.behavior.AttributeLimitsBehavior
+import io.opentelemetry.kotlin.behavior.LogLimitsBehavior
 import io.opentelemetry.kotlin.clock.FakeClock
 import io.opentelemetry.kotlin.error.FakeSdkErrorHandler
 import io.opentelemetry.kotlin.error.NoopSdkErrorHandler
@@ -26,10 +27,11 @@ internal class LoggerProviderConfigImplTest {
     private val clock = FakeClock()
     private val base = sdkDefaultResource()
     private val noGlobalLimits = AttributeLimitsBehavior()
+    private val noLogLimits = LogLimitsBehavior()
 
     @Test
     fun testDefaultLoggingConfig() {
-        val cfg = LoggerProviderConfigImpl(clock, NoopSdkErrorHandler).generateLoggingConfig(base, noGlobalLimits)
+        val cfg = LoggerProviderConfigImpl(clock, NoopSdkErrorHandler).generateLoggingConfig(base, noGlobalLimits, noLogLimits)
         assertNull(cfg.processor)
         assertEquals(sdkDefaultAttributes, cfg.resource.attributes)
         assertEquals(sdkDefaultSchemaUrl, cfg.resource.schemaUrl)
@@ -47,6 +49,10 @@ internal class LoggerProviderConfigImplTest {
         val attrCount = 100
         val attrValueCount = 200
         val schemaUrl = "https://example.com/schema"
+        val logLimits = LogLimitsBehavior(
+            attributeCountLimit = attrCount,
+            attributeValueLengthLimit = attrValueCount,
+        )
 
         val cfg = LoggerProviderConfigImpl(clock, NoopSdkErrorHandler).apply {
             export { compositeLogRecordProcessor(firstProcessor, secondProcessor) }
@@ -54,12 +60,7 @@ internal class LoggerProviderConfigImplTest {
             resource(schemaUrl) {
                 setStringAttribute("key", "value")
             }
-
-            logLimits {
-                attributeCountLimit = attrCount
-                attributeValueLengthLimit = attrValueCount
-            }
-        }.generateLoggingConfig(base, noGlobalLimits)
+        }.generateLoggingConfig(base, noGlobalLimits, logLimits)
 
         assertNotNull(cfg.processor)
         assertEquals(schemaUrl, cfg.resource.schemaUrl)
@@ -86,7 +87,7 @@ internal class LoggerProviderConfigImplTest {
                     second = this
                 }
             }
-        }.generateLoggingConfig(base, noGlobalLimits)
+        }.generateLoggingConfig(base, noGlobalLimits, noLogLimits)
         assertSame(first, cfg.processor)
         assertNotSame(second, cfg.processor)
     }
@@ -97,7 +98,7 @@ internal class LoggerProviderConfigImplTest {
         LoggerProviderConfigImpl(clock, handler).apply {
             export { simpleLogRecordProcessor(stdoutLogRecordExporter()) }
             export { simpleLogRecordProcessor(stdoutLogRecordExporter()) }
-        }.generateLoggingConfig(base, noGlobalLimits)
+        }.generateLoggingConfig(base, noGlobalLimits, noLogLimits)
         assertEquals(1, handler.apiMisuses.size)
         assertEquals("LoggerProviderConfigDsl.export", handler.apiMisuses.single().api)
         assertEquals("export() should only be called once.", handler.apiMisuses.single().message)
@@ -107,7 +108,7 @@ internal class LoggerProviderConfigImplTest {
     fun testResourceOverride() {
         val cfg = LoggerProviderConfigImpl(clock, NoopSdkErrorHandler).apply {
             resource(mapOf("extra" to true))
-        }.generateLoggingConfig(base, noGlobalLimits)
+        }.generateLoggingConfig(base, noGlobalLimits, noLogLimits)
         assertEquals(sdkDefaultAttributes + mapOf("extra" to true), cfg.resource.attributes)
     }
 
@@ -115,7 +116,7 @@ internal class LoggerProviderConfigImplTest {
     fun testSimpleResourceConfig() {
         val cfg = LoggerProviderConfigImpl(clock, NoopSdkErrorHandler).apply {
             resource(mapOf("key" to "value"))
-        }.generateLoggingConfig(base, noGlobalLimits)
+        }.generateLoggingConfig(base, noGlobalLimits, noLogLimits)
         assertEquals(sdkDefaultAttributes + mapOf("key" to "value"), cfg.resource.attributes)
     }
 
@@ -124,7 +125,7 @@ internal class LoggerProviderConfigImplTest {
         val value = "my-custom-sdk"
         val cfg = LoggerProviderConfigImpl(clock, NoopSdkErrorHandler).apply {
             resource(mapOf(TelemetryAttributes.TELEMETRY_SDK_NAME to value))
-        }.generateLoggingConfig(base, noGlobalLimits)
+        }.generateLoggingConfig(base, noGlobalLimits, noLogLimits)
         assertEquals(value, cfg.resource.attributes[TelemetryAttributes.TELEMETRY_SDK_NAME])
     }
 
@@ -133,7 +134,7 @@ internal class LoggerProviderConfigImplTest {
         val value = "my-service"
         val cfg = LoggerProviderConfigImpl(clock, NoopSdkErrorHandler).apply {
             resource(mapOf(ServiceAttributes.SERVICE_NAME to value))
-        }.generateLoggingConfig(base, noGlobalLimits)
+        }.generateLoggingConfig(base, noGlobalLimits, noLogLimits)
         assertEquals(value, cfg.resource.attributes[ServiceAttributes.SERVICE_NAME])
     }
 
@@ -143,7 +144,7 @@ internal class LoggerProviderConfigImplTest {
         val attrs = (0 until count).associate { "key$it" to "value$it" }
         val cfg = LoggerProviderConfigImpl(clock, NoopSdkErrorHandler).apply {
             resource(attrs)
-        }.generateLoggingConfig(base, noGlobalLimits)
+        }.generateLoggingConfig(base, noGlobalLimits, noLogLimits)
         assertEquals(count + sdkDefaultAttributes.size, cfg.resource.attributes.size)
     }
 }

--- a/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/init/OpenTelemetryConfigImplTest.kt
+++ b/implementation/src/commonTest/kotlin/io/opentelemetry/kotlin/init/OpenTelemetryConfigImplTest.kt
@@ -154,6 +154,43 @@ internal class OpenTelemetryConfigImplTest {
     }
 
     @Test
+    fun testLocalLogLimits() {
+        val cfg = OpenTelemetryConfigImpl(clock).apply {
+            attributeLimits {
+                attributeCountLimit = 64
+                attributeValueLengthLimit = 256
+            }
+            loggerProvider {
+                logLimits {
+                    attributeCountLimit = 8
+                    attributeValueLengthLimit = 16
+                }
+            }
+        }
+        val logLimits = cfg.generateLoggingConfig().logLimits
+        assertEquals(8, logLimits.attributeCountLimit)
+        assertEquals(16, logLimits.attributeValueLengthLimit)
+    }
+
+    @Test
+    fun testLocalLogLimits2() {
+        val cfg = OpenTelemetryConfigImpl(clock).apply {
+            attributeLimits {
+                attributeCountLimit = 64
+            }
+            loggerProvider {
+                logLimits {
+                    attributeValueLengthLimit = 256
+                }
+            }
+        }
+        with(cfg.generateLoggingConfig().logLimits) {
+            assertEquals(64, attributeCountLimit)
+            assertEquals(256, attributeValueLengthLimit)
+        }
+    }
+
+    @Test
     fun testSignalZeroAttrLimitBeatsGlobal() {
         val cfg = OpenTelemetryConfigImpl(clock).apply {
             attributeLimits {


### PR DESCRIPTION
## Goal

Route log record limits through `LogLimitsBehavior` in the implementation SDK.

Include the logger provider's DSL limits in behavior resolution, then pass the resolved limits into `LoggingConfig`. Preserve per-field fallback to global attribute limits and existing SDK defaults.

Refs #908. Compat mode remains separate work.

## Testing

- Verify both log limits are applied from `LogLimitsBehavior`.
- Verify DSL-configured log limits take precedence over global attribute limits.
- Verify partially specified log limits inherit unset fields from global attribute limits.
- Preserve existing coverage for unspecified limits and zero-value precedence.
- Local JVM tests and Detekt checks pass.
- CI `gradle-test`, `integration-test`, and required status checks pass.
